### PR TITLE
feat(discuss): capture reasoning depth in CONTEXT.md

### DIFF
--- a/get-shit-done/templates/context.md
+++ b/get-shit-done/templates/context.md
@@ -1,14 +1,18 @@
 # Phase Context Template
 
-Template for `.planning/phases/XX-name/{phase}-CONTEXT.md` - captures implementation decisions for a phase.
+Template for `.planning/phases/XX-name/{phase}-CONTEXT.md` - captures implementation decisions AND their reasoning for a phase.
 
-**Purpose:** Document decisions that downstream agents need. Researcher uses this to know WHAT to investigate. Planner uses this to know WHAT choices are locked vs flexible.
+**Purpose:** Document decisions and the reasoning behind them for downstream agents. Researcher uses this to know WHAT to investigate and WHY the user cares about it. Planner uses this to know WHAT choices are locked, WHY they were made, and what constraints exist.
 
 **Key principle:** Categories are NOT predefined. They emerge from what was actually discussed for THIS phase. A CLI phase has CLI-relevant sections, a UI phase has UI-relevant sections.
 
+**Quality principle:** Each decision must carry its reasoning. The planner reads this file ONCE in a fresh context window — they were not in the discussion. A decision without its WHY forces the planner to guess intent or ask the user again, which defeats the purpose of this file.
+
+**Voice preservation:** When the user uses specific terminology, metaphors, or phrasing that carries design intent, preserve it in the context file. These are not decoration — they are constraints that downstream agents need to understand the spirit of the decision, not just the letter.
+
 **Downstream consumers:**
-- `gsd-phase-researcher` — Reads decisions to focus research (e.g., "card layout" → research card component patterns)
-- `gsd-planner` — Reads decisions to create specific tasks (e.g., "infinite scroll" → task includes virtualization)
+- `gsd-phase-researcher` — Reads decisions + reasoning to focus research (e.g., "card layout because contained units" → researcher investigates card patterns with isolation in mind)
+- `gsd-planner` — Reads decisions + reasoning + constraints to create specific tasks (e.g., "infinite scroll for uninterrupted flow" → planner includes virtualization + knows WHY)
 
 ---
 
@@ -25,20 +29,32 @@ Template for `.planning/phases/XX-name/{phase}-CONTEXT.md` - captures implementa
 
 [Clear statement of what this phase delivers — the scope anchor. This comes from ROADMAP.md and is fixed. Discussion clarifies implementation within this boundary.]
 
+[What this phase changes in the system — which files/modules are affected, if known from discussion.]
+
+[What is explicitly NOT in scope — constraints that emerged from discussion, with reasoning.]
+
 </domain>
 
 <decisions>
 ## Implementation Decisions
 
 ### [Area 1 that was discussed]
