### PR TITLE
feat(project-types): project-type awareness for adaptive workflows

### DIFF
--- a/commands/gsd/new-project.md
+++ b/commands/gsd/new-project.md
@@ -64,6 +64,42 @@ This is the most leveraged moment in any project. Deep questioning here means be
    HAS_CODEBASE_MAP=$([ -d .planning/codebase ] && echo "yes")
    ```
 
+4. **Detect project type:**
+   ```bash
+   # Detect project type from dependencies and file patterns
+   PROJECT_TYPE="general"
+
+   if [ -f package.json ]; then
+     # Check for frontend frameworks
+     if grep -q '"react"\|"vue"\|"angular"\|"svelte"\|"next"\|"nuxt"\|"@angular"' package.json 2>/dev/null; then
+       PROJECT_TYPE="web-frontend"
+     # Check for backend frameworks
+     elif grep -q '"express"\|"fastify"\|"koa"\|"hapi"\|"nestjs"\|"hono"' package.json 2>/dev/null; then
+       PROJECT_TYPE="web-backend"
+     # Check for CLI tools
+     elif grep -q '"commander"\|"yargs"\|"inquirer"\|"chalk"\|"ora"\|"meow"' package.json 2>/dev/null; then
+       PROJECT_TYPE="cli-tool"
+     # Check for libraries
+     elif grep -q '"types"\|"main"\|"module"\|"exports"' package.json 2>/dev/null && ! grep -q '"start"\|"dev"' package.json 2>/dev/null; then
+       PROJECT_TYPE="library"
+     fi
+   elif [ -f requirements.txt ] || [ -f pyproject.toml ]; then
+     if grep -q 'flask\|django\|fastapi\|starlette' requirements.txt pyproject.toml 2>/dev/null; then
+       PROJECT_TYPE="web-backend"
+     elif grep -q 'click\|typer\|argparse' requirements.txt pyproject.toml 2>/dev/null; then
+       PROJECT_TYPE="cli-tool"
+     fi
+   elif [ -f go.mod ]; then
+     if grep -q 'gin\|echo\|fiber\|chi' go.mod 2>/dev/null; then
+       PROJECT_TYPE="web-backend"
+     elif grep -q 'cobra\|urfave/cli' go.mod 2>/dev/null; then
+       PROJECT_TYPE="cli-tool"
+     fi
+   fi
+
+   echo "Detected project type: $PROJECT_TYPE"
+   ```
+
    **You MUST run all bash commands above using the Bash tool before proceeding.**
 
 ## Phase 2: Brownfield Offer
@@ -341,6 +377,7 @@ Create `.planning/config.json` with all settings:
 {
   "mode": "yolo|interactive",
   "depth": "quick|standard|comprehensive",
+  "project_type": "web-frontend|web-backend|cli-tool|library|general",
   "parallelization": true|false,
   "commit_docs": true|false,
   "model_profile": "quality|balanced|budget",
@@ -351,6 +388,18 @@ Create `.planning/config.json` with all settings:
   }
 }
 ```
+
+**Project type:**
+
+Store the detected `PROJECT_TYPE` from Phase 1 in config. This enables type-specific templates and research focus.
+
+| Type | Description | Research Focus |
+|------|-------------|----------------|
+| `web-frontend` | React, Vue, Angular, Svelte apps | UI/UX patterns, component design, state management |
+| `web-backend` | Express, FastAPI, Go servers | API design, data modeling, auth patterns |
+| `cli-tool` | Command-line tools | Argument parsing, output formatting, shell integration |
+| `library` | Shared packages/modules | API surface design, versioning, documentation |
+| `general` | Default for unknown types | Full-stack research |
 
 **If commit_docs = No:**
 - Set `commit_docs: false` in config.json

--- a/get-shit-done/references/planning-config.md
+++ b/get-shit-done/references/planning-config.md
@@ -17,6 +17,7 @@ Configuration options for `.planning/` directory behavior.
 
 | Option | Default | Description |
 |--------|---------|-------------|
+| `project_type` | `"general"` | Project type: `"web-frontend"`, `"web-backend"`, `"cli-tool"`, `"library"`, `"general"` |
 | `commit_docs` | `true` | Whether to commit planning artifacts to git |
 | `search_gitignored` | `false` | Add `--no-ignore` to broad rg searches |
 | `git.branching_strategy` | `"none"` | Git branching approach: `"none"`, `"phase"`, or `"milestone"` |

