### PR TITLE
docs: integrate unused reference files

### DIFF
--- a/get-shit-done/workflows/execute-plan.md
+++ b/get-shit-done/workflows/execute-plan.md
@@ -4,6 +4,8 @@ Execute a phase prompt (PLAN.md) and create the outcome summary (SUMMARY.md).
 
 <required_reading>
 Read STATE.md before any operation to load project context.
+
+@~/.claude/get-shit-done/references/git-integration.md
 </required_reading>
 
 <process>
@@ -1574,7 +1576,7 @@ lmn012o feat(08-02): create user registration endpoint
 
 Each task has its own commit, followed by one metadata commit documenting plan completion.
 
-For commit message conventions, see ~/.claude/get-shit-done/references/git-integration.md
+See `git-integration.md` (loaded via required_reading) for commit message conventions.
 </step>
 
 <step name="update_codebase_map">

--- a/get-shit-done/workflows/resume-project.md
+++ b/get-shit-done/workflows/resume-project.md
@@ -13,6 +13,10 @@ Enables seamless session continuity for fully autonomous workflows.
 "Where were we?" should have an immediate, complete answer.
 </purpose>
 
+<required_reading>
+@~/.claude/get-shit-done/references/continuation-format.md
+</required_reading>
+
 <process>
 
 <step name="detect_existing_project">

--- a/get-shit-done/workflows/verify-phase.md
+++ b/get-shit-done/workflows/verify-phase.md
@@ -18,9 +18,8 @@ Then verify each level against the actual codebase.
 </core_principle>
 
 <required_reading>
-**Load these references:**
-- ~/.claude/get-shit-done/references/verification-patterns.md (detection patterns)
-- ~/.claude/get-shit-done/templates/verification-report.md (output format)
+@~/.claude/get-shit-done/references/verification-patterns.md
+@~/.claude/get-shit-done/templates/verification-report.md
 </required_reading>
 
 <process>


### PR DESCRIPTION
Add proper @-references to three reference files that existed but were never loaded:

- git-integration.md -> execute-plan.md
- continuation-format.md -> resume-project.md
- verification-patterns.md -> verify-phase.md