### PR TITLE
fix(hooks): prevent console window flash on Windows

### DIFF
--- a/hooks/gsd-check-update.js
+++ b/hooks/gsd-check-update.js
@@ -17,7 +17,7 @@ if (!fs.existsSync(cacheDir)) {
   fs.mkdirSync(cacheDir, { recursive: true });
 }
 
-// Run check in background (spawn detached process)
+// Run check in background (spawn background process, windowsHide prevents console flash)
 const child = spawn(process.execPath, ['-e', `
   const fs = require('fs');
   const { execSync } = require('child_process');
@@ -32,7 +32,7 @@ const child = spawn(process.execPath, ['-e', `
 
   let latest = null;
   try {
-    latest = execSync('npm view get-shit-done-cc version', { encoding: 'utf8', timeout: 10000 }).trim();
+    latest = execSync('npm view get-shit-done-cc version', { encoding: 'utf8', timeout: 10000, windowsHide: true }).trim();
   } catch (e) {}
 
   const result = {
@@ -44,8 +44,8 @@ const child = spawn(process.execPath, ['-e', `
 
   fs.writeFileSync(cacheFile, JSON.stringify(result));
 `], {
-  detached: true,
-  stdio: 'ignore'
+  stdio: 'ignore',
+  windowsHide: true
 });
 
 child.unref();


### PR DESCRIPTION
## Summary
- Fix console window flash on Windows when GSD update check runs at session start
- The `detached: true` spawn option was creating a visible console window
- Combined with `npm` (which is a `.cmd` batch file), this caused focus stealing

## Changes
- Remove `detached: true` from spawn options (not needed, `child.unref()` handles non-blocking)
- Add `windowsHide: true` to both `spawn()` and inner `execSync()` calls

## Test plan
- [ ] Run `claude` on Windows Terminal with Git Bash
- [ ] Verify no console window flash appears on session start
- [ ] Verify GSD update check still works (check `~/.claude/cache/gsd-update-check.json`)