### PR TITLE
feat: /gsd:plant-seed — forward-looking idea capture with auto-surfacing

### DIFF
--- a/commands/gsd/new-milestone.md
+++ b/commands/gsd/new-milestone.md
@@ -54,6 +54,69 @@ Milestone name: $ARGUMENTS (optional - will prompt if not provided)
 - Read STATE.md (pending todos, blockers)
 - Check for MILESTONE-CONTEXT.md (from /gsd:discuss-milestone)
 
+## Phase 1.5: Scan Seeds
+
+Check for planted seeds that should surface for this milestone:
+
+```bash
+ls .planning/seeds/SEED-*.md 2>/dev/null
+```
+
+**If no seeds directory or no seed files:** Skip to Phase 2.
+
+**If seeds exist:**
+
+1. Read all seed files with `status: dormant` in frontmatter
+2. For each dormant seed, read its `trigger_when` field and "When to Surface" trigger conditions
+3. Compare trigger conditions against:
+   - The milestone name/topic (from $ARGUMENTS or MILESTONE-CONTEXT.md)
+   - Keywords from the user's stated goals
+   - STATE.md "Next Up" section
+4. Collect seeds where ANY trigger condition matches
+
+**If matching seeds found:**
+
+Present them to the user:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ GSD ► SEEDS FOUND
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+[N] planted seeds match this milestone:
+
+**Seed [NNN]: [Idea Summary]**
+Planted: [date] during [milestone/phase]
+Trigger: [trigger_when]
+Scope: [scope estimate]
+Why: [first line of Why This Matters]
+Breadcrumbs: [count] references
+
+[... repeat for each matching seed ...]
+```
+
+For each matching seed, use AskUserQuestion:
+- header: "Seed [NNN]"
+- question: "Include Seed [NNN] ([idea summary]) in this milestone?"
+- options:
+  - "Yes, fold into roadmap" — Seed's breadcrumbs and context feed into research/requirements
+  - "No, keep dormant" — Seed stays planted for a future milestone
+  - "Read full seed" — Show the complete seed file before deciding
+
+**If user accepts a seed:**
+- Update seed frontmatter: `status: harvested`
+- Add seed's "Why This Matters" and "Breadcrumbs" to the milestone context
+- The roadmapper will receive this context and can create phases/requirements from it
+
+**If user declines a seed:**
+- Leave seed as `status: dormant` (no changes)
+
+**If no matching seeds:** Display briefly and continue:
+```
+◆ Seed scan: [N] dormant seeds, none match this milestone scope.
+```
+
+
 ## Phase 2: Gather Milestone Goals
 
 **If MILESTONE-CONTEXT.md exists:**
@@ -703,6 +766,8 @@ Present completion with next steps:
 </process>
 
 <success_criteria>
+- [ ] Seeds scanned (if .planning/seeds/ exists) - matching seeds presented to user
+- [ ] Accepted seeds marked status: harvested, context folded into milestone
 - [ ] PROJECT.md updated with Current Milestone section
 - [ ] STATE.md reset for new milestone
 - [ ] MILESTONE-CONTEXT.md consumed and deleted (if existed)

--- a/commands/gsd/plant-seed.md
+++ b/commands/gsd/plant-seed.md
@@ -1,0 +1,236 @@
+---
+name: gsd:plant-seed
+description: Capture a forward-looking idea with trigger conditions so it surfaces automatically at the right milestone
+argument-hint: "[idea summary, e.g., 'benchmark scraping from canada.ca']"
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Glob
+  - AskUserQuestion
+---
+
+<objective>
+Capture an idea that's too big for now but should surface automatically when the right milestone arrives.
+
+Seeds solve context rot: instead of a one-liner in Deferred that nobody reads, a seed preserves the full WHY, WHEN to surface, and breadcrumbs to details. The `/gsd:new-milestone` command scans seeds and presents matches.
+
+**Creates:** `.planning/seeds/SEED-NNN-slug.md`
+**Consumed by:** `/gsd:new-milestone` (Phase 1.5: Seed Scan)
+</objective>
+
+<context>
+@.planning/STATE.md
+@.planning/PROJECT.md
+</context>
+
+<process>
+
+**Step 1: Pre-flight validation**
+
+Check that an active GSD project exists:
+
+```bash
+if [ ! -f .planning/PROJECT.md ]; then
+  echo "Seed planting requires an active project with PROJECT.md."
+  echo "Run /gsd:new-project first."
+  exit 1
+fi
+```
+
+If validation fails, stop immediately with the error message.
+
+---
+
+**Step 2: Capture the idea**
+
+If `$ARGUMENTS` is provided, use it as the idea summary.
+
+If `$ARGUMENTS` is empty, prompt:
+
+```
+AskUserQuestion(
+  header: "Seed",
+  question: "What's the idea you want to plant for the future?",
+  options: (none — free text via "Other")
+)
+```
+
+Wait — AskUserQuestion needs options. Instead, just ask conversationally:
+
+"What's the idea? Give me the elevator pitch — one or two sentences."
+
+Store response as `$IDEA_SUMMARY`.
+
+---
+
+**Step 3: Gather seed context**
+
+Ask these questions conversationally (not all at once — natural flow):
+
+1. **Why does this matter?** — What problem does it solve or what value does it add?
+2. **What triggered this?** — What were you working on when this came up?
+3. **When should this surface?** — Which milestone topic, feature area, or keyword should trigger it?
+4. **Any breadcrumbs?** — Files, URLs, code references, research that future-you should read?
+5. **How big is this?** — Quick task, a phase, or a whole milestone?
+
+Store responses as:
+- `$WHY`
+- `$TRIGGER_CONTEXT` (what you were doing when the idea came up)
+- `$TRIGGER_WHEN` (milestone topic / keyword / condition)
+- `$BREADCRUMBS` (files, URLs, references)
+- `$SCOPE_ESTIMATE` (quick / phase / milestone)
+
+---
+
+**Step 4: Calculate seed number and create directory**
+
+```bash
+mkdir -p .planning/seeds
+
+# Find highest existing seed number and increment
+last=$(ls -1 .planning/seeds/SEED-[0-9][0-9][0-9]-* 2>/dev/null | sort -r | head -1 | xargs -I{} basename {} | grep -oE '^SEED-([0-9]+)' | grep -oE '[0-9]+')
+
+if [ -z "$last" ]; then
+  next_num="001"
+else
+  next_num=$(printf "%03d" $((10#$last + 1)))
+fi
+```
+
+Generate slug from idea summary:
+```bash
+slug=$(echo "$IDEA_SUMMARY" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-//;s/-$//' | cut -c1-40)
+```
+
+---
+
+**Step 5: Determine current context**
+
+Read STATE.md to extract:
+- Current milestone (if any)
+- Current phase (if any)
+- Date
+
+These go into the `planted_during` metadata.
+
+---
+
+**Step 6: Write seed file**
+
+Write to `.planning/seeds/SEED-${next_num}-${slug}.md`:
+
+```markdown
+---
+seed: ${next_num}
+planted: [today's date]
+planted_during: [current milestone/phase or "between milestones"]
+status: dormant
+trigger_when: "${TRIGGER_WHEN}"
+scope: "${SCOPE_ESTIMATE}"
+---
+
+# Seed ${next_num}: ${IDEA_SUMMARY}
+
+## The Idea
+
+${IDEA_SUMMARY}
+
+## Why This Matters
+
+${WHY}
+
+## What Triggered This
+
+${TRIGGER_CONTEXT}
+
+## When to Surface
+
+**Trigger condition:** Surface this seed when ANY of:
+- [Derive 2-3 specific trigger conditions from $TRIGGER_WHEN]
+- [e.g., "Starting a milestone involving [topic]"]
+- [e.g., "Planning any phase involving [keyword]"]
+- [e.g., "User mentions [related concept]"]
+
+## Breadcrumbs
+
+${BREADCRUMBS}
+
+Format as:
+- `path/to/file.md` — what it contains
+- `path/to/code.py:L42` — relevant function/class
+- `https://url` — external reference
+
+If no breadcrumbs, write: "No existing artifacts. Research needed when harvested."
+
+## Suggested Scope
+
+${SCOPE_ESTIMATE} — [brief justification]
+
+---
+*Planted: [date] | Status: dormant | Scan: /gsd:new-milestone*
+```
+
+---
+
+**Step 7: Commit**
+
+Check planning config:
+```bash
+COMMIT_PLANNING_DOCS=$(cat .planning/config.json 2>/dev/null | grep -o '"commit_docs"[[:space:]]*:[[:space:]]*[^,}]*' | grep -o 'true\|false' || echo "true")
+git check-ignore -q .planning 2>/dev/null && COMMIT_PLANNING_DOCS=false
+```
+
+If `COMMIT_PLANNING_DOCS=true` (default):
+```bash
+git add .planning/seeds/SEED-${next_num}-${slug}.md
+git commit -m "$(cat <<'EOF'
+seed(${next_num}): ${IDEA_SUMMARY}
+
+Planted for future milestone. Trigger: ${TRIGGER_WHEN}
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+**Step 8: Confirmation**
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ GSD ► SEED PLANTED
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Seed ${next_num}: ${IDEA_SUMMARY}
+
+| Field          | Value                              |
+|----------------|------------------------------------|
+| File           | .planning/seeds/SEED-${next_num}-${slug}.md |
+| Trigger        | ${TRIGGER_WHEN}                    |
+| Scope          | ${SCOPE_ESTIMATE}                  |
+| Status         | dormant                            |
+
+This seed will be scanned automatically when you run
+/gsd:new-milestone. If the trigger condition matches,
+it will be presented for inclusion in the roadmap.
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+</process>
+
+<success_criteria>
+- [ ] PROJECT.md exists (pre-flight passes)
+- [ ] Idea summary captured (from args or conversation)
+- [ ] Context gathered: why, trigger, breadcrumbs, scope
+- [ ] Seed number calculated (sequential from existing seeds)
+- [ ] Seed file written to `.planning/seeds/SEED-NNN-slug.md`
+- [ ] All frontmatter fields populated (seed, planted, status, trigger_when, scope)
+- [ ] Breadcrumbs include specific file paths or URLs
+- [ ] Trigger condition has 2-3 specific, scannable conditions
+- [ ] Committed (if planning docs committed)
+- [ ] Confirmation output shown with file path
+</success_criteria>

--- a/get-shit-done/templates/seed.md
+++ b/get-shit-done/templates/seed.md
@@ -1,0 +1,42 @@
+---
+seed: ${SEED_NUM}
+planted: ${DATE}
+planted_during: ${CURRENT_MILESTONE_PHASE}
+status: dormant
+trigger_when: "${TRIGGER_WHEN}"
+scope: "${SCOPE_ESTIMATE}"
+---
+
+# Seed ${SEED_NUM}: ${IDEA_SUMMARY}
+
+## The Idea
+
+${IDEA_SUMMARY}
+
+## Why This Matters
+
+${WHY}
+
+## What Triggered This
+
+${TRIGGER_CONTEXT}
+
+## When to Surface
+
+**Trigger condition:** Surface this seed when ANY of:
+- ${TRIGGER_CONDITION_1}
+- ${TRIGGER_CONDITION_2}
+- ${TRIGGER_CONDITION_3}
+
+## Breadcrumbs
+
+- `path/to/file.md` — what it contains
+- `path/to/code.py:L42` — relevant function/class
+- `https://url` — external reference
+
+## Suggested Scope
+
+${SCOPE_ESTIMATE} — ${SCOPE_JUSTIFICATION}
+
+---
+*Planted: ${DATE} | Status: dormant | Scan: /gsd:new-milestone*


### PR DESCRIPTION
## Summary

Adds a seed planting system that prevents context rot across milestones:

- **New command: `/gsd:plant-seed`** — Captures ideas with trigger conditions, breadcrumbs, and scope estimates into `.planning/seeds/SEED-NNN-slug.md`
- **New template: `seed.md`** — Standardized seed file format
- **Patched `/gsd:new-milestone`** — Added Phase 1.5 (Seed Scan) that reads dormant seeds, matches trigger conditions against milestone scope, and presents matches to the user

### The Problem

Ideas captured during active development get written to PROJECT.md Deferred or STATE.md Next Up as cryptic one-liners. Nobody reads Deferred at milestone planning time. Context rots. The idea becomes unactionable.

### The Solution

Seeds preserve the full context: **why** it matters, **when** to surface it, and **breadcrumbs** to details. The `/gsd:new-milestone` command automatically scans seeds and presents matches before gathering milestone goals.

### Seed Lifecycle

```
Plant (dormant) → Scan (matched) → Harvest (accepted into roadmap)
                                  → Stay dormant (declined for now)
```

### Files Changed

| File | Change |
|------|--------|
| `commands/gsd/plant-seed.md` | New command — captures seeds with conversational flow |
| `get-shit-done/templates/seed.md` | New template — seed file structure |
| `commands/gsd/new-milestone.md` | Added Phase 1.5: Seed Scan between Load Context and Gather Goals |

### Seed File Format

```markdown
---
seed: 001
planted: 2026-02-06
planted_during: v4.0 phase 16
status: dormant
trigger_when: "any milestone involving Job Evaluation Standards"
scope: "phase"
---

# Seed 001: Scrape Benchmark Positions

## The Idea / Why This Matters / What Triggered This
## When to Surface (trigger conditions)
## Breadcrumbs (file paths, URLs, code refs)
## Suggested Scope
```

## Test plan

- [ ] Run `/gsd:plant-seed` — verify it prompts for idea, context, and writes seed file
- [ ] Run `/gsd:plant-seed "test idea"` — verify argument passthrough
- [ ] Verify seed numbering increments (001, 002, 003...)
- [ ] Create a seed, then run `/gsd:new-milestone` — verify Phase 1.5 scans and presents the seed
- [ ] Accept a seed — verify frontmatter updates to `status: harvested`
- [ ] Decline a seed — verify it stays `status: dormant`
- [ ] Run `/gsd:new-milestone` with no seeds directory — verify it skips cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)