### PR TITLE
fix(install): scope #330 statusline migration to GSD's own hooks/ path

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -750,16 +750,17 @@ function cleanupOrphanedHooks(settings) {
     console.log(`  ${green}✓${reset} Removed orphaned hook registrations`);
   }
 
-  // Fix #330: Update statusLine if it points to old statusline.js path
+  // Fix #330: Update statusLine if it points to old GSD statusline.js path
+  // Only match GSD's own old path (hooks/statusline.js), not custom user statuslines
   if (settings.statusLine && settings.statusLine.command &&
-      settings.statusLine.command.includes('statusline.js') &&
+      (settings.statusLine.command.includes('hooks/statusline.js') ||
+       settings.statusLine.command.includes('hooks\\statusline.js')) &&
       !settings.statusLine.command.includes('gsd-statusline.js')) {
-    // Replace old path with new path
     settings.statusLine.command = settings.statusLine.command.replace(
-      /statusline\.js/,
-      'gsd-statusline.js'
+      /hooks[/\\]statusline\.js/,
+      'hooks/gsd-statusline.js'
     );
-    console.log(`  ${green}✓${reset} Updated statusline path (statusline.js → gsd-statusline.js)`);
+    console.log(`  ${green}✓${reset} Updated statusline path (hooks/statusline.js → hooks/gsd-statusline.js)`);
   }
 
   return settings;


### PR DESCRIPTION
## Summary

- Narrows the `cleanupOrphanedHooks()` statusline migration regex to only match GSD's own old path (`hooks/statusline.js`), not arbitrary user paths containing `statusline.js`
- Handles both forward slash and backslash (Windows) path variants
- Custom user statusline configs are no longer silently overwritten on install/update

## Problem

The #330 fix added a migration in `cleanupOrphanedHooks()` that replaces `statusline.js` → `gsd-statusline.js` in `settings.json`. However, the `.includes('statusline.js')` check matches **any** path containing that filename — not just GSD's old `hooks/statusline.js`. Users with custom statusline scripts at other paths (e.g. a personal `statusline.js` outside `hooks/`) get their config silently rewritten to point to a nonexistent file, breaking the status line.

This runs on every install/update since `cleanupOrphanedHooks()` is called unconditionally.

## Fix

Changed the `.includes()` check and regex to specifically match `hooks/statusline.js` (and `hooks\statusline.js` for Windows), which is the only path GSD owns.

Related: #288, #330

## Test plan

- [ ] Install with old GSD `hooks/statusline.js` in settings → auto-migrates to `hooks/gsd-statusline.js`
- [ ] Install with custom `statusline.js` at a non-hooks path → config preserved, no rewrite
- [ ] Install with `gsd-statusline.js` already configured → no change (skip)
- [ ] Install with no statusline configured → normal install flow
- [ ] Windows-style backslash path `hooks\statusline.js` → migrates correctly