### PR TITLE
Add opt-in automated verification to /gsd:verify-work

### DIFF
--- a/commands/gsd/help.md
+++ b/commands/gsd/help.md
@@ -324,7 +324,7 @@ Change anytime by editing `.planning/config.json`
 
 ## Automated Verification
 
-`/gsd:verify-work` supports optional automated testing with Playwright MCP.
+`/gsd:verify-work` supports optional automated testing using available tools and MCPs.
 
 **Configuration** (in `.planning/config.json`):
 
@@ -332,8 +332,7 @@ Change anytime by editing `.planning/config.json`
 {
   "agent_acceptance_testing": {
     "auto_enabled": false,
-    "fallback_to_human": true,
-    "app_url": "http://localhost:3000"
+    "fallback_to_human": true
   }
 }
 ```
@@ -341,31 +340,35 @@ Change anytime by editing `.planning/config.json`
 | Setting | Description | Default |
 |---------|-------------|---------|
 | `auto_enabled` | Enable automated verification | `false` |
-| `fallback_to_human` | Fall back to human if Playwright unavailable | `true` |
-| `app_url` | URL to test against | `http://localhost:3000` |
+| `fallback_to_human` | Fall back to human if no tools available | `true` |
 
 **How it works:**
 
-1. Tests are categorized by keywords in expected behavior
-2. Automatable tests (element visibility, clicks, forms, navigation) run first
-3. Human-required tests (design, UX, clarity) always need manual verification
-4. Automated issues can be overridden if they're false positives
+1. Tests are categorized by verification type based on keywords in expected behavior
+2. Available tools are detected (Playwright, database MCPs, HTTP tools, etc.)
+3. Automatable tests run using appropriate tools for their verification type
+4. Falls back to human verification when no tool available for a test type
+5. Subjective tests (design, UX, clarity) always require human verification
+6. Automated issues can be overridden if they're false positives
 
-**Test categories:**
+**Verification types:**
 
-| Category | Keywords | Automatable |
-|----------|----------|-------------|
-| element_visibility | visible, appears, shows | Yes |
-| click_result | click + opens/closes | Yes |
-| form_submission | submit, form, sends | Yes |
-| text_content | contains, says, message | Yes |
-| navigation | navigate, redirect, URL | Yes |
-| visual_design | looks, style, design | No - Human |
-| subjective_ux | feels, intuitive, UX | No - Human |
+| Type | Keywords | Tools Used |
+|------|----------|------------|
+| ui | visible, click, page, form, navigate | Playwright MCP |
+| api | returns, response, endpoint, HTTP | WebFetch, HTTP tools |
+| data | database, record, table, persisted | Database MCPs (Supabase, etc.) |
+| file | file exists, created file, output | Read, Glob |
+| cli | command outputs, terminal, exit code | Bash |
 
-**Requirements:**
-- Playwright MCP server must be configured
-- App must be running at `app_url`
+**Automatable vs human-required:**
+- `automatable: true` — Mechanical interactions (click, type, submit) and structural checks (element exists, component at location)
+- `automatable: false` — Subjective judgments: "looks good", "feels right", "matches design"
+
+**Tool detection:**
+- Probes for available tools at runtime
+- Falls back gracefully when tools unavailable
+- Records which tool (`auto_method`) was used for each test
 
 ## Common Workflows
 

--- a/commands/gsd/verify-work.md
+++ b/commands/gsd/verify-work.md
@@ -38,12 +38,12 @@ Phase: $ARGUMENTS (optional)
 1. Check for active UAT sessions (resume or start new)
 2. Find SUMMARY.md files for the phase
 3. Extract testable deliverables (user-observable outcomes)
-4. Categorize tests for automation (based on keywords in expected behavior)
+4. Categorize tests by verification type (ui, api, data, file, cli, subjective)
 5. **If automated verification enabled** (config.agent_acceptance_testing.auto_enabled):
