### PR TITLE
feat: add unlimited model profile support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- **Unlimited model profile** — Use Opus for all agents without exception (`/gsd:set-profile unlimited` or configure in `/gsd:settings`)
+- **GSD_DEFAULT_MODEL_PROFILE** environment variable — Set default profile when no config.json exists (fallback: config.json -> env var -> "balanced")
+
 ## [1.11.1] - 2026-01-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ You're never locked in. The system adapts.
 | Command | What it does |
 |---------|--------------|
 | `/gsd:settings` | Configure model profile and workflow agents |
-| `/gsd:set-profile <profile>` | Switch model profile (quality/balanced/budget) |
+| `/gsd:set-profile <profile>` | Switch model profile (unlimited/quality/balanced/budget) |
 | `/gsd:add-todo [desc]` | Capture idea for later |
 | `/gsd:check-todos` | List pending todos |
 | `/gsd:debug [desc]` | Systematic debugging with persistent state |
@@ -494,6 +494,7 @@ Control which Claude model each agent uses. Balance quality vs token spend.
 
 | Profile | Planning | Execution | Verification |
 |---------|----------|-----------|--------------|
+| `unlimited` | Opus | Opus | Opus |
 | `quality` | Opus | Opus | Sonnet |
 | `balanced` (default) | Opus | Sonnet | Sonnet |
 | `budget` | Sonnet | Sonnet | Haiku |
@@ -518,6 +519,14 @@ These spawn additional agents during planning/execution. They improve quality bu
 Use `/gsd:settings` to toggle these, or override per-invocation:
 - `/gsd:plan-phase --skip-research`
 - `/gsd:plan-phase --skip-verify`
+
+### Environment Variables
+
+| Variable | Default | What it does |
+|----------|---------|--------------|
+| `GSD_DEFAULT_MODEL_PROFILE` | `balanced` | Default model profile when no `.planning/config.json` exists |
+
+Fallback chain: `config.json` -> `GSD_DEFAULT_MODEL_PROFILE` -> `balanced`
 
 ### Execution
 

