### PR TITLE
fix(parallel): prevent race conditions in parallel subagent execution

### DIFF
--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -218,6 +218,39 @@ waves = {
 
 **No dependency analysis needed.** Wave numbers are pre-computed during `/gsd:plan-phase`.
 
+**File conflict detection (safety check):**
+
+Before finalizing wave groups, check for `files_modified` overlap between plans in the same wave:
+
+```bash
+# For each wave with multiple plans, check files_modified frontmatter
+for wave_plans in same_wave_groups; do
+  if [ ${#wave_plans[@]} -gt 1 ]; then
+    # Extract files_modified from each plan's frontmatter
+    for plan in ${wave_plans[@]}; do
+      files=$(grep -A 20 "^files_modified:" "$plan" | grep "^  - " | sed 's/^  - //')
+      echo "$plan: $files"
+    done
+    # Check for overlapping files between any two plans
+  fi
+done
+```
+
+**If overlap detected:**
+
+```
+WARNING: File conflict detected in Wave {N}
+
+Plans {A} and {B} both modify: {overlapping_files}
+
+Parallel execution of these plans will cause race conditions.
+Bumping Plan {B} to Wave {N+1} to prevent conflicts.
+```
+
+Automatically move the later plan to the next wave. Parallel agents sharing files causes overwrite loops — one agent's commit silently replaces the other's changes, triggering cascading test failures.
+
+**If no `files_modified` in frontmatter:** Log warning but proceed — planner should include this field.
+
 Report wave structure with context:
 ```
 ## Execution Plan
@@ -276,14 +309,23 @@ Execute each wave in sequence. Autonomous plans within a wave run in parallel.
    CONFIG_CONTENT=$(cat .planning/config.json 2>/dev/null)
    ```
 
-   Use Task tool with multiple parallel calls. Each agent gets prompt with inlined content:
+   Use Task tool with multiple parallel calls. Each agent gets prompt with inlined content.
+
+   **Parallel safety:** When spawning multiple agents in the same wave, instruct each agent to skip STATE.md updates. The orchestrator consolidates STATE.md after the wave completes (see step 4).
 
    ```
    <objective>
    Execute plan {plan_number} of phase {phase_number}-{phase_name}.
 
-   Commit each task atomically. Create SUMMARY.md. Update STATE.md.
+   Commit each task atomically. Create SUMMARY.md.
+   Do NOT update STATE.md — orchestrator consolidates state after this wave completes.
    </objective>
+
+   <parallel_context>
+   You are running in PARALLEL with other agents in Wave {N}.
+   - Do NOT read or write STATE.md (orchestrator owns state updates)
+   - Only modify files listed in your plan's files_modified frontmatter
+   </parallel_context>
 
    <execution_context>
    @~/.claude/get-shit-done/workflows/execute-plan.md
@@ -296,7 +338,7 @@ Execute each wave in sequence. Autonomous plans within a wave run in parallel.
    Plan:
    {plan_content}
 
-   Project state:
+   Project state (read-only snapshot — do not update):
    {state_content}
 
    Config (if exists):
@@ -307,9 +349,11 @@ Execute each wave in sequence. Autonomous plans within a wave run in parallel.
    - [ ] All tasks executed
    - [ ] Each task committed individually
    - [ ] SUMMARY.md created in plan directory
-   - [ ] STATE.md updated with position and decisions
+   - [ ] STATE.md left untouched (orchestrator consolidates)
    </success_criteria>
    ```
+
+   **For single-agent waves (only 1 plan in wave):** The parallel safety restriction does NOT apply. Single agents can update STATE.md normally. Only add `<parallel_context>` when spawning 2+ agents simultaneously.
 
 2. **Wait for all agents in wave to complete:**
 
@@ -344,7 +388,29 @@ Execute each wave in sequence. Autonomous plans within a wave run in parallel.
    - Bad: "Wave 2 complete. Proceeding to Wave 3."
    - Good: "Terrain system complete — 3 biome types, height-based texturing, physics collision meshes. Vehicle physics (Wave 3) can now reference ground surfaces."
 
-4. **Handle failures:**
+4. **Consolidate STATE.md after wave (orchestrator-owned):**
+
+   After all agents in a multi-agent wave complete, the orchestrator performs a single STATE.md update. Only the orchestrator writes STATE.md — parallel agents never touch it.
+
+   ```
+   For each completed plan in this wave:
+     1. Read its SUMMARY.md "State Fragment" section
+     2. Collect: plan completion status, decisions, blockers
+
+   Perform ONE STATE.md update:
+     - Update Current Position (advance plan count by plans completed in wave)
+     - Add decisions from all plans in this wave
+     - Update progress bar
+     - Update Session Continuity timestamp
+   ```
+
+   Commit the consolidated state:
+   ```bash
+   git add .planning/STATE.md
+   git commit -m "docs(phase-{X}): consolidate state after wave {N}"
+   ```
+
+5. **Handle failures:**
 
    If any agent in wave fails:
    - Report which plan failed and why
@@ -352,11 +418,11 @@ Execute each wave in sequence. Autonomous plans within a wave run in parallel.
    - If continue: proceed to next wave (dependent plans may also fail)
    - If stop: exit with partial completion report
 
-5. **Execute checkpoint plans between waves:**
+6. **Execute checkpoint plans between waves:**
 
    See `<checkpoint_handling>` for details.
 
-6. **Proceed to next wave**
+7. **Proceed to next wave**
 
 </step>
 

--- a/get-shit-done/workflows/execute-plan.md
+++ b/get-shit-done/workflows/execute-plan.md
@@ -1379,6 +1379,8 @@ The one-liner must be SUBSTANTIVE:
   </step>
 
 <step name="update_current_position">
+**If `<parallel_context>` in prompt:** Skip this step. Include a "State Fragment" section in SUMMARY.md instead (see gsd-executor state_updates). Orchestrator consolidates state after wave.
+
 Update Current Position section in STATE.md to reflect plan completion.
 
 **Format:**
@@ -1437,6 +1439,8 @@ Progress: ███████░░░ 50%
       </step>
 
 <step name="extract_decisions_and_issues">
+**If `<parallel_context>` in prompt:** Skip this step. Decisions and issues go in SUMMARY.md's "State Fragment" section.
+
 Extract decisions, issues, and concerns from SUMMARY.md into STATE.md accumulated context.
 
 **Decisions Made:**
@@ -1454,6 +1458,8 @@ Extract decisions, issues, and concerns from SUMMARY.md into STATE.md accumulate
     </step>
 
 <step name="update_session_continuity">
+**If `<parallel_context>` in prompt:** Skip this step. Orchestrator updates session continuity after wave.
+
 Update Session Continuity section in STATE.md to enable resumption in future sessions.
 
 **Format:**
@@ -1528,10 +1534,16 @@ If `COMMIT_PLANNING_DOCS=true` (default):
 
 ```bash
 git add .planning/phases/XX-name/{phase}-{plan}-SUMMARY.md
+```
+
+**If NOT in parallel context** (no `<parallel_context>` in prompt):
+```bash
 git add .planning/STATE.md
 ```
 
-**2. Stage roadmap:**
+**If in parallel context:** Do NOT stage STATE.md or ROADMAP.md — orchestrator handles these after wave completion.
+
+**2. Stage roadmap (skip if in parallel context):**
 
 ```bash
 git add .planning/ROADMAP.md


### PR DESCRIPTION
## Summary

Fixes race conditions when multiple subagents execute in the same wave:

- **STATE.md lost updates** — parallel agents independently read/modify/write STATE.md, last writer silently drops the others' changes
- **Source file overwrite loops** — parallel agents modifying the same file enter cascading "fix, test, fail, fix" cycles

## Changes

- **Orchestrator-owned STATE.md writes** — parallel subagents skip STATE.md updates and output a "State Fragment" in SUMMARY.md. Orchestrator performs one atomic STATE.md update after each wave completes.
- **File conflict detection at wave grouping** — checks `files_modified` overlap between plans in the same wave. Overlapping plans are bumped to the next wave automatically.
- **`<parallel_context>` directive** — new prompt block tells executors they're running in parallel, scoping file modifications to their plan's declared files.

Single-agent waves are unaffected — the parallel safety logic only activates when spawning 2+ agents simultaneously.

## Files Changed

- `get-shit-done/workflows/execute-phase.md` — file conflict detection, parallel subagent prompt, state consolidation step
- `agents/gsd-executor.md` — parallel context awareness, State Fragment output
- `get-shit-done/workflows/execute-plan.md` — parallel context guards on state update steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)