-   - Detect Playwright MCP availability
-   - Run automated tests for eligible tests (element_visibility, click_result, etc.)
-   - Record pass:auto or issue:auto with evidence
-   - Falls back to human verification if Playwright unavailable
+   - Detect available verification tools (Playwright, database MCPs, HTTP tools, etc.)
+   - Run automated tests for eligible tests using appropriate tools
+   - Record pass:auto or issue:auto with auto_method and evidence
+   - Falls back to human verification if no tool available for a test type
 6. Create {phase}-UAT.md with test list and automation results
 7. Present remaining tests one at a time:
    - Skip pass:auto tests (already verified)
@@ -214,9 +214,9 @@ Review the issues above and either:
 
 <success_criteria>
 - [ ] UAT.md created with tests from SUMMARY.md
-- [ ] Tests categorized for automation (automatable, automation_category)
-- [ ] If auto_enabled: Playwright detected and automated tests run
-- [ ] Automated results recorded with evidence (pass:auto, issue:auto)
+- [ ] Tests categorized by verification type (ui, api, data, file, cli, subjective)
+- [ ] If auto_enabled: available tools detected and automated tests run
+- [ ] Automated results recorded with auto_method and evidence (pass:auto, issue:auto)
 - [ ] Human tests presented one at a time with expected behavior
 - [ ] Plain text responses (no structured forms)
 - [ ] Severity inferred, never asked

--- a/get-shit-done/templates/UAT.md
+++ b/get-shit-done/templates/UAT.md
@@ -28,43 +28,53 @@ awaiting: user response
 
 ### 1. [Test Name]
 expected: [observable behavior - what user should see]
+verification_type: ui | api | data | file | cli
 automatable: true | false
-automation_category: element_visibility | click_result | form_submission | text_content | navigation | null
 result: [pending]
 
 ### 2. [Test Name]
 expected: [observable behavior]
+verification_type: ui
 automatable: true
-automation_category: element_visibility
 result: pass:auto
+auto_method: playwright
 auto_evidence: "Element #login-form found and visible"
 
 ### 3. [Test Name]
 expected: [observable behavior]
+verification_type: ui
 automatable: false
-automation_category: null
 result: pass
-<!-- Human verification - no auto_evidence -->
+<!-- Human verification for subjective UI - no auto_evidence -->
 
 ### 4. [Test Name]
 expected: [observable behavior]
+verification_type: api
 automatable: true
-automation_category: text_content
 result: issue:auto
-auto_evidence: "Expected 'Welcome' but found 'Error: unauthorized'"
+auto_method: http
+auto_evidence: "Expected 200 OK but got 401 Unauthorized"
 
 ### 5. [Test Name]
 expected: [observable behavior]
+verification_type: ui
 automatable: false
-automation_category: null
 result: issue
 reported: "[verbatim user response]"
 severity: major
 
 ### 6. [Test Name]
 expected: [observable behavior]
+verification_type: data
+automatable: true
+result: pass:auto
+auto_method: supabase
+auto_evidence: "Record found in users table with expected fields"
+
+### 7. [Test Name]
+expected: [observable behavior]
+verification_type: ui
 automatable: false
-automation_category: null
 result: skipped
 reason: [why skipped]
 
@@ -114,16 +124,16 @@ automation_status: full | partial | unavailable | disabled
 **Tests:**
 - Each test: OVERWRITE result field when user responds or automation completes
 - `result` values: [pending], pass, pass:auto, issue, issue:auto, skipped
-- `automatable`: true if test can be automated, false if requires human judgment
-- `automation_category`: element_visibility, click_result, form_submission, text_content, navigation, or null
-- If automated: add `auto_evidence` with Playwright verification result
+- `verification_type`: ui, api, data, file, or cli
+- `automatable`: true for mechanical checks, false for subjective judgments
+- If automated: add `auto_method` (tool used) and `auto_evidence` (verification result)
 - If human issue: add `reported` (verbatim) and `severity` (inferred)
 - If skipped: add `reason` if provided
 
 **Summary:**
 - OVERWRITE counts after each response
 - Tracks: total, passed, passed_auto, passed_human, issues, pending, skipped
