### PR TITLE
feat(execute-plan): add pre-execution summary for interactive mode

### DIFF
--- a/commands/gsd/execute-plan.md
+++ b/commands/gsd/execute-plan.md
@@ -48,15 +48,44 @@ Plan path: $ARGUMENTS
    - plan_number: `02`
    - plan_path: full path
 
-4. **Fill and spawn subagent**
+4. **Pre-execution summary (interactive mode only)**
+   Check config.json for mode. Skip this step if mode=yolo.
+
+   Parse PLAN.md to extract:
+   - objective: First sentence or line from `<objective>` element
+   - task_count: Count of `<task` elements
+   - files: Collect unique file paths from `<files>` elements within tasks
+
+   Display friendly summary before spawning:
+   ```
+   ════════════════════════════════════════
+   EXECUTING: {phase_number}-{plan_number} {phase_name}
+   ════════════════════════════════════════
+
+   Building: {objective one-liner}
+   Tasks: {task_count}
+   Files: {comma-separated file list}
+
+   Full plan: {plan_path}
+   ════════════════════════════════════════
+   ```
+
+   No confirmation needed. Proceed to spawn after displaying.
+
+   In yolo mode, display abbreviated version:
+   ```
+   ⚡ Executing {phase_number}-{plan_number}: {objective one-liner}
+   ```
+
+5. **Fill and spawn subagent**
    - Fill subagent-task-prompt template with extracted values
    - Spawn: `Task(prompt=filled_template, subagent_type="general-purpose")`
 
-5. **Handle subagent return**
+6. **Handle subagent return**
    - If contains "## CHECKPOINT REACHED": Execute checkpoint_handling
    - If contains "## PLAN COMPLETE": Verify SUMMARY exists, report success
 
-6. **Report completion**
+7. **Report completion**
    - Show SUMMARY path
    - Show commits from subagent return
    - Offer next steps


### PR DESCRIPTION
## Summary

- Adds friendly pre-execution summary display before subagent spawns in `/gsd:execute-plan`
- Interactive mode: shows full summary (plan name, objective, task count, files, plan path)
- YOLO mode: shows abbreviated single-line version
- No y/n prompt - just visibility for new users to understand what's happening

## Motivation

Addresses GitHub issue #38 (plan approval request) with a visibility-first approach rather than approval gates.

After researching the feature request (see `.planning/research/subagent-plan-approval.md`), the core insight is:
- This isn't about trust or approval - it's about **helping new users understand what GSD is doing**
- The plan IS the strategy - if users want to review, they should review the plan
- What's missing is **in-chat visibility** that teaches users where artifacts live

## Implementation

Added step 4 "Pre-execution summary" to `commands/gsd/execute-plan.md`:

**Interactive mode displays:**
```
════════════════════════════════════════
EXECUTING: 03-02 auth
════════════════════════════════════════

Building: Implement JWT auth with refresh rotation
Tasks: 3
Files: src/middleware/auth.ts, src/lib/jwt.ts, src/routes/login.ts

Full plan: .planning/phases/03-auth/03-02-PLAN.md
════════════════════════════════════════
```

**YOLO mode displays:**
```
⚡ Executing 03-02: Implement JWT auth with refresh rotation
```

## Design Philosophy

- **No new commands** - uses existing mode system
- **No approval gate** - GSD philosophy trusts the workflow
- **Training wheels** - helps new users learn, then gets out of the way in YOLO mode
- **Teaches artifact locations** - users learn where plans live by seeing the path

## Test Plan

- [ ] Run `/gsd:execute-plan` in interactive mode - verify summary displays before spawn
- [ ] Run `/gsd:execute-plan` in yolo mode - verify abbreviated version displays
- [ ] Verify no y/n prompt appears (summary is informational only)