-- [Specific decision made]
-- [Another decision if applicable]
+
+**[Core principle — the north star for this area, in user's own words if they expressed one]**
+
+- **[Decision]:** [What was decided] — [Why, using user's reasoning. Include user's original phrasing when it carries design intent.]
+- **[Decision]:** [What was decided] — [Reasoning that led to this choice]
+- **Not:** [What was explicitly rejected] — [Why this was ruled out. If a scope discussion revealed why something doesn't belong here, capture the reasoning as a constraint.]
 
 ### [Area 2 that was discussed]
-- [Specific decision made]
+
+**[Core principle for this area]**
+
+- **[Decision]:** [What + Why]
+- **[Decision]:** [What + Why]
 
 ### [Area 3 that was discussed]
-- [Specific decision made]
+- **[Decision]:** [What + Why]
 
 ### Claude's Discretion
 [Areas where user explicitly said "you decide" — Claude has flexibility here during planning/implementation]
@@ -48,7 +64,7 @@ Template for `.planning/phases/XX-name/{phase}-CONTEXT.md` - captures implementa
 <specifics>
 ## Specific Ideas
 
-[Any particular references, examples, or "I want it like X" moments from discussion. Product references, specific behaviors, interaction patterns.]
+[Product references, anti-patterns, and "I want it like X" moments from discussion. Include enough context that the planner understands the reference without having been in the conversation.]
 
 [If none: "No specific requirements — open to standard approaches"]
 
@@ -57,7 +73,7 @@ Template for `.planning/phases/XX-name/{phase}-CONTEXT.md` - captures implementa
 <deferred>
 ## Deferred Ideas
 
-[Ideas that came up during discussion but belong in other phases. Captured here so they're not lost, but explicitly out of scope for this phase.]
+[Slim backlog capture: 1-2 lines per idea. If a deferred idea required significant discussion about WHY it's deferred, that reasoning belongs in the Decisions section as a constraint ("Not: X — because Y"), not here. This section just captures the backlog entry so it's not lost.]
 
 [If none: "None — discussion stayed within phase scope"]
 
@@ -71,7 +87,7 @@ Template for `.planning/phases/XX-name/{phase}-CONTEXT.md` - captures implementa
 
 <good_examples>
 
-**Example 1: Visual feature (Post Feed)**
+**Example 1: Visual feature (Post Feed) — showing decision + reasoning depth**
 
 ```markdown
 # Phase 3: Post Feed - Context
@@ -90,14 +106,22 @@ Display posts from followed users in a scrollable feed. Users can view posts and
 ## Implementation Decisions
 
 ### Layout style
-- Card-based layout, not timeline or list
+
+**Core principle: each post should feel like its own contained unit, not a stream of merged content.**
+
+- **Card-based layout**, not timeline or list — the user wants visual containment per post. Each card is a self-contained thought with clear boundaries. Reference: "like Linear's issue cards — clean, not cluttered"
 - Each card shows: author avatar, name, timestamp, full post content, reaction counts
-- Cards have subtle shadows, rounded corners — modern feel
+- Cards have subtle shadows, rounded corners — modern feel but not heavy
+- **Not:** Timeline layout (too dense, posts merge visually) or Grid layout (not enough content visible per item)
 
 ### Loading behavior
-- Infinite scroll, not pagination
+
+**Core principle: never interrupt the user's reading flow.**
+
+- **Infinite scroll**, not pagination — the user wants uninterrupted browsing without clicking "next page"
 - Pull-to-refresh on mobile
-- New posts indicator at top ("3 new posts") rather than auto-inserting
+- **New posts indicator** at top ("3 new posts") rather than auto-inserting — the user specifically referenced Twitter's approach: "I like how Twitter shows the new posts indicator without disrupting your scroll position." This means: never jump the user's scroll position, always let them opt in to new content.
+- **Not:** Auto-inserting new posts (disrupts reading position)
 
 ### Empty state
 - Friendly illustration + "Follow people to see posts here"
@@ -113,8 +137,8 @@ Display posts from followed users in a scrollable feed. Users can view posts and
 <specifics>
 ## Specific Ideas
 
-- "I like how Twitter shows the new posts indicator without disrupting your scroll position"
-- Cards should feel like Linear's issue cards — clean, not cluttered
+- **Linear's issue cards** as visual reference — clean, contained, not cluttered. The user values whitespace and clear boundaries over information density.
+- **Twitter's new-posts indicator** as interaction reference — non-disruptive, user-initiated content refresh. The scroll position is sacred.
 
 </specifics>
 
@@ -132,7 +156,7 @@ Display posts from followed users in a scrollable feed. Users can view posts and
 *Context gathered: 2025-01-20*
 ```
 
-**Example 2: CLI tool (Database backup)**
+**Example 2: CLI tool (Database backup) — showing constraints and reasoning**
 
 ```markdown
 # Phase 2: Backup Command - Context
@@ -151,9 +175,13 @@ CLI command to backup database to local file or S3. Supports full and incrementa
 ## Implementation Decisions
 
 ### Output format
-- JSON for programmatic use, table format for humans
-- Default to table, --json flag for JSON
-- Verbose mode (-v) shows progress, silent by default
+
+**Core principle: must work in both human-interactive and CI pipeline contexts without mode switching.**
+
+- JSON for programmatic use, table format for humans — the user needs this for CI pipeline integration where machines parse output
+- Default to table (human-first), --json flag for JSON — humans are the primary audience, machines opt in
+- Verbose mode (-v) shows progress, silent by default — CI pipelines need clean stdout, humans can opt into verbosity
+- "I want it to feel like pg_dump — familiar to database people" — the UX reference is pg_dump's straightforward, no-surprise interface
 
 ### Flag design
 - Short flags for common options: -o (output), -v (verbose), -f (force)
@@ -161,9 +189,13 @@ CLI command to backup database to local file or S3. Supports full and incrementa
 - Required: database connection string (positional or --db)
 
 ### Error recovery
-- Retry 3 times on network failure, then fail with clear message
-- --no-retry flag to fail fast
-- Partial backups are deleted on failure (no corrupt files)
+
+**Core principle: no human intervention needed in CI — fail cleanly or retry autonomously.**
+
+- Retry 3 times on network failure, then fail with clear message — the user needs unattended backup jobs that handle transient failures
+- --no-retry flag to fail fast — for debugging or when the user wants immediate failure
+- Partial backups are deleted on failure — no corrupt files left behind. The user was emphatic: "Should work in CI pipelines (exit codes, no interactive prompts)"
+- **Not:** Interactive prompts on failure (breaks CI), Silent failure (masks problems)
 
 ### Claude's Discretion
 - Exact progress bar implementation
@@ -175,8 +207,8 @@ CLI command to backup database to local file or S3. Supports full and incrementa
 <specifics>
 ## Specific Ideas
 
-- "I want it to feel like pg_dump — familiar to database people"
-- Should work in CI pipelines (exit codes, no interactive prompts)
+- **pg_dump as UX reference** — familiar, predictable, no surprises. The tool should feel like it belongs in a DBA's toolkit.
+- **CI-first mentality** — exit codes matter, stdout must be parseable, no interactive prompts ever. The user sees this as equally important as the backup functionality itself.
 
 </specifics>
 
@@ -194,7 +226,7 @@ CLI command to backup database to local file or S3. Supports full and incrementa
 *Context gathered: 2025-01-20*
 ```
 
-**Example 3: Organization task (Photo library)**
+**Example 3: Organization task (Photo library) — showing user philosophy**
 
 ```markdown
 # Phase 1: Photo Organization - Context
@@ -213,23 +245,30 @@ Organize existing photo library into structured folders. Handle duplicates and a
 ## Implementation Decisions
 
 ### Grouping criteria
-- Primary grouping by year, then by month
-- Events detected by time clustering (photos within 2 hours = same event)
-- Event folders named by date + location if available
+
+**Core principle: findability by approximate time — "I want to be able to find photos by roughly when they were taken."**
+
+- Primary grouping by year, then by month — the user thinks in calendar time, not events or people
+- Events detected by time clustering (photos within 2 hours = same event) — within a month, photos cluster naturally by activity
+- Event folders named by date + location if available — combines temporal and spatial context for recognition
 
 ### Duplicate handling
-- Keep highest resolution version
-- Move duplicates to _duplicates folder (don't delete)
-- Log all duplicate decisions for review
+
+**Core principle: never delete, always preserve the ability to review — "worst case, move to a review folder."**
+
+- Keep highest resolution version as the primary copy
+- Move duplicates to _duplicates folder (don't delete) — the user is risk-averse about data loss. Deletion is never automatic.
+- Log all duplicate decisions for review — the user wants to be able to audit what the system decided and override if needed
+- **Not:** Auto-delete duplicates (user doesn't trust automated deletion decisions on irreplaceable photos)
 
 ### Naming convention
 - Format: YYYY-MM-DD_HH-MM-SS_originalname.ext
-- Preserve original filename as suffix for searchability
+- Preserve original filename as suffix for searchability — the user may remember the original camera filename
 - Handle name collisions with incrementing suffix
 
 ### Claude's Discretion
-- Exact clustering algorithm
-- How to handle photos with no EXIF data
+- Exact clustering algorithm for event detection
+- How to handle photos with no EXIF data (likely move to "unsorted" folder)
 - Folder emoji usage
 
 </decisions>
@@ -237,8 +276,8 @@ Organize existing photo library into structured folders. Handle duplicates and a
 <specifics>
 ## Specific Ideas
 
-- "I want to be able to find photos by roughly when they were taken"
-- Don't delete anything — worst case, move to a review folder
+- **Safety-first philosophy** — the user repeatedly emphasized never deleting anything. Even duplicates get moved, not removed. The system should err on the side of preserving too much rather than too little.
+- **Calendar-based mental model** — the user navigates their memory by time ("roughly when they were taken"), not by content, people, or events. The folder structure should mirror this.
 
 </specifics>
 
@@ -259,15 +298,15 @@ Organize existing photo library into structured folders. Handle duplicates and a
 </good_examples>
 
 <guidelines>
-**This template captures DECISIONS for downstream agents.**
+**This template captures DECISIONS + REASONING for downstream agents.**
 
-The output should answer: "What does the researcher need to investigate? What choices are locked for the planner?"
+The output should answer: "What does the researcher need to investigate? What choices are locked for the planner? WHY were they made this way?"
 
-**Good content (concrete decisions):**
-- "Card-based layout, not timeline"
-- "Retry 3 times on network failure, then fail"
-- "Group by year, then by month"
-- "JSON for programmatic use, table for humans"
+**Good content (decision + reasoning):**
+- "Card-based layout, not timeline — user wants contained units, referenced Linear's cards"
+- "Retry 3 times on network failure, then fail — must work in CI pipelines without human intervention"
+- "Repetition allowed and valued — user called this a 'Hardening-Fact': re-retrieval IS the signal"
+- "Group by year, then by month — user thinks in calendar time, wants to find photos by 'roughly when'"
 
 **Bad content (too vague):**
 - "Should feel modern and clean"
@@ -275,9 +314,19 @@ The output should answer: "What does the researcher need to investigate? What ch
 - "Fast and responsive"
 - "Easy to use"
 
+**Also bad (decision without reasoning):**
+- "Card-based layout" (WHY? planner doesn't know the intent behind the choice)
+- "3-5 quotes per response" (WHY this density? what's the design goal?)
+- "Graph boost for citations" (what's the user's mental model here?)
+
+**Constraint vs Deferred — where reasoning lives:**
+- If a scope discussion revealed WHY something should NOT be built in this phase, that reasoning is a CONSTRAINT and belongs in the Decisions section: "Not: tap-to-source UI — single-source view is misleading when responses synthesize from multiple segments (NotebookLM anti-pattern)"
+- Deferred Ideas gets the slim backlog entry only: "Tap-to-source UI — future phase"
+- The reasoning stays where the planner needs it (Decisions). The backlog item goes where it won't be lost (Deferred).
+
 **After creation:**
 - File lives in phase directory: `.planning/phases/XX-name/{phase}-CONTEXT.md`
-- `gsd-phase-researcher` uses decisions to focus investigation
-- `gsd-planner` uses decisions + research to create executable tasks
+- `gsd-phase-researcher` uses decisions + reasoning to focus investigation
+- `gsd-planner` uses decisions + reasoning + constraints to create executable tasks
 - Downstream agents should NOT need to ask the user again about captured decisions
 </guidelines>

--- a/get-shit-done/workflows/discuss-phase.md
+++ b/get-shit-done/workflows/discuss-phase.md
@@ -7,15 +7,16 @@ You are a thinking partner, not an interviewer. The user is the visionary — yo
 <downstream_awareness>
 **CONTEXT.md feeds into:**
 
-1. **gsd-phase-researcher** — Reads CONTEXT.md to know WHAT to research
-   - "User wants card-based layout" → researcher investigates card component patterns
-   - "Infinite scroll decided" → researcher looks into virtualization libraries
+1. **gsd-phase-researcher** — Reads CONTEXT.md to know WHAT to research and WHY
+   - "User wants card-based layout because each post should feel contained" → researcher investigates card component patterns with isolation in mind
+   - "Infinite scroll decided for uninterrupted browsing flow" → researcher looks into virtualization libraries
 
-2. **gsd-planner** — Reads CONTEXT.md to know WHAT decisions are locked
+2. **gsd-planner** — Reads CONTEXT.md to know WHAT decisions are locked, WHY they were made, and what constraints exist
    - "Pull-to-refresh on mobile" → planner includes that in task specs
    - "Claude's Discretion: loading skeleton" → planner can decide approach
+   - "Not: timeline layout — user wants contained units" → planner knows what to avoid
 
-**Your job:** Capture decisions clearly enough that downstream agents can act on them without asking the user again.
+**Your job:** Capture decisions AND their reasoning clearly enough that downstream agents can act on them without asking the user again. A decision without its WHY forces the planner to guess intent.
 
 **Not your job:** Figure out HOW to implement. That's what research and planning do with the decisions you capture.
 </downstream_awareness>
@@ -28,6 +29,7 @@ The user knows:
 - What it should look/feel like
 - What's essential vs nice-to-have
 - Specific behaviors or references they have in mind
+- The deeper reasoning behind their preferences
 
 The user doesn't know (and shouldn't be asked):
 - Codebase patterns (researcher reads the code)
@@ -35,7 +37,9 @@ The user doesn't know (and shouldn't be asked):
 - Implementation approach (planner figures this out)
 - Success metrics (inferred from the work)
 
-Ask about vision and implementation choices. Capture decisions for downstream agents.
+Ask about vision and implementation choices. Capture decisions AND reasoning for downstream agents.
+
+**Listen for depth:** When the user gives extended answers that explain their thinking, this reasoning is gold for the context file. Don't compress it to a bullet point — the reasoning IS the value that downstream agents need.
 </philosophy>
 
 <scope_guardrail>
@@ -64,6 +68,9 @@ For now, let's focus on [phase domain]."
 ```
 
 Capture the idea in a "Deferred Ideas" section. Don't lose it, don't act on it.
+
+**When scope discussion reveals WHY something is deferred:**
+The reasoning about WHY something doesn't belong in this phase is a CONSTRAINT for the planner. Capture the reasoning in the Decisions section (e.g., "Not: tap-to-source UI — single-source view is misleading when responses synthesize from multiple segments"). The Deferred Ideas section only gets the slim backlog entry.
 </scope_guardrail>
 
 <gray_area_identification>
@@ -264,6 +271,13 @@ Ask 4 questions per area before offering to continue or move on. Each answer oft
 - Each answer should inform the next question
 - If user picks "Other", receive their input, reflect it back, confirm
 
+**Listening for depth:**
+When the user gives extended answers (not just picking an option), pay attention to:
+- **Terminology they use** — specific words that carry design intent (preserve these verbatim in context)
+- **Reasoning they share** — the WHY behind their preference (this is what the planner needs most)
+- **References they make** — products, experiences, anti-patterns they mention (capture as constraints or specifics)
+- **Philosophy they express** — deeper principles that should guide implementation (these become north stars in the context file)
+
 **Scope creep handling:**
 If user mentions something outside the phase domain:
 ```
@@ -277,7 +291,22 @@ Track deferred ideas internally.
 </step>
 
 <step name="write_context">
-Create CONTEXT.md capturing decisions made.
+Create CONTEXT.md capturing decisions AND their reasoning.
+
+**Quality standard — the planner test:**
+The planner reads this file in a FRESH context window. They were NOT in the discussion. Before writing each section, ask yourself: "If I read only this section, would I understand the user's intent well enough to plan without asking them again?" If no, the section needs more depth.
+
+**Writing principles:**
+
+1. **Decision + Reasoning:** Don't just list WHAT was decided. Capture WHY — the user's reasoning that led to the choice. A decision without reasoning is a shallow bullet that the planner can't act on confidently.
+
+2. **Preserve user voice:** When the user used specific terminology or metaphors that carry design intent, include them with context. These are not decoration — they are constraints that shape implementation spirit.
+
+3. **Constraints in Decisions:** If the discussion revealed something that should NOT be built (and WHY), that's a constraint in the Decisions section. Example: "Not: tap-to-source UI — single-source view is misleading when responses synthesize from multiple segments (NotebookLM anti-pattern)." Deferred Ideas is a slim backlog (1-2 lines per item), not an analysis section.
+
+4. **Core principles per area:** When the discussion revealed a north star or guiding principle for an area, state it prominently at the top of that section. This anchors all the specific decisions below it.
+
+5. **Specifics section:** Capture product references, anti-patterns, and "I want it like X" moments with enough context that the planner understands the reference without having been in the conversation.
 
 **Find or create phase directory:**
 
@@ -307,18 +336,27 @@ fi
 ## Phase Boundary
 
 [Clear statement of what this phase delivers — the scope anchor]
+[What this phase changes in the system — which files/modules are affected]
+[What is explicitly NOT in scope and why — constraints from discussion]
 
 </domain>
 
 <decisions>
 ## Implementation Decisions
 
-### [Category 1 that was discussed]
-- [Decision or preference captured]
-- [Another decision if applicable]
+### [Area 1 that was discussed]
 
-### [Category 2 that was discussed]
-- [Decision or preference captured]
+**[Core principle — the north star for this area, from discussion]**
+
+- **[Decision]:** [What was decided] — [Why, using user's reasoning and terminology]
+- **[Decision]:** [What was decided] — [Why]
+- **Not:** [What was explicitly rejected] — [Why this was ruled out]
+
+### [Area 2 that was discussed]
+
+**[Core principle for this area]**
+
+- **[Decision]:** [What + Why]
 
 ### Claude's Discretion
 [Areas where user said "you decide" — note that Claude has flexibility here]
@@ -328,16 +366,14 @@ fi
 <specifics>
 ## Specific Ideas
 
-[Any particular references, examples, or "I want it like X" moments from discussion]
-
-[If none: "No specific requirements — open to standard approaches"]
+[Product references, anti-patterns, and "I want it like X" moments — with enough context that the planner understands the reference]
 
 </specifics>
 
 <deferred>
 ## Deferred Ideas
 
-[Ideas that came up but belong in other phases. Don't lose them.]
+[Slim backlog: 1-2 lines per idea. Reasoning about WHY something is deferred belongs in Decisions as a constraint, not here.]
 
 [If none: "None — discussion stayed within phase scope"]
 
@@ -361,10 +397,10 @@ Created: .planning/phases/${PADDED_PHASE}-${SLUG}/${PADDED_PHASE}-CONTEXT.md
 ## Decisions Captured
 
 ### [Category]
-- [Key decision]
+- [Key decision + reasoning summary]
 
 ### [Category]
-- [Key decision]
+- [Key decision + reasoning summary]
 
 [If deferred ideas exist:]
 ## Noted for Later
@@ -427,7 +463,10 @@ Confirm: "Committed: docs(${PADDED_PHASE}): capture phase context"
 - User selected which areas to discuss
 - Each selected area explored until user satisfied
 - Scope creep redirected to deferred ideas
-- CONTEXT.md captures actual decisions, not vague vision
-- Deferred ideas preserved for future phases
+- CONTEXT.md captures decisions WITH their reasoning (not shallow bullet lists)
+- User's voice and terminology preserved where it carries design intent
+- Constraints (what NOT to build) captured in Decisions, not inflating Deferred
+- Deferred ideas slim (backlog entries only), reasoning in Decisions
+- Planner can act on every decision without asking the user again
 - User knows next steps
 </success_criteria>


### PR DESCRIPTION
## Summary

- Enhance `discuss-phase.md` to preserve user reasoning depth instead of compressing to shallow bullet points
- Enhance `context.md` template with decision+reasoning format, core principles, and constraint separation
- Rewrite all 3 template examples with reasoning depth

## Problem

The discuss-phase captures decisions as shallow bullets in CONTEXT.md:
```
- Card-based layout, not timeline
- Infinite scroll, not pagination
```

Downstream agents (researcher, planner) receive the **WHAT** but not the **WHY**. The planner then guesses intent and makes incorrect trade-off decisions when the plan requires judgment calls.

When users give extended answers explaining their reasoning during the discussion, that reasoning gets compressed to bullet points — losing the most valuable signal for downstream planning.

## Solution

**In `discuss-phase.md`:**
- "Listen for depth" — when users explain reasoning, preserve it
- Decisions must carry their WHY for downstream agents
- Constraints ("Not: X — because Y") go in Decisions, not Deferred Ideas
- "Planner test" quality standard: can someone in a fresh context window understand intent without re-asking?
- User voice preservation: specific terminology carries design intent

**In `context.md` template:**
- Decision format: `**[Decision]:** [What] — [Why]`
- Core principles per area as north stars
- `**Not:** [What rejected] — [Why]` for constraints
- Deferred Ideas stays slim (1-2 line backlog entries only)
- "Also bad: decision without reasoning" guideline
- All 3 examples rewritten to demonstrate the depth

## Before/After

**Before (current):**
```markdown
### Visual Design
- Card-based layout, not timeline
- Cards have subtle shadows, rounded corners — modern feel
```

**After (this PR):**
```markdown
### Visual Design

**Core principle: each post should feel like its own contained unit.**

- **Card-based layout**, not timeline — user wants visual containment per post.
  Reference: "like Linear's issue cards — clean, not cluttered"
- **Not:** Timeline layout (too dense, posts merge visually)
```

## Motivation

Discovered through real daily usage across multiple projects that plan quality correlates directly with CONTEXT.md reasoning depth. When the context file only has decision bullets, the planner produces generic plans. When it carries the WHY behind each decision, the planner makes better trade-offs because it understands intent.

## Test plan

- [ ] Run `/gsd:discuss-phase` on an existing phase — verify CONTEXT.md includes reasoning with decisions
- [ ] Run `/gsd:plan-phase` after — verify planner references reasoning from context
- [ ] Check that Deferred Ideas stays slim (reasoning in Decisions section)
- [ ] Verify all 3 template examples render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)