### PR TITLE
fix(agents): replace context7 wildcard with explicit tool names

### DIFF
--- a/agents/gsd-debugger.md
+++ b/agents/gsd-debugger.md
@@ -1,7 +1,18 @@
 ---
 name: gsd-debugger
 description: Investigates bugs using scientific method, manages debug sessions, handles checkpoints. Spawned by /gsd:debug orchestrator.
-tools: Read, Write, Edit, Bash, Grep, Glob, WebSearch
+tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Grep
+  - Glob
+  - WebSearch
+  - mcp__context7__resolve-library-id
+  - mcp__context7__query-docs
+  - mcp__plugin_context7_context7__resolve-library-id
+  - mcp__plugin_context7_context7__query-docs
 color: orange
 ---
 

--- a/agents/gsd-phase-researcher.md
+++ b/agents/gsd-phase-researcher.md
@@ -1,7 +1,18 @@
 ---
 name: gsd-phase-researcher
 description: Researches how to implement a phase before planning. Produces RESEARCH.md consumed by gsd-planner. Spawned by /gsd:plan-phase orchestrator.
-tools: Read, Write, Bash, Grep, Glob, WebSearch, WebFetch, mcp__context7__*
+tools:
+  - Read
+  - Write
+  - Bash
+  - Grep
+  - Glob
+  - WebSearch
+  - WebFetch
+  - mcp__context7__resolve-library-id
+  - mcp__context7__query-docs
+  - mcp__plugin_context7_context7__resolve-library-id
+  - mcp__plugin_context7_context7__query-docs
 color: cyan
 ---
 
@@ -111,11 +122,13 @@ Context7 provides authoritative, current documentation for libraries and framewo
 ```
 1. Resolve library ID:
    mcp__context7__resolve-library-id with libraryName: "[library name]"
+   (or mcp__plugin_context7_context7__resolve-library-id if using the plugin)
 
 2. Query documentation:
    mcp__context7__query-docs with:
    - libraryId: [resolved ID]
    - query: "[specific question]"
+   (or mcp__plugin_context7_context7__query-docs if using the plugin)
 ```
 
 **Best practices:**

--- a/agents/gsd-planner.md
+++ b/agents/gsd-planner.md
@@ -1,7 +1,17 @@
 ---
 name: gsd-planner
 description: Creates executable phase plans with task breakdown, dependency analysis, and goal-backward verification. Spawned by /gsd:plan-phase orchestrator.
-tools: Read, Write, Bash, Glob, Grep, WebFetch, mcp__context7__*
+tools:
+  - Read
+  - Write
+  - Bash
+  - Glob
+  - Grep
+  - WebFetch
+  - mcp__context7__resolve-library-id
+  - mcp__context7__query-docs
+  - mcp__plugin_context7_context7__resolve-library-id
+  - mcp__plugin_context7_context7__query-docs
 color: green
 ---
 

--- a/agents/gsd-project-researcher.md
+++ b/agents/gsd-project-researcher.md
@@ -1,7 +1,18 @@
 ---
 name: gsd-project-researcher
 description: Researches domain ecosystem before roadmap creation. Produces files in .planning/research/ consumed during roadmap creation. Spawned by /gsd:new-project or /gsd:new-milestone orchestrators.
-tools: Read, Write, Bash, Grep, Glob, WebSearch, WebFetch, mcp__context7__*
+tools:
+  - Read
+  - Write
+  - Bash
+  - Grep
+  - Glob
+  - WebSearch
+  - WebFetch
+  - mcp__context7__resolve-library-id
+  - mcp__context7__query-docs
+  - mcp__plugin_context7_context7__resolve-library-id
+  - mcp__plugin_context7_context7__query-docs
 color: cyan
 ---
 
