### PR TITLE
Feat/v1.11 parallel work support and task timeouts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.11.0] - 2026-01-24
+
+### Added
+- **Parallel Work Support** — Run multiple GSD sessions simultaneously without state corruption
+  - State derivation library (`get-shit-done/references/state-derivation.md`) with 6 bash functions
+  - Parallel safety test harness (`get-shit-done/references/state-derivation-tests.sh`) with 15 tests
+  - User documentation (`get-shit-done/docs/parallel-work.md`)
+  - Validation scenarios (`get-shit-done/references/parallel-validation-scenarios.md`)
+
+### Changed
+- Workflows and commands now derive state from filesystem (SUMMARY.md existence) instead of STATE.md
+- STATE.md becomes write-only for position tracking (human reference, not machine state store)
+
+## [1.10.0] - 2026-01-24
+
+### Added
+- **Agent Timeout Handling** — Graceful degradation when agents run longer than expected
+  - Timeout utility pattern (`get-shit-done/utilities/task-timeout.md`) with timing visibility and artifact-based success detection
+  - User-facing documentation (`get-shit-done/docs/timeout-behavior.md`, `get-shit-done/docs/configuration.md`)
+
+### Changed
+- Success determined by artifact presence, not just duration compliance
+
 ## [1.9.12] - 2025-01-23
 
 ### Removed

--- a/commands/gsd/progress.md
+++ b/commands/gsd/progress.md
@@ -49,10 +49,15 @@ If missing both ROADMAP.md and PROJECT.md: suggest `/gsd:new-project`.
 <step name="load">
 **Load full project context:**
 
-- Read `.planning/STATE.md` for living memory (position, decisions, issues)
+- Read `.planning/STATE.md` for accumulated context (decisions, issues, session info)
 - Read `.planning/ROADMAP.md` for phase structure and objectives
 - Read `.planning/PROJECT.md` for current state (What This Is, Core Value, Requirements)
 - Read `.planning/config.json` for settings (model_profile, workflow toggles)
+
+**State derivation reference:**
+@~/.claude/get-shit-done/references/state-derivation.md
+
+**Note:** Position/progress are derived from filesystem (SUMMARY.md existence = complete), not parsed from STATE.md. This enables parallel work from multiple terminals without race conditions.
   </step>
 
 <step name="recent">
@@ -64,14 +69,26 @@ If missing both ROADMAP.md and PROJECT.md: suggest `/gsd:new-project`.
   </step>
 
 <step name="position">
-**Parse current position:**
+**Parse current position using state derivation (parallel-safe):**
 
-- From STATE.md: current phase, plan number, status
-- Calculate: total plans, completed plans, remaining plans
-- Note any blockers or concerns
-- Check for CONTEXT.md: For phases without PLAN.md files, check if `{phase}-CONTEXT.md` exists in phase directory
-- Count pending todos: `ls .planning/todos/pending/*.md 2>/dev/null | wc -l`
-- Check for active debug sessions: `ls .planning/debug/*.md 2>/dev/null | grep -v resolved | wc -l`
+Use state derivation functions for position detection:
+
+```bash
+# Derive state from filesystem - parallel-safe, no race conditions
+CURRENT_PHASE=$(get_current_phase ".planning")
+CURRENT_PLAN=$(get_current_plan ".planning/phases/${CURRENT_PHASE}-"*)
+PROGRESS=$(get_progress ".planning")
+```
+
+Position is derived from filesystem (SUMMARY.md existence), not parsed from STATE.md.
+
+**Additional context from STATE.md:**
+- Blockers/concerns (accumulated context)
+- Recent decisions (constraints on current work)
+
+**Check for CONTEXT.md:** For phases without PLAN.md files, check if `{phase}-CONTEXT.md` exists in phase directory
+**Count pending todos:** `ls .planning/todos/pending/*.md 2>/dev/null | wc -l`
+**Check for active debug sessions:** `ls .planning/debug/*.md 2>/dev/null | grep -v resolved | wc -l`
   </step>
 
 <step name="report">

--- a/get-shit-done/docs/configuration.md
+++ b/get-shit-done/docs/configuration.md
@@ -1,0 +1,208 @@
+# Configuration Reference
+
+GSD behavior is controlled by `.planning/config.json` in your project directory.
+
+**Full schema reference:** See [`get-shit-done/templates/config-schema.md`](../templates/config-schema.md) for complete documentation of all configuration options.
+
+This document focuses on **timeout configuration** specifically.
+
+---
+
+## Timeouts
+
+Control expected duration for different agent types.
+
+**Important:** These are expectations, not hard limits. See [Timeout Behavior](timeout-behavior.md) for how GSD handles agents that exceed expected duration.
+
+### Configuration
+
+Add a `timeouts` section to `.planning/config.json`:
+
+```json
+{
+  "timeouts": {
+    "executor": 600000,
+    "planner": 300000,
+    "verifier": 180000,
+    "researcher": 420000,
+    "debugger": 600000,
+    "default": 300000
+  }
+}
+```
+
+All values are in **milliseconds**.
+
+### Agent Type Reference
+
+| Property | Default | Duration | When Used | Purpose |
+|----------|---------|----------|-----------|---------|
+| `executor` | 600000 | 10 min | Executing PLAN.md files | Complex plans with multiple tasks, commits, file operations |
+| `planner` | 300000 | 5 min | Creating PLAN.md files | Planning is faster than execution, mostly markdown |
+| `verifier` | 180000 | 3 min | Verifying work | Quick file reading and criteria checking |
+| `researcher` | 420000 | 7 min | Researching before planning | Exploration, reading multiple files, synthesis |
+| `debugger` | 600000 | 10 min | Diagnosing failures | Investigation, testing hypotheses, deeper analysis |
+| `default` | 300000 | 5 min | Unspecified agents | Conservative middle ground |
+
+### When to Adjust
+
+#### Increase Timeouts
+
+**Large/complex projects:**
+```json
+{
+  "timeouts": {
+    "executor": 900000,    // 15 min (+50%)
+    "researcher": 600000,  // 10 min (+43%)
+    "planner": 420000      // 7 min (+40%)
+  }
+}
+```
+
+Use when:
+- Agents regularly complete successfully but exceed expected duration
+- Project has large codebase (10k+ lines)
+- Plans have many tasks (10+ per plan)
+- Deep codebase exploration needed
+
+#### Decrease Timeouts
+
+**Quick experiments:**
+```json
+{
+  "timeouts": {
+    "executor": 300000,   // 5 min (-50%)
+    "planner": 180000,    // 3 min (-40%)
+    "verifier": 120000    // 2 min (-33%)
+  }
+}
+```
+
+Use when:
+- Running quick prototypes
+- Small project (< 1k lines)
+- Simple plans (1-3 tasks each)
+- Want faster feedback on failures
+
+### Valid Ranges
+
+- **Minimum:** 60000ms (1 minute)
+  - Prevents unrealistic expectations
+  - Agents need time to read context and work
+
+- **Maximum:** 1800000ms (30 minutes)
+  - Prevents indefinite waiting
+  - If agents take this long, something is wrong
+
+- **Invalid values:** Fall back to defaults with warning
+
+### Example Configurations
+
+#### Production Quality (Thorough)
+```json
+{
+  "depth": "comprehensive",
+  "model_profile": "quality",
+  "timeouts": {
+    "executor": 900000,
+    "planner": 420000,
+    "verifier": 300000,
+    "researcher": 600000,
+    "debugger": 900000
+  }
+}
+```
+
+#### Budget Mode (Fast & Cheap)
+```json
+{
+  "depth": "quick",
+  "model_profile": "budget",
+  "timeouts": {
+    "executor": 420000,
+    "planner": 180000,
+    "verifier": 120000,
+    "researcher": 300000
+  }
+}
+```
+
+#### Balanced (Default)
+```json
+{
+  "depth": "standard",
+  "model_profile": "balanced",
+  "timeouts": {
+    "executor": 600000,
+    "planner": 300000,
+    "verifier": 180000,
+    "researcher": 420000,
+    "debugger": 600000,
+    "default": 300000
+  }
+}
+```
+
+### How Timeouts Are Used
+
+When GSD spawns an agent:
+
+1. **Read config** - Parse `.planning/config.json` for timeout value
+2. **Fall back to default** - If config missing or invalid, use default
+3. **Show expectation** - Display expected duration to user before spawning
+4. **Start timer** - Record start time
+5. **Spawn agent** - Call Task() (blocks until complete)
+6. **Measure duration** - Calculate actual time taken
+7. **Check artifacts** - Verify agent produced expected outputs
+8. **Report status** - Success/failure based on artifacts + duration
+
+See [Timeout Behavior](timeout-behavior.md) for complete details on status reporting.
+
+### Monitoring and Tuning
+
+**Signs you should increase timeouts:**
+
+- Agents regularly show "⚠️ took longer than expected but completed successfully"
+- Actual durations consistently 20-50% over expected
+- Work is completing correctly, just slower than expected
+
+**Signs you should investigate (not just increase):**
+
+- Agents regularly exceed by 100%+ (may indicate hanging)
+- Timeouts followed by missing artifacts (actual failures)
+- Inconsistent timing (sometimes 5 min, sometimes 20 min)
+
+**Don't increase timeouts to hide problems.** If agents are failing or hanging, fix the root cause instead of just increasing limits.
+
+### Implementation Details
+
+GSD commands read timeout config using this pattern:
+
+```bash
+# Read from config, fall back to default
+EXECUTOR_TIMEOUT=$(cat .planning/config.json 2>/dev/null | \
+  grep -o '"executor"[[:space:]]*:[[:space:]]*[0-9]*' | \
+  grep -o '[0-9]*' || echo "600000")
+```
+
+This approach:
+- Works without jq dependency
+- Handles missing config gracefully
+- Falls back to hardcoded defaults
+- Consistent across all commands
+
+For integration details, see [`get-shit-done/utilities/task-timeout.md`](../utilities/task-timeout.md).
+
+---
+
+## Other Configuration
+
+This document focuses on timeout configuration. For complete configuration reference including:
+
+- Workflow mode (yolo vs interactive)
+- Planning depth (quick vs comprehensive)
+- Parallelization settings
+- Model profiles
+- Safety gates
+
+See the **[Config Schema](../templates/config-schema.md)** for complete documentation.