-- `automation_status`: full (all automatable passed), partial (some automated), unavailable (Playwright not available), disabled (config off)
+- `automation_status`: full (all automatable passed), partial (some automated), unavailable (no tools available), disabled (config off)
 
 **Gaps:**
 - APPEND only when issue found (YAML format)
@@ -169,17 +179,18 @@ automation_status: full | partial | unavailable | disabled
 **Creation:** When /gsd:verify-work starts new session
 - Extract tests from SUMMARY.md files
 - Set status to "testing"
-- Categorize each test for automation potential (automatable: true/false, automation_category)
+- Categorize each test for automation potential (automatable: true/false, verification_type)
 - Current Test points to test 1
 - All tests have result: [pending]
 
 **Automation phase (if enabled):**
 - Check config.agent_acceptance_testing.auto_enabled
-- Detect Playwright MCP availability
+- Detect available verification tools (Playwright, database MCPs, HTTP tools, etc.)
 - For each test with automatable: true:
-  - Execute Playwright verification based on automation_category
+  - Select appropriate tool based on verification_type
+  - Execute verification and record auto_method used
   - Record pass:auto or issue:auto with auto_evidence
-  - On error: fall back to [pending] for human verification
+  - On error or no tool available: fall back to [pending] for human verification
 - Update automation_status in Summary
 
 **During human testing:**
@@ -239,51 +250,72 @@ updated: 2025-01-15T10:45:00Z
 
 ### 1. View Comments on Post
 expected: Comments section expands, shows count and comment list
+verification_type: ui
 automatable: true
-automation_category: element_visibility
 result: pass:auto
+auto_method: playwright
 auto_evidence: "Element [data-testid='comments-section'] visible with 3 comments"
 
 ### 2. Create Top-Level Comment
 expected: Submit comment via rich text editor, appears in list with author info
+verification_type: ui
 automatable: true
-automation_category: form_submission
 result: issue:auto
+auto_method: playwright
 auto_evidence: "Form submitted but comment not found in list after 5s wait"
 
 ### 3. Reply to a Comment
 expected: Click Reply, inline composer appears, submit shows nested reply
+verification_type: ui
 automatable: true
-automation_category: click_result
 result: pass:auto
+auto_method: playwright
 auto_evidence: "Reply button clicked, composer visible, reply submitted and nested under parent"
 
 ### 4. Visual Nesting
 expected: 3+ level thread shows indentation, left borders, caps at reasonable depth
+verification_type: ui
 automatable: false
-automation_category: null
 result: pass
-<!-- Human verified visual appearance -->
+<!-- Human verified - subjective visual design -->
 
 ### 5. Delete Own Comment
 expected: Click delete on own comment, removed or shows [deleted] if has replies
+verification_type: ui
 automatable: true
-automation_category: click_result
 result: pass:auto
+auto_method: playwright
 auto_evidence: "Delete clicked, confirmation accepted, comment replaced with [deleted]"
 
 ### 6. Comment Count
 expected: Post shows accurate count, increments when adding comment
+verification_type: ui
 automatable: true
-automation_category: text_content
 result: pass:auto
+auto_method: playwright
 auto_evidence: "Count element shows '4', incremented from '3' after adding comment"
+
+### 7. API Returns Comments
+expected: GET /api/comments returns array of comment objects with id, text, author
+verification_type: api
+automatable: true
+result: pass:auto
+auto_method: http
+auto_evidence: "Response 200 OK, body contains array with 4 comment objects"
+
+### 8. Comment Persisted to Database
+expected: New comment record exists in comments table with correct post_id
+verification_type: data
+automatable: true
+result: pass:auto
+auto_method: supabase
+auto_evidence: "SELECT returned 1 row matching post_id and user_id"
 
 ## Summary
 
-total: 6
-passed: 5
-passed_auto: 4
+total: 8
+passed: 7
+passed_auto: 6
 passed_human: 1
 issues: 1
 pending: 0

