### PR TITLE
feat: add Gemini support to installer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "get-shit-done-cc",
   "version": "1.9.13",
-  "description": "A meta-prompting, context engineering and spec-driven development system for Claude Code by TÂCHES.",
+  "description": "A meta-prompting, context engineering and spec-driven development system for Claude Code, OpenCode and Gemini by TÂCHES.",
   "bin": {
     "get-shit-done-cc": "bin/install.js"
   },
@@ -19,7 +19,9 @@
     "ai",
     "meta-prompting",
     "context-engineering",
-    "spec-driven-development"
+    "spec-driven-development",
+    "gemini",
+    "gemini-cli"
   ],
   "author": "TÂCHES",
   "license": "MIT",


### PR DESCRIPTION
## Add Gemini Support to GSD Installer

###  Description

  This PR expands the "Get Shit Done" (GSD) installer (bin/install.js) to support Gemini as a first-class runtime target, alongside the existing support for Claude Code and OpenCode. This update allows users to install GSD's meta-prompting and context-engineering tools
  directly into their Gemini environment.

###  Key Changes

  1. Gemini Runtime Integration
   * New Flag: Added --gemini command-line flag to target Gemini installations specifically.
   * Interactive Menu: Updated the interactive installer menu to include "Gemini" and an "All" option.
   * Environment Handling:
       * Respects GEMINI_CONFIG_DIR environment variable.
       * Defaults to ~/.gemini if no configuration directory is specified.
       * Supports the global --config-dir override for custom locations.

  2. Intelligent Format Conversion (`.md` → `.toml`)
  Gemini requires prompts to be in TOML format, whereas GSD maintains source prompts in Markdown. I've implemented an on-the-fly converter that:
   * Parses Markdown: Reads existing GSD command files (.md).
   * Extracts Metadata: Pulls descriptions from YAML frontmatter.
   * Constructs TOML: Wraps the markdown body into a valid TOML prompt string and includes the description.
   * File Extension: Automatically saves installed files with the .toml extension required by Gemini.

  3. Directory Structure Management
   * Nested Commands: Maintained the nested folder structure (e.g., commands/gsd/) for Gemini, consistent with its expected command organization (similar to Claude Code but distinct from OpenCode's flat structure).
   * Cleanup: Implemented logic to remove old or orphaned GSD files (.gemini/commands/gsd/) before installing new ones to ensure a clean state.

  4. Full Uninstall Support
   * Added logic to cleanly uninstall GSD from Gemini environments.
   * Removes:
       * commands/gsd/
       * get-shit-done/ (templates & docs)
       * agents/
       * GSD-specific hooks (gsd-statusline.js, gsd-check-update.js).
   * Updates settings.json to remove GSD hook registrations and statusline configurations without affecting other user settings.

  5. Shared Hook System
   * Leverages the existing hook system (shared with Claude Code) to provide statusline integration and update checks for Gemini users.
   
###  How to Test

   1. Local Installation (Dry Run):
   1     node bin/install.js --gemini --local
       * Verify: A .gemini folder is created in your current directory. Inside commands/gsd/, check that files end in .toml and contain valid TOML content.

   2. Global Installation:
   1     node bin/install.js --gemini --global
       * Verify: Check ~/.gemini/commands/gsd for installed commands.
       * Verify: Run Gemini and type /gsd:help to confirm the integration works.

   3. Uninstall:

   1     node bin/install.js --gemini --global --uninstall
       * Verify: The commands/gsd folder and other GSD artifacts are removed from ~/.gemini.

###  Solved Related Issues
   * Addresses the need for multi-LLM support in the GSD ecosystem.

  ---