### PR TITLE
fix(commands): migrate Task() calls to YAML syntax to fix parsing bug

### DIFF
--- a/commands/gsd/audit-milestone.md
+++ b/commands/gsd/audit-milestone.md
@@ -92,18 +92,19 @@ If a phase is missing VERIFICATION.md, flag it as "unverified phase" — this is
 
 With phase context collected:
 
-```
-Task(
-  prompt="Check cross-phase integration and E2E flows.
+```yaml
+Task:
+  subagent_type: gsd-integration-checker
+  model: "{integration_checker_model}"
+  description: Check cross-phase integration and E2E flows
+  prompt: |
+    Check cross-phase integration and E2E flows.
 
-Phases: {phase_dirs}
-Phase exports: {from SUMMARYs}
-API routes: {routes created}
+    Phases: {phase_dirs}
+    Phase exports: {from SUMMARYs}
+    API routes: {routes created}
 
-Verify cross-phase wiring and E2E user flows.",
-  subagent_type="gsd-integration-checker",
-  model="{integration_checker_model}"
-)
+    Verify cross-phase wiring and E2E user flows.
 ```
 
 ## 4. Collect Results

--- a/commands/gsd/debug.md
+++ b/commands/gsd/debug.md
@@ -96,13 +96,13 @@ Create: .planning/debug/{slug}.md
 </debug_file>
 ```
 
-```
-Task(
-  prompt=filled_prompt,
-  subagent_type="gsd-debugger",
-  model="{debugger_model}",
-  description="Debug {slug}"
-)
+```yaml
+Task:
+  subagent_type: gsd-debugger
+  model: "{debugger_model}"
+  description: Debug {slug}
+  prompt: |
+    {filled_prompt}
 ```
 
 ## 4. Handle Agent Return
@@ -149,13 +149,13 @@ goal: find_and_fix
 </mode>
 ```
 
-```
-Task(
-  prompt=continuation_prompt,
-  subagent_type="gsd-debugger",
-  model="{debugger_model}",
-  description="Continue debug {slug}"
-)
+```yaml
+Task:
+  subagent_type: gsd-debugger
+  model: "{debugger_model}"
+  description: Continue debug {slug}
+  prompt: |
+    {continuation_prompt}
 ```
 
 </process>

--- a/commands/gsd/execute-phase.md
+++ b/commands/gsd/execute-phase.md
@@ -269,10 +269,45 @@ STATE_CONTENT=$(cat .planning/STATE.md)
 
 Spawn all plans in a wave with a single message containing multiple Task calls, with inlined content:
 
-```
-Task(prompt="Execute plan at {plan_01_path}\n\nPlan:\n{plan_01_content}\n\nProject state:\n{state_content}", subagent_type="gsd-executor", model="{executor_model}")
-Task(prompt="Execute plan at {plan_02_path}\n\nPlan:\n{plan_02_content}\n\nProject state:\n{state_content}", subagent_type="gsd-executor", model="{executor_model}")
-Task(prompt="Execute plan at {plan_03_path}\n\nPlan:\n{plan_03_content}\n\nProject state:\n{state_content}", subagent_type="gsd-executor", model="{executor_model}")
+```yaml
+Task:
+  subagent_type: gsd-executor
+  model: "{executor_model}"
+  description: Execute plan {plan_01_path}
+  prompt: |
+    Execute plan at {plan_01_path}
+
+    Plan:
+    {plan_01_content}
+
+    Project state:
+    {state_content}
+
+Task:
+  subagent_type: gsd-executor
+  model: "{executor_model}"
+  description: Execute plan {plan_02_path}
+  prompt: |
+    Execute plan at {plan_02_path}
+
+    Plan:
+    {plan_02_content}
+
+    Project state:
+    {state_content}
+
+Task:
+  subagent_type: gsd-executor
+  model: "{executor_model}"
+  description: Execute plan {plan_03_path}
+  prompt: |
+    Execute plan at {plan_03_path}
+
+    Plan:
+    {plan_03_content}
+
+    Project state:
+    {state_content}
 ```
 
 All three run in parallel. Task tool blocks until all complete.

--- a/commands/gsd/new-milestone.md
+++ b/commands/gsd/new-milestone.md
@@ -178,192 +178,208 @@ Display spawning indicator:
 
 Spawn 4 parallel gsd-project-researcher agents with milestone-aware context:
 
+```yaml
+Task:
+  subagent_type: gsd-project-researcher
+  model: "{researcher_model}"
+  description: Stack research for new features
+  prompt: |
+    <research_type>
+    Project Research — Stack dimension for [new features].
+    </research_type>
+
+    <milestone_context>
+    SUBSEQUENT MILESTONE — Adding [target features] to existing app.
+
+    Existing validated capabilities (DO NOT re-research):
+    [List from PROJECT.md Validated requirements]
+
+    Focus ONLY on what's needed for the NEW features.
+    </milestone_context>
+
+    <question>
+    What stack additions/changes are needed for [new features]?
+    </question>
+
+    <project_context>
+    [PROJECT.md summary - current state, new milestone goals]
+    </project_context>
+
+    <downstream_consumer>
+    Your STACK.md feeds into roadmap creation. Be prescriptive:
+    - Specific libraries with versions for NEW capabilities
+    - Integration points with existing stack
+    - What NOT to add and why
+    </downstream_consumer>
+
+    <quality_gate>
+    - [ ] Versions are current (verify with Context7/official docs, not training data)
+    - [ ] Rationale explains WHY, not just WHAT
+    - [ ] Integration with existing stack considered
+    </quality_gate>
+
+    <output>
+    Write to: .planning/research/STACK.md
+    Use template: ~/.claude/get-shit-done/templates/research-project/STACK.md
+    </output>
 ```
