### PR TITLE
fix(hooks): update check now finds VERSION in local project installs

### DIFF
--- a/hooks/gsd-check-update.js
+++ b/hooks/gsd-check-update.js
@@ -5,12 +5,16 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { execSync, spawn } = require('child_process');
+const { spawn } = require('child_process');
 
 const homeDir = os.homedir();
+const cwd = process.cwd();
 const cacheDir = path.join(homeDir, '.claude', 'cache');
 const cacheFile = path.join(cacheDir, 'gsd-update-check.json');
-const versionFile = path.join(homeDir, '.claude', 'get-shit-done', 'VERSION');
+
+// VERSION file locations (check project first, then global)
+const projectVersionFile = path.join(cwd, '.claude', 'get-shit-done', 'VERSION');
+const globalVersionFile = path.join(homeDir, '.claude', 'get-shit-done', 'VERSION');
 
 // Ensure cache directory exists
 if (!fs.existsSync(cacheDir)) {
@@ -23,11 +27,17 @@ const child = spawn(process.execPath, ['-e', `
   const { execSync } = require('child_process');
 
   const cacheFile = ${JSON.stringify(cacheFile)};
-  const versionFile = ${JSON.stringify(versionFile)};
+  const projectVersionFile = ${JSON.stringify(projectVersionFile)};
+  const globalVersionFile = ${JSON.stringify(globalVersionFile)};
 
+  // Check project directory first (local install), then global
   let installed = '0.0.0';
   try {
-    installed = fs.readFileSync(versionFile, 'utf8').trim();
+    if (fs.existsSync(projectVersionFile)) {
+      installed = fs.readFileSync(projectVersionFile, 'utf8').trim();
+    } else if (fs.existsSync(globalVersionFile)) {
+      installed = fs.readFileSync(globalVersionFile, 'utf8').trim();
+    }
   } catch (e) {}
 
   let latest = null;


### PR DESCRIPTION
## Summary
- Update check script now checks project directory (`./.claude/get-shit-done/VERSION`) before falling back to global (`~/.claude/get-shit-done/VERSION`)
- Fixes false "update available" notifications for local installations

## Problem
When GSD is installed with `--local` flag, the VERSION file is written to `./.claude/get-shit-done/VERSION`. However, the update check hook only looked in `~/.claude/get-shit-done/VERSION`, causing it to default to `0.0.0` and incorrectly show updates as available.

## Test plan
- [ ] Install GSD locally with `npx get-shit-done-cc --local`
- [ ] Start a new Claude Code session
- [ ] Verify statusline doesn't show false update notification
- [ ] Check `~/.claude/cache/gsd-update-check.json` shows correct installed version