### PR TITLE
fix(workflows): add explicit TaskOutput instructions to map-codebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- `/gsd:map-codebase` now explicitly uses TaskOutput tool to wait for background agents, preventing indefinite "Waiting for agents to complete..." state
+
 ## [1.11.1] - 2026-01-31
 
 ### Added

--- a/get-shit-done/workflows/map-codebase.md
+++ b/get-shit-done/workflows/map-codebase.md
@@ -190,9 +190,19 @@ Continue to collect_confirmations.
 </step>
 
 <step name="collect_confirmations">
-Wait for all 4 agents to complete.
+Wait for all 4 agents to complete using TaskOutput tool.
 
-Read each agent's output file to collect confirmations.
+**For each agent task_id returned by the Task tool calls above:**
+```
+TaskOutput tool:
+  task_id: "{task_id from Task result}"
+  block: true
+  timeout: 300000
+```
+
+Call TaskOutput for all 4 agents in parallel (single message with 4 TaskOutput calls).
+
+Once all TaskOutput calls return, read each agent's output file to collect confirmations.
 
 **Expected confirmation format from each agent:**
 ```


### PR DESCRIPTION
## What
Adds explicit TaskOutput tool instructions to the `collect_confirmations` step in `/gsd:map-codebase` workflow.

## Why
The workflow spawns 4 background agents with `run_in_background=true` but didn't tell Claude *how* to wait for them. Claude has a `TaskOutput` tool for this, but without explicit instructions, the orchestrator displays "Waiting for agents to complete..." indefinitely even after agents finish.

## Testing
Identified issue during workflow execution where all 7 documents were written successfully but orchestrator remained stuck.

## Breaking Changes
None

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>