@@ -153,11 +164,13 @@ Context7 provides authoritative, current documentation for libraries and framewo
 ```
 1. Resolve library ID:
    mcp__context7__resolve-library-id with libraryName: "[library name]"
+   (or mcp__plugin_context7_context7__resolve-library-id if using the plugin)
 
 2. Query documentation:
    mcp__context7__query-docs with:
    - libraryId: [resolved ID]
    - query: "[specific question]"
+   (or mcp__plugin_context7_context7__query-docs if using the plugin)
 ```
 
 **Best practices:**

--- a/commands/gsd/plan-phase.md
+++ b/commands/gsd/plan-phase.md
@@ -11,7 +11,10 @@ allowed-tools:
   - Grep
   - Task
   - WebFetch
-  - mcp__context7__*
+  - mcp__context7__resolve-library-id
+  - mcp__context7__query-docs
+  - mcp__plugin_context7_context7__resolve-library-id
+  - mcp__plugin_context7_context7__query-docs
 ---
 
 <execution_context>

--- a/get-shit-done/workflows/discovery-phase.md
+++ b/get-shit-done/workflows/discovery-phase.md
@@ -53,14 +53,16 @@ For: Single known library, confirming syntax/version still correct.
 
    ```
    mcp__context7__resolve-library-id with libraryName: "[library]"
+   (or mcp__plugin_context7_context7__resolve-library-id if using the plugin)
    ```
 
 2. Fetch relevant docs:
 
    ```
-   mcp__context7__get-library-docs with:
-   - context7CompatibleLibraryID: [from step 1]
-   - topic: [specific concern]
+   mcp__context7__query-docs with:
+   - libraryId: [from step 1]
+   - query: [specific concern]
+   (or mcp__plugin_context7_context7__query-docs if using the plugin)
    ```
 
 3. Verify:
@@ -94,7 +96,8 @@ For: Choosing between options, new external integration.
    ```
    For each library/framework:
    - mcp__context7__resolve-library-id
-   - mcp__context7__get-library-docs (mode: "code" for API, "info" for concepts)
+   - mcp__context7__query-docs
+   (or plugin variants: mcp__plugin_context7_context7__resolve-library-id / query-docs)
    ```
 
 3. **Official docs** for anything Context7 lacks.


### PR DESCRIPTION
## What

Replace non-functional `mcp__context7__*` wildcard patterns in agent/command tool declarations with explicit tool names, supporting both direct MCP server and Claude Code plugin installations.

## Why

Claude Code's tool declaration system does not support wildcard (`*`) patterns in tool names. The `mcp__context7__*` entries in agent `tools:` and command `allowed-tools:` fields were silently ignored — meaning Context7 was **never actually available** to any subagent or slash command, despite being referenced in their instructions.

Additionally, `discovery-phase.md` referenced a non-existent tool name (`mcp__context7__get-library-docs`) with incorrect parameter names.

## Changes

**6 files updated:**

| File | Change |
|------|--------|
| `agents/gsd-project-researcher.md` | Wildcard → explicit tools + plugin variants in usage docs |
| `agents/gsd-phase-researcher.md` | Same |
| `agents/gsd-planner.md` | Wildcard → explicit tools |
| `agents/gsd-debugger.md` | Added context7 tools (was missing entirely despite referencing Context7 in its instructions) |
| `commands/gsd/plan-phase.md` | Wildcard → explicit entries in allowed-tools |
| `get-shit-done/workflows/discovery-phase.md` | Fixed wrong tool name (`get-library-docs` → `query-docs`), fixed parameter names, added plugin variants |

**Tool names added (both install methods supported):**
- `mcp__context7__resolve-library-id` / `mcp__context7__query-docs` (direct MCP server)
- `mcp__plugin_context7_context7__resolve-library-id` / `mcp__plugin_context7_context7__query-docs` (Claude Code plugin)

Also converted comma-separated `tools:` lines to YAML arrays for readability.

## Testing

- Verified YAML frontmatter parses correctly in all modified files
- Context7 tools are now explicitly declared and will be available to subagents at runtime
- Both installation methods (direct MCP server config and Claude Code plugin) are supported

## Breaking Changes

None