### PR TITLE
feat(hooks): automatic context exhaustion handling

### DIFF
--- a/get-shit-done/references/compact-instructions.md
+++ b/get-shit-done/references/compact-instructions.md
@@ -1,0 +1,11 @@
+# Compact Instructions
+
+When compacting a GSD project (.planning/ directory exists), preserve:
+1. Current position: which phase, plan, and task are active
+2. What is being built: the active plan's objective
+3. Decisions made this session and their rationale
+4. Blockers or concerns
+5. What action was in progress when compaction triggered
+
+After compaction, read .planning/STATE.md to restore full project context.
+If an active plan exists (PLAN.md without SUMMARY.md), read it to understand current work.

--- a/hooks/gsd-precompact.js
+++ b/hooks/gsd-precompact.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+// Update STATE.md Session Continuity before context compaction
+// Called by PreCompact hook - ensures STATE.md reflects current state before compaction
+
+const fs = require('fs');
+const path = require('path');
+
+// Read JSON from stdin (Claude Code passes hook context)
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', chunk => input += chunk);
+process.stdin.on('end', () => {
+  try {
+    const data = JSON.parse(input);
+    const cwd = data.cwd || process.cwd();
+
+    const statePath = path.join(cwd, '.planning', 'STATE.md');
+    if (!fs.existsSync(statePath)) {
+      process.exit(0); // Not a GSD project
+    }
+
+    let content = fs.readFileSync(statePath, 'utf8');
+
+    // Extract current status from Current Position section
+    let currentStatus = 'unknown';
+    const statusMatch = content.match(/^Status:\s*(.+)$/m);
+    if (statusMatch) {
+      currentStatus = statusMatch[1].trim();
+    }
+
+    const now = new Date().toISOString().replace('T', ' ').replace(/\.\d+Z$/, '');
+
+    const newContinuity = `## Session Continuity
+
+Last session: ${now}
+Stopped at: Context compaction during "${currentStatus}"
+Resume file: None`;
+
+    // Replace existing Session Continuity section or append
+    const sectionRegex = /## Session Continuity[\s\S]*$/;
+    if (sectionRegex.test(content)) {
+      content = content.replace(sectionRegex, newContinuity);
+    } else {
+      content = content.trimEnd() + '\n\n' + newContinuity + '\n';
+    }
+
+    fs.writeFileSync(statePath, content);
+  } catch (e) {
+    // Silent fail - don't block compaction
+  }
+});

--- a/scripts/build-hooks.js
+++ b/scripts/build-hooks.js
@@ -12,6 +12,7 @@ const DIST_DIR = path.join(HOOKS_DIR, 'dist');
 // Hooks to copy (pure Node.js, no bundling needed)
 const HOOKS_TO_COPY = [
   'gsd-check-update.js',
+  'gsd-precompact.js',
   'gsd-statusline.js'
 ];
 


### PR DESCRIPTION
## Summary

- Adds a `PreCompact` hook (`gsd-precompact.js`) that updates STATE.md's Session Continuity section with the current timestamp and status before context compaction occurs
- Adds `compact-instructions.md` reference doc to guide the compaction summarizer on preserving GSD project state
- Registers the PreCompact hook in the installer and adds cleanup to the uninstaller

No new user-facing commands, no new state files. The existing resume workflow (`/gsd:resume-work`, `/gsd:progress`) picks up the updated STATE.md naturally.

## Test plan

- [x] Run installer, verify `settings.json` has `PreCompact` hook registered
- [x] Start a GSD project, execute a phase partway, run `/compact` — verify STATE.md Session Continuity updates with compaction timestamp
- [x] Run uninstaller, verify PreCompact hook is cleaned from `settings.json`