### PR TITLE
fix: add gsd-pipeline: prefix to all subagent_type calls

### DIFF
--- a/commands/gsd/audit-milestone.md
+++ b/commands/gsd/audit-milestone.md
@@ -101,7 +101,7 @@ Phase exports: {from SUMMARYs}
 API routes: {routes created}
 
 Verify cross-phase wiring and E2E user flows.",
-  subagent_type="gsd-integration-checker",
+  subagent_type="gsd-pipeline:gsd-integration-checker",
   model="{integration_checker_model}"
 )
 ```

--- a/commands/gsd/debug.md
+++ b/commands/gsd/debug.md
@@ -99,7 +99,7 @@ Create: .planning/debug/{slug}.md
 ```
 Task(
   prompt=filled_prompt,
-  subagent_type="gsd-debugger",
+  subagent_type="gsd-pipeline:gsd-debugger",
   model="{debugger_model}",
   description="Debug {slug}"
 )
@@ -152,7 +152,7 @@ goal: find_and_fix
 ```
 Task(
   prompt=continuation_prompt,
-  subagent_type="gsd-debugger",
+  subagent_type="gsd-pipeline:gsd-debugger",
   model="{debugger_model}",
   description="Continue debug {slug}"
 )

--- a/commands/gsd/execute-phase.md
+++ b/commands/gsd/execute-phase.md
@@ -266,9 +266,9 @@ STATE_CONTENT=$(cat .planning/STATE.md)
 Spawn all plans in a wave with a single message containing multiple Task calls, with inlined content:
 
 ```
-Task(prompt="Execute plan at {plan_01_path}\n\nPlan:\n{plan_01_content}\n\nProject state:\n{state_content}", subagent_type="gsd-executor", model="{executor_model}")
-Task(prompt="Execute plan at {plan_02_path}\n\nPlan:\n{plan_02_content}\n\nProject state:\n{state_content}", subagent_type="gsd-executor", model="{executor_model}")
-Task(prompt="Execute plan at {plan_03_path}\n\nPlan:\n{plan_03_content}\n\nProject state:\n{state_content}", subagent_type="gsd-executor", model="{executor_model}")
+Task(prompt="Execute plan at {plan_01_path}\n\nPlan:\n{plan_01_content}\n\nProject state:\n{state_content}", subagent_type="gsd-pipeline:gsd-executor", model="{executor_model}")
+Task(prompt="Execute plan at {plan_02_path}\n\nPlan:\n{plan_02_content}\n\nProject state:\n{state_content}", subagent_type="gsd-pipeline:gsd-executor", model="{executor_model}")
+Task(prompt="Execute plan at {plan_03_path}\n\nPlan:\n{plan_03_content}\n\nProject state:\n{state_content}", subagent_type="gsd-pipeline:gsd-executor", model="{executor_model}")
 ```
 
 All three run in parallel. Task tool blocks until all complete.

--- a/commands/gsd/new-milestone.md
+++ b/commands/gsd/new-milestone.md
@@ -218,7 +218,7 @@ Your STACK.md feeds into roadmap creation. Be prescriptive:
 Write to: .planning/research/STACK.md
 Use template: ~/.claude/get-shit-done/templates/research-project/STACK.md
 </output>
-", subagent_type="gsd-project-researcher", model="{researcher_model}", description="Stack research")
+", subagent_type="gsd-pipeline:gsd-project-researcher", model="{researcher_model}", description="Stack research")
 
 Task(prompt="
 <research_type>
@@ -259,7 +259,7 @@ Your FEATURES.md feeds into requirements definition. Categorize clearly:
 Write to: .planning/research/FEATURES.md
 Use template: ~/.claude/get-shit-done/templates/research-project/FEATURES.md
 </output>
-", subagent_type="gsd-project-researcher", model="{researcher_model}", description="Features research")
+", subagent_type="gsd-pipeline:gsd-project-researcher", model="{researcher_model}", description="Features research")
 
 Task(prompt="
 <research_type>
@@ -301,7 +301,7 @@ Your ARCHITECTURE.md informs phase structure in roadmap. Include:
 Write to: .planning/research/ARCHITECTURE.md
 Use template: ~/.claude/get-shit-done/templates/research-project/ARCHITECTURE.md
 </output>
-", subagent_type="gsd-project-researcher", model="{researcher_model}", description="Architecture research")
+", subagent_type="gsd-pipeline:gsd-project-researcher", model="{researcher_model}", description="Architecture research")
 
 Task(prompt="
 <research_type>
@@ -339,7 +339,7 @@ Your PITFALLS.md prevents mistakes in roadmap/planning. For each pitfall:
 Write to: .planning/research/PITFALLS.md
 Use template: ~/.claude/get-shit-done/templates/research-project/PITFALLS.md
 </output>
-", subagent_type="gsd-project-researcher", model="{researcher_model}", description="Pitfalls research")
+", subagent_type="gsd-pipeline:gsd-project-researcher", model="{researcher_model}", description="Pitfalls research")
 ```
 
 After all 4 agents complete, spawn synthesizer to create SUMMARY.md:
