### PR TITLE
feat: add archive-session skill for context management

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -163,6 +163,14 @@ function install(isGlobal) {
   copyWithPathReplacement(skillSrc, skillDest, pathPrefix);
   console.log(`  ${green}✓${reset} Installed get-shit-done`);
 
+  // Copy skills directory
+  const skillsDir = path.join(claudeDir, 'skills');
+  fs.mkdirSync(skillsDir, { recursive: true });
+  const archiveSessionSrc = path.join(src, 'skills', 'archive-session');
+  const archiveSessionDest = path.join(skillsDir, 'archive-session');
+  copyWithPathReplacement(archiveSessionSrc, archiveSessionDest, pathPrefix);
+  console.log(`  ${green}✓${reset} Installed skills/archive-session`);
+
   // Copy CHANGELOG.md
   const changelogSrc = path.join(src, 'CHANGELOG.md');
   const changelogDest = path.join(claudeDir, 'get-shit-done', 'CHANGELOG.md');

--- a/commands/gsd/archive-session.md
+++ b/commands/gsd/archive-session.md
@@ -1,0 +1,13 @@
+---
+description: Archive current session transcript and subagent logs with HTML report
+argument-hint: "[session-id] [--output=path]"
+allowed-tools: Bash
+---
+
+Archive session transcript and subagent logs. Auto-detects current session, or pass specific session ID.
+
+GSD projects archive to `.planning/sessions/`. Override with `--output=<path>`.
+
+```bash
+CLAUDE_ARCHIVE_DIR=".planning/sessions" bash ~/.claude/skills/archive-session/scripts/archive.sh $ARGUMENTS
+```

--- a/get-shit-done/references/context-management.md
+++ b/get-shit-done/references/context-management.md
@@ -1,0 +1,56 @@
+# High Context Protocol
+
+Save detailed session transcripts and logs when context usage hits ~90% by proactively interrupting and presenting options:
+
+```
+Context at ~90% capacity.
+
+Options:
+A. Archive session (/archive-session) - Save JSON transcripts (with individual spawned subagents) + HTML report
+B. Export conversation (/export) - Save plain text via built-in Claude Code command
+C. Both - Full audit trail
+
+Which would you like?
+```
+
+Wait for user choice before continuing.
+
+## If User Chooses A or C (Archive)
+
+Before running `/archive-session`, confirm destination:
+
+```
+Archiving to default: .claude/session-archive/exported-on-<timestamp>/
+
+Override? Provide a path, or enter for default.
+```
+
+If user provides a path, run:
+```bash
+/archive-session --output=<user-provided-path>
+```
+
+Otherwise run with default:
+```bash
+/archive-session
+```
+
+## Archive-Session vs Export
+
+**Archive-Session (/archive-session):**
+- Archives main session transcript (session.jsonl)
+- Archives subagent transcripts if present
+- Generates browsable HTML report
+- Opens report in browser
+- Default: `.claude/session-archive/exported-on-<timestamp>/`
+- Override exported path with either
+    - env var: `CLAUDE_ARCHIVE_DIR=.planning/sessions` or
+    - flag: `--output=.planning/sessions`
+
+**Export (/export):**
+- Saves main conversation to markdown file
+- Simpler format, no HTML generation
+- Built-in Claude Code command
+
+**Both:**
+Most complete audit trail - structured archive + readable markdown.

--- a/skills/archive-session/SKILL.md
+++ b/skills/archive-session/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: archive-session
+description: Archive session transcripts + subagent logs to browsable HTML. Default output is .claude/session-archive/exported-on-<timestamp>/. User may override with --output=<path>. Ask user for destination preference before running.
+user-invocable: true
+allowed-tools:
+  - Bash(bash .claude/skills/archive-session/scripts/archive.sh:*)
+---
+
+# Archive Session
+
+Archives the current Claude Code session transcript and any subagent logs, generating a browsable HTML file.
+
+## When to Use
+
+- Context reaches ~90% capacity (per high-context protocol)
+- End of work session for audit trail
+- Debugging session or subagent execution
+
+## Before Running
+
+Ask user where to archive:
+
+```
+Archiving session. Default: .claude/session-archive/exported-on-<timestamp>/
+
+Override? Provide a path, or press enter for default.
+```
+
+If user provides path, pass via `--output=<path>`. Otherwise use default.
+
+## What It Does
+
+1. Detects current session (most recently modified transcript)
+2. Archives main session transcript (`session.jsonl`)
+3. Archives subagent transcripts if present (`subagents/`)
+4. Generates HTML file via `claude-code-log` dependency, or uvx
+5. Opens file in browser
+
+## Output Location
+
+**Default:** in the project claude folder at `.claude/session-archive/exported-on-<timestamp>/`
+
+**Override:** Set either `CLAUDE_ARCHIVE_DIR` env var or use `--output=<path>` argument.
+
+**Location override:** Useful in scenarios where you want to archive to a different location to fit other frameworks and processes. 
+
+For example, when using the [Get Shit Done](https://github.com/glittercowboy/get-shit-done) CC framework, a better location might be in `.planning/sessions/`, where that framework generates all of its other plans and records. 
+
+## Default exported folder structure
+```
+.claude/session-archive/exported-on-2026-01-14_15-51-05/
+├── session-info.txt      # Metadata
+├── session.jsonl         # Main transcript
+├── session.html          # Main file (if no subagents)
+└── subagents/            # If subagents exist
+    ├── agent-*.jsonl     # Raw transcripts
+    ├── cache/            # Parsed JSON
+    └── session-*.html    # Browsable file
+```
+
+## Usage
+
+```bash
+# Archive current session (auto-detected, to default location)
+/archive-session
+
+# Archive specific session by ID
+/archive-session 602fca42-0159-466c-bdb7-00745e1939f1
+
+# Archive to a custom location either with: 
+/archive-session --output=./my-archives
+
+# or
+CLAUDE_ARCHIVE_DIR=~/some/other/path bash .claude/skills/archive-session/scripts/archive.sh
+
+# Both: specific session to custom location
+/archive-session 602fca42-0159-466c-bdb7-00745e1939f1 --output=./my-archives
+```
+
+## TUI for Richer Experience
+
+For interactive session management, `claude-code-log` provides a TUI:
+
+```bash
+claude-code-log --tui
+# or
+uvx claude-code-log@latest --tui
+```
+
+Features: session list with timestamps/token counts, keyboard nav (`h` HTML, `m` Markdown, `v` view), cross-project traversal, `c` to resume sessions.
+
+## Dependencies
+
+[claude-code-log](https://github.com/daaain/claude-code-log) generates browsable HTML reports from transcript files. Primarily a TUI with CLI capabilities for batch export.
+
+You can install it as a project dependency or run it on-demand:
+
+**Project dependency** (recommended if using frequently):
+```bash
+uv add claude-code-log
+```
+Adds to `pyproject.toml` and installs via [uv package manager](https://docs.astral.sh/uv/).
+
+**On-demand execution** (no install):
+```bash
+uvx claude-code-log@latest
+```
+`uvx` is uv's tool runner that fetches and runs packages without permanent installation.
+
+The script checks for `claude-code-log` first, falls back to `uvx`. If neither available, transcripts are still archived but HTML generation is skipped.
+
+Note: You can also use `pip install claude-code-log`, but we default to uv for convenience and speed.
+
+## Script Location
+
+```bash
+.claude/skills/archive-session/scripts/archive.sh
+```

--- a/skills/archive-session/scripts/archive.sh
+++ b/skills/archive-session/scripts/archive.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+# archive.sh - Archive Claude Code session transcript and subagent logs
+
+set -euo pipefail
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+# Archive destination - configurable via env var or argument
+# Default: .claude/session-archive/ (project-local)
+# Can be overridden with CLAUDE_ARCHIVE_DIR env var or --output=<path> argument
+DEFAULT_ARCHIVE_BASE="${PROJECT_DIR}/.claude/session-archive"
+ARCHIVE_BASE="${CLAUDE_ARCHIVE_DIR:-${DEFAULT_ARCHIVE_BASE}}"
+
+# Claude Code stores transcripts in ~/.claude/projects/<project-hash>/
+PROJECT_HASH=$(echo "${PROJECT_DIR}" | sed 's|/|-|g')
+TRANSCRIPT_DIR="${HOME}/.claude/projects/${PROJECT_HASH}"
+
+# Accept session ID as first positional arg, or detect from most recent
+SESSION_ID=""
+for arg in "$@"; do
+    case "$arg" in
+        --output=*) ARCHIVE_BASE="${arg#*=}" ;;
+        *) [ -z "$SESSION_ID" ] && SESSION_ID="$arg" ;;
+    esac
+done
+
+# Security: Validate SESSION_ID format (UUID only)
+if [ -n "${SESSION_ID}" ]; then
+    if ! [[ "${SESSION_ID}" =~ ^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$ ]]; then
+        echo "Error: Invalid session ID format. Expected UUID format (e.g., 602fca42-0159-466c-bdb7-00745e1939f1)"
+        exit 1
+    fi
+fi
+
+# Security: Validate and normalize ARCHIVE_BASE path
+# Expand tilde
+ARCHIVE_BASE=$(eval echo "${ARCHIVE_BASE}")
+
+# Security: Ensure archive path is not a sensitive system directory (before path normalization)
+case "${ARCHIVE_BASE}" in
+    /etc|/etc/*|/bin|/bin/*|/sbin|/sbin/*|/usr/bin|/usr/bin/*|/usr/sbin|/usr/sbin/*|/System|/System/*|/private/etc|/private/etc/*|/private/var/root|/private/var/root/*)
+        echo "Error: Cannot archive to system directory: ${ARCHIVE_BASE}"
+        exit 1
+        ;;
+esac
+
+# Normalize to absolute path
+ARCHIVE_BASE=$(cd "$(dirname "${ARCHIVE_BASE}")" 2>/dev/null && pwd)/$(basename "${ARCHIVE_BASE}") || {
+    echo "Error: Invalid output path: ${ARCHIVE_BASE}"
+    exit 1
+}
+
+if [ -z "${SESSION_ID}" ]; then
+    # Find most recently modified .jsonl file = current session
+    LATEST_TRANSCRIPT=$(ls -t "${TRANSCRIPT_DIR}"/*.jsonl 2>/dev/null | head -1)
+    if [ -n "${LATEST_TRANSCRIPT}" ]; then
+        SESSION_ID=$(basename "${LATEST_TRANSCRIPT}" .jsonl)
+
+        # Validate auto-detected session ID
+        if ! [[ "${SESSION_ID}" =~ ^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$ ]]; then
+            echo "Error: Auto-detected invalid session ID format"
+            exit 1
+        fi
+
+        echo "Detected current session: ${SESSION_ID}"
+    fi
+fi
+
+if [ -z "${SESSION_ID}" ]; then
+    echo "No session found to archive"
+    exit 0
+fi
+
+# Verify session exists
+MAIN_TRANSCRIPT="${TRANSCRIPT_DIR}/${SESSION_ID}.jsonl"
+if [ ! -f "${MAIN_TRANSCRIPT}" ]; then
+    echo "Session transcript not found: ${MAIN_TRANSCRIPT}"
+    exit 1
+fi
+
+# Archive destination with export timestamp
+TIMESTAMP=$(date +%Y-%m-%d_%H-%M-%S)
+SESSION_ARCHIVE="${ARCHIVE_BASE}/exported-on-${TIMESTAMP}"
+
+mkdir -p "${SESSION_ARCHIVE}"
+
+# Archive main transcript
+echo "Archiving main transcript..."
+cp "${MAIN_TRANSCRIPT}" "${SESSION_ARCHIVE}/session.jsonl"
+MAIN_SIZE=$(ls -lh "${SESSION_ARCHIVE}/session.jsonl" | awk '{print $5}')
+echo "Main transcript: ${MAIN_SIZE}"
+
+# Archive subagent logs if they exist
+SUBAGENTS_DIR="${TRANSCRIPT_DIR}/${SESSION_ID}/subagents"
+SUBAGENT_COUNT=0
+if [ -d "${SUBAGENTS_DIR}" ]; then
+    SUBAGENT_COUNT=$(find "${SUBAGENTS_DIR}" -name "agent-*.jsonl" 2>/dev/null | wc -l | tr -d ' ')
+    if [ "${SUBAGENT_COUNT}" -gt 0 ]; then
+        echo "Archiving ${SUBAGENT_COUNT} subagent transcripts..."
+        cp -r "${SUBAGENTS_DIR}" "${SESSION_ARCHIVE}/subagents"
+    fi
+fi
+
+# Generate HTML report with claude-code-log
+if [ "${SUBAGENT_COUNT}" -gt 0 ]; then
+    REPORT_SOURCE="${SESSION_ARCHIVE}/subagents"
+elif [ -f "${SESSION_ARCHIVE}/session.jsonl" ]; then
+    REPORT_SOURCE="${SESSION_ARCHIVE}/session.jsonl"
+else
+    REPORT_SOURCE=""
+fi
+
+if [ -n "${REPORT_SOURCE}" ]; then
+    if command -v claude-code-log &>/dev/null; then
+        echo "Generating HTML report..."
+        claude-code-log "${REPORT_SOURCE}" --open-browser 2>/dev/null || {
+            echo "Warning: HTML report generation failed"
+        }
+    elif command -v uvx &>/dev/null; then
+        echo "Generating HTML report via uvx..."
+        uvx claude-code-log@latest "${REPORT_SOURCE}" --open-browser 2>/dev/null || {
+            echo "Warning: HTML report generation failed"
+        }
+    else
+        echo "Warning: claude-code-log not available, skipping report generation"
+    fi
+
+    # Remove redundant combined file if subagents were processed
+    if [ "${SUBAGENT_COUNT}" -gt 0 ]; then
+        rm -f "${SESSION_ARCHIVE}/subagents/combined_transcripts.html"
+    fi
+fi
+
+# Create session metadata
+cat >"${SESSION_ARCHIVE}/session-info.txt" <<EOF
+Session ID: ${SESSION_ID}
+Project: ${PROJECT_DIR}
+Timestamp: ${TIMESTAMP}
+Main Transcript: ${MAIN_SIZE}
+Subagent Count: ${SUBAGENT_COUNT}
+EOF
+
+echo ""
+echo "Session archive complete: ${SESSION_ARCHIVE}"
+cat "${SESSION_ARCHIVE}/session-info.txt"


### PR DESCRIPTION
## Overview

This adds a way to track detailed history. Particularly useful when auto-compacting is on, and multiple agents are making changes that you later want to review and track. 

I set the proactive behavior to 90% context window, might have to play with this depending on your use case.

## Components Added

### 1. Skill Implementation (`skills/archive-session/`)
Portable, reusable skill that:
- Auto-detects current session (most recently modified transcript)
- Archives main transcript + subagent logs
- Generates browsable HTML reports via `claude-code-log`
- Validates session IDs (UUID format only) for security
- Blocks writes to system directories

Copied from my standalone Skill: https://github.com/lifeinchords/claude-code-skills/blob/main/.claude/skills/archive-session/SKILL.md

I included it directly in this repo for convenience

### 2. GSD Command Wrapper (`commands/gsd/archive-session.md`)
Convenience command `/gsd:archive-session` that:
- Sets GSD default: `CLAUDE_ARCHIVE_DIR=".planning/sessions"`
- Integrates with GSD's planning directory structure
- Provides shortcut for users (vs invoking skill manually)

### 3. Context Management Reference (`get-shit-done/references/context-management.md`)
Protocol documentation for agents:
- 90% context threshold detection prompt
- Archive vs export decision flow
- Integration with phase execution workflow

## Installation Integration

Updated `bin/install.js` to copy skill to `~/.claude/skills/archive-session/` during GSD installation, making it available across all projects.

## Usage

```bash
# Via GSD command (archives to .planning/sessions/)
/gsd:archive-session

# Via skill directly (custom location)
/archive-session --output=./my-archives

# Specific session
/gsd:archive-session 602fca42-0159-466c-bdb7-00745e1939f1
```

## Use Case

When context usage hits ~90% during multi-phase execution, agent proactively prompts:
```
Context at ~90% capacity.

Options:
A. Archive session - Save transcript + subagents + HTML report
B. Export conversation - Save main conversation to markdown
C. Both - Full audit trail

Which would you like?
```

Preserves execution history before auto-compaction or context reset, maintaining audit trail for complex workflows.

## Dependencies

`claude-code-log` for HTML report generation:
- Project dependency: `uv add claude-code-log`
- On-demand: `uvx claude-code-log@latest`
- Alternative: `pip install claude-code-log`

Script gracefully falls back if unavailable (transcripts still archived, HTML skipped).

## Security

- Session ID validation: UUID format only
- Path validation: blocks system directories (`/etc`, `/bin`, etc.)
- Path normalization before filesystem operations