### PR TITLE
fix: support both MCP tool naming patterns for context7

### DIFF
--- a/agents/gsd-phase-researcher.md
+++ b/agents/gsd-phase-researcher.md
@@ -1,7 +1,7 @@
 ---
 name: gsd-phase-researcher
 description: Researches how to implement a phase before planning. Produces RESEARCH.md consumed by gsd-planner. Spawned by /gsd:plan-phase orchestrator.
-tools: Read, Write, Bash, Grep, Glob, WebSearch, WebFetch, mcp__context7__*
+tools: Read, Write, Bash, Grep, Glob, WebSearch, WebFetch, mcp__context7__*, mcp__plugin_context7_context7__*
 color: cyan
 ---
 

--- a/agents/gsd-planner.md
+++ b/agents/gsd-planner.md
@@ -1,7 +1,7 @@
 ---
 name: gsd-planner
 description: Creates executable phase plans with task breakdown, dependency analysis, and goal-backward verification. Spawned by /gsd:plan-phase orchestrator.
-tools: Read, Write, Bash, Glob, Grep, WebFetch, mcp__context7__*
+tools: Read, Write, Bash, Glob, Grep, WebFetch, mcp__context7__*, mcp__plugin_context7_context7__*
 color: green
 ---
 

--- a/agents/gsd-project-researcher.md
+++ b/agents/gsd-project-researcher.md
@@ -1,7 +1,7 @@
 ---
 name: gsd-project-researcher
 description: Researches domain ecosystem before roadmap creation. Produces files in .planning/research/ consumed during roadmap creation. Spawned by /gsd:new-project or /gsd:new-milestone orchestrators.
-tools: Read, Write, Bash, Grep, Glob, WebSearch, WebFetch, mcp__context7__*
+tools: Read, Write, Bash, Grep, Glob, WebSearch, WebFetch, mcp__context7__*, mcp__plugin_context7_context7__*
 color: cyan
 ---
 


### PR DESCRIPTION
## Summary
- Add `mcp__plugin_context7_context7__*` pattern alongside existing `mcp__context7__*`
- Fixes agents not getting Context7 MCP tools when Claude Code uses full plugin naming

## Problem
MCP tools can be named either:
- `mcp__context7__*` (shorthand)
- `mcp__plugin_context7_context7__*` (full: `mcp__plugin_<plugin>_<server>__*`)

The pattern depends on how Claude Code resolves plugin names. Currently only the shorthand is listed, causing agents to miss Context7 access in some environments.

## Test plan
- [ ] Spawn `gsd-phase-researcher` and verify it has `mcp__context7__*` tools
- [ ] Test Context7 lookup works within agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)