### PR TITLE
feat: optimize context consumption via sub-agent delegation

### DIFF
--- a/commands/gsd/create-roadmap.md
+++ b/commands/gsd/create-roadmap.md
@@ -4,6 +4,8 @@ allowed-tools:
   - Read
   - Write
   - Bash
+  - Task
+  - TodoWrite
   - AskUserQuestion
   - Glob
 ---
@@ -14,101 +16,71 @@ Create project roadmap with phase breakdown.
 Roadmaps define what work happens in what order. Run after /gsd:new-project.
 </objective>
 
-<execution_context>
-@~/.claude/get-shit-done/workflows/create-roadmap.md
-@~/.claude/get-shit-done/templates/roadmap.md
-@~/.claude/get-shit-done/templates/state.md
-</execution_context>
-
 <context>
-@.planning/PROJECT.md
+**Load minimal state for orchestration:**
 @.planning/config.json
 </context>
 
-<process>
+<delegate_execution>
+**IMPORTANT: Delegate to sub-agent for context efficiency.**
 
-<step name="validate">
+**Step 1: Validate project exists**
 ```bash
-# Verify project exists
 [ -f .planning/PROJECT.md ] || { echo "ERROR: No PROJECT.md found. Run /gsd:new-project first."; exit 1; }
 ```
-</step>
 
-<step name="check_existing">
-Check if roadmap already exists:
-
+**Step 2: Check for existing roadmap**
 ```bash
 [ -f .planning/ROADMAP.md ] && echo "ROADMAP_EXISTS" || echo "NO_ROADMAP"
 ```
 
-**If ROADMAP_EXISTS:**
-Use AskUserQuestion:
-- header: "Roadmap exists"
-- question: "A roadmap already exists. What would you like to do?"
-- options:
-  - "View existing" - Show current roadmap
-  - "Replace" - Create new roadmap (will overwrite)
-  - "Cancel" - Keep existing roadmap
+If ROADMAP_EXISTS, ask user:
+- "View existing" - Show current roadmap and exit
+- "Replace" - Continue with creation
+- "Cancel" - Exit
 
-If "View existing": `cat .planning/ROADMAP.md` and exit
-If "Cancel": Exit
-If "Replace": Continue with workflow
-</step>
+**Step 3: Delegate roadmap creation to sub-agent**
 
-<step name="create_roadmap">
-Follow the create-roadmap.md workflow starting from detect_domain step.
+Use Task tool with subagent_type="general-purpose":
 
-The workflow handles:
-- Domain expertise detection
-- Phase identification
-- Research flags for each phase
-- Confirmation gates (respecting config mode)
-- ROADMAP.md creation
-- STATE.md initialization
-- Phase directory creation
-- Git commit
-</step>
-
-<step name="done">
 ```
-Roadmap created:
-- Roadmap: .planning/ROADMAP.md
-- State: .planning/STATE.md
-- [N] phases defined
+Create a project roadmap.
 
----
+**Read and follow the workflow:**
+~/.claude/get-shit-done/workflows/create-roadmap.md
 
-## ▶ Next Up
+**Templates to use:**
+- ~/.claude/get-shit-done/templates/roadmap.md (ROADMAP.md structure)
+- ~/.claude/get-shit-done/templates/state.md (STATE.md structure)
 
-**Phase 1: [Name]** — [Goal from ROADMAP.md]
+**Project context to read:**
+- .planning/PROJECT.md (project vision, requirements, constraints)
+- .planning/config.json (depth setting for phase count)
 
-`/gsd:plan-phase 1`
+**Your task:**
+1. Read PROJECT.md to understand the project
+2. Detect domain expertise level
+3. Identify phases (quick: 3-5, standard: 5-8, comprehensive: 8-12)
+4. Assign research flags to each phase
+5. Create ROADMAP.md following template
+6. Initialize STATE.md
+7. Create phase directories
+8. Commit changes
 
-<sub>`/clear` first → fresh context window</sub>
-
----
-
-**Also available:**
-- `/gsd:discuss-phase 1` — gather context first
-- `/gsd:research-phase 1` — investigate unknowns
-- Review roadmap
-
----
+**Return to parent:**
+- Number of phases created
+- Phase names and goals (brief)
+- Research flags summary
+- Git commit hash
+- Suggested next command (/gsd:plan-phase 1)
 ```
-</step>
 
-</process>
-
-<output>
-- `.planning/ROADMAP.md`
-- `.planning/STATE.md`
-- `.planning/phases/XX-name/` directories
-</output>
+</delegate_execution>
 
 <success_criteria>