--- a/get-shit-done/docs/parallel-work.md
+++ b/get-shit-done/docs/parallel-work.md
@@ -1,0 +1,138 @@
+# Parallel Work Support
+
+GSD v1.11 enables running multiple GSD sessions simultaneously from different terminal windows without state corruption.
+
+## How It Works
+
+**The Problem (Before v1.11)**:
+When two terminals ran GSD commands simultaneously, they could both:
+1. Read STATE.md at the same time
+2. Make different decisions about "current position"
+3. Write conflicting updates to STATE.md
+4. Corrupt project state
+
+**The Solution (v1.11 State Derivation)**:
+Instead of reading a centralized STATE.md for position, GSD now DERIVES state from the filesystem:
+
+- **Plan complete?** Check if SUMMARY.md exists (atomic operation)
+- **Current phase?** Find first phase with incomplete plans (read-only scan)
+- **Progress?** Count SUMMARY files / PLAN files (pure calculation)
+
+File existence checks are atomic - two processes can check simultaneously and both get correct answers.
+
+## Safe Parallel Scenarios
+
+### Two Terminals, Different Phases
+```
+Terminal 1: /gsd:execute-phase 2
+Terminal 2: /gsd:execute-phase 3
+```
+✓ Safe - Each works on its own phase, creates its own SUMMARY files.
+
+### Two Terminals, Same Phase, Different Plans
+```
+Terminal 1: Executing 02-01-PLAN.md
+Terminal 2: Executing 02-02-PLAN.md (Plan 02-01 was already complete)
+```
+✓ Safe - Each creates its own SUMMARY file in the same directory.
+
+### Planning While Executing
+```
+Terminal 1: /gsd:execute-phase 2
+Terminal 2: /gsd:plan-phase 3
+```
+✓ Safe - Planning only reads existing files and writes new PLAN files.
+
+### Progress Queries During Execution
+```
+Terminal 1: /gsd:execute-phase 2 (long-running)
+Terminal 2: /gsd:progress (repeatedly)
+```
+✓ Safe - Progress queries are read-only filesystem scans.
+
+## Unsafe Scenarios (Avoid)
+
+### Two Terminals, Same Plan
+```
+Terminal 1: Executing 02-01-PLAN.md
+Terminal 2: Also executing 02-01-PLAN.md
+```
+✗ Unsafe - Both try to create the same SUMMARY file. One will fail.
+
+**Prevention**: GSD checks for existing SUMMARY before starting execution.
+
+### Simultaneous ROADMAP Edits
+```
+Terminal 1: /gsd:add-phase "New feature"
+Terminal 2: /gsd:remove-phase 3
+```
+✗ Unsafe - Both modify ROADMAP.md. Use sequentially.
+
+**Prevention**: Structural modifications should be done one at a time.
+
+### Simultaneous STATE.md Context Writes
+```
+Terminal 1: Completing plan, writing to STATE.md
+Terminal 2: Also completing plan, writing to STATE.md
+```
+⚠ Semi-safe - One write may overwrite the other's context notes, but the true state (SUMMARY existence) remains correct. Cosmetic issue only.
+
+## Verification
+
+Run the parallel safety test suite to verify your installation:
+
+```bash
+~/.claude/get-shit-done/references/state-derivation-tests.sh
+```
+
+Expected output:
+```
+Results: 15 passed, 0 failed
+✓ All tests passed - state derivation is parallel-safe
+```
+
+## Technical Details
+
+See `get-shit-done/references/state-derivation.md` for the complete function library:
+
+| Function | Purpose | Parallel Safe? |
+|----------|---------|----------------|
+| get_current_phase() | Find first incomplete phase | ✓ Yes |
+| get_current_plan() | Find first plan without SUMMARY | ✓ Yes |
+| get_progress() | Calculate completion percentage | ✓ Yes |
+| get_phase_status() | Check if phase is complete | ✓ Yes |
+| get_decisions() | Aggregate decisions from SUMMARYs | ✓ Yes |
+| get_blockers() | Aggregate blockers from SUMMARYs | ✓ Yes |
+
+All functions are read-only (ls, find, grep, wc). No writes, no locks.
+
+## STATE.md Role After v1.11
+
+STATE.md is now a **human-readable reference**, not a machine state store:
+
+- **Written**: After each plan completes (for human review)
+- **Read**: For accumulated context (decisions, blockers, session notes)
+- **NOT read**: For position/progress determination (derived instead)
+
+This means STATE.md can become slightly out of sync if multiple sessions write to it simultaneously - but that's cosmetic, not functional. The true state is always derivable from SUMMARY.md existence.
+
+## The Core Principle
+
+> SUMMARY.md existence = "complete". The filesystem IS the state.
+
+This principle enables parallel execution because:
+1. File existence is an atomic query (no partial reads)
+2. Multiple processes can check simultaneously without coordination
+3. Creating a SUMMARY file is the atomic "commit" operation
+4. No locks needed - just filesystem operations
+
+## Troubleshooting
+
+### "Plan already has SUMMARY" error
+Another terminal (or previous session) already completed this plan. Run `/gsd:progress` to see current state.
+
+### Progress shows different values between terminals
+Both are correct - one terminal may have just completed a plan. Derived state is always current.
+
+### STATE.md looks outdated
+STATE.md is for human reference. The true state is derived from SUMMARY files. STATE.md will be updated when the next plan completes.

