### PR TITLE
fix(install): use absolute paths for hook commands on Windows

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -106,6 +106,16 @@ function expandTilde(filePath) {
 }
 
 /**
+ * Build a hook command path using forward slashes for cross-platform compatibility.
+ * On Windows, $HOME is not expanded by cmd.exe/PowerShell, so we use the actual path.
+ */
+function buildHookCommand(claudeDir, hookName) {
+  // Use forward slashes for Node.js compatibility on all platforms
+  const hooksPath = claudeDir.replace(/\\/g, '/') + '/hooks/' + hookName;
+  return `node "${hooksPath}"`;
+}
+
+/**
  * Read and parse settings.json, returning empty object if doesn't exist
  */
 function readSettings(settingsPath) {
@@ -390,10 +400,10 @@ function install(isGlobal) {
   const settingsPath = path.join(claudeDir, 'settings.json');
   const settings = cleanupOrphanedHooks(readSettings(settingsPath));
   const statuslineCommand = isGlobal
-    ? 'node "$HOME/.claude/hooks/gsd-statusline.js"'
+    ? buildHookCommand(claudeDir, 'gsd-statusline.js')
     : 'node .claude/hooks/gsd-statusline.js';
   const updateCheckCommand = isGlobal
-    ? 'node "$HOME/.claude/hooks/gsd-check-update.js"'
+    ? buildHookCommand(claudeDir, 'gsd-check-update.js')
     : 'node .claude/hooks/gsd-check-update.js';
 
   // Configure SessionStart hook for update checking


### PR DESCRIPTION
## Summary
- Fix MODULE_NOT_FOUND errors on Windows caused by `$HOME` not being expanded
- Replace `$HOME` with actual resolved path using new `buildHookCommand()` helper
- Normalize backslashes to forward slashes for cross-platform Node.js compatibility

## Problem
On Windows, `$HOME` is a Unix shell variable that is not expanded by `cmd.exe` or PowerShell. When Claude Code executes hooks, it passes the command directly to the system, resulting in paths like:
```
D:\dev\fix-claude-code\$HOME\.claude\hooks\gsd-intel-prune.js
```

This causes all hook commands (statusline, update-check, intel-index, intel-session, intel-prune) to fail with `MODULE_NOT_FOUND`.

## Solution
Added `buildHookCommand(claudeDir, hookName)` helper that:
1. Uses the actual `claudeDir` path (resolved via `os.homedir()`) instead of `$HOME`
2. Converts Windows backslashes to forward slashes for Node.js compatibility

## Test plan
- [x] Tested on Windows 10 with Git Bash + Windows Terminal
- [x] Tested on Windows 10 with cmd + Windows Terminal
- [x] Tested on Windows 10 with Powershell + Windows Terminal
- [x] Verified generated settings.json contains correct absolute paths
- [x] Tested with custom `--config-dir` option
- [x] Tested with default home directory