### PR TITLE
feat(config): enhanced configuration options for user control

### DIFF
--- a/agents/gsd-phase-researcher.md
+++ b/agents/gsd-phase-researcher.md
@@ -455,10 +455,23 @@ PHASE_DIR=$(ls -d .planning/phases/$PADDED_PHASE-* .planning/phases/$PHASE-* 2>/
 cat "$PHASE_DIR"/*-CONTEXT.md 2>/dev/null
 
 # Check if planning docs should be committed (default: true)
-COMMIT_PLANNING_DOCS=$(cat .planning/config.json 2>/dev/null | grep -o '"commit_docs"[[:space:]]*:[[:space:]]*[^,}]*' | grep -o 'true\|false' || echo "true")
+COMMIT_PLANNING_DOCS=$(jq -r '.planning.commit_docs // true' .planning/config.json 2>/dev/null || echo "true")
 # Auto-detect gitignored (overrides config)
 git check-ignore -q .planning 2>/dev/null && COMMIT_PLANNING_DOCS=false
+
+# Load research depth config (default: standard)
+RESEARCH_DEPTH=$(jq -r '.workflow.research_depth // "standard"' .planning/config.json 2>/dev/null || echo "standard")
 ```
+
+**Research depth determines thoroughness:**
+
+| Depth | Behavior | Use when |
+|-------|----------|----------|
+| `quick` | 1 focused search, summary only | You know the domain well |
+| `standard` | 3-5 searches, analysis | Default for most projects |
+| `deep` | Comprehensive research with alternatives | New domain, complex architecture |
+
+Adjust your research scope based on `$RESEARCH_DEPTH`.
 
 **If CONTEXT.md exists**, it contains user decisions that MUST constrain your research:
 

--- a/get-shit-done/references/git-integration.md
+++ b/get-shit-done/references/git-integration.md
@@ -252,3 +252,74 @@ Each plan produces 2-4 commits (tasks + metadata). Clear, granular, bisectable.
 - "Commit noise" irrelevant when consumer is Claude, not humans
 
 </commit_strategy_rationale>
+
+<branch_templates>
+
+## Branch Templates
+
+Custom branch naming via `git.branch_template` in config.json.
+
+**Template variables:**
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `{type}` | Branch type (feat, fix, etc.) | `feat` |
+| `{phase}` | Zero-padded phase number | `03` |
+| `{name}` | Phase or plan name | `authentication` |
+| `{slug}` | Lowercase, hyphenated name | `user-auth` |
+| `{milestone}` | Milestone version | `v1.0` |
+
+**Configuration:**
+
+```json
+{
+  "git": {
+    "branching_strategy": "phase",
+    "branch_template": "{type}/{phase}-{name}"
+  }
+}
+```
+
+**Examples:**
+
+| Template | Result |
+|----------|--------|
+| `{type}/{phase}-{name}` | `feat/03-authentication` |
+| `gsd/{milestone}/{phase}` | `gsd/v1.0/03` |
+| `feature/{slug}` | `feature/user-auth` |
+| `gsd/phase-{phase}-{slug}` | `gsd/phase-03-auth` |
+
+</branch_templates>
+
+<commit_formats_config>
+
+## Commit Format Configuration
+
+Control commit message style via `git.commit_format` in config.json.
+
+**Options:**
+
+| Format | Style | Example |
+|--------|-------|---------|
+| `conventional` | `type(scope): message` | `feat(03-01): add login endpoint` |
+| `simple` | Plain message | `Add login endpoint` |
+
+**Default:** `conventional` (recommended for GSD context engineering).
+
+**Configuration:**
+
+```json
+{
+  "git": {
+    "commit_format": "conventional"
+  }
+}
+```
+
+**Conventional format** enables:
+- `git log --grep="feat("` to find all features
+- `git log --grep="(03-"` to find all Phase 3 work
+- Semantic versioning automation
+- Changelog generation
+
+</commit_formats_config>

--- a/get-shit-done/templates/config.json
+++ b/get-shit-done/templates/config.json
@@ -1,14 +1,24 @@
 {
   "mode": "interactive",
+  "model_profile": "balanced",
   "depth": "standard",
   "workflow": {
     "research": true,
     "plan_check": true,
-    "verifier": true
+    "verifier": true,
+    "research_depth": "standard",
+    "plan_atomicity": "medium"
   },
   "planning": {
     "commit_docs": true,
     "search_gitignored": false
+  },
+  "git": {
+    "branching_strategy": "none",
+    "branch_template": "{type}/{phase}-{name}",
+    "phase_branch_template": "gsd/phase-{phase}-{slug}",
+    "milestone_branch_template": "gsd/{milestone}-{slug}",
+    "commit_format": "conventional"
   },
   "parallelization": {
     "enabled": true,
@@ -16,6 +26,7 @@
     "task_level": false,
     "skip_checkpoints": true,
     "max_concurrent_agents": 3,
+    "max_wave_size": 4,
     "min_plans_for_parallel": 2
   },
   "gates": {


### PR DESCRIPTION
## Goal
Give users control over behaviors currently hardcoded.

## GSD Alignment
- **Solo Developer Autonomy**: Users control their workflow without forking.
- **No Enterprise Patterns**: Unlike rigid enterprise tools, GSD adapts to individual preferences.

## Deviation Note
Adds complexity via new config options. Justified because: defaults match current behavior (no breaking changes), power users get control, simple users can ignore.

## Changes
- New config options: research_depth, plan_atomicity, branch_template, max_wave_size, commit_format
- Agents read new config via jq (replacing fragile grep/sed parsing)
- Custom git branch templates (#173)
- Expanded planning-config.md schema documentation

## Files
- `agents/gsd-phase-researcher.md` — Reads research_depth via jq
- `agents/gsd-planner.md` — Reads plan_atomicity via jq
- `get-shit-done/references/git-integration.md` — Branch templates, commit format docs
- `get-shit-done/references/planning-config.md` — Expanded schema with all new options
- `get-shit-done/templates/config.json` — New defaults added

## Related
- Extends #379 (parallelization config) with `max_wave_size`

## Testing
- Each new config option tested individually
- Defaults produce identical behavior to current GSD
- jq parsing works consistently