### PR TITLE
feat(git): add branch-per-phase option

### DIFF
--- a/commands/gsd/settings.md
+++ b/commands/gsd/settings.md
@@ -34,6 +34,8 @@ Parse current values (default to `true` if not present):
 - `workflow.plan_check` — spawn plan checker during plan-phase
 - `workflow.verifier` — spawn verifier during execute-phase
 - `model_profile` — which model each agent uses (default: `balanced`)
+- `git.branch_per_phase` — create branch per phase (default: `false`)
+- `git.branch_template` — branch naming template (default: `"gsd/phase-{phase}-{slug}"`)
 
 ## 3. Present Settings
 
@@ -77,6 +79,15 @@ AskUserQuestion([
       { label: "Yes", description: "Verify must-haves after execution" },
       { label: "No", description: "Skip post-execution verification" }
     ]
+  },
+  {
+    question: "Create git branch for each phase?",
+    header: "Branching",
+    multiSelect: false,
+    options: [
+      { label: "No (Recommended)", description: "Commit directly to current branch" },
+      { label: "Yes", description: "Create gsd/phase-{phase}-{slug} branch per phase" }
+    ]
   }
 ])
 ```
@@ -95,6 +106,9 @@ Merge new settings into existing config.json:
     "research": true/false,
     "plan_check": true/false,
     "verifier": true/false
+  },
+  "git": {
+    "branch_per_phase": true/false
   }
 }
 ```
@@ -116,6 +130,7 @@ Display:
 | Plan Researcher      | {On/Off} |
 | Plan Checker         | {On/Off} |
 | Execution Verifier   | {On/Off} |
+| Branch Per Phase     | {On/Off} |
 
 These settings apply to future /gsd:plan-phase and /gsd:execute-phase runs.
 
@@ -130,7 +145,7 @@ Quick commands:
 
 <success_criteria>
 - [ ] Current config read
-- [ ] User presented with 4 settings (profile + 3 toggles)
-- [ ] Config updated with model_profile and workflow section
+- [ ] User presented with 5 settings (profile + 3 workflow toggles + git branching)
+- [ ] Config updated with model_profile, workflow, and git sections
 - [ ] Changes confirmed to user
 </success_criteria>


### PR DESCRIPTION
## Summary

Implements optional git branching workflow for GSD phases (closes #173):

- **New config options**: `git.branch_per_phase` (default: false) and `git.branch_template` (default: `gsd/phase-{phase}-{slug}`)
- **execute-phase**: Creates/switches to phase branch when enabled before execution begins
- **settings**: Adds git branching toggle to `/gsd:settings` command
- **complete-milestone**: Offers merge options (merge all, delete, keep) when phase branches exist

## Files Changed

- `get-shit-done/references/planning-config.md` - Added git config schema and documentation
- `get-shit-done/workflows/execute-phase.md` - Added branch creation step after load_project_state
- `commands/gsd/settings.md` - Added git branching question to settings
- `get-shit-done/workflows/complete-milestone.md` - Added branch merge handling step

## Test Instructions

1. Create a new GSD project
2. Run `/gsd:settings` and enable "Branch Per Phase"
3. Run `/gsd:execute-phase` and verify branch creation
4. Run `/gsd:complete-milestone` and verify branch merge options appear