### PR TITLE
fix(phases): add .gitkeep so Git tracks empty phase directories

### DIFF
--- a/commands/gsd/add-phase.md
+++ b/commands/gsd/add-phase.md
@@ -109,7 +109,10 @@ Create the phase directory structure:
 ```bash
 phase_dir=".planning/phases/${phase_num}-${slug}"
 mkdir -p "$phase_dir"
+touch "$phase_dir/.gitkeep"
 ```
+
+The `.gitkeep` file ensures Git tracks the directory even before plans are created. Without it, empty phase directories are lost when syncing across machines.
 
 Confirm: "Created directory: $phase_dir"
 </step>

--- a/commands/gsd/insert-phase.md
+++ b/commands/gsd/insert-phase.md
@@ -124,7 +124,10 @@ Create the phase directory structure:
 ```bash
 phase_dir=".planning/phases/${decimal_phase}-${slug}"
 mkdir -p "$phase_dir"
+touch "$phase_dir/.gitkeep"
 ```
+
+The `.gitkeep` file ensures Git tracks the directory even before plans are created. Without it, empty phase directories are lost when syncing across machines.
 
 Confirm: "Created directory: $phase_dir"
 </step>

--- a/commands/gsd/plan-milestone-gaps.md
+++ b/commands/gsd/plan-milestone-gaps.md
@@ -154,6 +154,7 @@ Add new phases to current milestone:
 
 ```bash
 mkdir -p ".planning/phases/{NN}-{name}"
+touch ".planning/phases/{NN}-{name}/.gitkeep"
 ```
 
 ## 8. Commit Roadmap Update

--- a/commands/gsd/plan-phase.md
+++ b/commands/gsd/plan-phase.md
@@ -115,6 +115,7 @@ if [ -z "$PHASE_DIR" ]; then
   # Create phase directory from roadmap name
   PHASE_NAME=$(grep "Phase ${PHASE}:" .planning/ROADMAP.md | sed 's/.*Phase [0-9]*: //' | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
   mkdir -p ".planning/phases/${PHASE}-${PHASE_NAME}"
+  touch ".planning/phases/${PHASE}-${PHASE_NAME}/.gitkeep"
   PHASE_DIR=".planning/phases/${PHASE}-${PHASE_NAME}"
 fi
 

--- a/get-shit-done/workflows/discuss-phase.md
+++ b/get-shit-done/workflows/discuss-phase.md
@@ -289,6 +289,7 @@ if [ -z "$PHASE_DIR" ]; then
   # Create from roadmap name (lowercase, hyphens)
   PHASE_NAME=$(grep "Phase ${PHASE}:" .planning/ROADMAP.md | sed 's/.*Phase [0-9]*: //' | tr '[:upper:]' '[:lower:]' | tr ' ' '-')
   mkdir -p ".planning/phases/${PADDED_PHASE}-${PHASE_NAME}"
+  touch ".planning/phases/${PADDED_PHASE}-${PHASE_NAME}/.gitkeep"
   PHASE_DIR=".planning/phases/${PADDED_PHASE}-${PHASE_NAME}"
 fi
 ```

--- a/get-shit-done/workflows/verify-work.md
+++ b/get-shit-done/workflows/verify-work.md
@@ -129,6 +129,7 @@ Skip internal/non-observable items (refactors, type changes, etc.).
 
 ```bash
 mkdir -p "$PHASE_DIR"
+touch "$PHASE_DIR/.gitkeep"
 ```
 
 Build test list from extracted deliverables.


### PR DESCRIPTION
## What

Add `.gitkeep` files to phase directories at creation time so Git tracks them even before plans are created.

## Why

Empty directories created by `add-phase`, `insert-phase`, and other commands are invisible to Git. When syncing across machines, these directories vanish — breaking phase lookups and causing hallucinated context.

Fixes #427

## GSD Alignment

GSD optimizes for solo developer + Claude workflow. Working across multiple machines is a core solo dev pattern. Without tracked directories, phase context fractures between machines — Claude can't find phase folders referenced in the roadmap and hallucinates or ignores phases. This fix preserves the single-command simplicity while ensuring Git tracks the full planning structure.

## Changes

Added `touch "$phase_dir/.gitkeep"` after every `mkdir -p` that creates a phase directory:

- `commands/gsd/insert-phase.md` — decimal phase directory creation
- `commands/gsd/add-phase.md` — integer phase directory creation
- `commands/gsd/plan-phase.md` — fallback directory creation
- `commands/gsd/plan-milestone-gaps.md` — gap-closure phase directories
- `get-shit-done/workflows/discuss-phase.md` — fallback directory creation
- `get-shit-done/workflows/verify-work.md` — fallback directory creation

## Testing

- Verified all `mkdir -p` calls for phase directories now include a `.gitkeep` touch
- Grep confirms no remaining phase directory creation sites without `.gitkeep`

## Breaking Changes

None