### PR TITLE
fix(settings): auto-create config.json when missing (#264)

### DIFF
--- a/commands/gsd/set-profile.md
+++ b/commands/gsd/set-profile.md
@@ -30,17 +30,27 @@ if $ARGUMENTS.profile not in ["quality", "balanced", "budget"]:
   STOP
 ```
 
-## 2. Check for project
+## 2. Ensure config exists
 
 ```bash
 ls .planning/config.json 2>/dev/null
 ```
 
-If no `.planning/` directory:
+If `.planning/config.json` missing, create it with defaults:
+```bash
+mkdir -p .planning
 ```
-Error: No GSD project found.
-Run /gsd:new-project first to initialize a project.
+```json
+{
+  "model_profile": "balanced",
+  "workflow": {
+    "research": true,
+    "plan_check": true,
+    "verifier": true
+  }
+}
 ```
+Write this to `.planning/config.json`, then continue.
 
 ## 3. Update config.json
 
@@ -49,7 +59,7 @@ Read current config:
 cat .planning/config.json
 ```
 
-Update `model_profile` field (or add if missing):
+Update `model_profile` field:
 ```json
 {
   "model_profile": "$ARGUMENTS.profile"

--- a/commands/gsd/settings.md
+++ b/commands/gsd/settings.md
@@ -15,13 +15,27 @@ Updates `.planning/config.json` with workflow preferences and model profile sele
 
 <process>
 
-## 1. Validate Environment
+## 1. Ensure config exists
 
 ```bash
 ls .planning/config.json 2>/dev/null
 ```
 
-**If not found:** Error - run `/gsd:new-project` first.
+If `.planning/config.json` missing, create it with defaults:
+```bash
+mkdir -p .planning
+```
+```json
+{
+  "model_profile": "balanced",
+  "workflow": {
+    "research": true,
+    "plan_check": true,
+    "verifier": true
+  }
+}
+```
+Write this to `.planning/config.json`, then continue.
 
 ## 2. Read Current Config
 


### PR DESCRIPTION
## What
Auto-create `.planning/config.json` with balanced defaults when missing, instead of hard-erroring.

## Why
`/gsd:set-profile` and `/gsd:settings` require `.planning/config.json` to exist, but `/gsd:map-codebase` explicitly supports running before `/gsd:new-project` for brownfield codebases. Users mapping an existing codebase cannot change the model profile because config.json doesn't exist yet Fixes #264 

## Testing
- Verified set-profile creates config.json with defaults when `.planning/` doesn't exist
- Verified settings creates config.json with defaults when `.planning/` doesn't exist
- Verified existing config.json is read normally (no behavior change for initialized projects)

## Breaking Changes
None