### PR TITLE
feat(agent-teams): add per-workflow agent teams configuration

### DIFF
--- a/commands/gsd/debug.md
+++ b/commands/gsd/debug.md
@@ -67,7 +67,53 @@ Use AskUserQuestion for each:
 
 After all gathered, confirm ready to investigate.
 
-## 3. Spawn gsd-debugger Agent
+## 3. Spawn Debugger (Agent Team or Subagent)
+
+**Check for agent teams capability:**
+
+Read `.planning/config.json` and check `agent_teams.debug`:
+- If `agent_teams` is `false` (boolean) or missing → disabled
+- If `agent_teams` is an object → check `agent_teams.debug` (default: `false`)
+
+**If agent_teams.debug is true AND model_profile is "quality":**
+
+Use agent teams for competing-hypothesis investigation — investigators challenge each other's theories:
+
+```
+◆ Creating debug team (agent teams mode)...
+
+Create an agent team with 3-5 investigator teammates for debugging {slug}.
+Use Opus for each teammate.
+
+Issue: {trigger}
+Symptoms:
+- Expected: {expected}
+- Actual: {actual}
+- Errors: {errors}
+- Reproduction: {reproduction}
+- Timeline: {timeline}
+
+Each teammate investigates a different hypothesis:
+1. "Hypothesis A" — [Most likely theory based on symptoms]
+2. "Hypothesis B" — [Second theory, different component/layer]
+3. "Hypothesis C" — [Third theory, environmental/config angle]
+
+Rules:
+- Each investigator writes findings to .planning/debug/{slug}-{hypothesis}.md
+- Investigators MUST message each other to share evidence and challenge theories
+- When one investigator finds evidence that disproves another's theory, message them
+- The team should converge on the most supported hypothesis
+- Lead synthesizes final root cause into .planning/debug/{slug}.md
+
+Wait for team consensus before presenting results.
+Clean up the team after investigation completes.
+```
+
+Handle agent team results same as step 4 below. Continue to step 4.
+
+**If agent_teams.debug is false OR profile is not "quality":**
+
+Fall back to single debugger subagent:
 
 Fill prompt and spawn:
 

--- a/commands/gsd/execute-phase.md
+++ b/commands/gsd/execute-phase.md
@@ -73,8 +73,25 @@ Phase: $ARGUMENTS
    - Report wave structure to user
 
 4. **Execute waves**
+
+   **Check for agent teams capability:**
+
+   Read `.planning/config.json` and check `agent_teams.execution`:
+   - If `agent_teams` is `false` (boolean) or missing → disabled
+   - If `agent_teams` is an object → check `agent_teams.execution` (default: `false`)
+
    For each wave in order:
+
+   **If agent_teams.execution is true AND model_profile is "quality" AND wave has 2+ plans:**
+   - Create an agent team of executor teammates for this wave
+   - Use executor model for each teammate
+   - Teammates can message each other to coordinate on shared dependencies
+   - Wait for team completion, then clean up team
+
+   **If agent_teams.execution is false OR profile is not "quality" OR wave has 1 plan:**
    - Spawn `gsd-executor` for each plan in wave (parallel Task calls)
+
+   After wave completes (either mode):
    - Wait for completion (Task blocks)
    - Verify SUMMARYs created and spot-check claims
    - Proceed to next wave

--- a/commands/gsd/new-milestone.md
+++ b/commands/gsd/new-milestone.md
@@ -167,6 +167,31 @@ Create research directory:
 mkdir -p .planning/research
 ```
 
+**Check for agent teams capability:**
+
+Read `.planning/config.json` and check `agent_teams.research`:
+- If `agent_teams` is `false` (boolean) or missing → disabled
+- If `agent_teams` is an object → check `agent_teams.research` (default: `false`)
+
+**If agent_teams.research is true AND model_profile is "quality":**
+
+Display spawning indicator:
+```
+◆ Creating research team (agent teams mode)...
+  → Stack research (for new features)
+  → Features research
+  → Architecture research (integration)
+  → Pitfalls research
+```
+
+Create an agent team of 4 researcher teammates instead of independent subagents.
+Use researcher model for each teammate. Researchers can message each other to
+cross-pollinate findings — e.g., stack choices inform architecture, pitfalls
+challenge feature assumptions. Wait for team completion, then continue to
+synthesizer below.
+
+**If agent_teams.research is false OR profile is not "quality":**
+
 Display spawning indicator:
 ```
 ◆ Spawning 4 researchers in parallel...

--- a/commands/gsd/new-project.md
+++ b/commands/gsd/new-project.md
@@ -344,6 +344,11 @@ Create `.planning/config.json` with all settings:
   "parallelization": true|false,
   "commit_docs": true|false,
   "model_profile": "quality|balanced|budget",
