### PR TITLE
fix: scale context bar in statusline to show 100% at actual 80% limit

### DIFF
--- a/hooks/gsd-statusline.js
+++ b/hooks/gsd-statusline.js
@@ -18,22 +18,25 @@ process.stdin.on('end', () => {
     const session = data.session_id || '';
     const remaining = data.context_window?.remaining_percentage;
 
-    // Context window display (shows USED percentage)
+    // Context window display (shows USED percentage scaled to 80% limit)
+    // Claude Code enforces an 80% context limit, so we scale to show 100% at that point
     let ctx = '';
     if (remaining != null) {
       const rem = Math.round(remaining);
-      const used = Math.max(0, Math.min(100, 100 - rem));
+      const rawUsed = Math.max(0, Math.min(100, 100 - rem));
+      // Scale: 80% real usage = 100% displayed
+      const used = Math.min(100, Math.round((rawUsed / 80) * 100));
 
       // Build progress bar (10 segments)
       const filled = Math.floor(used / 10);
       const bar = '█'.repeat(filled) + '░'.repeat(10 - filled);
 
-      // Color based on usage
-      if (used < 50) {
+      // Color based on scaled usage (thresholds adjusted for new scale)
+      if (used < 63) {        // ~50% real
         ctx = ` \x1b[32m${bar} ${used}%\x1b[0m`;
-      } else if (used < 65) {
+      } else if (used < 81) { // ~65% real
         ctx = ` \x1b[33m${bar} ${used}%\x1b[0m`;
-      } else if (used < 80) {
+      } else if (used < 95) { // ~76% real
         ctx = ` \x1b[38;5;208m${bar} ${used}%\x1b[0m`;
       } else {
         ctx = ` \x1b[5;31m💀 ${bar} ${used}%\x1b[0m`;


### PR DESCRIPTION
## The problem: 

At 80% of statusline I already got an error from calude code that it run out of context. 

Claude Code intentionally reserves 20% of the context window as a buffer for:                                                                     
  - Claude's response generation                                           
  - System prompts and formatting                                          
  - Tool use overhead                                                      
  - Preventing mid-response cutoffs                                        
                                                                           
  To make the bar reach 100% at the actual limit, you would modify your statusline to scale the percentage:                                      
  - Calculate: (used_percentage / 80) * 100                                
  - This way, when you hit the real 80% limit, your bar shows 100% 

## Summary

- Scales the context bar percentage so it shows 100% when reaching Claude Code's actual 80% context limit
- Adjusts color thresholds to maintain the same visual progression

## Problem

Claude Code enforces an 80% context window limit as a safety mechanism. The statusline was showing the raw percentage, which meant the bar never reached 100% before Claude ran out of context - this was confusing as users would see ~80% and then suddenly hit the limit.

## Solution

Scale the percentage calculation: `(rawUsed / 80) * 100`

This means:
- 0% real usage = 0% displayed
- 40% real usage = 50% displayed  
- 80% real usage (the actual limit) = 100% displayed

Color thresholds are adjusted accordingly:
- Green: 0-62% (was 0-50% raw)
- Yellow: 63-80% (was 50-65% raw)
- Orange: 81-94% (was 65-80% raw)
- Red with skull: 95%+ (was 80%+ raw)

## Test plan

- [ ] Run with fresh context and verify bar starts at 0%
- [ ] Use context and verify bar fills proportionally
- [ ] Verify bar reaches 100% when Claude reports context exhaustion

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)