### PR TITLE
fix(#330): update statusline.js reference during install

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -716,7 +716,7 @@ function cleanupOrphanedHooks(settings) {
     'gsd-intel-prune.js',  // Removed in v1.9.2
   ];
 
-  let cleaned = false;
+  let cleanedHooks = false;
 
   // Check all hook event types (Stop, SessionStart, etc.)
   if (settings.hooks) {
@@ -731,7 +731,7 @@ function cleanupOrphanedHooks(settings) {
               h.command && orphanedHookPatterns.some(pattern => h.command.includes(pattern))
             );
             if (hasOrphaned) {
-              cleaned = true;
+              cleanedHooks = true;
               return false;  // Remove this entry
             }
           }
@@ -742,8 +742,20 @@ function cleanupOrphanedHooks(settings) {
     }
   }
 
-  if (cleaned) {
+  if (cleanedHooks) {
     console.log(`  ${green}✓${reset} Removed orphaned hook registrations`);
+  }
+
+  // Fix #330: Update statusLine if it points to old statusline.js path
+  if (settings.statusLine && settings.statusLine.command &&
+      settings.statusLine.command.includes('statusline.js') &&
+      !settings.statusLine.command.includes('gsd-statusline.js')) {
+    // Replace old path with new path
+    settings.statusLine.command = settings.statusLine.command.replace(
+      /statusline\.js/,
+      'gsd-statusline.js'
+    );
+    console.log(`  ${green}✓${reset} Updated statusline path (statusline.js → gsd-statusline.js)`);
   }
 
   return settings;


### PR DESCRIPTION
## Summary

Fixes #330 - status line disappearing after `/gsd:update`.

## Root Cause

When updating GSD, the installer:
1. Renames `statusline.js` → `gsd-statusline.js` (file rename works)
2. Does NOT update `settings.json` reference (bug)

Users with an existing statusLine config pointing to `statusline.js` would see their status line disappear because the file no longer exists at that path.

## Fix

Added logic to `cleanupOrphanedHooks()` to detect and update any `statusLine.command` that references the old `statusline.js` path:

```javascript
if (settings.statusLine && settings.statusLine.command &&
    settings.statusLine.command.includes('statusline.js') &&
    !settings.statusLine.command.includes('gsd-statusline.js')) {
  settings.statusLine.command = settings.statusLine.command.replace(
    /statusline\.js/,
    'gsd-statusline.js'
  );
}
```

## Test plan

- [ ] Have settings.json with old path: `"command": "node \"$HOME/.claude/hooks/statusline.js\""`
- [ ] Run `npx get-shit-done-cc --global`
- [ ] Verify settings.json now has: `"command": "node \"$HOME/.claude/hooks/gsd-statusline.js\""`
- [ ] Verify status line works after update

🤖 Generated with [Claude Code](https://claude.com/claude-code)