@@ -363,7 +363,7 @@ Write to: .planning/research/SUMMARY.md
 Use template: ~/.claude/get-shit-done/templates/research-project/SUMMARY.md
 Commit after writing.
 </output>
-", subagent_type="gsd-research-synthesizer", model="{synthesizer_model}", description="Synthesize research")
+", subagent_type="gsd-pipeline:gsd-research-synthesizer", model="{synthesizer_model}", description="Synthesize research")
 ```
 
 Display research complete banner and key findings:
@@ -568,7 +568,7 @@ Create roadmap for milestone v[X.Y]:
 
 Write files first, then return. This ensures artifacts persist even if context is lost.
 </instructions>
-", subagent_type="gsd-roadmapper", model="{roadmapper_model}", description="Create roadmap")
+", subagent_type="gsd-pipeline:gsd-roadmapper", model="{roadmapper_model}", description="Create roadmap")
 ```
 
 **Handle roadmapper return:**
@@ -635,7 +635,7 @@ Use AskUserQuestion:
   Update the roadmap based on feedback. Edit files in place.
   Return ROADMAP REVISED with changes made.
   </revision>
-  ", subagent_type="gsd-roadmapper", model="{roadmapper_model}", description="Revise roadmap")
+  ", subagent_type="gsd-pipeline:gsd-roadmapper", model="{roadmapper_model}", description="Revise roadmap")
   ```
 - Present revised roadmap
 - Loop until user approves

--- a/commands/gsd/new-project.md
+++ b/commands/gsd/new-project.md
@@ -621,7 +621,7 @@ Write to: .planning/research/SUMMARY.md
 Use template: ~/.claude/get-shit-done/templates/research-project/SUMMARY.md
 Commit after writing.
 </output>
-", subagent_type="gsd-research-synthesizer", model="{synthesizer_model}", description="Synthesize research")
+", subagent_type="gsd-pipeline:gsd-research-synthesizer", model="{synthesizer_model}", description="Synthesize research")
 ```
 
 Display research complete banner and key findings:
@@ -826,7 +826,7 @@ Create roadmap:
 
 Write files first, then return. This ensures artifacts persist even if context is lost.
 </instructions>
-", subagent_type="gsd-roadmapper", model="{roadmapper_model}", description="Create roadmap")
+", subagent_type="gsd-pipeline:gsd-roadmapper", model="{roadmapper_model}", description="Create roadmap")
 ```
 
 **Handle roadmapper return:**
@@ -902,7 +902,7 @@ Use AskUserQuestion:
   Update the roadmap based on feedback. Edit files in place.
   Return ROADMAP REVISED with changes made.
   </revision>
-  ", subagent_type="gsd-roadmapper", model="{roadmapper_model}", description="Revise roadmap")
+  ", subagent_type="gsd-pipeline:gsd-roadmapper", model="{roadmapper_model}", description="Revise roadmap")
   ```
 - Present revised roadmap
 - Loop until user approves

