### PR TITLE
fix: researcher agent always writes RESEARCH.md to disk

### DIFF
--- a/agents/gsd-phase-researcher.md
+++ b/agents/gsd-phase-researcher.md
@@ -523,15 +523,19 @@ Run through verification protocol checklist:
 
 ## Step 5: Write RESEARCH.md
 
+**ALWAYS use the Write tool to persist RESEARCH.md to disk.** This is mandatory regardless of `commit_docs` setting.
+
 Use the output format template. Populate all sections with verified findings.
 
 Write to: `$PHASE_DIR/$PADDED_PHASE-RESEARCH.md`
 
 Where `PHASE_DIR` is the full path (e.g., `.planning/phases/01-foundation`)
 
-## Step 6: Commit Research
+⚠️ **The `commit_docs` setting only controls git commits, NOT file writing.** Always write the file first.
 
-**If `COMMIT_PLANNING_DOCS=false`:** Skip git operations, log "Skipping planning docs commit (commit_docs: false)"
+## Step 6: Commit Research (optional)
+
+**If `COMMIT_PLANNING_DOCS=false`:** Skip git operations only. The file MUST already be written in Step 5.
 
 **If `COMMIT_PLANNING_DOCS=true` (default):**
 


### PR DESCRIPTION
## Summary
Fixes #343

The `gsd-phase-researcher` agent was misinterpreting `commit_docs=false` as "skip file write" when it should only skip git commit operations. This caused expensive research runs (~5min, 50k+ tokens) to produce no artifact.

## Root Cause
Step 5 said "Write to: $PHASE_DIR/..." but didn't explicitly require the Write tool. Step 6 said "If commit_docs=false: Skip git operations" which the agent interpreted as skipping the entire output.

## Changes
- Explicitly state **Write tool is mandatory** in Step 5
- Clarify `commit_docs` only affects git operations, not file writes  
- Rename Step 6 to "Commit Research (optional)"
- Make the file-write-then-commit order explicit

## Testing
1. Set `commit_docs: false` in `.planning/config.json`
2. Run `/gsd:plan-phase` on a phase needing research
3. Verify RESEARCH.md is created on disk even without git commit