### PR TITLE
fix: validate empty --config-dir value

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -48,7 +48,12 @@ function parseConfigDirArg() {
   // Also handle --config-dir=value format
   const configDirArg = args.find(arg => arg.startsWith('--config-dir=') || arg.startsWith('-c='));
   if (configDirArg) {
-    return configDirArg.split('=')[1];
+    const value = configDirArg.split('=')[1];
+    if (!value) {
+      console.error(`  ${yellow}--config-dir requires a non-empty path${reset}`);
+      process.exit(1);
+    }
+    return value;
   }
   return null;
 }


### PR DESCRIPTION
Reject --config-dir= with empty value with a clear error message
instead of silently failing. Helps users catch typos.