-- [ ] PROJECT.md validated
-- [ ] ROADMAP.md created with phases
-- [ ] STATE.md initialized
-- [ ] Phase directories created
-- [ ] Changes committed
+- ROADMAP.md created with phases
+- STATE.md initialized
+- Phase directories created
+- Changes committed
+- User knows next steps
 </success_criteria>

--- a/commands/gsd/discuss-milestone.md
+++ b/commands/gsd/discuss-milestone.md
@@ -1,5 +1,12 @@
 ---
 description: Gather context for next milestone through adaptive questioning
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+  - Glob
+  - AskUserQuestion
+  - SlashCommand
 ---
 
 <objective>
@@ -9,38 +16,46 @@ Purpose: After completing a milestone, explore what features you want to add, im
 Output: Context gathered, then routes to /gsd:new-milestone
 </objective>
 
-<execution_context>
-@~/.claude/get-shit-done/workflows/discuss-milestone.md
-</execution_context>
-
 <context>
-**Load project state first:**
+**Load minimal state for context:**
 @.planning/STATE.md
-
-**Load roadmap:**
-@.planning/ROADMAP.md
-
-**Load milestones (if exists):**
-@.planning/MILESTONES.md
+@.planning/config.json
 </context>
 
-<process>
-1. Verify previous milestone complete (or acknowledge active milestone)
-2. Present context from previous milestone (accomplishments, phase count)
-3. Follow discuss-milestone.md workflow with **ALL questions using AskUserQuestion**:
-   - Use AskUserQuestion: "What do you want to add, improve, or fix?" with feature categories
-   - Use AskUserQuestion to dig into features they mention
-   - Use AskUserQuestion to help them articulate what matters most
-   - Use AskUserQuestion for decision gate (ready / ask more / let me add context)
-4. Hand off to /gsd:new-milestone with gathered context
+<interactive_execution>
+**NOTE: This command is interactive and runs in main context.**
+
+**Step 1: Validate project exists**
+```bash
+[ -d .planning ] || { echo "ERROR: No .planning/ directory. Run /gsd:new-project first."; exit 1; }
+```
+
+**Step 2: Load workflow guidance (read on-demand, not preloaded)**
+Read and follow: `~/.claude/get-shit-done/workflows/discuss-milestone.md`
+
+**Step 3: Load project context**
+- Read `.planning/ROADMAP.md` for previous milestone info
+- Read `.planning/MILESTONES.md` if exists
+
+**Step 4: Interactive milestone discussion using AskUserQuestion**
+Follow the workflow to:
+- Verify previous milestone complete (or acknowledge active milestone)
+- Present context from previous milestone (accomplishments, phase count)
+- Ask "What do you want to add, improve, or fix?" with feature categories
+- Dig into features they mention
+- Help them articulate what matters most
+- Decision gate (ready / ask more / let me add context)
 
 **CRITICAL: ALL questions use AskUserQuestion. Never ask inline text questions.**
-</process>
+
+**Step 5: Hand off to new-milestone**
+Route to `/gsd:new-milestone` with gathered context.
+
+</interactive_execution>
 
 <success_criteria>
-
 - Project state loaded and presented
 - Previous milestone context summarized
 - Milestone scope gathered through adaptive questioning
 - Context handed off to /gsd:new-milestone
-  </success_criteria>
+</success_criteria>

--- a/commands/gsd/discuss-phase.md
+++ b/commands/gsd/discuss-phase.md
@@ -1,59 +1,74 @@
 ---
 description: Gather phase context through adaptive questioning before planning
 argument-hint: "[phase]"
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+  - Glob
+  - AskUserQuestion
 ---
 
 <objective>
 Help the user articulate their vision for a phase through collaborative thinking.
 
-Purpose: Understand HOW the user imagines this phase working — what it looks like, what's essential, what's out of scope. You're a thinking partner helping them crystallize their vision, not an interviewer gathering technical requirements.
+Purpose: Understand HOW the user imagines this phase working. You're a thinking partner helping them crystallize their vision.
 
 Output: {phase}-CONTEXT.md capturing the user's vision for the phase
 </objective>
 
-<execution_context>
-@~/.claude/get-shit-done/workflows/discuss-phase.md
-@~/.claude/get-shit-done/templates/context.md
-</execution_context>
-
 <context>
 Phase number: $ARGUMENTS (required)
 
-**Load project state first:**
+**Load minimal state for context:**
 @.planning/STATE.md
-
-**Load roadmap:**
-@.planning/ROADMAP.md
+@.planning/config.json
 </context>
 
