### PR TITLE
feat(overrides): user override system for customization without forking

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -1275,7 +1275,83 @@ function install(isGlobal, runtime = 'claude') {
     }
   }
 
+  // Create gsd-overrides skeleton directory for user customizations
+  if (isGlobal && !isOpencode) {
+    createOverridesDirectory(targetDir);
+  }
+
   return { settingsPath, settings, statuslineCommand, runtime };
+}
+
+/**
+ * Create gsd-overrides skeleton directory for user customizations
+ * This allows users to override GSD files without forking the repository
+ * @param {string} targetDir - The config directory (e.g., ~/.claude)
+ */
+function createOverridesDirectory(targetDir) {
+  const overridesDir = path.join(targetDir, 'gsd-overrides');
+
+  // Only create if it doesn't exist (preserve user customizations)
+  if (fs.existsSync(overridesDir)) {
+    return;
+  }
+
+  fs.mkdirSync(overridesDir, { recursive: true });
+
+  // Create subdirectories
+  const subdirs = ['agents', 'templates', 'workflows'];
+  for (const subdir of subdirs) {
+    fs.mkdirSync(path.join(overridesDir, subdir), { recursive: true });
+  }
+
+  // Create README.md explaining the override system
+  const readme = `# GSD Overrides Directory
+
+This directory allows you to customize GSD behavior without forking the repository.
+
+## How It Works
+
+GSD checks for override files in this directory before using defaults.
+
+**Priority order:**
+1. \`~/.claude/gsd-overrides/{type}/{filename}\` (your customizations)
+2. \`~/.claude/{type}/{filename}\` (GSD defaults)
+
+## Directory Structure
+
+\`\`\`
+gsd-overrides/
+├── agents/          # Custom agent definitions
+│   └── gsd-executor.md    # Override the executor agent
+├── templates/       # Custom templates
+│   └── plan.md            # Override plan template
+└── workflows/       # Custom workflow pieces
+    └── _commits.md        # Override commit logic
+\`\`\`
+
+## Example: Custom Executor Agent
+
+To customize the executor agent:
+
+1. Copy the default: \`cp ~/.claude/agents/gsd-executor.md ~/.claude/gsd-overrides/agents/\`
+2. Edit your copy
+3. GSD will use your version instead
+
+## Updates
+
+When GSD updates, your overrides are preserved.
+Check the CHANGELOG to see if default files changed that affect your overrides.
+
+## Debugging
+
+If GSD behavior seems wrong, check for override files first:
+\`ls -la ~/.claude/gsd-overrides/\`
+
+To disable an override, rename or remove the file.
+`;
+
+  fs.writeFileSync(path.join(overridesDir, 'README.md'), readme);
+  console.log(`  ${green}✓${reset} Created gsd-overrides/ for customizations`);
 }
 
 /**

--- a/get-shit-done/references/user-overrides.md
+++ b/get-shit-done/references/user-overrides.md
@@ -1,0 +1,171 @@
+<user_overrides>
+
+Customize GSD behavior without forking the repository.
+
+<overview>
+
+## What It Is
+
+The user override system lets you customize GSD agents, templates, and workflows by placing files in `~/.claude/gsd-overrides/`. GSD checks for override files before using defaults.
+
+## Why It Exists
+
+Previously, customizing GSD required:
+1. Fork the entire repository
+2. Modify source files
+3. Maintain your fork against upstream changes
+
+Now you can customize just the files you need, and updates won't overwrite your changes.
+
+</overview>
+
+<directory_structure>
+
+## Directory Structure
+
+```
+~/.claude/
+├── gsd-overrides/           # Your customizations (highest priority)
+│   ├── agents/
+│   │   └── gsd-executor.md  # Custom executor agent
+│   ├── templates/
+│   │   └── plan.md          # Custom plan template
+│   └── workflows/
+│       └── execute-plan/
+│           └── _commits.md  # Custom commit logic
+├── agents/                   # GSD defaults (lower priority)
+│   └── gsd-executor.md
+└── get-shit-done/
+    └── workflows/
+        └── execute-plan/
+            └── _commits.md
+```
+
+</directory_structure>
+
+<resolution_order>
+
+## Priority Resolution
+
+When GSD needs a file, it checks in this order:
+
+1. `~/.claude/gsd-overrides/{type}/{filename}` — **User override (wins)**
+2. `~/.claude/{type}/{filename}` or `~/.claude/get-shit-done/{type}/{filename}` — **GSD default**
+
+**Example:** When spawning an executor agent:
+- Check: `~/.claude/gsd-overrides/agents/gsd-executor.md`
+- If exists: Use override
+- If not: Use `~/.claude/agents/gsd-executor.md`
+
+</resolution_order>
+
+<creating_overrides>
+
+## Creating Overrides
+
+### Step 1: Copy the Default
+
+```bash
+# Copy default to override location
+cp ~/.claude/agents/gsd-executor.md ~/.claude/gsd-overrides/agents/
+
+# For workflows
+cp ~/.claude/get-shit-done/workflows/execute-plan/_commits.md \
+   ~/.claude/gsd-overrides/workflows/execute-plan/
+
+# For templates
+cp ~/.claude/get-shit-done/templates/plan.md \
+   ~/.claude/gsd-overrides/templates/
+```
+
+### Step 2: Edit Your Copy
+
+Modify the override file to customize behavior.
+
+### Step 3: Test
+
+Run GSD commands. Your override is automatically used.
+
+</creating_overrides>
+
+<common_overrides>
+
+## Common Customizations
+
+### Custom Commit Messages
+
+Override `_commits.md` to change commit format:
+
+```bash
+cp ~/.claude/get-shit-done/workflows/execute-plan/_commits.md \
+   ~/.claude/gsd-overrides/workflows/execute-plan/
+# Edit: Change commit message format from conventional to simple
+```
+
+### Custom Executor Behavior
+
+Override `gsd-executor.md` to change how plans are executed:
+
+```bash
+cp ~/.claude/agents/gsd-executor.md ~/.claude/gsd-overrides/agents/
+# Edit: Add custom verification steps, change commit frequency, etc.
+```
+
+### Custom Plan Templates
+
+Override templates to change plan structure:
+
+```bash
+cp ~/.claude/get-shit-done/templates/plan.md ~/.claude/gsd-overrides/templates/
+# Edit: Add custom frontmatter fields, change task format, etc.
+```
+
+</common_overrides>
+
+<maintenance>
+
+## Maintenance
+
+### Updates
+
+When GSD updates, your overrides are preserved. However:
+
+1. **Check CHANGELOG** — See if default files you override changed
+2. **Merge changes** — If defaults changed significantly, update your overrides
+3. **Test** — Run GSD commands to verify overrides still work
+
+### Debugging
+
+If GSD behavior seems wrong:
+
+```bash
+# Check for override files
+ls -la ~/.claude/gsd-overrides/
+
+# Remove override to test default behavior
+mv ~/.claude/gsd-overrides/agents/gsd-executor.md \
+   ~/.claude/gsd-overrides/agents/gsd-executor.md.disabled
+```
+
+### Detection Logging
+
+When GSD uses an override, it logs:
+```
+[GSD] Using override: ~/.claude/gsd-overrides/agents/gsd-executor.md
+```
+
+This helps you know when customizations are active.
+
+</maintenance>
+
+<limitations>
+
+## Limitations
+
+1. **Global installs only** — Overrides only work for global GSD installations
+2. **Claude Code only** — Override system not available for OpenCode (yet)
+3. **Manual sync** — You must manually update overrides when GSD defaults change significantly
+
+</limitations>
+
+</user_overrides>

--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -244,6 +244,111 @@ Report wave structure with context:
 The "What it builds" column comes from skimming plan names/objectives. Keep it brief (3-8 words).
 </step>
 
+<step name="check_overrides">
+Check for user override files before using GSD defaults.
+
+```bash
+# Helper function to resolve file with override support
+# Returns override path if exists, otherwise default path
+resolve_gsd_file() {
+  local type="$1"      # e.g., "workflows", "agents", "templates"
+  local filename="$2"  # e.g., "_base.md", "gsd-executor.md"
+
+  local override_path="$HOME/.claude/gsd-overrides/$type/$filename"
+  local default_path="$HOME/.claude/get-shit-done/$type/$filename"
+
+  # For agents, default is in agents/ not get-shit-done/agents/
+  if [ "$type" = "agents" ]; then
+    default_path="$HOME/.claude/agents/$filename"
+  fi
+
+  if [ -f "$override_path" ]; then
+    echo "[GSD] Using override: $override_path" >&2
+    echo "$override_path"
+  else
+    echo "$default_path"
+  fi
+}
+```
+
+**Override detection logging:**
+
+When spawning agents, check for overrides and log if detected:
+
+```bash
+EXECUTOR_PATH=$(resolve_gsd_file "agents" "gsd-executor.md")
+```
+
+If override is detected, a message is logged to stderr so the user knows their customization is being used.
+</step>
+
+<step name="build_execution_context">
+Build minimal execution context for each plan by loading only required workflow modules.
+
+**Always load (core modules) with override support:**
+```bash
+BASE_PATH=$(resolve_gsd_file "workflows/execute-plan" "_base.md")
+COMMITS_PATH=$(resolve_gsd_file "workflows/execute-plan" "_commits.md")
+DEVIATION_PATH=$(resolve_gsd_file "workflows/execute-plan" "_deviation.md")
+
+BASE_CONTENT=$(cat "$BASE_PATH")
+COMMITS_CONTENT=$(cat "$COMMITS_PATH")
+DEVIATION_CONTENT=$(cat "$DEVIATION_PATH")
+```
+
+**Conditionally load based on plan frontmatter:**
+
+```bash
+# For each plan in the wave, check frontmatter
+for plan in $WAVE_PLANS; do
+  # Check for TDD flag
+  HAS_TDD=$(grep -q 'tdd:\s*true\|tdd="true"' "$plan" && echo "true" || echo "false")
+
+  # Check for checkpoints (autonomous: false means has checkpoints)
+  HAS_CHECKPOINTS=$(grep -q 'autonomous:\s*false\|type="checkpoint' "$plan" && echo "true" || echo "false")
+
+  # Check verifier config
+  VERIFIER_ENABLED=$(cat .planning/config.json 2>/dev/null | grep -o '"verifier"[[:space:]]*:[[:space:]]*[^,}]*' | grep -q 'true' && echo "true" || echo "false")
+
+  # Build execution context for this plan
+  EXECUTION_CONTEXT="$BASE_CONTENT\n\n$COMMITS_CONTENT\n\n$DEVIATION_CONTENT"
+
+  if [ "$HAS_TDD" = "true" ]; then
+    TDD_PATH=$(resolve_gsd_file "workflows/execute-plan" "_tdd.md")
+    TDD_CONTENT=$(cat "$TDD_PATH")
+    EXECUTION_CONTEXT="$EXECUTION_CONTEXT\n\n$TDD_CONTENT"
+  fi
+
+  if [ "$HAS_CHECKPOINTS" = "true" ]; then
+    CHECKPOINTS_PATH=$(resolve_gsd_file "workflows/execute-plan" "_checkpoints.md")
+    CHECKPOINTS_CONTENT=$(cat "$CHECKPOINTS_PATH")
+    EXECUTION_CONTEXT="$EXECUTION_CONTEXT\n\n$CHECKPOINTS_CONTENT"
+  fi
+
+  if [ "$VERIFIER_ENABLED" = "true" ]; then
+    VERIFICATION_PATH=$(resolve_gsd_file "workflows/execute-plan" "_verification.md")
+    VERIFICATION_CONTENT=$(cat "$VERIFICATION_PATH")
+    EXECUTION_CONTEXT="$EXECUTION_CONTEXT\n\n$VERIFICATION_CONTENT"
+  fi
+
+  # Store for spawn step
+  PLAN_EXECUTION_CONTEXTS["$plan"]="$EXECUTION_CONTEXT"
+done
+```
+
+**Expected context savings:**
+
+| Plan Type | Modules Loaded | Approximate Lines | Savings vs Full |
+|-----------|----------------|-------------------|-----------------|
+| Standard | base + commits + deviation | ~750 | 60% |
+| TDD | + tdd | ~900 | 52% |
+| With Checkpoints | + checkpoints | ~950 | 49% |
+| With Verification | + verification | ~1050 | 44% |
+| Full (all modules) | All 6 modules | ~1400 | 25% |
+
+**Note:** Original monolithic execute-plan.md was ~1,856 lines.
+</step>
+
 <step name="execute_waves">
 Execute each wave in sequence. Autonomous plans within a wave run in parallel **only if `PARALLELIZATION=true`**.
 


### PR DESCRIPTION
## Goal
Allow customization without forking GSD.

## GSD Alignment
- **Solo Developer Autonomy**: Customize GSD for specific workflows without maintaining a fork.
- **Simplicity**: Override is optional. Default GSD works out of the box.

## Deviation Note
Overrides could cause unexpected behavior, complicating troubleshooting. Justified because: overrides are explicit (user creates files in known location), GSD logs when overrides are detected, support requests should include override info.

## Changes
- `gsd-overrides/` directory structure for agents, templates, workflows
- Priority-based resolution: user override > GSD default via `resolve_gsd_file()` helper
- Override detection logging to stderr
- Installer creates overrides directory structure

## Files
- `bin/install.js` — `createOverridesDirectory()` function added
- `get-shit-done/references/user-overrides.md` — NEW: Override documentation
- `get-shit-done/workflows/execute-phase.md` — `check_overrides` step, `resolve_gsd_file()`

## Related
- Addresses #348 (custom rules that persist across updates)

## Testing
- Create override agent, verify it's used
- Remove override, verify default is used
- Override detection logging works