+  "agent_teams": {
+    "research": false,
+    "execution": false,
+    "debug": false
+  },
   "workflow": {
     "research": true|false,
     "plan_check": true|false,
@@ -426,6 +431,31 @@ mkdir -p .planning/research
 Check if this is greenfield or subsequent milestone:
 - If no "Validated" requirements in PROJECT.md → Greenfield (building from scratch)
 - If "Validated" requirements exist → Subsequent milestone (adding to existing app)
+
+**Check for agent teams capability:**
+
+Read `.planning/config.json` and check `agent_teams.research`:
+- If `agent_teams` is `false` (boolean) or missing → disabled
+- If `agent_teams` is an object → check `agent_teams.research` (default: `false`)
+
+**If agent_teams.research is true AND model_profile is "quality":**
+
+Display spawning indicator:
+```
+◆ Creating research team (agent teams mode)...
+  → Stack research
+  → Features research
+  → Architecture research
+  → Pitfalls research
+```
+
+Create an agent team of 4 researcher teammates instead of independent subagents.
+Use researcher model for each teammate. Researchers can message each other to
+cross-pollinate findings — e.g., stack choices inform architecture, pitfalls
+challenge feature assumptions. Wait for team completion, then continue to
+synthesizer below.
+
+**If agent_teams.research is false OR profile is not "quality":**
 
 Display spawning indicator:
 ```

--- a/commands/gsd/settings.md
+++ b/commands/gsd/settings.md
@@ -43,12 +43,13 @@ Write this to `.planning/config.json`, then continue.
 cat .planning/config.json
 ```
 
-Parse current values (default to `true` if not present):
+Parse current values (default to `true` if not present unless noted):
 - `workflow.research` — spawn researcher during plan-phase
 - `workflow.plan_check` — spawn plan checker during plan-phase
 - `workflow.verifier` — spawn verifier during execute-phase
 - `model_profile` — which model each agent uses (default: `balanced`)
 - `git.branching_strategy` — branching approach (default: `"none"`)
+- `agent_teams` — per-workflow agent teams config: `{ research, execution, debug }` (defaults: all `false`)
 
 ## 3. Present Settings
 
@@ -102,6 +103,17 @@ AskUserQuestion([
       { label: "Per Phase", description: "Create branch for each phase (gsd/phase-{N}-{name})" },
       { label: "Per Milestone", description: "Create branch for entire milestone (gsd/{version}-{name})" }
     ]
+  },
+  {
+    question: "Which workflows should use agent teams? (inter-agent messaging, slower but better coordination)",
+    header: "Agent Teams",
+    multiSelect: true,
+    options: [
+      { label: "Research", description: "new-project/new-milestone research — researchers cross-pollinate findings" },
+      { label: "Debug", description: "Competing hypothesis investigators challenge each other's theories" },
+      { label: "Execution", description: "Wave executors coordinate on shared dependencies (rarely needed)" },
+      { label: "None (Recommended)", description: "Standard parallel Task() calls everywhere — faster, no overhead" }
+    ]
   }
 ])
 ```
@@ -116,6 +128,11 @@ Merge new settings into existing config.json:
 {
   ...existing_config,
   "model_profile": "quality" | "balanced" | "budget",
+  "agent_teams": {
+    "research": true/false,
+    "execution": true/false,
+    "debug": true/false
+  },
   "workflow": {
     "research": true/false,
     "plan_check": true/false,
@@ -145,6 +162,9 @@ Display:
 | Plan Checker         | {On/Off} |
 | Execution Verifier   | {On/Off} |
 | Git Branching        | {None/Per Phase/Per Milestone} |
+| Agent Teams Research | {On/Off} |
+| Agent Teams Debug    | {On/Off} |
+| Agent Teams Execution| {On/Off} |
 
 These settings apply to future /gsd:plan-phase and /gsd:execute-phase runs.
 
@@ -159,7 +179,7 @@ Quick commands:
 
 <success_criteria>
 - [ ] Current config read
-- [ ] User presented with 5 settings (profile + 3 workflow toggles + git branching)
-- [ ] Config updated with model_profile, workflow, and git sections
+- [ ] User presented with 6 settings (profile + 3 workflow toggles + git branching + agent teams)
+- [ ] Config updated with model_profile, workflow, git, and agent_teams sections
 - [ ] Changes confirmed to user
 </success_criteria>

--- a/get-shit-done/references/model-profiles.md
+++ b/get-shit-done/references/model-profiles.md
@@ -58,6 +58,53 @@ Per-project default: Set in `.planning/config.json`:
 }
 ```
 
