### PR TITLE
fix: add character preservation rules and clarify ASCII terminology

### DIFF
--- a/GSD-STYLE.md
+++ b/GSD-STYLE.md
@@ -216,6 +216,17 @@ Present: Factual statements, verification results, direct answers
 
 **Bad one-liner:** "Phase complete" or "Authentication implemented"
 
+### Character Preservation
+
+**ALWAYS preserve diacritics and special characters in text content.**
+
+- ą, ę, ć, ź, ż, ó, ł, ń, ś (Polish)
+- ü, ö, ä, ß (German)
+- é, è, ê, ç (French)
+- and all other language-specific characters
+
+**User's typing style ≠ output style.**
+
 ---
 
 ## Context Engineering

--- a/commands/gsd/add-todo.md
+++ b/commands/gsd/add-todo.md
@@ -93,7 +93,7 @@ timestamp=$(date "+%Y-%m-%dT%H:%M")
 date_prefix=$(date "+%Y-%m-%d")
 ```
 
-Generate slug from title (lowercase, hyphens, no special chars).
+Generate slug from title (lowercase, hyphens, no special chars in FILENAME only).
 
 Write to `.planning/todos/pending/${date_prefix}-${slug}.md`:
 

--- a/get-shit-done/templates/codebase/structure.md
+++ b/get-shit-done/templates/codebase/structure.md
@@ -15,7 +15,7 @@ Template for `.planning/codebase/STRUCTURE.md` - captures physical file organiza
 
 ## Directory Layout
 
-[ASCII tree of top-level directories with purpose]
+[ASCII box-drawing tree of top-level directories with purpose - use ├── └── │ characters for tree structure only]
 
 ```
 [project-root]/
@@ -247,7 +247,7 @@ get-shit-done/
 
 <guidelines>
 **What belongs in STRUCTURE.md:**
-- Directory layout (ASCII tree)
+- Directory layout (ASCII box-drawing tree for structure visualization)
 - Purpose of each directory
 - Key file locations (entry points, configs, core logic)
 - Naming conventions
@@ -267,7 +267,7 @@ get-shit-done/
 - Locate entry points, configs, and main logic areas
 - Keep directory tree concise (max 2-3 levels)
 
-**ASCII tree format:**
+**Tree format (ASCII box-drawing characters for structure only):**
 ```
 root/
 ├── dir1/           # Purpose

--- a/get-shit-done/templates/research-project/ARCHITECTURE.md
+++ b/get-shit-done/templates/research-project/ARCHITECTURE.md
@@ -177,7 +177,7 @@ src/
 <guidelines>
 
 **System Overview:**
-- Use ASCII diagrams for clarity
+- Use ASCII box-drawing diagrams for clarity (├── └── │ ─ for structure visualization only)
 - Show major components and their relationships
 - Don't over-detail — this is conceptual, not implementation
 


### PR DESCRIPTION
## Summary
- Add Character Preservation section to GSD-STYLE.md
- Clarify 'no special chars' applies to FILENAME only in add-todo
- Use 'box-drawing' terminology for tree structure visualization

## What
Clarifies that "ASCII" in GSD templates refers only to box-drawing characters (├── └── │) for tree visualization, not to stripping diacritics from text content.

## Why
Claude was incorrectly stripping Polish/German/French diacritics (ą, ę, ü, é, etc.) from generated content when seeing "ASCII" in template instructions.

## Testing
- [x] Tested on Linux

## Checklist
- [x] Follows GSD style (no enterprise patterns, no filler)
- [ ] Updates CHANGELOG.md for user-facing changes
- [x] No unnecessary dependencies added
- [x] Works on Windows (backslash paths tested)

## Breaking Changes
None