--- a/get-shit-done/docs/timeout-behavior.md
+++ b/get-shit-done/docs/timeout-behavior.md
@@ -1,0 +1,331 @@
+# Timeout Behavior
+
+Understanding how GSD handles agent timeouts, what to expect when agents run long, and how to customize behavior.
+
+## Overview
+
+GSD agents (executors, planners, verifiers, etc.) are spawned using the Task() API to complete work. While these agents usually complete within expected durations, sometimes they run longer than anticipated.
+
+**This document explains:**
+- How timeout handling works (and what it can't do)
+- What happens when agents exceed expected duration
+- How artifact recovery ensures work isn't lost
+- How to configure timeout behavior for your project
+
+## The Reality: No Hard Timeout Enforcement
+
+**Important:** The Task() API used to spawn GSD agents does not support native timeout enforcement. This means:
+
+- **Agents cannot be automatically interrupted** if they exceed expected duration
+- **Task() blocks until the agent completes** (or you press Ctrl+C)
+- **GSD provides graceful degradation**, not hard limits
+
+### What GSD Does Instead
+
+GSD implements a **graceful degradation pattern** that:
+
+1. **Sets expectations** - Shows expected duration before spawning agent
+2. **Measures actual duration** - Tracks how long agent actually took
+3. **Checks for artifacts** - Verifies agent produced expected outputs
+4. **Reports status intelligently** - Success based on artifacts, not just timing
+
+This approach handles the common case where an agent completes successfully but runs slower than expected, while still detecting failures where agents neither complete on time nor produce outputs.
+
+## Expected Durations by Agent Type
+
+Each agent type has a default expected duration based on its typical workload:
+
+| Agent Type | Default Duration | When It Runs | Why This Duration |
+|------------|-----------------|--------------|-------------------|
+| **Executor** | 10 minutes | Executing PLAN.md files | Complex plans with multiple tasks, file operations, commits |
+| **Planner** | 5 minutes | Creating PLAN.md files | Planning is faster than execution, mostly markdown |
+| **Verifier** | 3 minutes | Verifying work meets requirements | Quick file reading and criteria checking |
+| **Researcher** | 7 minutes | Researching domain before planning | Exploration, reading multiple files, synthesis |
+| **Debugger** | 10 minutes | Diagnosing failures | Investigation, testing hypotheses, deeper analysis |
+| **Default** | 5 minutes | Any unspecified agent type | Conservative middle ground |
+
+**These are user guidance, not enforced limits.** Agents that exceed these durations may still complete successfully.
+
+## What You See: Agent Lifecycle
+
+### 1. Agent Starting
+
+When GSD spawns an agent, you see:
+
+```
+Starting gsd-executor agent...
+Expected duration: 10 minutes
+Expected outputs:
+  - .planning/phases/01-auth/01-01-SUMMARY.md
+  - .planning/STATE.md
+
+⏳ Task in progress...
+```
+
+This sets expectations and shows what artifacts the agent should produce.
+
+### 2. While Agent Runs
+
+The Task() call blocks. You see Claude's normal thinking/working output. If the agent exceeds expected duration, you'll still be waiting - there's no automatic interrupt.
+
+**If agent hangs indefinitely:** Press Ctrl+C to interrupt manually. GSD will check for partial work.
+
+### 3. Agent Completes
+
+After Task() returns, GSD checks duration and artifacts, then reports status:
+
+#### Success Within Expected Time
+```
+✅ gsd-executor completed successfully
+   Duration: 487s (expected: 600s)
+   Artifacts: All present
+```
+
+Agent completed on time with all outputs. Ideal case.
+
+#### Success But Slow
+```
+⚠️  gsd-executor took longer than expected but completed successfully
+   Expected: 600s, Actual: 847s
+   Artifacts: All present
+
+   Note: Consider increasing timeout config for this agent type if this happens frequently.
+```
+
+Agent completed but ran slow. Work is done, but you might want to adjust expectations.
+
+#### Failure - No Artifacts
+```
+❌ gsd-executor did not produce expected artifacts
+   Duration: 234s
+   Missing:
+     - .planning/phases/01-auth/01-01-SUMMARY.md
+
+   This indicates the agent failed to complete its task.
+```
+
+Agent returned but didn't create expected outputs. Likely encountered an error.
+
+#### Failure - Exceeded Time AND No Artifacts
+```
+❌ gsd-executor exceeded expected duration and did not produce artifacts
+   Expected: 600s, Actual: 1847s
+   Missing:
+     - .planning/phases/01-auth/01-01-SUMMARY.md
+     - .planning/STATE.md
+
+   The agent may have hung or encountered an error. Check logs for details.
+```
+
+Agent ran very long and produced nothing. May have been stuck or failed repeatedly.
+
+## Artifact Recovery: How Work Is Preserved
+
+**Core principle:** Success is determined by artifact presence, not duration compliance.
+
+### What Are Artifacts?
+
+Artifacts are the expected outputs an agent should produce:
+
+- **Executor agents:** SUMMARY.md, modified source files, commits
+- **Planner agents:** PLAN.md files
+- **Verifier agents:** VERIFICATION.md files
+- **Researcher agents:** RESEARCH.md files
+
+### How Recovery Works
+
+After Task() completes, GSD:
+
+1. **Checks if expected artifacts exist** - File presence on filesystem
+2. **Validates freshness** - Files modified within last 10 minutes (not stale from previous run)
+3. **Reports success if artifacts exist** - Even if duration exceeded
+
+This means if an agent takes 15 minutes instead of 10 but completes the work, **you don't lose that work**. GSD recognizes success and lets you proceed.
+
+### User Interruption (Ctrl+C)
+
+If you interrupt an agent manually:
+
+```
+⚠️  Task interrupted by user
+   Checking for partial work...
+
+   Artifacts found:
+     ✅ .planning/phases/01-auth/01-01-SUMMARY.md
+     ❌ .planning/STATE.md (missing)
+
+   The agent may have completed some work. Review artifacts and decide:
+   - If sufficient: Continue with next step
+   - If incomplete: Re-run the agent
+```
+
+GSD checks what the agent managed to complete before interruption. You can decide whether partial work is usable or if re-running is needed.
+
+## When Timeouts Actually Matter
+
+### Scenario 1: Agent Completes Slowly
+
+**What happens:** Agent takes 15 minutes instead of 10, produces all artifacts
+
+**Outcome:** ⚠️ Success with warning
+
+**What to do:** Increase timeout config if this happens regularly
+
+**Impact:** Minor - work completed, just took longer
+
+### Scenario 2: Agent Fails Fast
+
+**What happens:** Agent encounters error at 2 minutes, exits without artifacts
+
+**Outcome:** ❌ Failure
+
+**What to do:** Review logs, fix underlying issue, re-run
+
+**Impact:** High - work not completed
+
+### Scenario 3: Agent Hangs Indefinitely
+
+**What happens:** Agent gets stuck, never returns
+
+**Outcome:** You wait indefinitely until Ctrl+C
+
+**What to do:** Interrupt manually, check partial work, investigate hang
+
+**Impact:** High - blocks progress, requires manual intervention
+
+**Note:** This is the case GSD cannot handle automatically due to API limitations.
+
+### Scenario 4: Agent Exceeds Duration, No Artifacts
+
+**What happens:** Agent runs 20 minutes, produces nothing
+
+**Outcome:** ❌ Failure
+
+**What to do:** Review logs, agent may have been stuck or repeatedly failing
+
+**Impact:** High - time wasted, no progress made
+
+## Configuring Timeouts
+
+You can customize expected durations in `.planning/config.json`:
+
+```json
+{
+  "timeouts": {
+    "executor": 600000,
+    "planner": 300000,
+    "verifier": 180000,
+    "researcher": 420000,
+    "debugger": 600000,
+    "default": 300000
+  }
+}
+```
+
+Values are in milliseconds.
+
+### When to Adjust Timeouts
+
+**Increase timeouts if:**
+- Agents regularly complete successfully but exceed expected duration
+- Your project is large/complex (increase all by 50-100%)
+- Specific agent types consistently run longer (increase just those)
+
+**Decrease timeouts if:**
+- You want faster feedback on likely failures
+- Your project is simple/small (decrease all by 30-50%)
+- Running quick experiments (decrease all for faster iteration)
+
+**Example: Large codebase project**
+```json
+{
+  "timeouts": {
+    "executor": 900000,     // 15 min (was 10)
+    "researcher": 600000,   // 10 min (was 7)
+    "planner": 420000       // 7 min (was 5)
+  }
+}
+```
+
+### Valid Ranges
+
+- **Minimum:** 60000ms (1 minute) - Prevents unrealistic expectations
+- **Maximum:** 1800000ms (30 minutes) - Prevents indefinite waiting
+- **Invalid values:** Fall back to defaults with warning
+
+See [Configuration Reference](configuration.md#timeouts) for complete details.
+
+## Limitations and Workarounds
+
+### What GSD Cannot Do
+
+**Cannot prevent indefinite hangs**
+- Task() API has no timeout parameter
+- If agent truly hangs, GSD cannot interrupt it
+- **Workaround:** Press Ctrl+C, check partial work
+
+**Cannot guarantee completion within expected time**
+- Timeouts are guidance, not enforcement
+- Slow agents will take as long as they need
+- **Workaround:** Adjust timeout config to match reality
+
+**Cannot recover from agent crashes**
+- If agent crashes without writing artifacts, work is lost
+- GSD can detect this but cannot prevent it
+- **Workaround:** Review logs, fix root cause, re-run
+
+### What GSD Does Well
+
+**Detects slow-but-successful agents**
+- Reports completion even if duration exceeded
+- Preserves work that was produced
+- Provides guidance on config adjustment
+
+**Validates agent output**
+- Checks artifacts exist and are recent
+- Distinguishes "slow success" from "failure"
+- Prevents false positives from stale files
+
+**Sets clear expectations**
+- Shows expected duration before spawning
+- Reports actual vs expected after completion
+- Helps users understand normal vs abnormal behavior
+
+## Best Practices
+
+### For Project Owners
+
+1. **Set realistic timeouts** based on your project complexity
+2. **Monitor completion times** - If agents regularly exceed expectations, adjust config
+3. **Investigate consistent slow agents** - May indicate underlying issues
+4. **Keep config in version control** - Share timeout settings with team
+
+### For GSD Users
+
+1. **Trust the artifact check** - If GSD says success, artifacts exist
+2. **Don't panic on timeout warnings** - Agent completed, just ran slow
+3. **Investigate timeout failures** - These indicate real problems
+4. **Use Ctrl+C when stuck** - If agent hasn't responded in 2x expected duration, interrupt
+
+### For Integration
+
+1. **Reference timeout utility** - Use `@~/.claude/get-shit-done/utilities/task-timeout.md` in custom commands
+2. **Follow the pattern** - Start time, Task() call, end time, artifact check, status report
+3. **Handle all outcomes** - Success, slow success, failure, interruption
+4. **Log duration data** - Track actual vs expected for optimization
+
+## Summary
+
+**What timeouts are:** User expectations about how long agents should take
+
+**What timeouts are not:** Hard limits that interrupt agents
+
+**Success criteria:** Artifacts exist, regardless of duration
+
+**When to intervene:** Agent hasn't responded in 2x expected duration
+
+**How to customize:** Edit `.planning/config.json` timeouts section
+
+**What to do on failure:** Review logs, check artifacts, investigate root cause, re-run
+
+The timeout system provides **graceful degradation** and **artifact-based success detection**, not hard enforcement. It makes slow agents visible without losing successful work, and helps you understand when agents are truly failing vs just running slower than expected.

--- a/get-shit-done/references/git-integration.md
+++ b/get-shit-done/references/git-integration.md
@@ -252,3 +252,7 @@ Each plan produces 2-4 commits (tasks + metadata). Clear, granular, bisectable.
 - "Commit noise" irrelevant when consumer is Claude, not humans
 
 </commit_strategy_rationale>
+
+## See Also
+
+- **State Derivation**: @state-derivation.md - Parallel-safe state computation patterns

--- a/get-shit-done/references/parallel-validation-scenarios.md
+++ b/get-shit-done/references/parallel-validation-scenarios.md
@@ -1,0 +1,149 @@
+# Parallel Validation Scenarios
+
+Manual test scenarios to validate parallel GSD execution works correctly.
+
+## Scenario 1: Two Phases, Two Terminals
+
+**Setup:**
+1. Create test project with 3 phases, each with 1 simple plan
+2. Execute phase 1 to completion (creates baseline)
+
+**Test:**
+1. Open Terminal A: `cd project && /gsd:execute-phase 2`
+2. Open Terminal B: `cd project && /gsd:execute-phase 3`
+3. Both should complete without errors
+
+**Expected Results:**
+- Both terminals complete their respective phases
+- Both SUMMARY files created correctly
+- STATE.md may show Terminal A or B's last update (cosmetic)
+- ROADMAP.md shows both phases complete
+
+**Validation:**
+```bash
+# Check SUMMARYs exist
+ls .planning/phases/02-*/02-01-SUMMARY.md
+ls .planning/phases/03-*/03-01-SUMMARY.md
+
+# Verify ROADMAP checkboxes
+grep -E "^\s*-\s*\[x\].*Phase [23]" .planning/ROADMAP.md
+```
+
+## Scenario 2: Progress Query During Execution
+
+**Setup:**
+1. Create test project with 5 plans in phase 1
+2. Complete 2 plans manually
+
+**Test:**
+1. Terminal A: Start `/gsd:execute-phase 1` (will take time)
+2. Terminal B: Run `/gsd:progress` repeatedly during execution
+
+**Expected Results:**
+- Progress percentage increases as plans complete
+- No errors in either terminal
+- Progress queries don't block execution
+
+**Validation:**
+```bash
+# Watch progress update in real-time
+watch -n 2 'ls .planning/phases/01-*/*-SUMMARY.md 2>/dev/null | wc -l'
+```
+
+## Scenario 3: Plan While Execute
+
+**Setup:**
+1. Project with phase 1 executed, phase 2 empty (no plans)
+
+**Test:**
+1. Terminal A: `/gsd:execute-phase 1` (on remaining plans)
+2. Terminal B: `/gsd:plan-phase 2`
+
+**Expected Results:**
+- Phase 1 execution completes
+- Phase 2 plans created
+- No conflicts
+
+**Validation:**
+```bash
+# Both should exist
+ls .planning/phases/01-*/*-SUMMARY.md
+ls .planning/phases/02-*/*-PLAN.md
+```
+
+## Scenario 4: Resume After Crash
+
+**Setup:**
+1. Start executing a 3-plan phase
+2. Kill Claude session after 1 plan completes (Ctrl+C hard kill)
+
+**Test:**
+1. New session: `/gsd:resume-work`
+
+**Expected Results:**
+- Correctly identifies completed plan (SUMMARY exists)
+- Correctly identifies next plan (no SUMMARY)
+- No state corruption despite interrupted write to STATE.md
+
+**Validation:**
+```bash
+# SUMMARY count should match actual completed work
+ls .planning/phases/01-*/*-SUMMARY.md | wc -l
+
+# Next plan should be the one without SUMMARY
+ls .planning/phases/01-*/*-PLAN.md | while read plan; do
+  summary="${plan/PLAN/SUMMARY}"
+  [ ! -f "$summary" ] && echo "Next: $plan"
+done
+```
+
+## Scenario 5: Same Plan Race Condition (Negative Test)
+
+**Setup:**
+1. Project with an incomplete plan (no SUMMARY)
+
+**Test:**
+1. Terminal A: Start executing the plan
+2. Terminal B: Try to start the same plan before A completes
+
+**Expected Results:**
+- Terminal B should detect plan is in progress or wait
+- Only ONE SUMMARY file gets created
+- No duplicate work
+
+**Validation:**
+```bash
+# Should be exactly 1 SUMMARY
+ls .planning/phases/01-*/01-01-SUMMARY.md | wc -l  # Should be 1
+```
+
+## Validation Checklist
+
+For each scenario, verify:
+
+- [ ] Both terminals complete without error
+- [ ] SUMMARY files created in correct locations
+- [ ] No duplicate commits (git log clean)
+- [ ] STATE.md reflects reasonable state (may vary by last writer)
+- [ ] ROADMAP.md checkboxes match SUMMARY existence
+
+## Automated Validation
+
+The test harness validates the derivation functions:
+
+```bash
+~/.claude/get-shit-done/references/state-derivation-tests.sh
+```
+
+Tests cover:
+- Single-terminal state derivation
+- Parallel query safety (same dir, simultaneous reads)
+- Edge cases (empty phases, all complete, none complete)
+- Function consistency (repeated calls return same results)
+
+## Known Limitations
+
+1. **ROADMAP.md writes not parallelized** - Adding/removing phases should be done one at a time
+2. **STATE.md cosmetic races** - Last writer wins for human-readable state, but derived state is always correct
+3. **Same-plan execution** - Two terminals on the same plan will conflict; detected and prevented
+4. **Git commits** - Each terminal commits independently; may need merge if modifying same files

--- a/get-shit-done/references/state-derivation-tests.sh
+++ b/get-shit-done/references/state-derivation-tests.sh
@@ -1,0 +1,569 @@
+#!/usr/bin/env bash
+# State Derivation Test Harness
+# Validates parallel execution safety and function correctness
+#
+# Run: ./get-shit-done/references/state-derivation-tests.sh
+
+set -euo pipefail
+
+# ============================================================================
+# Test Utilities
+# ============================================================================
+
+PASS_COUNT=0
+FAIL_COUNT=0
+TEST_DIR=""
+
+pass() {
+  echo "  ✓ $1"
+  PASS_COUNT=$((PASS_COUNT + 1))
+}
+
+fail() {
+  echo "  ✗ $1"
+  FAIL_COUNT=$((FAIL_COUNT + 1))
+}
+
+# ============================================================================
+# Setup/Teardown
+# ============================================================================
+
+setup_test_project() {
+  TEST_DIR=$(mktemp -d)
+  mkdir -p "${TEST_DIR}/.planning/phases/01-foundation"
+  mkdir -p "${TEST_DIR}/.planning/phases/02-auth"
+  mkdir -p "${TEST_DIR}/.planning/phases/03-features"
+
+  # Create ROADMAP.md
+  cat > "${TEST_DIR}/.planning/ROADMAP.md" << 'ROADMAP'
+# Roadmap
+
+## Phase 1: Foundation
+- [x] 01-01-PLAN.md - Setup project
+- [ ] 01-02-PLAN.md - Configure database
+
+## Phase 2: Auth
+- [ ] 02-01-PLAN.md - JWT implementation
+- [ ] 02-02-PLAN.md - User registration
+
+## Phase 3: Features
+- [ ] 03-01-PLAN.md - Main feature
+ROADMAP
+
+  # Phase 1: One complete, one not
+  touch "${TEST_DIR}/.planning/phases/01-foundation/01-01-PLAN.md"
+  touch "${TEST_DIR}/.planning/phases/01-foundation/01-01-SUMMARY.md"
+  touch "${TEST_DIR}/.planning/phases/01-foundation/01-02-PLAN.md"
+  # No 01-02-SUMMARY.md
+
+  # Phase 2: Neither complete
+  touch "${TEST_DIR}/.planning/phases/02-auth/02-01-PLAN.md"
+  touch "${TEST_DIR}/.planning/phases/02-auth/02-02-PLAN.md"
+  # No SUMMARYs
+
+  # Phase 3: Not started
+  touch "${TEST_DIR}/.planning/phases/03-features/03-01-PLAN.md"
+
+  # Add frontmatter with decisions to one SUMMARY
+  cat > "${TEST_DIR}/.planning/phases/01-foundation/01-01-SUMMARY.md" << 'SUMMARY'
+---
+phase: 01-foundation
+plan: 01
+key-decisions:
+  - "Use PostgreSQL for database"
+  - "JWT with 15-min expiry"
+---
+
+# Phase 1 Plan 1 Summary
+
+## Next Phase Readiness
+
+- Ready for next plan
+- All clear to proceed
+SUMMARY
+}
+
+cleanup_test_project() {
+  if [ -n "$TEST_DIR" ] && [ -d "$TEST_DIR" ]; then
+    rm -rf "$TEST_DIR"
+  fi
+  TEST_DIR=""
+}
+
+# ============================================================================
+# State Derivation Functions (Implementation)
+# ============================================================================
+
+get_current_phase() {
+  local planning_dir="${1:-.planning}"
+  local phases_dir="${planning_dir}/phases"
+
+  if [ ! -d "$phases_dir" ]; then
+    echo "none"
+    return 0
+  fi
+
+  # Find first phase dir with PLAN without SUMMARY
+  for phase_dir in "${phases_dir}"/*/; do
+    if [ -d "$phase_dir" ]; then
+      local plan_count=$(ls -1 "${phase_dir}"*-PLAN.md 2>/dev/null | wc -l | tr -d ' ')
+      local summary_count=$(ls -1 "${phase_dir}"*-SUMMARY.md 2>/dev/null | wc -l | tr -d ' ')
+
+      if [ "$plan_count" -gt "$summary_count" ]; then
+        local phase_name=$(basename "$phase_dir")
+        echo "${phase_name%%-*}"
+        return 0
+      fi
+    fi
+  done
+
+  echo "none"
+  return 0
+}
+
+get_current_plan() {
+  local phase_dir="$1"
+
+  if [ ! -d "$phase_dir" ]; then
+    echo "none"
+    return 0
+  fi
+
+  for plan_file in $(ls -1 "${phase_dir}"/*-PLAN.md 2>/dev/null | sort); do
+    local plan_basename=$(basename "$plan_file" .md)
+    local plan_id="${plan_basename%-PLAN}"
+    local summary_file="${phase_dir}/${plan_id}-SUMMARY.md"
+
+    if [ ! -f "$summary_file" ]; then
+      echo "$plan_id"
+      return 0
+    fi
+  done
+
+  echo "none"
+  return 0
+}
+
+get_progress() {
+  local planning_dir="${1:-.planning}"
+  local phases_dir="${planning_dir}/phases"
+
+  if [ ! -d "$phases_dir" ]; then
+    echo "0"
+    return 0
+  fi
+
+  local plan_count=$(find "$phases_dir" -name "*-PLAN.md" 2>/dev/null | wc -l | tr -d ' ')
+  local summary_count=$(find "$phases_dir" -name "*-SUMMARY.md" 2>/dev/null | wc -l | tr -d ' ')
+
+  if [ "$plan_count" -eq 0 ]; then
+    echo "0"
+    return 0
+  fi
+
+  local progress=$(( (summary_count * 100) / plan_count ))
+  echo "$progress"
+  return 0
+}
+
+get_phase_status() {
+  local phase_dir="$1"
+
+  if [ ! -d "$phase_dir" ]; then
+    echo "not-found"
+    return 0
+  fi
+
+  local plan_count=$(ls -1 "${phase_dir}"/*-PLAN.md 2>/dev/null | wc -l | tr -d ' ')
+  local summary_count=$(ls -1 "${phase_dir}"/*-SUMMARY.md 2>/dev/null | wc -l | tr -d ' ')
+
+  if [ "$plan_count" -eq 0 ]; then
+    echo "empty"
+  elif [ "$summary_count" -eq 0 ]; then
+    echo "not-started"
+  elif [ "$summary_count" -eq "$plan_count" ]; then
+    echo "complete"
+  else
+    echo "in-progress"
+  fi
+
+  return 0
+}
+
+get_decisions() {
+  local planning_dir="${1:-.planning}"
+  local phases_dir="${planning_dir}/phases"
+
+  if [ ! -d "$phases_dir" ]; then
+    echo ""
+    return 0
+  fi
+
+  for summary_file in $(find "$phases_dir" -name "*-SUMMARY.md" 2>/dev/null | sort); do
+    local in_frontmatter=0
+    local in_decisions=0
+    local phase=$(basename "$(dirname "$summary_file")")
+
+    while IFS= read -r line || [ -n "$line" ]; do
+      if [ "$line" = "---" ]; then
+        if [ "$in_frontmatter" -eq 0 ]; then
+          in_frontmatter=1
+          continue
+        else
+          break
+        fi
+      fi
+
+      if [ "$in_frontmatter" -eq 1 ]; then
+        if echo "$line" | grep -qE "^key-decisions:"; then
+          in_decisions=1
+          continue
+        fi
+
+        if [ "$in_decisions" -eq 1 ]; then
+          if echo "$line" | grep -qE "^\s*-\s"; then
+            local decision=$(echo "$line" | sed 's/^\s*-\s*//' | sed 's/^"//' | sed 's/"$//')
+            echo "[$phase] $decision"
+          elif ! echo "$line" | grep -qE "^\s"; then
+            in_decisions=0
+          fi
+        fi
+      fi
+    done < "$summary_file"
+  done
+}
+
+get_blockers() {
+  local planning_dir="${1:-.planning}"
+  local phases_dir="${planning_dir}/phases"
+
+  if [ ! -d "$phases_dir" ]; then
+    echo ""
+    return 0
+  fi
+
+  for summary_file in $(find "$phases_dir" -name "*-SUMMARY.md" 2>/dev/null | sort); do
+    local in_readiness=0
+    local phase=$(basename "$(dirname "$summary_file")")
+
+    while IFS= read -r line || [ -n "$line" ]; do
+      if echo "$line" | grep -qiE "^##.*Next Phase Readiness|^##.*Blockers"; then
+        in_readiness=1
+        continue
+      fi
+
+      if [ "$in_readiness" -eq 1 ]; then
+        if echo "$line" | grep -qE "^##"; then
+          in_readiness=0
+          continue
+        fi
+
+        if echo "$line" | grep -qiE "^\s*-.*blocker"; then
+          local blocker=$(echo "$line" | sed 's/^\s*-\s*//')
+          echo "[$phase] $blocker"
+        fi
+      fi
+    done < "$summary_file"
+  done
+}
+
+# ============================================================================
+# Correctness Tests
+# ============================================================================
+
+test_get_current_phase() {
+  echo "Testing get_current_phase()..."
+  setup_test_project
+
+  local result=$(get_current_phase "${TEST_DIR}/.planning")
+
+  if [ "$result" = "01" ]; then
+    pass "Returns '01' for first incomplete phase"
+  else
+    fail "Expected '01', got '$result'"
+  fi
+
+  cleanup_test_project
+}
+
+test_get_current_plan() {
+  echo "Testing get_current_plan()..."
+  setup_test_project
+
+  local result=$(get_current_plan "${TEST_DIR}/.planning/phases/01-foundation")
+
+  if [ "$result" = "01-02" ]; then
+    pass "Returns '01-02' for first plan without SUMMARY"
+  else
+    fail "Expected '01-02', got '$result'"
+  fi
+
+  # Test complete phase
+  local result2=$(get_current_plan "/nonexistent/path")
+  if [ "$result2" = "none" ]; then
+    pass "Returns 'none' for nonexistent directory"
+  else
+    fail "Expected 'none' for nonexistent, got '$result2'"
+  fi
+
+  cleanup_test_project
+}
+
+test_get_progress() {
+  echo "Testing get_progress()..."
+  setup_test_project
+
+  local result=$(get_progress "${TEST_DIR}/.planning")
+
+  # 1 SUMMARY out of 5 PLANs = 20%
+  if [ "$result" = "20" ]; then
+    pass "Returns '20' for 1/5 plans complete"
+  else
+    fail "Expected '20', got '$result'"
+  fi
+
+  cleanup_test_project
+}
+
+test_get_phase_status() {
+  echo "Testing get_phase_status()..."
+  setup_test_project
+
+  local result1=$(get_phase_status "${TEST_DIR}/.planning/phases/01-foundation")
+  if [ "$result1" = "in-progress" ]; then
+    pass "Phase 1 is 'in-progress' (1/2 complete)"
+  else
+    fail "Expected 'in-progress' for phase 1, got '$result1'"
+  fi
+
+  local result2=$(get_phase_status "${TEST_DIR}/.planning/phases/02-auth")
+  if [ "$result2" = "not-started" ]; then
+    pass "Phase 2 is 'not-started' (0/2 complete)"
+  else
+    fail "Expected 'not-started' for phase 2, got '$result2'"
+  fi
+
+  local result3=$(get_phase_status "/nonexistent/path")
+  if [ "$result3" = "not-found" ]; then
+    pass "Nonexistent phase returns 'not-found'"
+  else
+    fail "Expected 'not-found', got '$result3'"
+  fi
+
+  cleanup_test_project
+}
+
+test_get_decisions() {
+  echo "Testing get_decisions()..."
+  setup_test_project
+
+  local result=$(get_decisions "${TEST_DIR}/.planning")
+
+  if echo "$result" | grep -q "PostgreSQL"; then
+    pass "Extracts 'PostgreSQL' decision from frontmatter"
+  else
+    fail "Failed to extract PostgreSQL decision, got: $result"
+  fi
+
+  if echo "$result" | grep -q "JWT"; then
+    pass "Extracts 'JWT' decision from frontmatter"
+  else
+    fail "Failed to extract JWT decision"
+  fi
+
+  cleanup_test_project
+}
+
+test_get_blockers() {
+  echo "Testing get_blockers()..."
+  setup_test_project
+
+  # Our test SUMMARY has "No blockers" so should return empty
+  local result=$(get_blockers "${TEST_DIR}/.planning")
+
+  if [ -z "$result" ]; then
+    pass "Returns empty when no blockers found"
+  else
+    fail "Expected empty, got: $result"
+  fi
+
+  cleanup_test_project
+}
+
+test_edge_cases() {
+  echo "Testing edge cases..."
+
+  # Test with empty directory
+  local empty_dir=$(mktemp -d)
+  mkdir -p "${empty_dir}/.planning/phases"
+
+  local result1=$(get_progress "${empty_dir}/.planning")
+  if [ "$result1" = "0" ]; then
+    pass "Empty project returns 0% progress"
+  else
+    fail "Expected 0 for empty project, got '$result1'"
+  fi
+
+  local result2=$(get_current_phase "${empty_dir}/.planning")
+  if [ "$result2" = "none" ]; then
+    pass "Empty project returns 'none' for current phase"
+  else
+    fail "Expected 'none' for empty project, got '$result2'"
+  fi
+
+  rm -rf "$empty_dir"
+}
+
+# ============================================================================
+# Parallel Safety Tests
+# ============================================================================
+
+test_parallel_reads() {
+  echo "Testing parallel state derivation (10 concurrent processes)..."
+  setup_test_project
+
+  local results_file=$(mktemp)
+  local pids=""
+
+  # Spawn 10 background processes
+  for i in $(seq 1 10); do
+    (
+      PHASE=$(get_current_phase "${TEST_DIR}/.planning")
+      PLAN=$(get_current_plan "${TEST_DIR}/.planning/phases/01-foundation")
+      PROGRESS=$(get_progress "${TEST_DIR}/.planning")
+      echo "Process $i: Phase=$PHASE, Plan=$PLAN, Progress=$PROGRESS"
+    ) >> "$results_file" &
+    pids="$pids $!"
+  done
+
+  # Wait for all to complete
+  for pid in $pids; do
+    wait "$pid" 2>/dev/null || true
+  done
+
+  # All processes should report same values (ignoring process ID)
+  # Extract just the values (Phase=X, Plan=Y, Progress=Z)
+  local unique_values=$(cut -d':' -f2 "$results_file" | sort -u | wc -l | tr -d ' ')
+
+  if [ "$unique_values" -eq 1 ]; then
+    pass "All 10 processes reported identical state values"
+  else
+    fail "Processes reported different state values (got $unique_values unique)"
+    cat "$results_file"
+  fi
+
+  rm -f "$results_file"
+  cleanup_test_project
+}
+
+test_no_file_writes() {
+  echo "Testing that state derivation performs no writes..."
+  setup_test_project
+
+  # Record all file modification times (using portable stat)
+  local before_file=$(mktemp)
+  find "${TEST_DIR}/.planning" -type f -exec ls -la {} \; > "$before_file" 2>/dev/null
+
+  # Small delay to ensure timestamp would change if modified
+  sleep 0.1
+
+  # Call all state functions
+  get_current_phase "${TEST_DIR}/.planning" > /dev/null
+  get_current_plan "${TEST_DIR}/.planning/phases/01-foundation" > /dev/null
+  get_progress "${TEST_DIR}/.planning" > /dev/null
+  get_phase_status "${TEST_DIR}/.planning/phases/01-foundation" > /dev/null
+  get_decisions "${TEST_DIR}/.planning" > /dev/null
+  get_blockers "${TEST_DIR}/.planning" > /dev/null
+
+  # Record after
+  local after_file=$(mktemp)
+  find "${TEST_DIR}/.planning" -type f -exec ls -la {} \; > "$after_file" 2>/dev/null
+
+  # Compare
+  if diff -q "$before_file" "$after_file" > /dev/null; then
+    pass "No files modified during state derivation"
+  else
+    fail "Files were modified during state derivation"
+    diff "$before_file" "$after_file" || true
+  fi
+
+  rm -f "$before_file" "$after_file"
+  cleanup_test_project
+}
+
+test_consistency_under_load() {
+  echo "Testing consistency with rapid parallel calls..."
+  setup_test_project
+
+  local results_file=$(mktemp)
+  local pids=""
+
+  # Call get_progress 50 times in parallel
+  for i in $(seq 1 50); do
+    (
+      PROGRESS=$(get_progress "${TEST_DIR}/.planning")
+      echo "$PROGRESS"
+    ) >> "$results_file" &
+    pids="$pids $!"
+  done
+
+  # Wait for all
+  for pid in $pids; do
+    wait "$pid" 2>/dev/null || true
+  done
+
+  # All should be identical
+  local unique_results=$(sort -u "$results_file" | wc -l | tr -d ' ')
+  local expected_value=$(head -1 "$results_file")
+
+  if [ "$unique_results" -eq 1 ] && [ "$expected_value" = "20" ]; then
+    pass "All 50 parallel calls returned consistent value (20%)"
+  else
+    fail "Inconsistent results: $unique_results unique values"
+  fi
+
+  rm -f "$results_file"
+  cleanup_test_project
+}
+
+# ============================================================================
+# Main Test Runner
+# ============================================================================
+
+main() {
+  echo ""
+  echo "╔════════════════════════════════════════════════════════════════╗"
+  echo "║  State Derivation Test Suite                                   ║"
+  echo "╚════════════════════════════════════════════════════════════════╝"
+  echo ""
+
+  echo "=== Correctness Tests ==="
+  test_get_current_phase
+  test_get_current_plan
+  test_get_progress
+  test_get_phase_status
+  test_get_decisions
+  test_get_blockers
+  test_edge_cases
+  echo ""
+
+  echo "=== Parallel Safety Tests ==="
+  test_parallel_reads
+  test_no_file_writes
+  test_consistency_under_load
+  echo ""
+
+  echo "════════════════════════════════════════════════════════════════"
+  echo "Results: $PASS_COUNT passed, $FAIL_COUNT failed"
+  echo ""
+
+  if [ "$FAIL_COUNT" -eq 0 ]; then
+    echo "✓ All tests passed - state derivation is parallel-safe"
+    exit 0
+  else
+    echo "✗ Some tests failed"
+    exit 1
+  fi
+}
+
+main "$@"

--- a/get-shit-done/references/state-derivation.md
+++ b/get-shit-done/references/state-derivation.md
@@ -1,0 +1,570 @@
+# State Derivation Reference
+
+**Purpose**: Derive project state from filesystem examination instead of reading centralized STATE.md.
+
+**Philosophy**: File existence is atomic. Two processes can check "does SUMMARY.md exist?" simultaneously without corruption. Race conditions occur when multiple processes READ and WRITE the same file - but reads-only are safe.
+
+**Key Insight**: SUMMARY.md existence already means "plan complete". The filesystem IS the state - we just need functions to read it instead of duplicating it in STATE.md.
+
+**Why This Matters**: When two terminals run GSD simultaneously, reading/writing STATE.md creates race conditions. Deriving state from filesystem artifacts (PLAN/SUMMARY files) eliminates this entirely.
+
+---
+
+## Function 1: get_current_phase() — DRV-01
+
+**Purpose**: Scan ROADMAP.md for the first incomplete phase (has unchecked plans).
+
+**Logic**:
+1. Read ROADMAP.md
+2. Find phase sections with unchecked plan items (`- [ ]`)
+3. Return first phase with incomplete plans
+4. If all complete, return "none" (project done)
+
+**Implementation**:
+
+```bash
+get_current_phase() {
+  local planning_dir="${1:-.planning}"
+  local roadmap="${planning_dir}/ROADMAP.md"
+
+  if [ ! -f "$roadmap" ]; then
+    echo "none"
+    return 1
+  fi
+
+  # Parse ROADMAP.md for phases with unchecked items
+  # Phase format: "### Phase N:" or "- [ ] **Phase N:"
+  # Look for first phase section containing "- [ ]" (incomplete checkbox)
+
+  local current_phase=""
+  local in_phase=""
+
+  while IFS= read -r line; do
+    # Match phase header: "### Phase 1:" or "## Phase 01:" etc
+    if echo "$line" | grep -qE "^#{2,4} Phase [0-9]+(\.[0-9]+)?"; then
+      # Extract phase number (handles 01, 1, 01.1, etc)
+      in_phase=$(echo "$line" | grep -oE "Phase [0-9]+(\.[0-9]+)?" | grep -oE "[0-9]+(\.[0-9]+)?")
+    fi
+
+    # If we're in a phase and find unchecked plan
+    if [ -n "$in_phase" ]; then
+      if echo "$line" | grep -qE "^\s*-\s*\[ \]"; then
+        echo "$in_phase"
+        return 0
+      fi
+    fi
+  done < "$roadmap"
+
+  # Alternative: Check phase directories directly
+  # Find first phase dir with PLAN without SUMMARY
+  for phase_dir in "${planning_dir}"/phases/*/; do
+    if [ -d "$phase_dir" ]; then
+      local plan_count=$(ls -1 "${phase_dir}"*-PLAN.md 2>/dev/null | wc -l)
+      local summary_count=$(ls -1 "${phase_dir}"*-SUMMARY.md 2>/dev/null | wc -l)
+
+      if [ "$plan_count" -gt "$summary_count" ]; then
+        # Extract phase number from directory name (e.g., "01-foundation" -> "01")
+        local phase_name=$(basename "$phase_dir")
+        echo "${phase_name%%-*}"
+        return 0
+      fi
+    fi
+  done
+
+  echo "none"
+  return 0
+}
+```
+
+**Example Usage**:
+
+```bash
+CURRENT_PHASE=$(get_current_phase)
+if [ "$CURRENT_PHASE" = "none" ]; then
+  echo "All phases complete!"
+else
+  echo "Currently on phase: $CURRENT_PHASE"
+fi
+```
+
+---
+
+## Function 2: get_current_plan() — DRV-02
+
+**Purpose**: Scan phase directory for first PLAN without matching SUMMARY.
+
+**Logic**:
+1. List all *-PLAN.md files in phase directory (sorted)
+2. For each PLAN, check if corresponding SUMMARY exists
+3. Return first plan ID where SUMMARY doesn't exist
+4. If all have SUMMARYs, return "none" (phase complete)
+
+**Implementation**:
+
+```bash
+get_current_plan() {
+  local phase_dir="$1"
+
+  if [ ! -d "$phase_dir" ]; then
+    echo "none"
+    return 1
+  fi
+
+  # Get all PLAN files, sorted
+  for plan_file in $(ls -1 "${phase_dir}"/*-PLAN.md 2>/dev/null | sort); do
+    # Extract plan identifier (e.g., "01-01" from "01-01-PLAN.md")
+    local plan_basename=$(basename "$plan_file" .md)
+    local plan_id="${plan_basename%-PLAN}"
+
+    # Check if corresponding SUMMARY exists
+    local summary_file="${phase_dir}/${plan_id}-SUMMARY.md"
+
+    if [ ! -f "$summary_file" ]; then
+      echo "$plan_id"
+      return 0
+    fi
+  done
+
+  echo "none"
+  return 0
+}
+```
+
+**Example Usage**:
+
+```bash
+CURRENT_PLAN=$(get_current_plan ".planning/phases/01-state-derivation-core")
+if [ "$CURRENT_PLAN" = "none" ]; then
+  echo "Phase complete!"
+else
+  echo "Next plan to execute: $CURRENT_PLAN"
+fi
+```
+
+---
+
+## Function 3: get_progress() — DRV-03
+
+**Purpose**: Compute completion percentage from file counts across all phases.
+
+**Logic**:
+1. Count all *-PLAN.md files in all phase directories
+2. Count all *-SUMMARY.md files in all phase directories
+3. Return percentage: (summaries / plans) * 100
+4. Handle edge case: 0 plans = 0%
+
+**Implementation**:
+
+```bash
+get_progress() {
+  local planning_dir="${1:-.planning}"
+  local phases_dir="${planning_dir}/phases"
+
+  if [ ! -d "$phases_dir" ]; then
+    echo "0"
+    return 0
+  fi
+
+  # Count PLANs and SUMMARYs across all phases
+  local plan_count=$(find "$phases_dir" -name "*-PLAN.md" 2>/dev/null | wc -l | tr -d ' ')
+  local summary_count=$(find "$phases_dir" -name "*-SUMMARY.md" 2>/dev/null | wc -l | tr -d ' ')
+
+  # Handle edge case: no plans
+  if [ "$plan_count" -eq 0 ]; then
+    echo "0"
+    return 0
+  fi
+
+  # Calculate percentage (integer math, bash doesn't do floats)
+  local progress=$(( (summary_count * 100) / plan_count ))
+  echo "$progress"
+  return 0
+}
+```
+
+**Example Usage**:
+
+```bash
+PROGRESS=$(get_progress)
+echo "Project: ${PROGRESS}% complete"
+
+# Visual progress bar
+filled=$(( PROGRESS / 10 ))
+empty=$(( 10 - filled ))
+bar=$(printf "█%.0s" $(seq 1 $filled 2>/dev/null) || echo "")
+bar+=$(printf "░%.0s" $(seq 1 $empty 2>/dev/null) || echo "░░░░░░░░░░")
+echo "Progress: [${bar:0:10}] ${PROGRESS}%"
+```
+
+---
+
+## Function 4: get_phase_status() — DRV-04
+
+**Purpose**: Determine if a specific phase is complete (all plans have SUMMARYs).
+
+**Logic**:
+1. Count PLANs in phase directory
+2. Count SUMMARYs in phase directory
+3. Return "complete" if counts match
+4. Return "in-progress" if some SUMMARYs exist
+5. Return "not-started" if 0 SUMMARYs
+
+**Implementation**:
+
+```bash
+get_phase_status() {
+  local phase_dir="$1"
+
+  if [ ! -d "$phase_dir" ]; then
+    echo "not-found"
+    return 1
+  fi
+
+  local plan_count=$(ls -1 "${phase_dir}"/*-PLAN.md 2>/dev/null | wc -l | tr -d ' ')
+  local summary_count=$(ls -1 "${phase_dir}"/*-SUMMARY.md 2>/dev/null | wc -l | tr -d ' ')
+
+  # Handle edge case: no plans
+  if [ "$plan_count" -eq 0 ]; then
+    echo "empty"
+    return 0
+  fi
+
+  if [ "$summary_count" -eq 0 ]; then
+    echo "not-started"
+  elif [ "$summary_count" -eq "$plan_count" ]; then
+    echo "complete"
+  else
+    echo "in-progress"
+  fi
+
+  return 0
+}
+```
+
+**Example Usage**:
+
+```bash
+STATUS=$(get_phase_status ".planning/phases/01-foundation")
+case "$STATUS" in
+  "complete")     echo "Phase 1 complete!" ;;
+  "in-progress")  echo "Phase 1 in progress..." ;;
+  "not-started")  echo "Phase 1 not yet started" ;;
+  "empty")        echo "Phase 1 has no plans" ;;
+  "not-found")    echo "Phase 1 directory not found" ;;
+esac
+```
+
+---
+
+## Function 5: get_decisions() — DRV-05
+
+**Purpose**: Aggregate decisions from all SUMMARY.md frontmatter.
+
+**Logic**:
+1. Find all *-SUMMARY.md files
+2. Extract `key-decisions:` field from frontmatter
+3. Combine into chronological list
+4. Return as newline-separated list
+
+**Implementation**:
+
+```bash
+get_decisions() {
+  local planning_dir="${1:-.planning}"
+  local phases_dir="${planning_dir}/phases"
+
+  if [ ! -d "$phases_dir" ]; then
+    echo ""
+    return 0
+  fi
+
+  # Find all SUMMARYs and extract decisions from frontmatter
+  # Frontmatter is between --- markers at start of file
+  # key-decisions is a YAML list
+
+  for summary_file in $(find "$phases_dir" -name "*-SUMMARY.md" 2>/dev/null | sort); do
+    # Extract frontmatter (between first and second ---)
+    local in_frontmatter=0
+    local in_decisions=0
+
+    while IFS= read -r line; do
+      # Track frontmatter boundaries
+      if [ "$line" = "---" ]; then
+        if [ "$in_frontmatter" -eq 0 ]; then
+          in_frontmatter=1
+          continue
+        else
+          break  # End of frontmatter
+        fi
+      fi
+
+      # Inside frontmatter, look for key-decisions
+      if [ "$in_frontmatter" -eq 1 ]; then
+        if echo "$line" | grep -qE "^key-decisions:"; then
+          in_decisions=1
+          continue
+        fi
+
+        # If in decisions section, extract list items
+        if [ "$in_decisions" -eq 1 ]; then
+          # Check if line is a list item (starts with -)
+          if echo "$line" | grep -qE "^\s*-\s"; then
+            # Extract decision text (remove leading - and quotes)
+            local decision=$(echo "$line" | sed 's/^\s*-\s*//' | sed 's/^"//' | sed 's/"$//')
+            local phase=$(basename "$(dirname "$summary_file")")
+            echo "[$phase] $decision"
+          elif ! echo "$line" | grep -qE "^\s"; then
+            # Non-indented line means end of decisions section
+            in_decisions=0
+          fi
+        fi
+      fi
+    done < "$summary_file"
+  done
+}
+```
+
+**Example Usage**:
+
+```bash
+echo "=== All Project Decisions ==="
+DECISIONS=$(get_decisions)
+if [ -n "$DECISIONS" ]; then
+  echo "$DECISIONS"
+else
+  echo "No decisions recorded yet."
+fi
+```
+
+---
+
+## Function 6: get_blockers() — DRV-06
+
+**Purpose**: Aggregate blockers/concerns from SUMMARY.md "Next Phase Readiness" sections.
+
+**Logic**:
+1. Find all *-SUMMARY.md files
+2. Search for "Next Phase Readiness" or "Blockers" sections
+3. Extract listed concerns/blockers
+4. Return as newline-separated list
+
+**Implementation**:
+
+```bash
+get_blockers() {
+  local planning_dir="${1:-.planning}"
+  local phases_dir="${planning_dir}/phases"
+
+  if [ ! -d "$phases_dir" ]; then
+    echo ""
+    return 0
+  fi
+
+  for summary_file in $(find "$phases_dir" -name "*-SUMMARY.md" 2>/dev/null | sort); do
+    local in_readiness=0
+    local phase=$(basename "$(dirname "$summary_file")")
+
+    while IFS= read -r line; do
+      # Look for readiness section header
+      if echo "$line" | grep -qiE "^##.*Next Phase Readiness|^##.*Blockers|^##.*Concerns"; then
+        in_readiness=1
+        continue
+      fi
+
+      # If in readiness section
+      if [ "$in_readiness" -eq 1 ]; then
+        # Stop at next section header
+        if echo "$line" | grep -qE "^##"; then
+          in_readiness=0
+          continue
+        fi
+
+        # Extract bullet items that mention blockers, concerns, issues
+        if echo "$line" | grep -qiE "^\s*-.*blocker|^\s*-.*concern|^\s*-.*issue|^\s*-.*warning"; then
+          local blocker=$(echo "$line" | sed 's/^\s*-\s*//')
+          echo "[$phase] $blocker"
+        fi
+
+        # Also extract items that explicitly say "not ready" or "blocked"
+        if echo "$line" | grep -qiE "not ready|blocked by|waiting on|depends on"; then
+          local blocker=$(echo "$line" | sed 's/^\s*-\s*//')
+          echo "[$phase] $blocker"
+        fi
+      fi
+    done < "$summary_file"
+  done
+}
+```
+
+**Example Usage**:
+
+```bash
+echo "=== Active Blockers ==="
+BLOCKERS=$(get_blockers)
+if [ -n "$BLOCKERS" ]; then
+  echo "$BLOCKERS"
+else
+  echo "No blockers - clear to proceed!"
+fi
+```
+
+---
+
+## Function 7: get_agent_tracking_path() — PAR-05 (Scoped Agent Tracking)
+
+**Purpose**: Return per-plan agent tracking path instead of global path.
+
+**Logic**:
+- Instead of `.planning/current-agent-id.txt` (global)
+- Use `.planning/phases/{phase-dir}/{plan-id}-agent.txt` (per-plan)
+- This allows parallel plan execution without agent ID conflicts
+
+**Implementation**:
+
+```bash
+get_agent_tracking_path() {
+  local phase_dir="$1"
+  local plan_id="$2"
+
+  echo "${phase_dir}/${plan_id}-agent.txt"
+}
+```
+
+**Why This Matters**:
+Agent tracking is WRITE during execution (not read for state derivation). By scoping the path per-plan, two concurrent executions write to different files, eliminating conflicts. The state derivation functions (DRV-01 through DRV-06) derive project state from PLAN/SUMMARY existence - they don't read agent state.
+
+---
+
+## Parallel Safety Guarantees
+
+### All Functions Are Read-Only
+
+Every function above performs ONLY:
+- `ls` - List files (atomic)
+- `find` - Find files (atomic)
+- `grep` - Search content (atomic)
+- `wc` - Count lines (atomic)
+- `cat` - Read files (atomic)
+
+No function WRITES any files. This is critical.
+
+### File Existence Checks Are Atomic
+
+```bash
+# This is atomic - safe for concurrent access
+[ -f "$summary_file" ]
+```
+
+Two processes checking file existence simultaneously will both get correct results.
+
+### No Locking Needed
+
+Because all state derivation is read-only:
+- Two terminals can call `get_progress()` simultaneously
+- Both will see the same result
+- Neither will corrupt anything
+
+Race conditions require READ-MODIFY-WRITE cycles. Pure reads are always safe.
+
+### ROADMAP.md Update Safety
+
+ROADMAP.md checkbox updates (`- [ ]` to `- [x]`) are the only potential conflict point. However:
+1. Phase completion happens when SUMMARY.md is created (atomic)
+2. ROADMAP.md updates are cosmetic (human-readable)
+3. Worst case: cosmetic mismatch, not data corruption
+
+Recommendation: After state derivation adoption, ROADMAP.md becomes human reference only. State comes from SUMMARY existence.
+
+---
+
+## Complete Usage Example
+
+```bash
+#!/usr/bin/env bash
+# Example: Derive full project state from filesystem
+
+# Source the functions (or include them directly)
+# source ~/.claude/get-shit-done/references/state-derivation-impl.sh
+
+# Get current position
+CURRENT_PHASE=$(get_current_phase ".planning")
+CURRENT_PLAN=$(get_current_plan ".planning/phases/${CURRENT_PHASE}-"*)
+PROGRESS=$(get_progress ".planning")
+
+echo "╔══════════════════════════════════════════════════════════════╗"
+echo "║  PROJECT STATE (Derived from Filesystem)                     ║"
+echo "╠══════════════════════════════════════════════════════════════╣"
+printf "║  Current Phase: %-44s ║\n" "$CURRENT_PHASE"
+printf "║  Current Plan:  %-44s ║\n" "$CURRENT_PLAN"
+printf "║  Progress:      %-44s ║\n" "${PROGRESS}%"
+echo "╚══════════════════════════════════════════════════════════════╝"
+
+# Check for blockers
+BLOCKERS=$(get_blockers ".planning")
+if [ -n "$BLOCKERS" ]; then
+  echo ""
+  echo "⚠️  Active Blockers:"
+  echo "$BLOCKERS" | while read -r line; do
+    echo "   - $line"
+  done
+fi
+
+# Show recent decisions
+DECISIONS=$(get_decisions ".planning")
+if [ -n "$DECISIONS" ]; then
+  echo ""
+  echo "📋 Recent Decisions:"
+  echo "$DECISIONS" | tail -5 | while read -r line; do
+    echo "   - $line"
+  done
+fi
+```
+
+---
+
+## Integration with Existing GSD Commands
+
+These functions replace STATE.md reads in:
+
+| Command | Replaces | With |
+|---------|----------|------|
+| `/gsd:progress` | `cat STATE.md` | `get_progress()` |
+| `/gsd:execute-phase` | `cat STATE.md \| grep "Current Plan"` | `get_current_plan()` |
+| `/gsd:plan-phase` | `cat STATE.md \| grep "Current Phase"` | `get_current_phase()` |
+| `/gsd:resume-work` | `cat STATE.md` | All derivation functions |
+
+STATE.md becomes a **write-only human reference** - updated for human readability but never read by machines.
+
+---
+
+## Test Validation
+
+These patterns have been validated for parallel safety using the test harness at `@state-derivation-tests.sh`.
+
+**Tests passed:**
+- ✓ Correctness: All 6 functions return expected values for known inputs
+- ✓ Edge cases: Handles empty projects, complete projects, nonexistent paths
+- ✓ Parallel reads: 10 concurrent processes produce identical state values
+- ✓ No writes: File modification times unchanged after state derivation
+- ✓ Consistency under load: 50 parallel calls produce identical results
+
+**Parallel safety guarantee:**
+State derivation functions are read-only and use atomic filesystem operations (ls, find, grep, wc). Two terminal windows can execute different plans simultaneously without any risk of data corruption or race conditions.
+
+**To verify parallel safety yourself:**
+```bash
+./get-shit-done/references/state-derivation-tests.sh
+```
+
+---
+
+## See Also
+
+- **Test Harness**: @state-derivation-tests.sh - Validates parallel safety
+- **Git Integration**: @git-integration.md - Commit patterns that enable derivation
+
+---
+
+*Reference Document: State Derivation for Parallel Work Support*
+*Version: 1.0*
+*Created: 2026-01-24*

--- a/get-shit-done/utilities/task-timeout.md
+++ b/get-shit-done/utilities/task-timeout.md
@@ -1,0 +1,429 @@
+# Task Timeout Utility
+
+Reusable pattern for Task() calls with graceful degradation when agents run longer than expected.
+
+## Limitation Notice
+
+**Task() has no native timeout parameter.** This utility provides:
+- Expected duration documentation
+- Artifact-based success detection
+- User guidance when agents run long
+- Post-execution timing analysis
+
+**Does NOT provide:**
+- Hard timeout enforcement (not possible with current API)
+- Ability to interrupt hung agents
+
+See `.planning/phases/01-timeout-infrastructure/01-01-DISCOVERY.md` for investigation details.
+
+---
+
+## Timeout Wrapper Pattern
+
+Wrap each Task() call with timing, artifact checking, and user communication:
+
+```markdown
+# Define expectations before Task()
+AGENT_TYPE="gsd-executor"
+EXPECTED_DURATION_MS=600000  # 10 minutes
+EXPECTED_ARTIFACTS=(
+  ".planning/phases/XX-name/XX-YY-SUMMARY.md"
+  ".planning/STATE.md"
+)
+
+# Log start for user visibility
+echo "Starting ${AGENT_TYPE} agent..."
+echo "Expected duration: $((EXPECTED_DURATION_MS / 60000)) minutes"
+echo "Expected outputs: ${EXPECTED_ARTIFACTS[@]}"
+START_TIME=$(date +%s)
+
+# Execute Task (blocks until complete)
+Task(prompt="...", subagent_type="${AGENT_TYPE}", model="...")
+
+# Measure and report
+END_TIME=$(date +%s)
+ACTUAL_DURATION_MS=$(( (END_TIME - START_TIME) * 1000 ))
+
+# Check artifacts
+check_artifacts() {
+  local all_exist=true
+  for artifact in "${EXPECTED_ARTIFACTS[@]}"; do
+    if [[ ! -f "$artifact" ]]; then
+      echo "Missing artifact: $artifact"
+      all_exist=false
+    fi
+  done
+  echo "$all_exist"
+}
+
+ARTIFACTS_EXIST=$(check_artifacts)
+
+# Report status
+if [[ $ACTUAL_DURATION_MS -gt $EXPECTED_DURATION_MS ]]; then
+  if [[ "$ARTIFACTS_EXIST" == "true" ]]; then
+    echo "⚠️  Agent took longer than expected but completed successfully"
+    echo "   Expected: $((EXPECTED_DURATION_MS / 1000))s, Actual: $((ACTUAL_DURATION_MS / 1000))s"
+  else
+    echo "❌ Agent exceeded expected duration and did not produce artifacts"
+    echo "   Expected: $((EXPECTED_DURATION_MS / 1000))s, Actual: $((ACTUAL_DURATION_MS / 1000))s"
+    exit 1
+  fi
+else
+  if [[ "$ARTIFACTS_EXIST" == "true" ]]; then
+    echo "✅ Agent completed successfully in $((ACTUAL_DURATION_MS / 1000))s"
+  else
+    echo "❌ Agent completed but did not produce expected artifacts"
+    exit 1
+  fi
+fi
+```
+
+**Key points:**
+- Task() still blocks until agent completes (no way to interrupt)
+- Timing provides visibility and warnings, not enforcement
+- Artifact checking determines actual success/failure
+- Users can Ctrl+C if Task() blocks too long and manually check artifacts
+
+---
+
+## Artifact Check Function
+
+Pattern for verifying agent produced expected outputs:
+
+```bash
+check_artifacts() {
+  local expected_artifacts=("$@")
+  local now=$(date +%s)
+  local max_age_seconds=600  # 10 minutes
+
+  for artifact in "${expected_artifacts[@]}"; do
+    if [[ ! -f "$artifact" ]]; then
+      echo "artifacts_missing"
+      return 1
+    fi
+
+    # Check if file is recent (modified in last max_age_seconds)
+    local file_mtime=$(stat -c %Y "$artifact" 2>/dev/null || echo 0)
+    local age=$((now - file_mtime))
+
+    if [[ $age -gt $max_age_seconds ]]; then
+      echo "artifacts_stale"
+      return 2
+    fi
+  done
+
+  echo "artifacts_exist"
+  return 0
+}
+
+# Usage:
+EXPECTED_ARTIFACTS=(
+  ".planning/phases/01-timeout/01-01-SUMMARY.md"
+  ".planning/STATE.md"
+)
+
+STATUS=$(check_artifacts "${EXPECTED_ARTIFACTS[@]}")
+
+case "$STATUS" in
+  artifacts_exist)
+    echo "✅ All expected artifacts exist and are recent"
+    ;;
+  artifacts_missing)
+    echo "❌ Some expected artifacts are missing"
+    ;;
+  artifacts_stale)
+    echo "⚠️  Artifacts exist but are stale (may be from previous run)"
+    ;;
+esac
+```
+
+**Return codes:**
+- `artifacts_exist` (0): All files exist and modified within max_age_seconds
+- `artifacts_missing` (1): One or more files don't exist
+- `artifacts_stale` (2): Files exist but are older than max_age_seconds
+
+---
+
+## Timeout Defaults Table
+
+Recommended expected durations by agent type:
+
+| Agent Type | Expected Duration | Rationale |
+|------------|-------------------|-----------|
+| `gsd-executor` | 600000ms (10 min) | Complex plans with multiple tasks, commits, file operations |
+| `gsd-planner` | 300000ms (5 min) | Planning is faster than execution, mostly reading and writing markdown |
+| `gsd-verifier` | 180000ms (3 min) | Verification reads files and checks criteria, quick operation |
+| `gsd-researcher` | 420000ms (7 min) | Research involves exploration, reading multiple files, synthesis |
+| `gsd-debugger` | 600000ms (10 min) | Debugging requires investigation, testing hypotheses, longer duration |
+| `general-purpose` | 300000ms (5 min) | Default for unspecified agent types |
+
+**Configuration override:**
+These are defaults. Users can configure custom durations in `.planning/config.json` (see Config Integration below).
+
+**When to adjust defaults:**
+- Complex plans: Add 50-100% to executor duration
+- Large codebases: Add 50% to researcher duration
+- Deep debugging: Add 100% to debugger duration
+
+---
+
+## User Message Templates
+
+### Agent Running (at start)
+```
+Starting {agent-type} agent...
+Expected duration: {N} minutes
+Expected outputs:
+  - {artifact-1}
+  - {artifact-2}
+
+⏳ Task in progress...
+```
+
+### Success Within Expected Time
+```
+✅ {agent-type} completed successfully
+   Duration: {actual}s (expected: {expected}s)
+   Artifacts: All present
+```
+
+### Success But Slow
+```
+⚠️  {agent-type} took longer than expected but completed successfully
+   Expected: {expected}s, Actual: {actual}s
+   Artifacts: All present
+
+   Note: Consider increasing timeout config for this agent type if this happens frequently.
+```
+
+### Failure - No Artifacts
+```
+❌ {agent-type} did not produce expected artifacts
+   Duration: {actual}s
+   Missing:
+     - {artifact-1}
+     - {artifact-2}
+
+   This indicates the agent failed to complete its task.
+```
+
+### Failure - Exceeded Time And No Artifacts
+```
+❌ {agent-type} exceeded expected duration and did not produce artifacts
+   Expected: {expected}s, Actual: {actual}s
+   Missing:
+     - {artifact-1}
+     - {artifact-2}
+
+   The agent may have hung or encountered an error. Check logs for details.
+```
+
+### User Interrupted (Ctrl+C)
+```
+⚠️  Task interrupted by user
+   Checking for partial work...
+
+   Artifacts found:
+     ✅ {artifact-1}
+     ❌ {artifact-2} (missing)
+
+   The agent may have completed some work. Review artifacts and decide:
+   - If sufficient: Continue with next step
+   - If incomplete: Re-run the agent
+```
+
+---
+
+## Config Integration
+
+Read custom timeout values from `.planning/config.json`:
+
+```json
+{
+  "timeouts": {
+    "executor": 600000,
+    "planner": 300000,
+    "verifier": 180000,
+    "researcher": 420000,
+    "debugger": 600000,
+    "default": 300000
+  }
+}
+```
+
+**Shell implementation:**
+
+```bash
+# Read timeout from config, fall back to defaults
+read_timeout_config() {
+  local agent_type=$1
+  local default_ms=$2
+  local config_file=".planning/config.json"
+
+  if [[ -f "$config_file" ]]; then
+    local timeout=$(grep -o "\"${agent_type}\"[[:space:]]*:[[:space:]]*[0-9]*" "$config_file" | grep -o '[0-9]*')
+    if [[ -n "$timeout" ]]; then
+      echo "$timeout"
+      return
+    fi
+  fi
+
+  echo "$default_ms"
+}
+
+# Usage example:
+EXECUTOR_TIMEOUT=$(read_timeout_config "executor" 600000)
+PLANNER_TIMEOUT=$(read_timeout_config "planner" 300000)
+
+echo "Using executor timeout: ${EXECUTOR_TIMEOUT}ms"
+```
+
+**Default values** (if config doesn't exist or doesn't specify):
+- executor: 600000ms (10 min)
+- planner: 300000ms (5 min)
+- verifier: 180000ms (3 min)
+- researcher: 420000ms (7 min)
+- debugger: 600000ms (10 min)
+- default: 300000ms (5 min)
+
+**Config validation:**
+- Minimum timeout: 60000ms (1 minute) - prevent unrealistic expectations
+- Maximum timeout: 1800000ms (30 minutes) - prevent indefinite waiting
+- Invalid values: Fall back to defaults with warning
+
+---
+
+## Complete Example
+
+Putting it all together for an executor agent:
+
+```bash
+#!/bin/bash
+
+# 1. Read timeout configuration
+read_timeout_config() {
+  local agent_type=$1
+  local default_ms=$2
+  local config_file=".planning/config.json"
+
+  if [[ -f "$config_file" ]]; then
+    local timeout=$(grep -o "\"${agent_type}\"[[:space:]]*:[[:space:]]*[0-9]*" "$config_file" | grep -o '[0-9]*')
+    if [[ -n "$timeout" ]]; then
+      echo "$timeout"
+      return
+    fi
+  fi
+
+  echo "$default_ms"
+}
+
+# 2. Define expectations
+AGENT_TYPE="gsd-executor"
+EXPECTED_DURATION_MS=$(read_timeout_config "executor" 600000)
+EXPECTED_ARTIFACTS=(
+  ".planning/phases/01-timeout/01-01-SUMMARY.md"
+  ".planning/STATE.md"
+)
+
+# 3. Inform user
+echo "Starting ${AGENT_TYPE} agent..."
+echo "Expected duration: $((EXPECTED_DURATION_MS / 60000)) minutes"
+echo "Expected outputs:"
+for artifact in "${EXPECTED_ARTIFACTS[@]}"; do
+  echo "  - $artifact"
+done
+echo ""
+echo "⏳ Task in progress..."
+
+# 4. Execute Task
+START_TIME=$(date +%s)
+
+Task(prompt="Execute plan at .planning/phases/01-timeout/01-01-PLAN.md
+
+Plan:
+{plan-content}
+
+Project state:
+{state-content}", subagent_type="gsd-executor", model="sonnet")
+
+# 5. Measure duration
+END_TIME=$(date +%s)
+ACTUAL_DURATION_MS=$(( (END_TIME - START_TIME) * 1000 ))
+
+# 6. Check artifacts
+check_artifacts() {
+  local all_exist=true
+  for artifact in "${EXPECTED_ARTIFACTS[@]}"; do
+    if [[ ! -f "$artifact" ]]; then
+      echo "Missing: $artifact" >&2
+      all_exist=false
+    fi
+  done
+  echo "$all_exist"
+}
+
+ARTIFACTS_EXIST=$(check_artifacts)
+
+# 7. Report status
+echo ""
+if [[ $ACTUAL_DURATION_MS -gt $EXPECTED_DURATION_MS ]]; then
+  if [[ "$ARTIFACTS_EXIST" == "true" ]]; then
+    echo "⚠️  Agent took longer than expected but completed successfully"
+    echo "   Expected: $((EXPECTED_DURATION_MS / 1000))s, Actual: $((ACTUAL_DURATION_MS / 1000))s"
+    echo "   Artifacts: All present"
+    echo ""
+    echo "   Consider increasing 'executor' timeout in .planning/config.json"
+  else
+    echo "❌ Agent exceeded expected duration and did not produce artifacts"
+    echo "   Expected: $((EXPECTED_DURATION_MS / 1000))s, Actual: $((ACTUAL_DURATION_MS / 1000))s"
+    check_artifacts  # Will print missing artifacts
+    exit 1
+  fi
+else
+  if [[ "$ARTIFACTS_EXIST" == "true" ]]; then
+    echo "✅ Agent completed successfully"
+    echo "   Duration: $((ACTUAL_DURATION_MS / 1000))s (expected: $((EXPECTED_DURATION_MS / 1000))s)"
+    echo "   Artifacts: All present"
+  else
+    echo "❌ Agent completed but did not produce expected artifacts"
+    echo "   Duration: $((ACTUAL_DURATION_MS / 1000))s"
+    check_artifacts  # Will print missing artifacts
+    exit 1
+  fi
+fi
+```
+
+---
+
+## Requirements Satisfied
+
+This pattern satisfies the following requirements:
+
+- **TMO-01**: Expected duration defaults documented for all agent types
+- **TMO-02**: Graceful handling - success determined by artifacts, not just duration
+- **TMO-03**: If artifacts exist, report success even if duration exceeded
+- **TMO-04**: Configuration option in `.planning/config.json` to adjust expected durations
+- **TMO-05**: Clear user messages at start, during, and after execution
+- **ART-01**: On duration exceeded, check if expected output files exist
+- **ART-02**: If artifacts exist, report success with warning
+
+**Not satisfied** (due to API limitations):
+- Hard timeout enforcement - Task() has no timeout parameter
+- Ability to interrupt hung agents - would require API changes
+
+---
+
+## Integration Checklist
+
+When adding this pattern to a command or workflow:
+
+- [ ] Add reference: `@~/.claude/get-shit-done/utilities/task-timeout.md`
+- [ ] Define EXPECTED_ARTIFACTS array for each Task() call
+- [ ] Read timeout config at command start
+- [ ] Add user message before Task() execution
+- [ ] Start timing before Task()
+- [ ] Call Task() as usual (no API changes)
+- [ ] Measure duration after Task()
+- [ ] Check artifacts with check_artifacts()
+- [ ] Report status with appropriate template
+- [ ] Exit with proper code (0 = success, 1 = failure)


### PR DESCRIPTION
● What

  Enable simultaneous GSD execution from multiple terminal windows by
  deriving state from filesystem (SUMMARY.md existence) instead of reading
  centralized STATE.md.

  Why

  Two terminals reading STATE.md simultaneously could make conflicting
  decisions about "current position" and corrupt project state.

  Testing

  - [ ] Tested on macOS
  - [ ] Tested on Windows
  - [x] Tested on Linux

  # Run parallel safety tests (15 tests)
  `./get-shit-done/references/state-derivation-tests.sh`
  # Expected: 15 passed, 0 failed

  Checklist

  - Follows GSD style (no enterprise patterns, no filler)
  - Updates CHANGELOG.md for user-facing changes
  - No unnecessary dependencies added

  Breaking Changes

  None — STATE.md remains functional as human-readable reference; existing
  workflows continue to work.