### PR TITLE
fix: GSD-STYLE.md XML tag example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.11.2] - 2026-02-01
+
+### Fixed
+- GSD-STYLE.md XML tags	kebab-case example
+
 ## [1.11.1] - 2026-01-31
 
 ### Added

--- a/GSD-STYLE.md
+++ b/GSD-STYLE.md
@@ -183,7 +183,7 @@ Build authentication system
 |------|------------|---------|
 | Files | kebab-case | `execute-phase.md` |
 | Commands | `gsd:kebab-case` | `gsd:execute-phase` |
-| XML tags | kebab-case | `<execution_context>` |
+| XML tags | kebab-case | `<execution-context>` |
 | Step names | snake_case | `name="load_project_state"` |
 | Bash variables | CAPS_UNDERSCORES | `PHASE_ARG`, `PLAN_START_TIME` |
 | Type attributes | colon separator | `type="checkpoint:human-verify"` |


### PR DESCRIPTION
## What

Naming Conventions XML tag example fix in GSD-STYLE.md 

## Why

The incorrect example might confuse the LLM

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [* ] Tested on Linux

## Checklist

- [ *] Follows GSD style (no enterprise patterns, no filler)
- [ *] Updates CHANGELOG.md for user-facing changes
- [ *] No unnecessary dependencies added
- [ ] Works on Windows (backslash paths tested)

## Breaking Changes

None
