### PR TITLE
fix(parallel): prevent race conditions in parallel subagent execution

### DIFF
--- a/get-shit-done/workflows/execute-plan.md
+++ b/get-shit-done/workflows/execute-plan.md
@@ -1379,6 +1379,8 @@ The one-liner must be SUBSTANTIVE:
   </step>
 
 <step name="update_current_position">
+**If `<parallel_context>` in prompt:** Skip this step. Include a "State Fragment" section in SUMMARY.md instead (see gsd-executor state_updates). Orchestrator consolidates state after wave.
+
 Update Current Position section in STATE.md to reflect plan completion.
 
 **Format:**
@@ -1437,6 +1439,8 @@ Progress: ███████░░░ 50%
       </step>
 
 <step name="extract_decisions_and_issues">
+**If `<parallel_context>` in prompt:** Skip this step. Decisions and issues go in SUMMARY.md's "State Fragment" section.
+
 Extract decisions, issues, and concerns from SUMMARY.md into STATE.md accumulated context.
 
 **Decisions Made:**
@@ -1454,6 +1458,8 @@ Extract decisions, issues, and concerns from SUMMARY.md into STATE.md accumulate
     </step>
 
 <step name="update_session_continuity">
+**If `<parallel_context>` in prompt:** Skip this step. Orchestrator updates session continuity after wave.
+
 Update Session Continuity section in STATE.md to enable resumption in future sessions.
 
 **Format:**
@@ -1528,10 +1534,16 @@ If `COMMIT_PLANNING_DOCS=true` (default):
 
 ```bash
 git add .planning/phases/XX-name/{phase}-{plan}-SUMMARY.md
+```
+
+**If NOT in parallel context** (no `<parallel_context>` in prompt):
+```bash
 git add .planning/STATE.md
 ```
 
-**2. Stage roadmap:**
+**If in parallel context:** Do NOT stage STATE.md or ROADMAP.md — orchestrator handles these after wave completion.
+
+**2. Stage roadmap (skip if in parallel context):**
 
 ```bash
 git add .planning/ROADMAP.md


### PR DESCRIPTION
## Summary

Fixes race conditions when multiple subagents execute in the same wave:

- **STATE.md lost updates** — parallel agents independently read/modify/write STATE.md, last writer silently drops the others' changes
- **Source file overwrite loops** — parallel agents modifying the same file enter cascading "fix, test, fail, fix" cycles

## Changes

- **Orchestrator-owned STATE.md writes** — parallel subagents skip STATE.md updates and output a "State Fragment" in SUMMARY.md. Orchestrator performs one atomic STATE.md update after each wave completes.
- **File conflict detection at wave grouping** — checks `files_modified` overlap between plans in the same wave. Overlapping plans are bumped to the next wave automatically.
- **`<parallel_context>` directive** — new prompt block tells executors they're running in parallel, scoping file modifications to their plan's declared files.

Single-agent waves are unaffected — the parallel safety logic only activates when spawning 2+ agents simultaneously.

## Files Changed

- `get-shit-done/workflows/execute-phase.md` — file conflict detection, parallel subagent prompt, state consolidation step
- `agents/gsd-executor.md` — parallel context awareness, State Fragment output
- `get-shit-done/workflows/execute-plan.md` — parallel context guards on state update steps