### PR TITLE
fix: remove broken gsd-gemini link (404)

### DIFF
--- a/README.md
+++ b/README.md
@@ -595,7 +595,7 @@ These community ports pioneered multi-runtime support:
 | Project | Platform | Description |
 |---------|----------|-------------|
 | [gsd-opencode](https://github.com/rokicool/gsd-opencode) | OpenCode | Original OpenCode adaptation |
-| [gsd-gemini](https://github.com/uberfuzzy/gsd-gemini) | Gemini CLI | Original Gemini adaptation |
+| gsd-gemini (archived) | Gemini CLI | Original Gemini adaptation by uberfuzzy |
 
 ---
 


### PR DESCRIPTION
## Summary

The `uberfuzzy/gsd-gemini` repository linked in the Community Ports table no longer exists (returns 404).

## Changes

- Removed the dead hyperlink
- Kept the project name as "gsd-gemini (archived)" to preserve attribution
- Added uberfuzzy's name to the description

## Fixes

Closes #346