-<process>
-1. Validate phase number argument (error if missing or invalid)
-2. Check if phase exists in roadmap
-3. Check if CONTEXT.md already exists (offer to update if yes)
-4. Follow discuss-phase.md workflow with **ALL questions using AskUserQuestion**:
-   - Present phase from roadmap
-   - Use AskUserQuestion: "How do you imagine this working?" with interpretation options
-   - Use AskUserQuestion to follow their thread — probe what excites them
-   - Use AskUserQuestion to sharpen the core — what's essential for THIS phase
-   - Use AskUserQuestion to find boundaries — what's explicitly out of scope
-   - Use AskUserQuestion for decision gate (ready / ask more / let me add context)
-   - Create CONTEXT.md capturing their vision
-5. Offer next steps (research or plan the phase)
+<interactive_execution>
+**NOTE: This command is interactive and runs in main context.**
+
+**Step 1: Validate phase argument**
+```bash
+[ -z "$ARGUMENTS" ] && { echo "ERROR: Phase number required. Usage: /gsd:discuss-phase [phase]"; exit 1; }
+[ -d .planning ] || { echo "ERROR: No .planning/ directory. Run /gsd:new-project first."; exit 1; }
+```
+
+**Step 2: Load workflow guidance (read on-demand, not preloaded)**
+Read and follow: `~/.claude/get-shit-done/workflows/discuss-phase.md`
+
+**Step 3: Load phase context**
+- Read `.planning/ROADMAP.md` to find phase description
+- Check if `.planning/phases/XX-name/{phase}-CONTEXT.md` exists
+
+**Step 4: Collaborative discussion using AskUserQuestion**
+Follow the workflow to:
+- Present phase from roadmap
+- Ask "How do you imagine this working?" with interpretation options
+- Follow their thread — probe what excites them
+- Sharpen the core — what's essential for THIS phase
+- Find boundaries — what's explicitly out of scope
+- Decision gate (ready / ask more / let me add context)
 
 **CRITICAL: ALL questions use AskUserQuestion. Never ask inline text questions.**
 
+**Step 5: Create CONTEXT.md**
+Use template at `~/.claude/get-shit-done/templates/context.md`
+Write to `.planning/phases/XX-name/{phase}-CONTEXT.md`
+
+</interactive_execution>
+
+<guidance>
 User is the visionary, you are the builder:
 - Ask about vision, feel, essential outcomes
 - DON'T ask about technical risks (you figure those out)
 - DON'T ask about codebase patterns (you read the code)
 - DON'T ask about success metrics (too corporate)
-- DON'T interrogate about constraints they didn't mention
-</process>
+</guidance>
 
 <success_criteria>
-
 - Phase validated against roadmap
-- Vision gathered through collaborative thinking (not interrogation)
+- Vision gathered through collaborative thinking
 - CONTEXT.md captures: how it works, what's essential, what's out of scope
 - User knows next steps (research or plan the phase)
 </success_criteria>

--- a/commands/gsd/research-phase.md
+++ b/commands/gsd/research-phase.md
@@ -7,6 +7,8 @@ allowed-tools:
   - Glob
   - Grep
   - Write
+  - Task
+  - TodoWrite
   - WebFetch
   - WebSearch
   - mcp__context7__*
@@ -15,76 +17,78 @@ allowed-tools:
 <objective>
 Comprehensive research on HOW to implement a phase before planning.
 
-This is for niche/complex domains where Claude's training data is sparse or outdated. Research discovers:
-- What libraries exist for this problem
-- What architecture patterns experts use
-- What the standard stack looks like
-- What problems people commonly hit
-- What NOT to hand-roll (use existing solutions)
+For niche/complex domains where Claude's training data is sparse or outdated. Discovers libraries, architecture patterns, standard stacks, common pitfalls.
 
 Output: RESEARCH.md with ecosystem knowledge that informs quality planning.
 </objective>
 
-<execution_context>
-@~/.claude/get-shit-done/workflows/research-phase.md
-@~/.claude/get-shit-done/templates/research.md
-@~/.claude/get-shit-done/references/research-pitfalls.md
-</execution_context>
-
 <context>
 Phase number: $ARGUMENTS (required)
 
-**Load project state:**
+**Load minimal state for orchestration:**
 @.planning/STATE.md
-
-**Load roadmap:**
-@.planning/ROADMAP.md
-
-**Load phase context if exists:**
-Check for `.planning/phases/XX-name/{phase}-CONTEXT.md` - bonus context from discuss-phase.
 </context>
-
-<process>
-1. Validate phase number argument (error if missing or invalid)
-2. Check if phase exists in roadmap - extract phase description
-3. Check if RESEARCH.md already exists (offer to update or use existing)
-4. Load CONTEXT.md if it exists (bonus context for research direction)
-5. Follow research-phase.md workflow:
-   - Analyze phase to identify knowledge gaps
-   - Determine research domains (architecture, ecosystem, patterns, pitfalls)
-   - Execute comprehensive research via Context7, official docs, WebSearch
-   - Cross-verify all findings
-   - Create RESEARCH.md with actionable ecosystem knowledge
-6. Offer next steps (plan the phase)
-</process>
 
 <when_to_use>
 **Use research-phase for:**