--- a/get-shit-done/templates/config.json
+++ b/get-shit-done/templates/config.json
@@ -25,7 +25,6 @@
   },
   "agent_acceptance_testing": {
     "auto_enabled": false,
-    "fallback_to_human": true,
-    "app_url": "http://localhost:3000"
+    "fallback_to_human": true
   }
 }

--- a/get-shit-done/workflows/verify-work.md
+++ b/get-shit-done/workflows/verify-work.md
@@ -96,36 +96,22 @@ Focus on USER-OBSERVABLE outcomes, not implementation details.
 For each deliverable, create a test:
 - name: Brief test name
 - expected: What the user should see/experience (specific, observable)
-- automatable: Determined by categorization heuristics (default: false)
-- automation_category: Based on expected behavior keywords
+- verification_type: ui, api, data, file, or cli
+- automatable: true for mechanical checks, false for subjective judgments
 
-**Categorization heuristics:**
+**Verification types:**
 
-| Category | Keywords in expected | automatable |
-|----------|---------------------|-------------|
-| element_visibility | "visible", "appears", "shows", "displays", "rendered", "present" | true |
-| click_result | "click" + ("opens", "closes", "toggles", "expands", "collapses") | true |
-| form_submission | "submit", "form", "sends", "creates", "saves" | true |
-| text_content | "text", "contains", "says", "message", "shows [specific text]" | true |
-| navigation | "navigate", "redirect", "route", "URL", "page loads" | true |
+| Type | Keywords | Example |
+|------|----------|---------|
+| ui | visible, click, button, page, form, input, navigate | "Login button redirects to dashboard" |
+| api | returns, response, endpoint, HTTP, status code | "GET /api/users returns 200" |
+| data | database, record, table, persisted, stored | "User saved to users table" |
+| file | file exists, created, written to, output | "Config file created at ~/.app/config" |
+| cli | command outputs, terminal, exit code | "build command exits 0" |
 
-**Human-required overrides (always automatable: false):**
-- "looks", "feels", "design", "aesthetic", "style"
-- "intuitive", "UX", "smooth", "responsive" (subjective)
-- "matches" + ("mockup", "spec", "Figma", "design")
-- "clear", "understandable", "readable" (clarity)
-- "layout", "spacing", "alignment" (visual design)
-
-Examples:
-- Accomplishment: "Added comment threading with infinite nesting"
-  → Test: "Reply to a Comment"
-  → Expected: "Clicking Reply opens inline composer below comment. Submitting shows reply nested under parent."
-  → automatable: true, automation_category: click_result
-
-- Accomplishment: "Styled comment threads with visual hierarchy"
-  → Test: "Visual Nesting"
-  → Expected: "3+ level thread shows indentation, left borders, looks properly nested"
-  → automatable: false, automation_category: null (contains "looks")
+**Automatable vs human-required:**
+- `automatable: true` — Mechanical interactions and structural checks (click works, element exists, form submits, component at location X)
+- `automatable: false` — Subjective quality judgments: "looks", "feels", "design", "intuitive", "matches mockup"
 
 Skip internal/non-observable items (refactors, type changes, etc.).
 </step>
@@ -139,8 +125,7 @@ Read `.planning/config.json` and extract `agent_acceptance_testing` section:
 {
   "agent_acceptance_testing": {
     "auto_enabled": false,      // Master switch
-    "fallback_to_human": true,  // Graceful degradation
-    "app_url": "http://localhost:3000"  // Target URL
+    "fallback_to_human": true   // Graceful degradation
   }
 }
 ```
@@ -152,61 +137,117 @@ Read `.planning/config.json` and extract `agent_acceptance_testing` section:
 
 **If `auto_enabled` is true:**
 - Set `AUTOMATION_ENABLED = true`
-- Capture `app_url` for Playwright navigation
 - Capture `fallback_to_human` setting
 - Proceed to `detect_automation_tools`
 </step>
 
 <step name="detect_automation_tools">
-**Detect if Playwright MCP is available:**
+**Detect available verification tools:**
 
-Attempt a minimal Playwright operation to test availability:
+Probe for available tools by verification type. Record which tools are available:
 
 ```