--- a/get-shit-done/references/project-types.md
+++ b/get-shit-done/references/project-types.md
@@ -1,0 +1,203 @@
+<project_types>
+
+Project type detection and type-specific guidance for GSD workflows.
+
+<detection>
+
+## Auto-Detection
+
+GSD detects project type from dependencies during `/gsd:new-project`:
+
+**Node.js/TypeScript (package.json):**
+
+| Keywords | Type |
+|----------|------|
+| `react`, `vue`, `angular`, `svelte`, `next`, `nuxt` | `web-frontend` |
+| `express`, `fastify`, `koa`, `hapi`, `nestjs`, `hono` | `web-backend` |
+| `commander`, `yargs`, `inquirer`, `chalk`, `ora` | `cli-tool` |
+| `types`, `main`, `module`, `exports` (no `start`/`dev`) | `library` |
+
+**Python (requirements.txt, pyproject.toml):**
+
+| Keywords | Type |
+|----------|------|
+| `flask`, `django`, `fastapi`, `starlette` | `web-backend` |
+| `click`, `typer`, `argparse` | `cli-tool` |
+
+**Go (go.mod):**
+
+| Keywords | Type |
+|----------|------|
+| `gin`, `echo`, `fiber`, `chi` | `web-backend` |
+| `cobra`, `urfave/cli` | `cli-tool` |
+
+**Default:** `general` when no patterns match.
+
+</detection>
+
+<type_guidance>
+
+## Type-Specific Guidance
+
+### web-frontend
+
+**Focus areas:**
+- Component architecture and design system
+- State management patterns
+- User experience and accessibility
+- Performance optimization (bundling, lazy loading)
+- Testing (unit, integration, E2E)
+
+**Research emphasis:**
+- UI/UX patterns for the domain
+- Component library choices
+- State management approaches
+- Build tooling and optimization
+
+**Common phases:**
+1. Project scaffold and design system
+2. Core components and layouts
+3. State management and data fetching
+4. Feature pages
+5. Polish and optimization
+
+---
+
+### web-backend
+
+**Focus areas:**
+- API design and documentation
+- Data modeling and database design
+- Authentication and authorization
+- Error handling and validation
+- Testing and monitoring
+
+**Research emphasis:**
+- API patterns (REST, GraphQL, tRPC)
+- Database choices and ORM patterns
+- Auth approaches (JWT, sessions, OAuth)
+- Deployment and infrastructure
+
+**Common phases:**
+1. Project scaffold and database setup
+2. Auth and user management
+3. Core API endpoints
+4. Background jobs and integrations
+5. Deployment and monitoring
+
+---
+
+### cli-tool
+
+**Focus areas:**
+- Command structure and argument parsing
+- Output formatting and user feedback
+- Configuration and persistence
+- Shell integration and scripting
+- Testing and distribution
+
+**Research emphasis:**
+- Argument parsing libraries
+- Terminal UI patterns (colors, spinners, tables)
+- Configuration file formats
+- Distribution methods (npm, homebrew, etc.)
+
+**Common phases:**
+1. Project scaffold and CLI framework
+2. Core commands
+3. Configuration and persistence
+4. Output formatting and UX
+5. Distribution and documentation
+
+---
+
+### library
+
+**Focus areas:**
+- API surface design
+- Type definitions and documentation
+- Versioning and changelog
+- Testing across environments
+- Bundle size and tree-shaking
+
+**Research emphasis:**
+- API design patterns
+- Documentation standards
+- Testing strategies
+- Build and publish workflows
+
+**Common phases:**
+1. Project scaffold and build setup
+2. Core API implementation
+3. Documentation and examples
+4. Testing and edge cases
+5. Publishing and versioning
+
+---
+
+### general
+
+**Focus areas:**
+- Full-stack considerations
+- No assumptions about architecture
+- Flexible research
+
+**Research emphasis:**
+- Broader ecosystem research
+- Multiple stack options presented
+- User preference weighted
+
+**Common phases:**
+Determined by project requirements, no preset structure.
+
+</type_guidance>
+
+<research_adaptation>
+
+## Adapting Research by Type
+
+When spawning research agents, adapt focus based on `project_type`:
+
+**web-frontend:**
+- Stack: Focus on frontend frameworks, component libraries, state management
+- Features: UI patterns, accessibility requirements, responsive design
+- Architecture: Component hierarchy, data flow, client-side routing
+- Pitfalls: Bundle size, hydration issues, SEO considerations
+
+**web-backend:**
+- Stack: Focus on server frameworks, ORMs, auth libraries
+- Features: API capabilities, integrations, real-time features
+- Architecture: API design, database schema, service layers
+- Pitfalls: N+1 queries, auth vulnerabilities, rate limiting
+
+**cli-tool:**
+- Stack: Focus on CLI frameworks, terminal UI libraries
+- Features: Command patterns, configuration options
+- Architecture: Command hierarchy, plugin systems
+- Pitfalls: Cross-platform compatibility, shell escaping
+
+**library:**
+- Stack: Focus on build tools, testing frameworks, type generation
+- Features: API surface, customization points
+- Architecture: Module structure, dependency management
+- Pitfalls: Breaking changes, bundle size, type accuracy
+
+</research_adaptation>
+
+<manual_override>
+
+## Manual Override
+
+If auto-detection is wrong, users can override in config.json:
+
+```json
+{
+  "project_type": "web-backend"
+}
+```
+
+Or during `/gsd:new-project`, answer "Other" when asked and specify the type.
+
+</manual_override>
+
+</project_types>

--- a/get-shit-done/templates/config.json
+++ b/get-shit-done/templates/config.json
@@ -1,6 +1,7 @@
 {
   "mode": "interactive",
   "depth": "standard",
+  "project_type": "general",
   "workflow": {
     "research": true,
     "plan_check": true,


### PR DESCRIPTION
## Goal
Adaptive workflows based on project type.

## GSD Alignment
- **Context Engineering**: Load only relevant context for the project type. CLI projects don't need frontend research templates.
- **Solo Developer Efficiency**: Get relevant suggestions without manually configuring project type.

## Deviation Note
Auto-detection can be wrong for edge cases (mixed-stack projects). Justified because: detection result is stored in config.json and can be manually overridden, defaults to "general" if uncertain.

## Changes
- Project type detection during `/gsd:new-project`: web-frontend, web-backend, cli-tool, library, general
- `project_type` stored in config.json
- Type-specific guidance reference for research and planning adaptation

## Files
- `commands/gsd/new-project.md` — Detection logic in Phase 1
- `get-shit-done/references/planning-config.md` — `project_type` in option table
- `get-shit-done/references/project-types.md` — NEW: Type guidance reference
- `get-shit-done/templates/config.json` — `project_type` field added

## Testing
- Detection accuracy on various project types
- Manual override via config.json works
- Type-specific templates used correctly