### PR TITLE
Reduce manual verification in checkpoint system

### DIFF
--- a/agents/gsd-executor.md
+++ b/agents/gsd-executor.md
@@ -364,27 +364,15 @@ Type "done" when authenticated.
 
 **CRITICAL: Automation before verification**
 
-Before any `checkpoint:human-verify`, ensure the verification environment is ready:
+Before any `checkpoint:human-verify`, ensure verification environment is ready. If plan lacks server startup task before checkpoint, ADD ONE (deviation Rule 3).
 
-1. **Dev server running** - User should never run `npm run dev`
-2. **Database seeded** - Test data already populated
-3. **Environment configured** - All env vars set via CLI
-4. **Services started** - Convex, Stripe CLI, etc. running in background
+For full automation-first patterns, server lifecycle, CLI handling, and error recovery:
+**See @~/.claude/get-shit-done/references/checkpoints.md**
 
-If the plan doesn't include an auto task for server startup before a verification checkpoint, ADD ONE using deviation Rule 3 (blocking issue).
-
-**What users NEVER do:**
-- Run CLI commands (`npm`, `npx`, `vercel`, `convex`, etc.)
-- Start servers or processes
-- Add env vars to dashboards
-- Run migrations or seeds
-
-**What users ONLY do:**
-- Visit URLs (server already running)
-- Click through UI flows
-- Evaluate visual appearance
-- Provide secret values (API keys)
-- Complete OAuth in browser
+**Quick reference:**
+- Users NEVER run CLI commands - Claude does all automation
+- Users ONLY visit URLs, click UI, evaluate visuals, provide secrets
+- Claude starts servers, seeds databases, configures env vars
 
 ---
 

--- a/get-shit-done/references/verification-patterns.md
+++ b/get-shit-done/references/verification-patterns.md
@@ -594,96 +594,19 @@ Some things can't be verified programmatically. Flag these for human testing:
 
 </human_verification_triggers>
 
-<automated_verification_setup>
+<checkpoint_automation_reference>
 
 ## Pre-Checkpoint Automation
 
-**Critical principle:** Claude sets up the verification environment BEFORE presenting checkpoints. Users should never run CLI commands.
+For automation-first checkpoint patterns, server lifecycle management, CLI installation handling, and error recovery protocols, see:
 
-### What Claude Automates Before Checkpoint
+**@~/.claude/get-shit-done/references/checkpoints.md** → `<automation_reference>` section
 
-| Setup Task | Claude Command | Not User Task |
-|------------|----------------|---------------|
-| Start dev server | `npm run dev` (background) | User visits URL |
-| Start backend | `npx convex dev` (background) | User tests features |
-| Run database migrations | `npx prisma migrate deploy` | User confirms data |
-| Seed test data | `npm run seed` or API calls | User views seeded content |
-| Set environment variables | `npx convex env set`, `vercel env add` | User provides secrets only |
-| Build application | `npm run build` | User visits production URL |
-| Deploy application | `vercel --yes`, `fly deploy` | User tests deployment |
+Key principles:
+- Claude sets up verification environment BEFORE presenting checkpoints
+- Users never run CLI commands (visit URLs only)
+- Server lifecycle: start before checkpoint, handle port conflicts, keep running for duration
+- CLI installation: auto-install where safe, checkpoint for user choice otherwise
+- Error handling: fix broken environment before checkpoint, never present checkpoint with failed setup
 
-### Pattern: Server Startup Before Verification
-
-```xml
-<!-- Claude starts everything -->
-<task type="auto">
-  <name>Prepare verification environment</name>
-  <action>
-    1. Run `npm run dev` in background
-    2. Wait for "ready" message
-    3. Verify curl localhost:3000 returns 200
-    4. Run `npx convex dev` if using Convex
-    5. Seed test data if needed
-  </action>
-  <verify>All services responding</verify>
-  <done>Environment ready for testing</done>
-</task>
-
-<!-- User only interacts visually -->
-<task type="checkpoint:human-verify">
-  <what-built>Feature X - all services running</what-built>
-  <how-to-verify>
-    Visit http://localhost:3000/feature and verify:
-    1. [Visual verification only]
-    2. [No CLI commands]
-  </how-to-verify>
-</task>
-```
-
-### Secret Collection Pattern
-
-When secrets are needed, Claude asks for values then uses CLI to configure:
-
-```xml
-<!-- Ask for secret value -->
-<task type="checkpoint:human-action">
-  <action>Provide your Stripe secret key</action>
-  <instructions>
-    Get your secret key from: https://dashboard.stripe.com/apikeys
-    Paste the key (starts with sk_)
-  </instructions>
-  <resume-signal>Paste your key</resume-signal>
-</task>
-
-<!-- Claude configures via CLI -->
-<task type="auto">
-  <name>Configure Stripe key</name>
-  <action>
-    1. Write STRIPE_SECRET_KEY to .env.local
-    2. Run `vercel env add STRIPE_SECRET_KEY` for production
-    3. Verify configuration
-  </action>
-</task>
-```
-
-### Never Ask Users To
-
-- Run `npm run dev` or any dev server command
-- Run `npm install` or any package manager command
-- Run database migrations (`prisma migrate`, `drizzle-kit push`)
-- Add environment variables via dashboard UI
-- Copy/paste values between terminal and browser
-- Run build commands (`npm run build`, `next build`)
-- Execute any CLI tool (git, vercel, convex, stripe, etc.)
-
-### Users Only Do
-
-- Visit URLs (after Claude starts servers)
-- Click through UI flows
-- Evaluate visual appearance
-- Test interactive features
-- Provide secret values (API keys, passwords)
-- Complete OAuth flows in browser (after Claude initiates)
-- Click email verification links
-
-</automated_verification_setup>
+</checkpoint_automation_reference>