-mcp__plugin_playwright_playwright__browser_navigate(url: "about:blank")
+AVAILABLE_TOOLS = {}
 ```
 
-**If succeeds:**
-- Set `PLAYWRIGHT_AVAILABLE = true`
-- Close the test page
-- Proceed to `run_automated_tests`
+**UI verification (Playwright):**
+```
+Try: mcp__plugin_playwright_playwright__browser_navigate(url: "about:blank")
+If succeeds: AVAILABLE_TOOLS.ui = "playwright", close browser
+If fails: AVAILABLE_TOOLS.ui = null
+```
 
-**If fails (tool not available, browser not installed, etc.):**
-- Set `PLAYWRIGHT_AVAILABLE = false`
+**API verification (HTTP tools):**
+- WebFetch tool is always available for basic HTTP checks
+- Set `AVAILABLE_TOOLS.api = "webfetch"`
+
+**Data verification (Database MCPs):**
+```
+Probe for available database MCPs:
+- Supabase MCP: Try listing tables or a simple query
+- Other database MCPs: Similar probes
+
+If any available: AVAILABLE_TOOLS.data = "[mcp_name]"
+If none: AVAILABLE_TOOLS.data = null
+```
+
+**File verification:**
+- Read/Glob tools are always available
+- Set `AVAILABLE_TOOLS.file = "read"`
+
+**CLI verification:**
+- Bash tool is always available
+- Set `AVAILABLE_TOOLS.cli = "bash"`
+
+**After probing:**
+
+Count how many verification types have tools available.
+
+**If no tools available for any automatable tests:**
 - **If `fallback_to_human: true`:**
-  - Display: "Playwright MCP not available. Falling back to manual verification."
+  - Display: "No automated verification tools available. Using manual verification."
   - Set `automation_status: unavailable` in Summary
   - Proceed to `create_uat_file` (manual-only flow)
 - **If `fallback_to_human: false`:**
-  - Display error: "Automated verification enabled but Playwright MCP unavailable. Install Playwright MCP or set `fallback_to_human: true` in config."
+  - Display error: "Automated verification enabled but no tools available. Configure MCPs or set `fallback_to_human: true`."
   - Exit workflow
+
+**If some tools available:**
+- Proceed to `run_automated_tests` with `AVAILABLE_TOOLS`
 </step>
 
 <step name="run_automated_tests">
 **Execute automated verification for eligible tests:**
 
-Navigate to `app_url` from config:
-```
-mcp__plugin_playwright_playwright__browser_navigate(url: "{app_url}")
-```
+For each test with `automatable: true`, check if a tool is available for its `verification_type`:
 
-For each test with `automatable: true`:
+**Based on verification_type and AVAILABLE_TOOLS:**
 
-**Based on automation_category:**
-
-| Category | Verification approach |
-|----------|----------------------|
-| element_visibility | Take snapshot, search for described element in accessibility tree |
-| click_result | Click element, take snapshot, verify expected state change |
-| form_submission | Fill form fields, submit, verify success indicator or new content |
-| text_content | Take snapshot, search for expected text in page content |
-| navigation | Navigate to URL, verify final URL or page title |
+| Type | Tool | Verification approach |
+|------|------|----------------------|
+| ui | playwright | Navigate to app, take snapshot, verify elements/interactions |
+| api | webfetch | Make HTTP request, verify response status and body |
+| data | supabase/db-mcp | Execute query, verify record exists with expected values |
+| file | read/glob | Check file existence, read contents, verify expected content |
+| cli | bash | Run command, capture output, verify expected result |
 
 **For each test:**
-1. Attempt verification using Playwright tools
-2. **On success:** Set `result: pass:auto`, add `auto_evidence: "[what was verified]"`
-3. **On failure:** Set `result: issue:auto`, add `auto_evidence: "[what failed]"`
-4. **On error (Playwright error, timeout, etc.):** Keep `result: [pending]` for human verification
+1. Check if `AVAILABLE_TOOLS[verification_type]` exists
+2. If tool available:
+   - Attempt verification using the appropriate tool
+   - **On success:** Set `result: pass:auto`, `auto_method: "[tool]"`, `auto_evidence: "[what was verified]"`
+   - **On failure:** Set `result: issue:auto`, `auto_method: "[tool]"`, `auto_evidence: "[what failed]"`
+   - **On error (tool error, timeout, etc.):** Keep `result: [pending]` for human verification
+3. If no tool available for this type:
+   - Keep `result: [pending]` for human verification
+
+**Verification approaches by type:**
+
+**ui (Playwright):**
+- Navigate to app URL (inferred from project or test context)
+- Take snapshot, search for described elements
+- For interactions: click, verify state change
+- For forms: fill fields, submit, verify result
+
+**api (WebFetch/HTTP):**
+- Make request to endpoint mentioned in expected behavior
+- Verify response status code
+- Verify response body contains expected data
+
+**data (Database MCP):**
+- Execute query based on expected behavior
+- Verify record exists with expected values
+- Example: "SELECT * FROM users WHERE email = 'test@example.com'"
+
+**file (Read/Glob):**
+- Check file existence with Glob
+- Read file contents with Read
+- Verify expected content present
+
+**cli (Bash):**
+- Execute command from expected behavior
+- Capture stdout/stderr
+- Verify expected output or exit code
 
 **After all automated tests:**
 - Count results: `passed_auto`, `issue_auto`, `pending_for_human`
@@ -216,16 +257,17 @@ For each test with `automatable: true`:
 ```
 ## Automated Results
 