--- a/commands/gsd/plan-phase.md
+++ b/commands/gsd/plan-phase.md
@@ -388,7 +388,7 @@ Return one of:
 ```
 Task(
   prompt=checker_prompt,
-  subagent_type="gsd-plan-checker",
+  subagent_type="gsd-pipeline:gsd-plan-checker",
   model="{checker_model}",
   description="Verify Phase {phase} plans"
 )

--- a/commands/gsd/quick.md
+++ b/commands/gsd/quick.md
@@ -165,7 +165,7 @@ Write plan to: ${QUICK_DIR}/${next_num}-PLAN.md
 Return: ## PLANNING COMPLETE with plan path
 </output>
 ",
-  subagent_type="gsd-planner",
+  subagent_type="gsd-pipeline:gsd-planner",
   model="{planner_model}",
   description="Quick plan: ${DESCRIPTION}"
 )
@@ -199,7 +199,7 @@ Project state: @.planning/STATE.md
 - Do NOT update ROADMAP.md (quick tasks are separate from planned phases)
 </constraints>
 ",
-  subagent_type="gsd-executor",
+  subagent_type="gsd-pipeline:gsd-executor",
   model="{executor_model}",
   description="Execute: ${DESCRIPTION}"
 )

--- a/get-shit-done/templates/debug-subagent-prompt.md
+++ b/get-shit-done/templates/debug-subagent-prompt.md
@@ -55,14 +55,14 @@ Create: .planning/debug/{slug}.md
 ```python
 Task(
   prompt=filled_template,
-  subagent_type="gsd-debugger",
+  subagent_type="gsd-pipeline:gsd-debugger",
   description="Debug {slug}"
 )
 ```
 
 **From diagnose-issues (UAT):**
 ```python
-Task(prompt=template, subagent_type="gsd-debugger", description="Debug UAT-001")
+Task(prompt=template, subagent_type="gsd-pipeline:gsd-debugger", description="Debug UAT-001")
 ```
 
 ---

--- a/get-shit-done/templates/planner-subagent-prompt.md
+++ b/get-shit-done/templates/planner-subagent-prompt.md
@@ -72,7 +72,7 @@ Before returning PLANNING COMPLETE:
 ```python
 Task(
   prompt=filled_template,
-  subagent_type="gsd-planner",
+  subagent_type="gsd-pipeline:gsd-planner",
   description="Plan Phase {phase}"
 )
 ```
@@ -81,7 +81,7 @@ Task(
 ```python
 Task(
   prompt=filled_template,  # with mode: gap_closure
-  subagent_type="gsd-planner",
+  subagent_type="gsd-pipeline:gsd-planner",
   description="Plan gaps for Phase {phase}"
 )
 ```

--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -294,7 +294,7 @@ Plans with `autonomous: false` require user interaction.
 
 1. **Spawn agent for checkpoint plan:**
    ```
-   Task(prompt="{subagent-task-prompt}", subagent_type="gsd-executor", model="{executor_model}")
+   Task(prompt="{subagent-task-prompt}", subagent_type="gsd-pipeline:gsd-executor", model="{executor_model}")
    ```
 
 2. **Agent runs until checkpoint:**
@@ -333,7 +333,7 @@ Plans with `autonomous: false` require user interaction.
    ```
    Task(
      prompt=filled_continuation_template,
-     subagent_type="gsd-executor",
+     subagent_type="gsd-pipeline:gsd-executor",
      model="{executor_model}"
    )
    ```
@@ -410,7 +410,7 @@ Phase goal: {goal from ROADMAP.md}
 
 Check must_haves against actual codebase. Create VERIFICATION.md.
 Verify what actually exists in the code.",
-  subagent_type="gsd-verifier",
+  subagent_type="gsd-pipeline:gsd-verifier",
   model="{verifier_model}"
 )
 ```

--- a/get-shit-done/workflows/execute-plan.md
+++ b/get-shit-done/workflows/execute-plan.md
@@ -225,7 +225,7 @@ No segmentation benefit - execute entirely in main
 ```
 1. Run init_agent_tracking step first (see step below)
 
-2. Use Task tool with subagent_type="gsd-executor" and model="{executor_model}":
+2. Use Task tool with subagent_type="gsd-pipeline:gsd-executor" and model="{executor_model}":
 
    Prompt: "Execute plan at .planning/phases/{phase}-{plan}-PLAN.md
 
@@ -377,7 +377,7 @@ For Pattern A (fully autonomous) and Pattern C (decision-dependent), skip this s
 
    B. If routing = Subagent:
       ```
