### PR TITLE
feat(preferences): extract GSD Preferences from CLAUDE.md into agent spawn prompts (#381)

### DIFF
--- a/commands/gsd/help.md
+++ b/commands/gsd/help.md
@@ -394,6 +394,25 @@ Set during `/gsd:new-project`:
 
 Change anytime by editing `.planning/config.json`
 
+## Tool & Skill Preferences
+
+Add a `## GSD Preferences` section to your project's `CLAUDE.md` to configure tool, skill, and MCP preferences. Orchestrators extract this section and inject it into agent spawn prompts.
+
+```markdown
+## GSD Preferences
+
+### Skills
+- Use `frontend-design` skill for all UI work
+
+### MCPs
+- Use `context7` MCP for library documentation lookups
+
+### Tools
+- Use `pnpm` instead of `npm`
+```
+
+Only the `## GSD Preferences` section is extracted — the rest of CLAUDE.md is not injected into agent prompts.
+
 ## Planning Configuration
 
 Configure how planning artifacts are managed in `.planning/config.json`:

--- a/commands/gsd/plan-phase.md
+++ b/commands/gsd/plan-phase.md
@@ -266,6 +266,9 @@ RESEARCH_CONTENT=$(cat "${PHASE_DIR}"/*-RESEARCH.md 2>/dev/null)
 # Gap closure files (only if --gaps mode)
 VERIFICATION_CONTENT=$(cat "${PHASE_DIR}"/*-VERIFICATION.md 2>/dev/null)
 UAT_CONTENT=$(cat "${PHASE_DIR}"/*-UAT.md 2>/dev/null)
+
+# Extract "## GSD Preferences" section from CLAUDE.md (if exists)
+GSD_PREFERENCES=$(sed -n '/^## GSD Preferences$/,/^## /{/^## /!p}' CLAUDE.md 2>/dev/null)
 ```
 
 ## 8. Spawn gsd-planner Agent
@@ -311,6 +314,9 @@ IMPORTANT: If phase context exists below, it contains USER DECISIONS from /gsd:d
 **Gap Closure (if --gaps mode):**
 {verification_content}
 {uat_content}
+
+**GSD Preferences (from CLAUDE.md, if exists):**
+{gsd_preferences}
 
 </planning_context>
 

--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -285,6 +285,9 @@ Execute each wave in sequence. Autonomous plans within a wave run in parallel **
    PLAN_CONTENT=$(cat "{plan_path}")
    STATE_CONTENT=$(cat .planning/STATE.md)
    CONFIG_CONTENT=$(cat .planning/config.json 2>/dev/null)
+   # Extract "## GSD Preferences" section from CLAUDE.md (if exists)
+   # Reads from heading to next ## heading or EOF
+   GSD_PREFERENCES=$(sed -n '/^## GSD Preferences$/,/^## /{/^## /!p}' CLAUDE.md 2>/dev/null)
    ```
 
    **If `PARALLELIZATION=true` (default):** Use Task tool with multiple parallel calls.
@@ -316,6 +319,9 @@ Execute each wave in sequence. Autonomous plans within a wave run in parallel **
 
    Config (if exists):
    {config_content}
+
+   GSD Preferences (from CLAUDE.md, if exists):
+   {gsd_preferences}
    </context>
 
    <success_criteria>


### PR DESCRIPTION
## What
Orchestrators extract the `## GSD Preferences` section from the project root `CLAUDE.md` and inject it into planner and executor agent spawn prompts.

## Why
Users working across multiple projects repeat the same tool/skill/MCP instructions on every command invocation. No project-level mechanism exists to declare these preferences once. Fixes #381 

## GSD Alignment
- Context engineering — only the `## GSD Preferences` section is extracted, not the whole CLAUDE.md
- Solo developer workflow — configure once per project, apply to all agent spawns
- No enterprise patterns — no plugin system, no registry, uses existing CLAUDE.md convention
- No new files — leverages root CLAUDE.md instead of adding a dedicated preferences file

## Scope
Reads from project root `CLAUDE.md` only. Could be extended to check `.claude/CLAUDE.md` or `.claude/rules/CLAUDE.md` if users need per-location preferences, but one obvious location keeps it simple for now.

## Deviation Note
None — fully aligned.

## Testing
- Verified GSD Preferences section is extracted from CLAUDE.md and injected into agent spawn prompts
- Verified missing CLAUDE.md or missing section is handled gracefully (empty string, no error)
- Verified help.md documents the feature with example

## Breaking Changes
None