-| Test | Category | Result | Evidence |
-|------|----------|--------|----------|
-| 1. Login visible | element_visibility | pass:auto | Element #login-form found |
-| 2. Submit creates user | form_submission | pass:auto | User created, redirect to dashboard |
-| 4. Error shown | text_content | issue:auto | Expected 'Success' found 'Error' |
+| Test | Type | Method | Result | Evidence |
+|------|------|--------|--------|----------|
+| 1. Login visible | ui | playwright | pass:auto | Element #login-form found |
+| 2. API returns user | api | webfetch | pass:auto | 200 OK, user object in body |
+| 3. User in database | data | supabase | pass:auto | Record found with matching email |
+| 4. Config file created | file | read | issue:auto | File exists but missing 'debug' key |
 
 {N} tests require human verification.
 ```
 
-Close browser and proceed to `create_uat_file`.
+Clean up any open resources (close browser, etc.) and proceed to `create_uat_file`.
 </step>
 
 <step name="create_uat_file">
@@ -261,16 +303,18 @@ awaiting: user response
 
 ### 1. [Test Name]
 expected: [observable behavior]
+verification_type: [ui | api | data | file | cli]
 automatable: true | false
-automation_category: [category] | null
 result: [pending] | pass:auto | issue:auto
+auto_method: "[tool used, if automated]"
 auto_evidence: "[if automated]"
 
 ### 2. [Test Name]
 expected: [observable behavior]
+verification_type: [ui | api | data | file | cli]
 automatable: true | false
-automation_category: [category] | null
 result: [pending] | pass:auto | issue:auto
+auto_method: "[tool used, if automated]"
 auto_evidence: "[if automated]"
 
 ...
@@ -293,8 +337,8 @@ automation_status: [full | partial | unavailable | disabled]
 
 **Determine automation_status:**
 - `disabled`: `auto_enabled` was false in config
-- `unavailable`: `auto_enabled` was true but Playwright not available
-- `partial`: Some tests automated, some require human
+- `unavailable`: `auto_enabled` was true but no tools available for any test types
+- `partial`: Some tests automated, some require human (or no tool for their type)
 - `full`: All automatable tests passed (only human-required tests remain)
 
 Write to `.planning/phases/XX-name/{phase}-UAT.md`
@@ -355,7 +399,7 @@ Wait for user response (plain text, no AskUserQuestion).
 **If current test has `result: issue:auto` and response is "override":**
 - User confirms the automated issue was a false positive
 - Change result from `issue:auto` to `pass`
-- Keep auto_evidence for record
+- Keep auto_method and auto_evidence for record
 - Increment passed_human, decrement issues
 
 Update Tests section:
@@ -363,8 +407,9 @@ Update Tests section:
 ### {N}. {name}
 expected: {expected}
 automatable: {preserved}
-automation_category: {preserved}
+verification_type: {preserved}
 result: pass
+auto_method: {preserved}
 auto_evidence: "{preserved} [OVERRIDDEN by user]"
 ```
 