--- a/get-shit-done/templates/phase-prompt.md
+++ b/get-shit-done/templates/phase-prompt.md
@@ -75,41 +75,23 @@ Output: [What artifacts will be created]
   <done>[Acceptance criteria]</done>
 </task>
 
+<!-- For checkpoint task examples and patterns, see @~/.claude/get-shit-done/references/checkpoints.md -->
+<!-- Key rule: Claude starts dev server BEFORE human-verify checkpoints. User only visits URLs. -->
+
 <task type="checkpoint:decision" gate="blocking">
   <decision>[What needs deciding]</decision>
   <context>[Why this decision matters]</context>
   <options>
-    <option id="option-a">
-      <name>[Option name]</name>
-      <pros>[Benefits and advantages]</pros>
-      <cons>[Tradeoffs and limitations]</cons>
-    </option>
-    <option id="option-b">
-      <name>[Option name]</name>
-      <pros>[Benefits and advantages]</pros>
-      <cons>[Tradeoffs and limitations]</cons>
-    </option>
+    <option id="option-a"><name>[Name]</name><pros>[Benefits]</pros><cons>[Tradeoffs]</cons></option>
+    <option id="option-b"><name>[Name]</name><pros>[Benefits]</pros><cons>[Tradeoffs]</cons></option>
   </options>
-  <resume-signal>[How to indicate choice - "Select: option-a or option-b"]</resume-signal>
-</task>
-
-<!-- NOTE: Add auto task to start dev server BEFORE any human-verify checkpoint -->
-<task type="auto">
-  <name>Start dev server for verification</name>
-  <action>Run dev server in background, wait for ready signal</action>
-  <verify>curl returns 200</verify>
-  <done>Server running at [URL]</done>
+  <resume-signal>Select: option-a or option-b</resume-signal>
 </task>
 
 <task type="checkpoint:human-verify" gate="blocking">
-  <what-built>[What Claude built] - dev server running at [URL]</what-built>
-  <how-to-verify>
-    Visit [URL] and verify:
-    1. [Visual/functional check - NO CLI COMMANDS]
-    2. [Test: Specific interactions]
-    3. [Confirm: Expected behaviors]
-  </how-to-verify>
-  <resume-signal>Type "approved" to continue, or describe issues to fix</resume-signal>
+  <what-built>[What Claude built] - server running at [URL]</what-built>
+  <how-to-verify>Visit [URL] and verify: [visual checks only, NO CLI commands]</how-to-verify>
+  <resume-signal>Type "approved" or describe issues</resume-signal>
 </task>
 
 </tasks>
@@ -411,21 +393,16 @@ Output: Working dashboard component.
   <done>Dashboard renders without errors</done>
 </task>
 
+<!-- Checkpoint pattern: Claude starts server, user visits URL. See checkpoints.md for full patterns. -->
 <task type="auto">
-  <name>Start dev server for verification</name>
-  <action>Run `npm run dev` in background, wait for "ready" message</action>
-  <verify>curl http://localhost:3000 returns 200</verify>
-  <done>Dev server running at http://localhost:3000</done>
+  <name>Start dev server</name>
+  <action>Run `npm run dev` in background, wait for ready</action>
+  <verify>curl localhost:3000 returns 200</verify>
 </task>
 
 <task type="checkpoint:human-verify" gate="blocking">
-  <what-built>Responsive dashboard - dev server running at http://localhost:3000</what-built>
-  <how-to-verify>
-    Visit http://localhost:3000/dashboard and verify:
-    1. Desktop: Two-column grid layout
-    2. Mobile: Stacked layout
-    3. No layout shift or scroll issues
-  </how-to-verify>
+  <what-built>Dashboard - server at http://localhost:3000</what-built>
+  <how-to-verify>Visit localhost:3000/dashboard. Check: desktop grid, mobile stack, no scroll issues.</how-to-verify>
   <resume-signal>Type "approved" or describe issues</resume-signal>
 </task>
 </tasks>


### PR DESCRIPTION
Checkpoints should never ask users to run CLI commands that Claude Code can execute. This update reinforces the automation-first principle:

Key changes:
- Add golden rules: Claude runs CLI, users only visit URLs
- Add dev server automation patterns (start before checkpoint)
- Add environment variable CLI patterns (Convex, Vercel, etc.)
- Add anti-patterns: asking user to run npm, add dashboard env vars
- Update all examples to show Claude starting servers
- Add comprehensive "Never Ask Users To" and "Users Only Do" lists
- Update gsd-executor with pre-checkpoint automation requirements

The core principle: if Claude CAN automate it, Claude MUST automate it. Users only do what requires human judgment (visual verification, UX).