+## Agent Teams
+
+Controlled per-workflow in `.planning/config.json`:
+
+```json
+"agent_teams": {
+  "research": true,    // new-project, new-milestone research phases
+  "execution": false,  // execute-phase wave execution
+  "debug": true        // debug hypothesis investigation
+}
+```
+
+Template defaults: all `false`. Each workflow checks its own key.
+
+**Backward compatibility:** If `agent_teams` is `false` (boolean) or missing, all workflows default to disabled.
+
+**Agent teams vs subagents:**
+- Subagents: report results back to caller only, no cross-communication — faster, no overhead
+- Agent teams: teammates message each other, share task lists, self-coordinate — slower, better coordination
+
+Toggle via `/gsd:settings` or edit `.planning/config.json` directly.
+
+**When GSD uses agent teams (quality profile + workflow key is true):**
+
+| Workflow | Subagent Default | Agent Team Upgrade | Benefit |
+|----------|------------------|--------------------|---------|
+| `new-project` Phase 6 | 4 parallel Task() researchers | Team of 4 researcher teammates | Researchers challenge/build on each other's findings |
+| `new-milestone` research | 4 parallel Task() researchers | Team of 4 researcher teammates | Same as above |
+| `execute-phase` wave execution | Parallel Task() executors per wave | Team of executor teammates per wave | Executors coordinate on shared dependencies |
+| `debug` investigation | Single debugger subagent | Team of hypothesis investigators | Competing theories, adversarial debate |
+
+**When GSD still uses subagents (no agent team upgrade):**
+- Single-agent spawns (planner, verifier, plan-checker, roadmapper)
+- Sequential execution (one plan at a time)
+- Budget/balanced profiles (overhead not justified)
+- When the workflow's `agent_teams` key is `false` (default for templates)
+
+**Fallback:** If agent teams fail to spawn or are disabled in config, all orchestrators fall back to standard Task() subagent calls.
+
+**Recommended config for quality profile:**
+```json
+"agent_teams": { "research": true, "execution": false, "debug": true }
+```
+- Research: moderate benefit (cross-pollination between dimensions)
+- Debug: high benefit (adversarial hypothesis testing)
+- Execution: low benefit (plans designed to be independent)
+
 ## Design Rationale
 
 **Why Opus for gsd-planner?**

--- a/get-shit-done/templates/config.json
+++ b/get-shit-done/templates/config.json
@@ -1,6 +1,11 @@
 {
   "mode": "interactive",
   "depth": "standard",
+  "agent_teams": {
+    "research": false,
+    "execution": false,
+    "debug": false
+  },
   "workflow": {
     "research": true,
     "plan_check": true,


### PR DESCRIPTION
## What

Add per-workflow `agent_teams` configuration to `.planning/config.json`, replacing the current global on/off approach. Users can selectively enable agent teams for workflows where inter-agent coordination provides the most value.

## Why

Agent teams add coordination overhead (inter-agent messaging, shared task lists). This overhead is justified for some workflows (debug hypothesis investigation) but not others (plan execution where plans are designed to be independent). Per-workflow toggles let users opt in selectively.

## Changes

**Config format** (new field in `.planning/config.json`):
```json
"agent_teams": {
  "research": false,
  "execution": false,
  "debug": false
}
```

**Command files updated** (4 files):

| Command | Workflow Key | Agent Team Mode |
|---------|-------------|-----------------|
| `debug.md` | `agent_teams.debug` | 3-5 competing hypothesis investigators that challenge each other's theories |
| `execute-phase.md` | `agent_teams.execution` | Wave executor teammates that coordinate on shared dependencies |
| `new-project.md` | `agent_teams.research` | 4 researcher teammates that cross-pollinate findings |
| `new-milestone.md` | `agent_teams.research` | Same as new-project |

**Activation conditions:**
- `model_profile` must be `"quality"` AND the workflow's key must be `true`
- Falls back to standard parallel `Task()` calls otherwise

**Additional changes:**
- `settings.md` — multiSelect toggle for agent teams (6th setting)
- `model-profiles.md` — full agent teams documentation section
- `templates/config.json` — defaults (all `false`)

**Backward compatibility:**
- If `agent_teams` is `false` (boolean) or missing entirely → all workflows default to disabled
- Existing configs without `agent_teams` field work unchanged

## Recommended Config

For quality profile users:
```json
"agent_teams": { "research": true, "execution": false, "debug": true }
```

| Workflow | Benefit Level | Rationale |
|----------|--------------|-----------|
| Debug | High | Adversarial hypothesis testing finds root causes faster |
| Research | Moderate | Cross-pollination between stack/features/architecture/pitfalls |
| Execution | Low | Plans are designed to be independent; coordination rarely needed |

## Testing

- Verified agent teams check logic in all 4 command files
- Confirmed backward compatibility with boolean `false` and missing `agent_teams`
- Tested settings.md multiSelect renders correctly
- Config template includes defaults

## Breaking Changes

None. Purely additive — new config field with safe defaults (all `false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)