-      Spawn Task tool with subagent_type="gsd-executor" and model="{executor_model}":
+      Spawn Task tool with subagent_type="gsd-pipeline:gsd-executor" and model="{executor_model}":
 
       Prompt: "Execute tasks [task numbers/names] from plan at [plan path].
 

--- a/get-shit-done/workflows/map-codebase.md
+++ b/get-shit-done/workflows/map-codebase.md
@@ -91,7 +91,7 @@ Continue to spawn_agents.
 <step name="spawn_agents">
 Spawn 4 parallel gsd-codebase-mapper agents.
 
-Use Task tool with `subagent_type="gsd-codebase-mapper"`, `model="{mapper_model}"`, and `run_in_background=true` for parallel execution.
+Use Task tool with `subagent_type="gsd-pipeline:gsd-codebase-mapper"`, `model="{mapper_model}"`, and `run_in_background=true` for parallel execution.
 
 **CRITICAL:** Use the dedicated `gsd-codebase-mapper` agent, NOT `Explore`. The mapper agent writes documents directly.
 

--- a/get-shit-done/workflows/verify-work.md
+++ b/get-shit-done/workflows/verify-work.md
@@ -407,7 +407,7 @@ Output consumed by /gsd:execute-phase
 Plans must be executable prompts.
 </downstream_consumer>
 """,
-  subagent_type="gsd-planner",
+  subagent_type="gsd-pipeline:gsd-planner",
   model="{planner_model}",
   description="Plan gap fixes for Phase {phase}"
 )
@@ -453,7 +453,7 @@ Return one of:
 - ## ISSUES FOUND — structured issue list
 </expected_output>
 """,
-  subagent_type="gsd-plan-checker",
+  subagent_type="gsd-pipeline:gsd-plan-checker",
   model="{checker_model}",
   description="Verify Phase {phase} fix plans"
 )
@@ -494,7 +494,7 @@ Read existing PLAN.md files. Make targeted updates to address checker issues.
 Do NOT replan from scratch unless issues are fundamental.
 </instructions>
 """,
-  subagent_type="gsd-planner",
+  subagent_type="gsd-pipeline:gsd-planner",
   model="{planner_model}",
   description="Revise Phase {phase} plans"
 )


### PR DESCRIPTION
## Summary

- Adds required `gsd-pipeline:` namespace prefix to all `subagent_type` parameters in Task tool calls
- Fixes agent resolution failures when GSD is installed as a Claude Code plugin

## Problem

When GSD is installed as a Claude Code plugin, all agents are registered under the namespace `gsd-pipeline:{agent-name}`. The current code uses short-form names like `gsd-executor`, causing Task tool failures:

```
Error: Agent type 'gsd-executor' not found. 
Available agents: [...] gsd-pipeline:gsd-executor, gsd-pipeline:gsd-planner, ...
```

## Changes

Updated 32 occurrences across 13 files:

| Before | After |
|--------|-------|
| `subagent_type="gsd-executor"` | `subagent_type="gsd-pipeline:gsd-executor"` |
| `subagent_type="gsd-planner"` | `subagent_type="gsd-pipeline:gsd-planner"` |
| `subagent_type="gsd-verifier"` | `subagent_type="gsd-pipeline:gsd-verifier"` |
| ... | ... |

**Files changed:**
- `commands/gsd/execute-phase.md`
- `commands/gsd/plan-phase.md`
- `commands/gsd/new-milestone.md`
- `commands/gsd/new-project.md`
- `commands/gsd/quick.md`
- `commands/gsd/debug.md`
- `commands/gsd/audit-milestone.md`
- `get-shit-done/workflows/execute-phase.md`
- `get-shit-done/workflows/execute-plan.md`
- `get-shit-done/workflows/verify-work.md`
- `get-shit-done/workflows/map-codebase.md`
- `get-shit-done/templates/planner-subagent-prompt.md`
- `get-shit-done/templates/debug-subagent-prompt.md`

## Test plan

- [x] Verify all `subagent_type="gsd-*"` patterns have been updated
- [ ] Test `/gsd:execute-phase` spawns agents successfully
- [ ] Test `/gsd:plan-phase` spawns planner/checker agents
- [ ] Test `/gsd:debug` spawns debugger agent

Fixes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)