@@ -376,7 +421,7 @@ Update Tests section:
 ### {N}. {name}
 expected: {expected}
 automatable: {preserved}
-automation_category: {preserved}
+verification_type: {preserved}
 result: pass
 ```
 
@@ -390,7 +435,7 @@ Update Tests section:
 ### {N}. {name}
 expected: {expected}
 automatable: {preserved}
-automation_category: {preserved}
+verification_type: {preserved}
 result: skipped
 reason: [user's reason if provided]
 ```
@@ -410,7 +455,7 @@ Update Tests section:
 ### {N}. {name}
 expected: {expected}
 automatable: {preserved}
-automation_category: {preserved}
+verification_type: {preserved}
 result: issue
 reported: "{verbatim user response}"
 severity: {inferred}
@@ -735,9 +780,9 @@ Default to **major** if unclear. User can correct if needed.
 
 <success_criteria>
 - [ ] UAT file created with all tests from SUMMARY.md
-- [ ] Tests categorized for automation potential (automatable, automation_category)
-- [ ] If auto_enabled: config checked and Playwright detected
-- [ ] If Playwright available: automated tests executed with evidence
+- [ ] Tests categorized for automation potential (automatable, verification_type)
+- [ ] If auto_enabled: config checked and available tools detected
+- [ ] If tools available: automated tests executed with auto_method and auto_evidence
 - [ ] Tests with pass:auto skipped in human verification
 - [ ] Tests with issue:auto presented with evidence, override supported
 - [ ] Human tests presented one at a time with expected behavior


### PR DESCRIPTION
## Summary

This PR adds the ability for `/gsd:verify-work` to automatically verify features using available tools, reducing reliance on manual human testing while keeping humans in the loop for subjective judgments.

**Key capabilities:**
- **Opt-in automation** — Enable with `auto_enabled: true` in config; disabled by default
- **Uses whatever tools are available** — Playwright for UI, WebFetch for APIs, database MCPs for data, built-in tools for files/CLI
- **Smart categorization** — Tests are classified by type (ui, api, data, file, cli) and whether they can be automated (mechanical checks vs subjective judgments)
- **Graceful degradation** — Falls back to human verification when no tools are available for a test type
- **Human override** — Automated failures can be overridden if they're false positives

**What stays manual:**
- Subjective quality judgments ("looks good", "feels intuitive", "matches design")
- Any test where no automation tool is available

## Why this matters

The `/gsd:verify-work` step previously required manual verification of every feature. For projects with available tooling (Playwright MCP, database MCPs, etc.), much of this testing can now be automated—catching regressions faster while reserving human attention for the things that actually need human judgment.

## Test plan

- [ ] Run `/gsd:verify-work` with `auto_enabled: false` — manual verification only
- [ ] Run `/gsd:verify-work` with `auto_enabled: true` and Playwright available — UI tests run automatically
- [ ] Run `/gsd:verify-work` with `auto_enabled: true` but no MCPs — falls back to human
- [ ] Verify `issue:auto` results can be overridden with "override" response
- [ ] Confirm subjective tests (automatable: false) always go to human

🤖 Generated with [Claude Code](https://claude.com/claude-code)