### PR TITLE
docs: use @latest for uninstall commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,13 +574,18 @@ To remove GSD completely:
 
 ```bash
 # Global installs
-npx get-shit-done-cc --claude --global --uninstall
-npx get-shit-done-cc --opencode --global --uninstall
+npx get-shit-done-cc@latest --claude --global --uninstall
+npx get-shit-done-cc@latest --opencode --global --uninstall
+npx get-shit-done-cc@latest --gemini --global --uninstall
 
 # Local installs (current project)
-npx get-shit-done-cc --claude --local --uninstall
-npx get-shit-done-cc --opencode --local --uninstall
+npx get-shit-done-cc@latest --claude --local --uninstall
+npx get-shit-done-cc@latest --opencode --local --uninstall
+npx get-shit-done-cc@latest --gemini --local --uninstall
 ```
+
+> [!IMPORTANT]
+> Always use `@latest` when uninstalling. If you installed an older version, npx may have cached it, and that version might not support the `--uninstall` flag.
 
 This removes all GSD commands, agents, hooks, and settings while preserving your other configurations.
 


### PR DESCRIPTION
## Summary
- Updated uninstall commands in README to use `@latest` suffix
- Added note explaining why `@latest` is required (npx caching issue)
- Added missing Gemini uninstall commands

## Fixes
Closes #388

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm uninstall instructions are clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)