### PR TITLE
feat: add Cursor IDE as supported runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # GET SHIT DONE
 
-**A light-weight and powerful meta-prompting, context engineering and spec-driven development system for Claude Code by TÂCHES.**
+**A light-weight and powerful meta-prompting, context engineering and spec-driven development system for Claude Code, Cursor, and OpenCode by TÂCHES.**
 
 **Solves context rot — the quality degradation that happens as Claude fills its context window.**
 
@@ -76,10 +76,10 @@ npx get-shit-done-cc
 ```
 
 The installer prompts you to choose:
-1. **Runtime** — Claude Code, OpenCode, or both
+1. **Runtime** — Claude Code, Cursor, OpenCode, or all
 2. **Location** — Global (all projects) or local (current project only)
 
-Verify with `/gsd:help` inside your Claude Code or OpenCode interface.
+Verify with `/gsd:help` inside your Claude Code, Cursor, or OpenCode interface.
 
 ### Staying Updated
 
@@ -103,15 +103,20 @@ npx get-shit-done-cc@latest
 npx get-shit-done-cc --claude --global   # Install to ~/.claude/
 npx get-shit-done-cc --claude --local    # Install to ./.claude/
 
-# OpenCode (open source, free models)
-npx get-shit-done-cc --opencode --global # Install to ~/.opencode/
+# Cursor
+npx get-shit-done-cc --cursor --global   # Install to ~/.cursor/
+npx get-shit-done-cc --cursor --local    # Install to ./.cursor/
 
-# Both runtimes
-npx get-shit-done-cc --both --global     # Install to both directories
+# OpenCode (open source, free models)
+npx get-shit-done-cc --opencode --global # Install to ~/.config/opencode/
+
+# Multiple runtimes
+npx get-shit-done-cc --both --global     # Claude Code + OpenCode
+npx get-shit-done-cc --all --global      # All three runtimes
 ```
 
 Use `--global` (`-g`) or `--local` (`-l`) to skip the location prompt.
-Use `--claude`, `--opencode`, or `--both` to skip the runtime prompt.
+Use `--claude`, `--cursor`, `--opencode`, `--both`, or `--all` to skip the runtime prompt.
 
 </details>
 
@@ -533,8 +538,11 @@ Use `/gsd:settings` to toggle these, or override per-invocation:
 ## Troubleshooting
 
 **Commands not found after install?**
-- Restart Claude Code to reload slash commands
-- Verify files exist in `~/.claude/commands/gsd/` (global) or `./.claude/commands/gsd/` (local)
+- Restart your IDE (Claude Code, Cursor, or OpenCode) to reload slash commands
+- Verify files exist in the appropriate location:
+  - Claude Code: `~/.claude/commands/gsd/` (global) or `./.claude/commands/gsd/` (local)
+  - Cursor: `~/.cursor/commands/gsd/` (global) or `./.cursor/commands/gsd/` (local)
+  - OpenCode: `~/.config/opencode/command/` (global) or `./.opencode/command/` (local)
 
 **Commands not working as expected?**
 - Run `/gsd:help` to verify installation
@@ -547,9 +555,13 @@ npx get-shit-done-cc@latest
 
 **Using Docker or containerized environments?**
 
-If file reads fail with tilde paths (`~/.claude/...`), set `CLAUDE_CONFIG_DIR` before installing:
+If file reads fail with tilde paths, set the appropriate config directory env var before installing:
 ```bash
-CLAUDE_CONFIG_DIR=/home/youruser/.claude npx get-shit-done-cc --global
+# Claude Code
+CLAUDE_CONFIG_DIR=/home/youruser/.claude npx get-shit-done-cc --claude --global
+
+# Cursor
+CURSOR_CONFIG_DIR=/home/youruser/.cursor npx get-shit-done-cc --cursor --global
 ```
 This ensures absolute paths are used instead of `~` which may not expand correctly in containers.
 
@@ -584,6 +596,6 @@ MIT License. See [LICENSE](LICENSE) for details.
 
 <div align="center">
 
-**Claude Code is powerful. GSD makes it reliable.**
+**AI coding agents are powerful. GSD makes them reliable.**
 
 </div>


### PR DESCRIPTION
## What

As of the latest update to cursor, they now support Agent Skills and subagents. In light of that, add Cursor IDE as a supported runtime for GSD installation alongside Claude Code and OpenCode. Here's a screenshot showing how it's using sub-agents to do research:
<img width="688" height="220" alt="image" src="https://github.com/user-attachments/assets/68c02a1b-65cd-4569-85ff-eab94cbbbb9e" />

I've tried the result of this in Cursor for a couple of tasks and it seems to work quite well. It's not always using subagents for the execution, though, so this might not yet be ready for merging. Wanted to get this on your radar to see if you have any interest in doing this in the first place.


## Why

Cursor supports Claude-based agents and the existing GSD commands/subagents already work in Cursor — this adds first-class installation support.

## Known Issues

1. Cursor slash commands do not work with a colon. So the commands end up being used like `/gsd/add-phase`. Annoyingly, when typing it out, you can't use a second slash after the first one or the filtered list goes away 🤦🏻‍♂️.
2. In the "Next Up" part of the final response to commands like planning a phase, it mentions to use `/clear`. That is not a command in Cursor, so we should probably grep that during the install process for Cursor and change it to say that the user should create a new new chat instead.

## Testing

- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Checklist

- [x] Follows GSD style (no enterprise patterns, no filler)
- [ ] Updates CHANGELOG.md for user-facing changes
- [x] No unnecessary dependencies added
- [ ] Works on Windows (backslash paths tested)

## Breaking Changes

None