--- a/commands/gsd/audit-milestone.md
+++ b/commands/gsd/audit-milestone.md
@@ -44,16 +44,19 @@ Glob: .planning/phases/*/*-VERIFICATION.md
 Read model profile for agent spawning:
 
 ```bash
-MODEL_PROFILE=$(cat .planning/config.json 2>/dev/null | grep -o '"model_profile"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"' || echo "balanced")
+# Read from config.json (may be empty if not set)
+CONFIG_PROFILE=$(cat .planning/config.json 2>/dev/null | grep -o '"model_profile"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"')
+# Fallback chain: config.json -> env var -> "balanced"
+MODEL_PROFILE="${CONFIG_PROFILE:-${GSD_DEFAULT_MODEL_PROFILE:-balanced}}"
 ```
 
-Default to "balanced" if not set.
+Default to "balanced" if neither config.json nor env var is set.
 
 **Model lookup table:**
 
-| Agent | quality | balanced | budget |
-|-------|---------|----------|--------|
-| gsd-integration-checker | sonnet | sonnet | haiku |
+| Agent | `unlimited` | `quality` | `balanced` | `budget` |
+|-------|-------------|-----------|------------|----------|
+| gsd-integration-checker | opus | sonnet | sonnet | haiku |
 
 Store resolved model for use in Task call below.
 

--- a/commands/gsd/debug.md
+++ b/commands/gsd/debug.md
@@ -33,16 +33,19 @@ ls .planning/debug/*.md 2>/dev/null | grep -v resolved | head -5
 Read model profile for agent spawning:
 
 ```bash
-MODEL_PROFILE=$(cat .planning/config.json 2>/dev/null | grep -o '"model_profile"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"' || echo "balanced")
+# Read from config.json (may be empty if not set)
+CONFIG_PROFILE=$(cat .planning/config.json 2>/dev/null | grep -o '"model_profile"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"')
+# Fallback chain: config.json -> env var -> "balanced"
+MODEL_PROFILE="${CONFIG_PROFILE:-${GSD_DEFAULT_MODEL_PROFILE:-balanced}}"
 ```
 
-Default to "balanced" if not set.
+Default to "balanced" if neither config.json nor env var is set.
 
 **Model lookup table:**
 
-| Agent | quality | balanced | budget |
-|-------|---------|----------|--------|
-| gsd-debugger | opus | sonnet | sonnet |
+| Agent | `unlimited` | `quality` | `balanced` | `budget` |
+|-------|-------------|-----------|------------|----------|
+| gsd-debugger | opus | opus | sonnet | sonnet |
 
 Store resolved model for use in Task calls below.
 

--- a/commands/gsd/execute-phase.md
+++ b/commands/gsd/execute-phase.md
@@ -42,17 +42,20 @@ Phase: $ARGUMENTS
 
    Read model profile for agent spawning:
    ```bash
-   MODEL_PROFILE=$(cat .planning/config.json 2>/dev/null | grep -o '"model_profile"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"' || echo "balanced")
+   # Read from config.json (may be empty if not set)
+   CONFIG_PROFILE=$(cat .planning/config.json 2>/dev/null | grep -o '"model_profile"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"')
+   # Fallback chain: config.json -> env var -> "balanced"
+   MODEL_PROFILE="${CONFIG_PROFILE:-${GSD_DEFAULT_MODEL_PROFILE:-balanced}}"
    ```
 
-   Default to "balanced" if not set.
+   Default to "balanced" if neither config.json nor env var is set.
 
    **Model lookup table:**
 
-   | Agent | quality | balanced | budget |
-   |-------|---------|----------|--------|
-   | gsd-executor | opus | sonnet | sonnet |
-   | gsd-verifier | sonnet | sonnet | haiku |
+   | Agent | `unlimited` | `quality` | `balanced` | `budget` |
+   |-------|-------------|-----------|------------|----------|
+   | gsd-executor | opus | opus | sonnet | sonnet |
+   | gsd-verifier | opus | sonnet | sonnet | haiku |
 
    Store resolved models for use in Task calls below.
 

--- a/commands/gsd/help.md
+++ b/commands/gsd/help.md
@@ -308,7 +308,7 @@ Usage: `/gsd:plan-milestone-gaps`
 Configure workflow toggles and model profile interactively.
 
 - Toggle researcher, plan checker, verifier agents
-- Select model profile (quality/balanced/budget)
+- Select model profile (unlimited/quality/balanced/budget)
 - Updates `.planning/config.json`
 
 Usage: `/gsd:settings`
@@ -316,6 +316,7 @@ Usage: `/gsd:settings`
 **`/gsd:set-profile <profile>`**
 Quick switch model profile for GSD agents.
 
+- `unlimited` — Opus for all agents (maximum quality)
 - `quality` — Opus everywhere except verification
 - `balanced` — Opus for planning, Sonnet for execution (default)
 - `budget` — Sonnet for writing, Haiku for research/verification

--- a/commands/gsd/new-milestone.md
+++ b/commands/gsd/new-milestone.md
@@ -127,18 +127,21 @@ git commit -m "docs: start milestone v[X.Y] [Name]"
 Read model profile for agent spawning:
 
 ```bash
-MODEL_PROFILE=$(cat .planning/config.json 2>/dev/null | grep -o '"model_profile"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"' || echo "balanced")
+# Read from config.json (may be empty if not set)
+CONFIG_PROFILE=$(cat .planning/config.json 2>/dev/null | grep -o '"model_profile"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"')
+# Fallback chain: config.json -> env var -> "balanced"
+MODEL_PROFILE="${CONFIG_PROFILE:-${GSD_DEFAULT_MODEL_PROFILE:-balanced}}"
 ```
 
-Default to "balanced" if not set.
+Default to "balanced" if neither config.json nor env var is set.
 
 **Model lookup table:**
 
-| Agent | quality | balanced | budget |
-|-------|---------|----------|--------|
-| gsd-project-researcher | opus | sonnet | haiku |
-| gsd-research-synthesizer | sonnet | sonnet | haiku |
-| gsd-roadmapper | opus | sonnet | sonnet |
+| Agent | `unlimited` | `quality` | `balanced` | `budget` |
+|-------|-------------|-----------|------------|----------|
+| gsd-project-researcher | opus | opus | sonnet | haiku |
+| gsd-research-synthesizer | opus | sonnet | sonnet | haiku |
+| gsd-roadmapper | opus | opus | sonnet | sonnet |
 
 Store resolved models for use in Task calls below.
 

--- a/commands/gsd/new-project.md
+++ b/commands/gsd/new-project.md
@@ -329,6 +329,7 @@ questions: [
     options: [
       { label: "Balanced (Recommended)", description: "Sonnet for most agents — good quality/cost ratio" },
       { label: "Quality", description: "Opus for research/roadmap — higher cost, deeper analysis" },
+      { label: "Unlimited", description: "Opus for all agents — maximum quality, highest cost" },
       { label: "Budget", description: "Haiku where possible — fastest, lowest cost" }
     ]
   }
@@ -343,7 +344,7 @@ Create `.planning/config.json` with all settings:
   "depth": "quick|standard|comprehensive",
   "parallelization": true|false,
   "commit_docs": true|false,
-  "model_profile": "quality|balanced|budget",
+  "model_profile": "unlimited|quality|balanced|budget",
   "workflow": {
     "research": true|false,
     "plan_check": true|false,
@@ -381,18 +382,21 @@ EOF
 Read model profile for agent spawning:
 
 ```bash
-MODEL_PROFILE=$(cat .planning/config.json 2>/dev/null | grep -o '"model_profile"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"' || echo "balanced")
+# Read from config.json (may be empty if not set)
+CONFIG_PROFILE=$(cat .planning/config.json 2>/dev/null | grep -o '"model_profile"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"')
+# Fallback chain: config.json -> env var -> "balanced"
+MODEL_PROFILE="${CONFIG_PROFILE:-${GSD_DEFAULT_MODEL_PROFILE:-balanced}}"
 ```
 
-Default to "balanced" if not set.
+Default to "balanced" if neither config.json nor env var is set.
 
 **Model lookup table:**
 
-| Agent | quality | balanced | budget |
-|-------|---------|----------|--------|
-| gsd-project-researcher | opus | sonnet | haiku |
-| gsd-research-synthesizer | sonnet | sonnet | haiku |
-| gsd-roadmapper | opus | sonnet | sonnet |
+| Agent | `unlimited` | `quality` | `balanced` | `budget` |
+|-------|-------------|-----------|------------|----------|
+| gsd-project-researcher | opus | opus | sonnet | haiku |
+| gsd-research-synthesizer | opus | sonnet | sonnet | haiku |
+| gsd-roadmapper | opus | opus | sonnet | sonnet |
 
 Store resolved models for use in Task calls below.
 

--- a/commands/gsd/plan-phase.md
+++ b/commands/gsd/plan-phase.md
@@ -53,18 +53,21 @@ ls .planning/ 2>/dev/null
 **Resolve model profile for agent spawning:**
 
 ```bash
-MODEL_PROFILE=$(cat .planning/config.json 2>/dev/null | grep -o '"model_profile"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"' || echo "balanced")
+# Read from config.json (may be empty if not set)
+CONFIG_PROFILE=$(cat .planning/config.json 2>/dev/null | grep -o '"model_profile"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"')
+# Fallback chain: config.json -> env var -> "balanced"
+MODEL_PROFILE="${CONFIG_PROFILE:-${GSD_DEFAULT_MODEL_PROFILE:-balanced}}"
 ```
 
-Default to "balanced" if not set.
+Default to "balanced" if neither config.json nor env var is set.
 
 **Model lookup table:**
 
-| Agent | quality | balanced | budget |
-|-------|---------|----------|--------|
-| gsd-phase-researcher | opus | sonnet | haiku |
-| gsd-planner | opus | opus | sonnet |
-| gsd-plan-checker | sonnet | sonnet | haiku |
+| Agent | `unlimited` | `quality` | `balanced` | `budget` |
+|-------|-------------|-----------|------------|----------|
+| gsd-phase-researcher | opus | opus | sonnet | haiku |
+| gsd-planner | opus | opus | opus | sonnet |
+| gsd-plan-checker | opus | sonnet | sonnet | haiku |
 
 Store resolved models for use in Task calls below.
 

--- a/commands/gsd/quick.md
+++ b/commands/gsd/quick.md
@@ -39,17 +39,20 @@ Orchestration is inline - no separate workflow file. Quick mode is deliberately 
 Read model profile for agent spawning:
 
 ```bash
-MODEL_PROFILE=$(cat .planning/config.json 2>/dev/null | grep -o '"model_profile"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"' || echo "balanced")
+# Read from config.json (may be empty if not set)
+CONFIG_PROFILE=$(cat .planning/config.json 2>/dev/null | grep -o '"model_profile"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"')
+# Fallback chain: config.json -> env var -> "balanced"
+MODEL_PROFILE="${CONFIG_PROFILE:-${GSD_DEFAULT_MODEL_PROFILE:-balanced}}"
 ```
 
-Default to "balanced" if not set.
+Default to "balanced" if neither config.json nor env var is set.
 
 **Model lookup table:**
 
-| Agent | quality | balanced | budget |
-|-------|---------|----------|--------|
-| gsd-planner | opus | opus | sonnet |
-| gsd-executor | opus | sonnet | sonnet |
+| Agent | `unlimited` | `quality` | `balanced` | `budget` |
+|-------|-------------|-----------|------------|----------|
+| gsd-planner | opus | opus | opus | sonnet |
+| gsd-executor | opus | opus | sonnet | sonnet |
 
 Store resolved models for use in Task calls below.
 

--- a/commands/gsd/research-phase.md
+++ b/commands/gsd/research-phase.md
@@ -36,16 +36,19 @@ Normalize phase input in step 1 before any directory lookups.
 Read model profile for agent spawning:
 
 ```bash
-MODEL_PROFILE=$(cat .planning/config.json 2>/dev/null | grep -o '"model_profile"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"' || echo "balanced")
+# Read from config.json (may be empty if not set)
+CONFIG_PROFILE=$(cat .planning/config.json 2>/dev/null | grep -o '"model_profile"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"')
+# Fallback chain: config.json -> env var -> "balanced"
+MODEL_PROFILE="${CONFIG_PROFILE:-${GSD_DEFAULT_MODEL_PROFILE:-balanced}}"
 ```
 
-Default to "balanced" if not set.
+Default to "balanced" if neither config.json nor env var is set.
 
 **Model lookup table:**
 
-| Agent | quality | balanced | budget |
-|-------|---------|----------|--------|
-| gsd-phase-researcher | opus | sonnet | haiku |
+| Agent | `unlimited` | `quality` | `balanced` | `budget` |
+|-------|-------------|-----------|------------|----------|
+| gsd-phase-researcher | opus | opus | sonnet | haiku |
 
 Store resolved model for use in Task calls below.
 

--- a/commands/gsd/set-profile.md
+++ b/commands/gsd/set-profile.md
@@ -3,7 +3,7 @@ name: set-profile
 description: Switch model profile for GSD agents (quality/balanced/budget)
 arguments:
   - name: profile
-    description: "Profile name: quality, balanced, or budget"
+    description: "Profile name: unlimited, quality, balanced, or budget"
     required: true
 ---
 
@@ -14,6 +14,7 @@ Switch the model profile used by GSD agents. This controls which Claude model ea
 <profiles>
 | Profile | Description |
 |---------|-------------|
+| **unlimited** | Opus for all agents without exception |
 | **quality** | Opus everywhere except read-only verification |
 | **balanced** | Opus for planning, Sonnet for execution/verification (default) |
 | **budget** | Sonnet for writing, Haiku for research/verification |
@@ -24,9 +25,9 @@ Switch the model profile used by GSD agents. This controls which Claude model ea
 ## 1. Validate argument
 
 ```
-if $ARGUMENTS.profile not in ["quality", "balanced", "budget"]:
+if $ARGUMENTS.profile not in ["unlimited", "quality", "balanced", "budget"]:
   Error: Invalid profile "$ARGUMENTS.profile"
-  Valid profiles: quality, balanced, budget
+  Valid profiles: unlimited, quality, balanced, budget
   STOP
 ```
 
@@ -100,6 +101,21 @@ Agents will now use:
 | gsd-planner | opus |
 | gsd-executor | opus |
 | gsd-verifier | sonnet |
+| ... | ... |
+```
+
+**Switch to unlimited mode:**
+```
+/gsd:set-profile unlimited
+
+✓ Model profile set to: unlimited
+
+Agents will now use:
+| Agent | Model |
+|-------|-------|
+| gsd-planner | opus |
+| gsd-executor | opus |
+| gsd-verifier | opus |
 | ... | ... |
 ```
 

--- a/commands/gsd/settings.md
+++ b/commands/gsd/settings.md
@@ -47,6 +47,7 @@ AskUserQuestion([
     header: "Model",
     multiSelect: false,
     options: [
+      { label: "Unlimited", description: "Opus for all agents (maximum quality, highest cost)" },
       { label: "Quality", description: "Opus everywhere except verification (highest cost)" },
       { label: "Balanced (Recommended)", description: "Opus for planning, Sonnet for execution/verification" },
       { label: "Budget", description: "Sonnet for writing, Haiku for research/verification (lowest cost)" }
@@ -101,7 +102,7 @@ Merge new settings into existing config.json:
 ```json
 {
   ...existing_config,
-  "model_profile": "quality" | "balanced" | "budget",
+  "model_profile": "unlimited" | "quality" | "balanced" | "budget",
   "workflow": {
     "research": true/false,
     "plan_check": true/false,
@@ -126,7 +127,7 @@ Display:
 
 | Setting              | Value |
 |----------------------|-------|
-| Model Profile        | {quality/balanced/budget} |
+| Model Profile        | {unlimited/quality/balanced/budget} |
 | Plan Researcher      | {On/Off} |
 | Plan Checker         | {On/Off} |
 | Execution Verifier   | {On/Off} |

--- a/get-shit-done/references/model-profiles.md
+++ b/get-shit-done/references/model-profiles.md
@@ -4,21 +4,27 @@ Model profiles control which Claude model each GSD agent uses. This allows balan
 
 ## Profile Definitions
 
-| Agent | `quality` | `balanced` | `budget` |
-|-------|-----------|------------|----------|
-| gsd-planner | opus | opus | sonnet |
-| gsd-roadmapper | opus | sonnet | sonnet |
-| gsd-executor | opus | sonnet | sonnet |
-| gsd-phase-researcher | opus | sonnet | haiku |
-| gsd-project-researcher | opus | sonnet | haiku |
-| gsd-research-synthesizer | sonnet | sonnet | haiku |
-| gsd-debugger | opus | sonnet | sonnet |
-| gsd-codebase-mapper | sonnet | haiku | haiku |
-| gsd-verifier | sonnet | sonnet | haiku |
-| gsd-plan-checker | sonnet | sonnet | haiku |
-| gsd-integration-checker | sonnet | sonnet | haiku |
+| Agent | `unlimited` | `quality` | `balanced` | `budget` |
+|-------|-------------|-----------|------------|----------|
+| gsd-planner | opus | opus | opus | sonnet |
+| gsd-roadmapper | opus | opus | sonnet | sonnet |
+| gsd-executor | opus | opus | sonnet | sonnet |
+| gsd-phase-researcher | opus | opus | sonnet | haiku |
+| gsd-project-researcher | opus | opus | sonnet | haiku |
+| gsd-research-synthesizer | opus | sonnet | sonnet | haiku |
+| gsd-debugger | opus | opus | sonnet | sonnet |
+| gsd-codebase-mapper | opus | sonnet | haiku | haiku |
+| gsd-verifier | opus | sonnet | sonnet | haiku |
+| gsd-plan-checker | opus | sonnet | sonnet | haiku |
+| gsd-integration-checker | opus | sonnet | sonnet | haiku |
 
 ## Profile Philosophy
+
+**unlimited** - Maximum reasoning power
+- Opus for all agents without exception
+- Every operation uses the most capable model
+- Use when: API quota is not a constraint, critical architecture work, complex debugging
+- Trade-off: Highest token spend, suitable for paid API or high-quota users
 
 **quality** - Maximum reasoning power
 - Opus for all decision-making agents
@@ -71,3 +77,6 @@ Verification requires goal-backward reasoning - checking if code *delivers* what
 
 **Why Haiku for gsd-codebase-mapper?**
 Read-only exploration and pattern extraction. No reasoning required, just structured output from file contents.
+
+**Why Opus for all in unlimited?**
+When cost is not a constraint, there's no reason to use lower-capability models. The unlimited profile is for users with paid API access or high quotas who want maximum quality for every operation.

--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -17,18 +17,21 @@ Read config.json for planning behavior settings.
 Read model profile for agent spawning:
 
 ```bash
-MODEL_PROFILE=$(cat .planning/config.json 2>/dev/null | grep -o '"model_profile"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"' || echo "balanced")
+# Read from config.json (may be empty if not set)
+CONFIG_PROFILE=$(cat .planning/config.json 2>/dev/null | grep -o '"model_profile"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"')
+# Fallback chain: config.json -> env var -> "balanced"
+MODEL_PROFILE="${CONFIG_PROFILE:-${GSD_DEFAULT_MODEL_PROFILE:-balanced}}"
 ```
 
-Default to "balanced" if not set.
+Default to "balanced" if neither config.json nor GSD_DEFAULT_MODEL_PROFILE env var is set.
 
 **Model lookup table:**
 
-| Agent | quality | balanced | budget |
-|-------|---------|----------|--------|
-| gsd-executor | opus | sonnet | sonnet |
-| gsd-verifier | sonnet | sonnet | haiku |
-| general-purpose | — | — | — |
+| Agent | `unlimited` | `quality` | `balanced` | `budget` |
+|-------|-------------|-----------|------------|----------|
+| gsd-executor | opus | opus | sonnet | sonnet |
+| gsd-verifier | opus | sonnet | sonnet | haiku |
+| general-purpose | --- | --- | --- | --- |
 
 Store resolved models for use in Task calls below.
 </step>

--- a/get-shit-done/workflows/execute-plan.md
+++ b/get-shit-done/workflows/execute-plan.md
@@ -15,16 +15,19 @@ Read config.json for planning behavior settings.
 Read model profile for agent spawning:
 
 ```bash
-MODEL_PROFILE=$(cat .planning/config.json 2>/dev/null | grep -o '"model_profile"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"' || echo "balanced")
+# Read from config.json (may be empty if not set)
+CONFIG_PROFILE=$(cat .planning/config.json 2>/dev/null | grep -o '"model_profile"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"')
+# Fallback chain: config.json -> env var -> "balanced"
+MODEL_PROFILE="${CONFIG_PROFILE:-${GSD_DEFAULT_MODEL_PROFILE:-balanced}}"
 ```
 
-Default to "balanced" if not set.
+Default to "balanced" if neither config.json nor GSD_DEFAULT_MODEL_PROFILE env var is set.
 
 **Model lookup table:**
 
-| Agent | quality | balanced | budget |
-|-------|---------|----------|--------|
-| gsd-executor | opus | sonnet | sonnet |
+| Agent | `unlimited` | `quality` | `balanced` | `budget` |
+|-------|-------------|-----------|------------|----------|
+| gsd-executor | opus | opus | sonnet | sonnet |
 
 Store resolved model for use in Task calls below.
 </step>

--- a/get-shit-done/workflows/map-codebase.md
+++ b/get-shit-done/workflows/map-codebase.md
@@ -26,16 +26,19 @@ Documents are reference material for Claude when planning/executing. Always incl
 Read model profile for agent spawning:
 
 ```bash
-MODEL_PROFILE=$(cat .planning/config.json 2>/dev/null | grep -o '"model_profile"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"' || echo "balanced")
+# Read from config.json (may be empty if not set)
+CONFIG_PROFILE=$(cat .planning/config.json 2>/dev/null | grep -o '"model_profile"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"')
+# Fallback chain: config.json -> env var -> "balanced"
+MODEL_PROFILE="${CONFIG_PROFILE:-${GSD_DEFAULT_MODEL_PROFILE:-balanced}}"
 ```
 
-Default to "balanced" if not set.
+Default to "balanced" if neither config.json nor GSD_DEFAULT_MODEL_PROFILE env var is set.
 
 **Model lookup table:**
 
-| Agent | quality | balanced | budget |
-|-------|---------|----------|--------|
-| gsd-codebase-mapper | sonnet | haiku | haiku |
+| Agent | `unlimited` | `quality` | `balanced` | `budget` |
+|-------|-------------|-----------|------------|----------|
+| gsd-codebase-mapper | opus | sonnet | haiku | haiku |
 
 Store resolved model for use in Task calls below.
 </step>

--- a/get-shit-done/workflows/verify-work.md
+++ b/get-shit-done/workflows/verify-work.md
@@ -24,17 +24,20 @@ No Pass/Fail buttons. No severity questions. Just: "Here's what should happen. D
 Read model profile for agent spawning:
 
 ```bash
-MODEL_PROFILE=$(cat .planning/config.json 2>/dev/null | grep -o '"model_profile"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"' || echo "balanced")
+# Read from config.json (may be empty if not set)
+CONFIG_PROFILE=$(cat .planning/config.json 2>/dev/null | grep -o '"model_profile"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -o '"[^"]*"$' | tr -d '"')
+# Fallback chain: config.json -> env var -> "balanced"
+MODEL_PROFILE="${CONFIG_PROFILE:-${GSD_DEFAULT_MODEL_PROFILE:-balanced}}"
 ```
 
-Default to "balanced" if not set.
+Default to "balanced" if neither config.json nor GSD_DEFAULT_MODEL_PROFILE env var is set.
 
 **Model lookup table:**
 
-| Agent | quality | balanced | budget |
-|-------|---------|----------|--------|
-| gsd-planner | opus | opus | sonnet |
-| gsd-plan-checker | sonnet | sonnet | haiku |
+| Agent | `unlimited` | `quality` | `balanced` | `budget` |
+|-------|-------------|-----------|------------|----------|
+| gsd-planner | opus | opus | opus | sonnet |
+| gsd-plan-checker | opus | sonnet | sonnet | haiku |
 
 Store resolved models for use in Task calls below.
 </step>


### PR DESCRIPTION
## What
Adds "unlimited" model profile (Opus for all agents) and `GSD_DEFAULT_MODEL_PROFILE` environment variable support. This fixes #356 

## Why
  - Users who prioritize quality over cost (or have unlimited access to Claude) need a way to use Opus across all GSD agents
  - Environment variable is needed for cases where repositories were created with older versions of GSD that didn't have support for profiles they all fallback to "balanced" at the moment. This one variable makes it easy to not bother setting it up everywhere every time

## Testing
  - [x] Tested on macOS
  - [ ] Tested on Windows
  - [ ] Tested on Linux

## Manual verification:
  - `/gsd:new-project `shows "Unlimited" option
  - `/gsd:settings` shows "Unlimited" in Model Profile selector
  - `/gsd:set-profile` unlimited works and shows opus for all agents
  - `/gsd:help lists` "unlimited" as a profile option
  - `GSD_DEFAULT_MODEL_PROFILE=unlimited` works as fallback
  - **config.json** takes precedence over env var

## Checklist
  - [x] Follows GSD style (no enterprise patterns, no filler)
  - [x] Updates CHANGELOG.md for user-facing changesa
  - [x] No unnecessary dependencies added\
  - [ ] Didn't test paths on Windows (not doing any paths)

## Breaking Changes
  None