-Task(prompt="
-<research_type>
-Project Research — Stack dimension for [new features].
-</research_type>
 
-<milestone_context>
-SUBSEQUENT MILESTONE — Adding [target features] to existing app.
+Task:
+  subagent_type: gsd-project-researcher
+  model: "{researcher_model}"
+  description: Features research for new capabilities
+  prompt: |
+    <research_type>
+    Project Research — Features dimension for [new features].
+    </research_type>
 
-Existing validated capabilities (DO NOT re-research):
-[List from PROJECT.md Validated requirements]
+    <milestone_context>
+    SUBSEQUENT MILESTONE — Adding [target features] to existing app.
 
-Focus ONLY on what's needed for the NEW features.
-</milestone_context>
+    Existing features (already built):
+    [List from PROJECT.md Validated requirements]
 
-<question>
-What stack additions/changes are needed for [new features]?
-</question>
+    Focus on how [new features] typically work, expected behavior.
+    </milestone_context>
 
-<project_context>
-[PROJECT.md summary - current state, new milestone goals]
-</project_context>
+    <question>
+    How do [target features] typically work? What's expected behavior?
+    </question>
 
-<downstream_consumer>
-Your STACK.md feeds into roadmap creation. Be prescriptive:
-- Specific libraries with versions for NEW capabilities
-- Integration points with existing stack
-- What NOT to add and why
-</downstream_consumer>
+    <project_context>
+    [PROJECT.md summary - new milestone goals]
+    </project_context>
 
-<quality_gate>
-- [ ] Versions are current (verify with Context7/official docs, not training data)
-- [ ] Rationale explains WHY, not just WHAT
-- [ ] Integration with existing stack considered
-</quality_gate>
+    <downstream_consumer>
+    Your FEATURES.md feeds into requirements definition. Categorize clearly:
+    - Table stakes (must have for these features)
+    - Differentiators (competitive advantage)
+    - Anti-features (things to deliberately NOT build)
+    </downstream_consumer>
 
-<output>
-Write to: .planning/research/STACK.md
-Use template: ~/.claude/get-shit-done/templates/research-project/STACK.md
-</output>
-", subagent_type="gsd-project-researcher", model="{researcher_model}", description="Stack research")
+    <quality_gate>
+    - [ ] Categories are clear (table stakes vs differentiators vs anti-features)
+    - [ ] Complexity noted for each feature
+    - [ ] Dependencies on existing features identified
+    </quality_gate>
 
-Task(prompt="
-<research_type>
-Project Research — Features dimension for [new features].
-</research_type>
+    <output>
+    Write to: .planning/research/FEATURES.md
+    Use template: ~/.claude/get-shit-done/templates/research-project/FEATURES.md
+    </output>
 
-<milestone_context>
-SUBSEQUENT MILESTONE — Adding [target features] to existing app.
+Task:
+  subagent_type: gsd-project-researcher
+  model: "{researcher_model}"
+  description: Architecture research for integration
+  prompt: |
+    <research_type>
+    Project Research — Architecture dimension for [new features].
+    </research_type>
 
-Existing features (already built):
-[List from PROJECT.md Validated requirements]
+    <milestone_context>
+    SUBSEQUENT MILESTONE — Adding [target features] to existing app.
 
-Focus on how [new features] typically work, expected behavior.
-</milestone_context>
+    Existing architecture:
+    [Summary from PROJECT.md or codebase map]
 
-<question>
-How do [target features] typically work? What's expected behavior?
-</question>
+    Focus on how [new features] integrate with existing architecture.
+    </milestone_context>
 
-<project_context>
-[PROJECT.md summary - new milestone goals]
-</project_context>
+    <question>
+    How do [target features] integrate with existing [domain] architecture?
+    </question>
 
-<downstream_consumer>
-Your FEATURES.md feeds into requirements definition. Categorize clearly:
-- Table stakes (must have for these features)
-- Differentiators (competitive advantage)
-- Anti-features (things to deliberately NOT build)
-</downstream_consumer>
+    <project_context>
+    [PROJECT.md summary - current architecture, new features]
+    </project_context>
 
-<quality_gate>
-- [ ] Categories are clear (table stakes vs differentiators vs anti-features)
-- [ ] Complexity noted for each feature
-- [ ] Dependencies on existing features identified
-</quality_gate>
+    <downstream_consumer>
+    Your ARCHITECTURE.md informs phase structure in roadmap. Include:
+    - Integration points with existing components
+    - New components needed
+    - Data flow changes
+    - Suggested build order
+    </downstream_consumer>
 
-<output>
-Write to: .planning/research/FEATURES.md
-Use template: ~/.claude/get-shit-done/templates/research-project/FEATURES.md
-</output>
-", subagent_type="gsd-project-researcher", model="{researcher_model}", description="Features research")
+    <quality_gate>
+    - [ ] Integration points clearly identified
+    - [ ] New vs modified components explicit
+    - [ ] Build order considers existing dependencies
+    </quality_gate>
 
-Task(prompt="
-<research_type>
-Project Research — Architecture dimension for [new features].
-</research_type>
+    <output>
+    Write to: .planning/research/ARCHITECTURE.md
+    Use template: ~/.claude/get-shit-done/templates/research-project/ARCHITECTURE.md
+    </output>
 
-<milestone_context>
-SUBSEQUENT MILESTONE — Adding [target features] to existing app.
+Task:
+  subagent_type: gsd-project-researcher
+  model: "{researcher_model}"
+  description: Pitfalls research for new features
+  prompt: |
+    <research_type>
+    Project Research — Pitfalls dimension for [new features].
+    </research_type>
 
-Existing architecture:
-[Summary from PROJECT.md or codebase map]
+    <milestone_context>
+    SUBSEQUENT MILESTONE — Adding [target features] to existing app.
 
-Focus on how [new features] integrate with existing architecture.
-</milestone_context>
+    Focus on common mistakes when ADDING these features to an existing system.
+    </milestone_context>
 
-<question>
-How do [target features] integrate with existing [domain] architecture?
-</question>
+    <question>
+    What are common mistakes when adding [target features] to [domain]?
+    </question>
 
-<project_context>
-[PROJECT.md summary - current architecture, new features]
-</project_context>
+    <project_context>
+    [PROJECT.md summary - current state, new features]
+    </project_context>
 
-<downstream_consumer>
-Your ARCHITECTURE.md informs phase structure in roadmap. Include:
-- Integration points with existing components
-- New components needed
-- Data flow changes
-- Suggested build order
-</downstream_consumer>
+    <downstream_consumer>
+    Your PITFALLS.md prevents mistakes in roadmap/planning. For each pitfall:
+    - Warning signs (how to detect early)
+    - Prevention strategy (how to avoid)
+    - Which phase should address it
+    </downstream_consumer>
 
-<quality_gate>
-- [ ] Integration points clearly identified
-- [ ] New vs modified components explicit
-- [ ] Build order considers existing dependencies
-</quality_gate>
+    <quality_gate>
+    - [ ] Pitfalls are specific to adding these features (not generic)
+    - [ ] Integration pitfalls with existing system covered
+    - [ ] Prevention strategies are actionable
+    </quality_gate>
 
-<output>
-Write to: .planning/research/ARCHITECTURE.md
-Use template: ~/.claude/get-shit-done/templates/research-project/ARCHITECTURE.md
-</output>
-", subagent_type="gsd-project-researcher", model="{researcher_model}", description="Architecture research")
-
-Task(prompt="
-<research_type>
-Project Research — Pitfalls dimension for [new features].
-</research_type>
-
-<milestone_context>
-SUBSEQUENT MILESTONE — Adding [target features] to existing app.
-
-Focus on common mistakes when ADDING these features to an existing system.
-</milestone_context>
-
-<question>
-What are common mistakes when adding [target features] to [domain]?
-</question>
-
-<project_context>
-[PROJECT.md summary - current state, new features]
-</project_context>
-
-<downstream_consumer>
-Your PITFALLS.md prevents mistakes in roadmap/planning. For each pitfall:
-- Warning signs (how to detect early)
-- Prevention strategy (how to avoid)
-- Which phase should address it
-</downstream_consumer>
-
-<quality_gate>
-- [ ] Pitfalls are specific to adding these features (not generic)
-- [ ] Integration pitfalls with existing system covered
-- [ ] Prevention strategies are actionable
-</quality_gate>
-
-<output>
-Write to: .planning/research/PITFALLS.md
-Use template: ~/.claude/get-shit-done/templates/research-project/PITFALLS.md
-</output>
-", subagent_type="gsd-project-researcher", model="{researcher_model}", description="Pitfalls research")
+    <output>
+    Write to: .planning/research/PITFALLS.md
+    Use template: ~/.claude/get-shit-done/templates/research-project/PITFALLS.md
+    </output>
 ```
 
 After all 4 agents complete, spawn synthesizer to create SUMMARY.md:
 
-```
-Task(prompt="
-<task>
-Synthesize research outputs into SUMMARY.md.
-</task>
+```yaml
+Task:
+  subagent_type: gsd-research-synthesizer
+  model: "{synthesizer_model}"
+  description: Synthesize research findings
+  prompt: |
+    <task>
+    Synthesize research outputs into SUMMARY.md.
+    </task>
 
-<research_files>
-Read these files:
-- .planning/research/STACK.md
-- .planning/research/FEATURES.md
-- .planning/research/ARCHITECTURE.md
-- .planning/research/PITFALLS.md
-</research_files>
+    <research_files>
+    Read these files:
+    - .planning/research/STACK.md
+    - .planning/research/FEATURES.md
+    - .planning/research/ARCHITECTURE.md
+    - .planning/research/PITFALLS.md
+    </research_files>
 
-<output>
-Write to: .planning/research/SUMMARY.md
-Use template: ~/.claude/get-shit-done/templates/research-project/SUMMARY.md
-Commit after writing.
-</output>
-", subagent_type="gsd-research-synthesizer", model="{synthesizer_model}", description="Synthesize research")
+    <output>
+    Write to: .planning/research/SUMMARY.md
+    Use template: ~/.claude/get-shit-done/templates/research-project/SUMMARY.md
+    Commit after writing.
+    </output>
 ```
 
 Display research complete banner and key findings:
@@ -535,40 +551,43 @@ New phases continue from there (e.g., if v1.0 ended at phase 5, v1.1 starts at p
 
 Spawn gsd-roadmapper agent with context:
 
-```
-Task(prompt="
-<planning_context>
+```yaml
+Task:
+  subagent_type: gsd-roadmapper
+  model: "{roadmapper_model}"
+  description: Create roadmap for milestone continuation
+  prompt: |
+    <planning_context>
 
-**Project:**
-@.planning/PROJECT.md
+    **Project:**
+    @.planning/PROJECT.md
 
-**Requirements:**
-@.planning/REQUIREMENTS.md
+    **Requirements:**
+    @.planning/REQUIREMENTS.md
 
-**Research (if exists):**
-@.planning/research/SUMMARY.md
+    **Research (if exists):**
+    @.planning/research/SUMMARY.md
 
-**Config:**
-@.planning/config.json
+    **Config:**
+    @.planning/config.json
 
-**Previous milestone (for phase numbering):**
-@.planning/MILESTONES.md
+    **Previous milestone (for phase numbering):**
+    @.planning/MILESTONES.md
 
-</planning_context>
+    </planning_context>
 
-<instructions>
-Create roadmap for milestone v[X.Y]:
-1. Start phase numbering from [N] (continues from previous milestone)
-2. Derive phases from THIS MILESTONE's requirements (don't include validated/existing)
-3. Map every requirement to exactly one phase
-4. Derive 2-5 success criteria per phase (observable user behaviors)
-5. Validate 100% coverage of new requirements
-6. Write files immediately (ROADMAP.md, STATE.md, update REQUIREMENTS.md traceability)
-7. Return ROADMAP CREATED with summary
+    <instructions>
+    Create roadmap for milestone v[X.Y]:
+    1. Start phase numbering from [N] (continues from previous milestone)
+    2. Derive phases from THIS MILESTONE's requirements (don't include validated/existing)
+    3. Map every requirement to exactly one phase
+    4. Derive 2-5 success criteria per phase (observable user behaviors)
+    5. Validate 100% coverage of new requirements
+    6. Write files immediately (ROADMAP.md, STATE.md, update REQUIREMENTS.md traceability)
+    7. Return ROADMAP CREATED with summary
 
-Write files first, then return. This ensures artifacts persist even if context is lost.
-</instructions>
-", subagent_type="gsd-roadmapper", model="{roadmapper_model}", description="Create roadmap")
+    Write files first, then return. This ensures artifacts persist even if context is lost.
+    </instructions>
 ```
 
 **Handle roadmapper return:**
@@ -624,18 +643,21 @@ Use AskUserQuestion:
 **If "Adjust phases":**
 - Get user's adjustment notes
 - Re-spawn roadmapper with revision context:
-  ```
-  Task(prompt="
-  <revision>
-  User feedback on roadmap:
-  [user's notes]
+  ```yaml
+  Task:
+    subagent_type: gsd-roadmapper
+    model: "{roadmapper_model}"
+    description: Revise roadmap based on feedback
+    prompt: |
+      <revision>
+      User feedback on roadmap:
+      [user's notes]
 
-  Current ROADMAP.md: @.planning/ROADMAP.md
+      Current ROADMAP.md: @.planning/ROADMAP.md
 
-  Update the roadmap based on feedback. Edit files in place.
-  Return ROADMAP REVISED with changes made.
-  </revision>
-  ", subagent_type="gsd-roadmapper", model="{roadmapper_model}", description="Revise roadmap")
+      Update the roadmap based on feedback. Edit files in place.
+      Return ROADMAP REVISED with changes made.
+      </revision>
   ```
 - Present revised roadmap
 - Loop until user approves

--- a/commands/gsd/new-project.md
+++ b/commands/gsd/new-project.md
@@ -438,190 +438,210 @@ Display spawning indicator:
 
 Spawn 4 parallel gsd-project-researcher agents with rich context:
 
+```yaml
+Task:
+  subagent_type: general-purpose
+  model: "{researcher_model}"
+  description: Stack research for domain
+  prompt: |
+    First, read ~/.claude/agents/gsd-project-researcher.md for your role and instructions.
+
+    <research_type>
+    Project Research — Stack dimension for [domain].
+    </research_type>
+
+    <milestone_context>
+    [greenfield OR subsequent]
+
+    Greenfield: Research the standard stack for building [domain] from scratch.
+    Subsequent: Research what's needed to add [target features] to an existing [domain] app. Don't re-research the existing system.
+    </milestone_context>
+
+    <question>
+    What's the standard 2025 stack for [domain]?
+    </question>
+
+    <project_context>
+    [PROJECT.md summary - core value, constraints, what they're building]
+    </project_context>
+
+    <downstream_consumer>
+    Your STACK.md feeds into roadmap creation. Be prescriptive:
+    - Specific libraries with versions
+    - Clear rationale for each choice
+    - What NOT to use and why
+    </downstream_consumer>
+
+    <quality_gate>
+    - [ ] Versions are current (verify with Context7/official docs, not training data)
+    - [ ] Rationale explains WHY, not just WHAT
+    - [ ] Confidence levels assigned to each recommendation
+    </quality_gate>
+
+    <output>
+    Write to: .planning/research/STACK.md
+    Use template: ~/.claude/get-shit-done/templates/research-project/STACK.md
+    </output>
 ```
-Task(prompt="First, read ~/.claude/agents/gsd-project-researcher.md for your role and instructions.
 
-<research_type>
-Project Research — Stack dimension for [domain].
-</research_type>
+Task:
+  subagent_type: general-purpose
+  model: "{researcher_model}"
+  description: Features research for domain
+  prompt: |
+    First, read ~/.claude/agents/gsd-project-researcher.md for your role and instructions.
 
-<milestone_context>
-[greenfield OR subsequent]
+    <research_type>
+    Project Research — Features dimension for [domain].
+    </research_type>
 
-Greenfield: Research the standard stack for building [domain] from scratch.
-Subsequent: Research what's needed to add [target features] to an existing [domain] app. Don't re-research the existing system.
-</milestone_context>
+    <milestone_context>
+    [greenfield OR subsequent]
 
-<question>
-What's the standard 2025 stack for [domain]?
-</question>
+    Greenfield: What features do [domain] products have? What's table stakes vs differentiating?
+    Subsequent: How do [target features] typically work? What's expected behavior?
+    </milestone_context>
 
-<project_context>
-[PROJECT.md summary - core value, constraints, what they're building]
-</project_context>
+    <question>
+    What features do [domain] products have? What's table stakes vs differentiating?
+    </question>
 
-<downstream_consumer>
-Your STACK.md feeds into roadmap creation. Be prescriptive:
-- Specific libraries with versions
-- Clear rationale for each choice
-- What NOT to use and why
-</downstream_consumer>
+    <project_context>
+    [PROJECT.md summary]
+    </project_context>
 
-<quality_gate>
-- [ ] Versions are current (verify with Context7/official docs, not training data)
-- [ ] Rationale explains WHY, not just WHAT
-- [ ] Confidence levels assigned to each recommendation
-</quality_gate>
+    <downstream_consumer>
+    Your FEATURES.md feeds into requirements definition. Categorize clearly:
+    - Table stakes (must have or users leave)
+    - Differentiators (competitive advantage)
+    - Anti-features (things to deliberately NOT build)
+    </downstream_consumer>
 
-<output>
-Write to: .planning/research/STACK.md
-Use template: ~/.claude/get-shit-done/templates/research-project/STACK.md
-</output>
-", subagent_type="general-purpose", model="{researcher_model}", description="Stack research")
+    <quality_gate>
+    - [ ] Categories are clear (table stakes vs differentiators vs anti-features)
+    - [ ] Complexity noted for each feature
+    - [ ] Dependencies between features identified
+    </quality_gate>
 
-Task(prompt="First, read ~/.claude/agents/gsd-project-researcher.md for your role and instructions.
+    <output>
+    Write to: .planning/research/FEATURES.md
+    Use template: ~/.claude/get-shit-done/templates/research-project/FEATURES.md
+    </output>
 
-<research_type>
-Project Research — Features dimension for [domain].
-</research_type>
+Task:
+  subagent_type: general-purpose
+  model: "{researcher_model}"
+  description: Architecture research for domain
+  prompt: |
+    First, read ~/.claude/agents/gsd-project-researcher.md for your role and instructions.
 
-<milestone_context>
-[greenfield OR subsequent]
+    <research_type>
+    Project Research — Architecture dimension for [domain].
+    </research_type>
 
-Greenfield: What features do [domain] products have? What's table stakes vs differentiating?
-Subsequent: How do [target features] typically work? What's expected behavior?
-</milestone_context>
+    <milestone_context>
+    [greenfield OR subsequent]
 
-<question>
-What features do [domain] products have? What's table stakes vs differentiating?
-</question>
+    Greenfield: How are [domain] systems typically structured? What are major components?
+    Subsequent: How do [target features] integrate with existing [domain] architecture?
+    </milestone_context>
 
-<project_context>
-[PROJECT.md summary]
-</project_context>
+    <question>
+    How are [domain] systems typically structured? What are major components?
+    </question>
 
-<downstream_consumer>
-Your FEATURES.md feeds into requirements definition. Categorize clearly:
-- Table stakes (must have or users leave)
-- Differentiators (competitive advantage)
-- Anti-features (things to deliberately NOT build)
-</downstream_consumer>
+    <project_context>
+    [PROJECT.md summary]
+    </project_context>
 
-<quality_gate>
-- [ ] Categories are clear (table stakes vs differentiators vs anti-features)
-- [ ] Complexity noted for each feature
-- [ ] Dependencies between features identified
-</quality_gate>
+    <downstream_consumer>
+    Your ARCHITECTURE.md informs phase structure in roadmap. Include:
+    - Component boundaries (what talks to what)
+    - Data flow (how information moves)
+    - Suggested build order (dependencies between components)
+    </downstream_consumer>
 
-<output>
-Write to: .planning/research/FEATURES.md
-Use template: ~/.claude/get-shit-done/templates/research-project/FEATURES.md
-</output>
-", subagent_type="general-purpose", model="{researcher_model}", description="Features research")
+    <quality_gate>
+    - [ ] Components clearly defined with boundaries
+    - [ ] Data flow direction explicit
+    - [ ] Build order implications noted
+    </quality_gate>
 
-Task(prompt="First, read ~/.claude/agents/gsd-project-researcher.md for your role and instructions.
+    <output>
+    Write to: .planning/research/ARCHITECTURE.md
+    Use template: ~/.claude/get-shit-done/templates/research-project/ARCHITECTURE.md
+    </output>
 
-<research_type>
-Project Research — Architecture dimension for [domain].
-</research_type>
+Task:
+  subagent_type: general-purpose
+  model: "{researcher_model}"
+  description: Pitfalls research for domain
+  prompt: |
+    First, read ~/.claude/agents/gsd-project-researcher.md for your role and instructions.
 
-<milestone_context>
-[greenfield OR subsequent]
+    <research_type>
+    Project Research — Pitfalls dimension for [domain].
+    </research_type>
 
-Greenfield: How are [domain] systems typically structured? What are major components?
-Subsequent: How do [target features] integrate with existing [domain] architecture?
-</milestone_context>
+    <milestone_context>
+    [greenfield OR subsequent]
 
-<question>
-How are [domain] systems typically structured? What are major components?
-</question>
+    Greenfield: What do [domain] projects commonly get wrong? Critical mistakes?
+    Subsequent: What are common mistakes when adding [target features] to [domain]?
+    </milestone_context>
 
-<project_context>
-[PROJECT.md summary]
-</project_context>
+    <question>
+    What do [domain] projects commonly get wrong? Critical mistakes?
+    </question>
 
-<downstream_consumer>
-Your ARCHITECTURE.md informs phase structure in roadmap. Include:
-- Component boundaries (what talks to what)
-- Data flow (how information moves)
-- Suggested build order (dependencies between components)
-</downstream_consumer>
+    <project_context>
+    [PROJECT.md summary]
+    </project_context>
 
-<quality_gate>
-- [ ] Components clearly defined with boundaries
-- [ ] Data flow direction explicit
-- [ ] Build order implications noted
-</quality_gate>
+    <downstream_consumer>
+    Your PITFALLS.md prevents mistakes in roadmap/planning. For each pitfall:
+    - Warning signs (how to detect early)
+    - Prevention strategy (how to avoid)
+    - Which phase should address it
+    </downstream_consumer>
 
-<output>
-Write to: .planning/research/ARCHITECTURE.md
-Use template: ~/.claude/get-shit-done/templates/research-project/ARCHITECTURE.md
-</output>
-", subagent_type="general-purpose", model="{researcher_model}", description="Architecture research")
+    <quality_gate>
+    - [ ] Pitfalls are specific to this domain (not generic advice)
+    - [ ] Prevention strategies are actionable
+    - [ ] Phase mapping included where relevant
+    </quality_gate>
 
-Task(prompt="First, read ~/.claude/agents/gsd-project-researcher.md for your role and instructions.
-
-<research_type>
-Project Research — Pitfalls dimension for [domain].
-</research_type>
-
-<milestone_context>
-[greenfield OR subsequent]
-
-Greenfield: What do [domain] projects commonly get wrong? Critical mistakes?
-Subsequent: What are common mistakes when adding [target features] to [domain]?
-</milestone_context>
-
-<question>
-What do [domain] projects commonly get wrong? Critical mistakes?
-</question>
-
-<project_context>
-[PROJECT.md summary]
-</project_context>
-
-<downstream_consumer>
-Your PITFALLS.md prevents mistakes in roadmap/planning. For each pitfall:
-- Warning signs (how to detect early)
-- Prevention strategy (how to avoid)
-- Which phase should address it
-</downstream_consumer>
-
-<quality_gate>
-- [ ] Pitfalls are specific to this domain (not generic advice)
-- [ ] Prevention strategies are actionable
-- [ ] Phase mapping included where relevant
-</quality_gate>
-
-<output>
-Write to: .planning/research/PITFALLS.md
-Use template: ~/.claude/get-shit-done/templates/research-project/PITFALLS.md
-</output>
-", subagent_type="general-purpose", model="{researcher_model}", description="Pitfalls research")
+    <output>
+    Write to: .planning/research/PITFALLS.md
+    Use template: ~/.claude/get-shit-done/templates/research-project/PITFALLS.md
+    </output>
 ```
 
 After all 4 agents complete, spawn synthesizer to create SUMMARY.md:
 
-```
-Task(prompt="
-<task>
-Synthesize research outputs into SUMMARY.md.
-</task>
+```yaml
+Task:
+  subagent_type: gsd-research-synthesizer
+  model: "{synthesizer_model}"
+  description: Synthesize research findings
+  prompt: |
+    <task>
+    Synthesize research outputs into SUMMARY.md.
+    </task>
 
-<research_files>
-Read these files:
-- .planning/research/STACK.md
-- .planning/research/FEATURES.md
-- .planning/research/ARCHITECTURE.md
-- .planning/research/PITFALLS.md
-</research_files>
+    <research_files>
+    Read these files:
+    - .planning/research/STACK.md
+    - .planning/research/FEATURES.md
+    - .planning/research/ARCHITECTURE.md
+    - .planning/research/PITFALLS.md
+    </research_files>
 
-<output>
-Write to: .planning/research/SUMMARY.md
-Use template: ~/.claude/get-shit-done/templates/research-project/SUMMARY.md
-Commit after writing.
-</output>
-", subagent_type="gsd-research-synthesizer", model="{synthesizer_model}", description="Synthesize research")
+    <output>
+    Write to: .planning/research/SUMMARY.md
+    Use template: ~/.claude/get-shit-done/templates/research-project/SUMMARY.md
+    Commit after writing.
+    </output>
 ```
 
 Display research complete banner and key findings:
@@ -797,36 +817,39 @@ Display stage banner:
 
 Spawn gsd-roadmapper agent with context:
 
-```
-Task(prompt="
-<planning_context>
+```yaml
+Task:
+  subagent_type: gsd-roadmapper
+  model: "{roadmapper_model}"
+  description: Create project roadmap from requirements
+  prompt: |
+    <planning_context>
 
-**Project:**
-@.planning/PROJECT.md
+    **Project:**
+    @.planning/PROJECT.md
 
-**Requirements:**
-@.planning/REQUIREMENTS.md
+    **Requirements:**
+    @.planning/REQUIREMENTS.md
 
-**Research (if exists):**
-@.planning/research/SUMMARY.md
+    **Research (if exists):**
+    @.planning/research/SUMMARY.md
 
-**Config:**
-@.planning/config.json
+    **Config:**
+    @.planning/config.json
 
-</planning_context>
+    </planning_context>
 
-<instructions>
-Create roadmap:
-1. Derive phases from requirements (don't impose structure)
-2. Map every v1 requirement to exactly one phase
-3. Derive 2-5 success criteria per phase (observable user behaviors)
-4. Validate 100% coverage
-5. Write files immediately (ROADMAP.md, STATE.md, update REQUIREMENTS.md traceability)
-6. Return ROADMAP CREATED with summary
+    <instructions>
+    Create roadmap:
+    1. Derive phases from requirements (don't impose structure)
+    2. Map every v1 requirement to exactly one phase
+    3. Derive 2-5 success criteria per phase (observable user behaviors)
+    4. Validate 100% coverage
+    5. Write files immediately (ROADMAP.md, STATE.md, update REQUIREMENTS.md traceability)
+    6. Return ROADMAP CREATED with summary
 
-Write files first, then return. This ensures artifacts persist even if context is lost.
-</instructions>
-", subagent_type="gsd-roadmapper", model="{roadmapper_model}", description="Create roadmap")
+    Write files first, then return. This ensures artifacts persist even if context is lost.
+    </instructions>
 ```
 
 **Handle roadmapper return:**
@@ -891,18 +914,21 @@ Use AskUserQuestion:
 **If "Adjust phases":**
 - Get user's adjustment notes
 - Re-spawn roadmapper with revision context:
-  ```
-  Task(prompt="
-  <revision>
-  User feedback on roadmap:
-  [user's notes]
+  ```yaml
+  Task:
+    subagent_type: gsd-roadmapper
+    model: "{roadmapper_model}"
+    description: Revise roadmap based on feedback
+    prompt: |
+      <revision>
+      User feedback on roadmap:
+      [user's notes]
 
-  Current ROADMAP.md: @.planning/ROADMAP.md
+      Current ROADMAP.md: @.planning/ROADMAP.md
 
-  Update the roadmap based on feedback. Edit files in place.
-  Return ROADMAP REVISED with changes made.
-  </revision>
-  ", subagent_type="gsd-roadmapper", model="{roadmapper_model}", description="Revise roadmap")
+      Update the roadmap based on feedback. Edit files in place.
+      Return ROADMAP REVISED with changes made.
+      </revision>
   ```
 - Present revised roadmap
 - Loop until user approves

--- a/commands/gsd/plan-phase.md
+++ b/commands/gsd/plan-phase.md
@@ -221,13 +221,15 @@ Write research findings to: {phase_dir}/{phase}-RESEARCH.md
 </output>
 ```
 
-```
-Task(
-  prompt="First, read ~/.claude/agents/gsd-phase-researcher.md for your role and instructions.\n\n" + research_prompt,
-  subagent_type="general-purpose",
-  model="{researcher_model}",
-  description="Research Phase {phase}"
-)
+```yaml
+Task:
+  subagent_type: general-purpose
+  model: "{researcher_model}"
+  description: Research phase implementation approach
+  prompt: |
+    First, read ~/.claude/agents/gsd-phase-researcher.md for your role and instructions.
+
+    {research_prompt}
 ```
 
 ### Handle Researcher Return
@@ -336,13 +338,15 @@ Before returning PLANNING COMPLETE:
 </quality_gate>
 ```
 
-```
-Task(
-  prompt="First, read ~/.claude/agents/gsd-planner.md for your role and instructions.\n\n" + filled_prompt,
-  subagent_type="general-purpose",
-  model="{planner_model}",
-  description="Plan Phase {phase}"
-)
+```yaml
+Task:
+  subagent_type: general-purpose
+  model: "{planner_model}"
+  description: Create execution plans for phase
+  prompt: |
+    First, read ~/.claude/agents/gsd-planner.md for your role and instructions.
+
+    {filled_prompt}
 ```
 
 ## 9. Handle Planner Return
@@ -419,13 +423,13 @@ Return one of:
 </expected_output>
 ```
 
-```
-Task(
-  prompt=checker_prompt,
-  subagent_type="gsd-plan-checker",
-  model="{checker_model}",
-  description="Verify Phase {phase} plans"
-)
+```yaml
+Task:
+  subagent_type: gsd-plan-checker
+  model: "{checker_model}"
+  description: Verify phase plans meet requirements
+  prompt: |
+    {checker_prompt}
 ```
 
 ## 11. Handle Checker Return
@@ -485,13 +489,15 @@ Return what changed.
 </instructions>
 ```
 
-```
-Task(
-  prompt="First, read ~/.claude/agents/gsd-planner.md for your role and instructions.\n\n" + revision_prompt,
-  subagent_type="general-purpose",
-  model="{planner_model}",
-  description="Revise Phase {phase} plans"
-)
+```yaml
+Task:
+  subagent_type: general-purpose
+  model: "{planner_model}"
+  description: Revise plans based on checker feedback
+  prompt: |
+    First, read ~/.claude/agents/gsd-planner.md for your role and instructions.
+
+    {revision_prompt}
 ```
 
 - After planner returns → spawn checker again (step 10)

--- a/commands/gsd/quick.md
+++ b/commands/gsd/quick.md
@@ -139,36 +139,34 @@ Store `$QUICK_DIR` for use in orchestration.
 
 Spawn gsd-planner with quick mode context:
 
-```
-Task(
-  prompt="
-<planning_context>
+```yaml
+Task:
+  subagent_type: gsd-planner
+  model: "{planner_model}"
+  description: Quick plan for task
+  prompt: |
+    <planning_context>
 
-**Mode:** quick
-**Directory:** ${QUICK_DIR}
-**Description:** ${DESCRIPTION}
+    **Mode:** quick
+    **Directory:** ${QUICK_DIR}
+    **Description:** ${DESCRIPTION}
 
-**Project State:**
-@.planning/STATE.md
+    **Project State:**
+    @.planning/STATE.md
 
-</planning_context>
+    </planning_context>
 
-<constraints>
-- Create a SINGLE plan with 1-3 focused tasks
-- Quick tasks should be atomic and self-contained
-- No research phase, no checker phase
-- Target ~30% context usage (simple, focused)
-</constraints>
+    <constraints>
+    - Create a SINGLE plan with 1-3 focused tasks
+    - Quick tasks should be atomic and self-contained
+    - No research phase, no checker phase
+    - Target ~30% context usage (simple, focused)
+    </constraints>
 
-<output>
-Write plan to: ${QUICK_DIR}/${next_num}-PLAN.md
-Return: ## PLANNING COMPLETE with plan path
-</output>
-",
-  subagent_type="gsd-planner",
-  model="{planner_model}",
-  description="Quick plan: ${DESCRIPTION}"
-)
+    <output>
+    Write plan to: ${QUICK_DIR}/${next_num}-PLAN.md
+    Return: ## PLANNING COMPLETE with plan path
+    </output>
 ```
 
 After planner returns:
@@ -184,25 +182,23 @@ If plan not found, error: "Planner failed to create ${next_num}-PLAN.md"
 
 Spawn gsd-executor with plan reference:
 
-```
-Task(
-  prompt="
-Execute quick task ${next_num}.
+```yaml
+Task:
+  subagent_type: gsd-executor
+  model: "{executor_model}"
+  description: Execute quick task
+  prompt: |
+    Execute quick task ${next_num}.
 
-Plan: @${QUICK_DIR}/${next_num}-PLAN.md
-Project state: @.planning/STATE.md
+    Plan: @${QUICK_DIR}/${next_num}-PLAN.md
+    Project state: @.planning/STATE.md
 
-<constraints>
-- Execute all tasks in the plan
-- Commit each task atomically
-- Create summary at: ${QUICK_DIR}/${next_num}-SUMMARY.md
-- Do NOT update ROADMAP.md (quick tasks are separate from planned phases)
-</constraints>
-",
-  subagent_type="gsd-executor",
-  model="{executor_model}",
-  description="Execute: ${DESCRIPTION}"
-)
+    <constraints>
+    - Execute all tasks in the plan
+    - Commit each task atomically
+    - Create summary at: ${QUICK_DIR}/${next_num}-SUMMARY.md
+    - Do NOT update ROADMAP.md (quick tasks are separate from planned phases)
+    </constraints>
 ```
 
 After executor returns:

--- a/commands/gsd/research-phase.md
+++ b/commands/gsd/research-phase.md
@@ -146,13 +146,15 @@ Write to: .planning/phases/${PHASE}-{slug}/${PHASE}-RESEARCH.md
 </output>
 ```
 
-```
-Task(
-  prompt="First, read ~/.claude/agents/gsd-phase-researcher.md for your role and instructions.\n\n" + filled_prompt,
-  subagent_type="general-purpose",
-  model="{researcher_model}",
-  description="Research Phase {phase}"
-)
+```yaml
+Task:
+  subagent_type: general-purpose
+  model: "{researcher_model}"
+  description: Research phase implementation approach
+  prompt: |
+    First, read ~/.claude/agents/gsd-phase-researcher.md for your role and instructions.
+
+    {filled_prompt}
 ```
 
 ## 5. Handle Agent Return
@@ -180,13 +182,15 @@ Research file: @.planning/phases/${PHASE}-{slug}/${PHASE}-RESEARCH.md
 </checkpoint_response>
 ```
 
-```
-Task(
-  prompt="First, read ~/.claude/agents/gsd-phase-researcher.md for your role and instructions.\n\n" + continuation_prompt,
-  subagent_type="general-purpose",
-  model="{researcher_model}",
-  description="Continue research Phase {phase}"
-)
+```yaml
+Task:
+  subagent_type: general-purpose
+  model: "{researcher_model}"
+  description: Continue phase research after checkpoint
+  prompt: |
+    First, read ~/.claude/agents/gsd-phase-researcher.md for your role and instructions.
+
+    {continuation_prompt}
 ```
 
 </process>


### PR DESCRIPTION
## Summary

- Fixes Claude Code parsing bug where `subagent_type="general-purpose"` gets parsed as `general-purpose"` (trailing quote)
- Converts all 28 Task() calls across 8 command files from Python-syntax to YAML-syntax
- No functional changes - only syntax transformation

## The Bug

When Claude Code parses Task() calls with Python-style parameters, the parser incorrectly handles quoted strings:

```python
# Current (buggy)
Task(
  prompt="...",
  subagent_type="general-purpose",  # Parsed as: general-purpose"
  model="sonnet"
)
```

The trailing quote remains attached to the value, causing agent type detection to fail.

## The Fix

YAML-syntax doesn't have this issue because values don't require quotes:

```yaml
# Fixed
Task:
  subagent_type: general-purpose  # No quotes = no parsing issue
  model: sonnet
  prompt: |
    ...
```

## Files Changed

| File | Task() Calls |
|------|--------------|
| audit-milestone.md | 1 |
| debug.md | 2 |
| execute-phase.md | 3 |
| new-milestone.md | 7 |
| new-project.md | 7 |
| plan-phase.md | 4 |
| quick.md | 2 |
| research-phase.md | 2 |
| **Total** | **28** |

## Testing

Verified no Python-syntax Task() calls remain:
```bash
grep -c 'subagent_type="' commands/gsd/*.md
# All files return 0
```

## Notes

This bug affects all GSD users running Claude Code. The YAML syntax is functionally equivalent but avoids the parsing issue entirely.

---

🤖 Generated with [Claude Code](https://claude.ai/code)