-- 3D graphics (Three.js, WebGL, procedural generation)
-- Game development (physics, collision, AI, procedural content)
-- Audio/music (Web Audio API, DSP, synthesis)
-- Shaders (GLSL, Metal, ISF)
-- ML/AI integration (model serving, inference, pipelines)
-- Real-time systems (WebSockets, WebRTC, sync)
-- Specialized frameworks with active ecosystems
+- 3D graphics, game dev, audio/music, shaders, ML/AI
+- Real-time systems, specialized frameworks
 - Any domain where "how do experts do this" matters
 
-**Skip research-phase for:**
-- Standard web dev (auth, CRUD, REST APIs)
-- Well-known patterns (forms, validation, testing)
-- Simple integrations (Stripe, SendGrid with clear docs)
-- Commodity features Claude handles well
+**Skip for:** Standard web dev, well-known patterns, simple integrations
 </when_to_use>
 
+<delegate_execution>
+**IMPORTANT: Delegate to sub-agent for context efficiency.**
+
+**Step 1: Validate phase argument**
+```bash
+[ -z "$ARGUMENTS" ] && { echo "ERROR: Phase number required. Usage: /gsd:research-phase [phase]"; exit 1; }
+[ -d .planning ] || { echo "ERROR: No .planning/ directory. Run /gsd:new-project first."; exit 1; }
+```
+
+**Step 2: Delegate research to sub-agent**
+
+Use Task tool with subagent_type="general-purpose":
+
+```
+Research phase: [PHASE_NUMBER]
+
+**Read and follow the workflow:**
+~/.claude/get-shit-done/workflows/research-phase.md
+
+**Reference files:**
+- ~/.claude/get-shit-done/templates/research.md (RESEARCH.md structure)
+- ~/.claude/get-shit-done/references/research-pitfalls.md (what to avoid)
+
+**Project context to read:**
+- .planning/ROADMAP.md (phase description and goals)
+- .planning/PROJECT.md (project constraints)
+- .planning/STATE.md (accumulated decisions)
+- .planning/phases/XX-name/*-CONTEXT.md (if exists)
+
+**Your task:**
+1. Identify the phase in ROADMAP.md
+2. Analyze phase to identify knowledge gaps
+3. Determine research domains (architecture, ecosystem, patterns, pitfalls)
+4. Execute comprehensive research (Context7, official docs, WebSearch)
+5. Cross-verify all findings
+6. Create RESEARCH.md with actionable ecosystem knowledge
+
+**Return to parent:**
+- Research domains covered
+- Key libraries/tools identified
+- Architecture patterns found
+- Major pitfalls catalogued
+- RESEARCH.md path
+- Suggested next command (/gsd:plan-phase [N])
+```
+
+</delegate_execution>
+
 <success_criteria>
-- [ ] Phase validated against roadmap
-- [ ] Domain/ecosystem identified from phase description
-- [ ] Comprehensive research executed (Context7 + official docs + WebSearch)
-- [ ] All WebSearch findings cross-verified with authoritative sources
-- [ ] RESEARCH.md created with ecosystem knowledge
-- [ ] Standard stack/libraries identified
-- [ ] Architecture patterns documented
-- [ ] Common pitfalls catalogued
-- [ ] What NOT to hand-roll is clear
-- [ ] User knows next steps (plan phase)
+- Phase validated against roadmap
+- Comprehensive research executed
+- RESEARCH.md created with ecosystem knowledge
+- User knows next steps (plan phase)
 </success_criteria>


### PR DESCRIPTION
High-impact commands now delegate workflow execution to sub-agents, keeping the parent context minimal (~80-110 lines per command instead of loading 400-1400+ line workflows directly).

Changes:
- execute-plan: Delegates 1,436-line workflow to sub-agent
- plan-phase: Delegates 392-line workflow + references to sub-agent
- create-roadmap: Delegates 481-line workflow to sub-agent
- research-phase: Delegates 416-line workflow to sub-agent
- new-milestone: Delegates 389-line workflow to sub-agent
- complete-milestone: Delegates 643-line workflow to sub-agent
- discuss-phase: Reads workflow on-demand (interactive, stays in main)
- discuss-milestone: Reads workflow on-demand (interactive, stays in main)

Pattern used:
- Remove @workflow.md references (preloads into parent context)
- Add <delegate_execution> section with Task tool instructions
- Sub-agent reads workflow in fresh 200k context
- Parent only receives compact summary

Estimated context reduction: ~88% for workflow-heavy commands (from ~5,900 lines to ~680 lines loaded in parent)