### PR TITLE
feat: add context-optimizing parsing commands to gsd-tools

### DIFF
--- a/get-shit-done/workflows/complete-milestone.md
+++ b/get-shit-done/workflows/complete-milestone.md
@@ -128,12 +128,13 @@ Milestone Stats:
 
 <step name="extract_accomplishments">
 
-Read all phase SUMMARY.md files in milestone range:
+Extract one-liners from SUMMARY.md files using summary-extract:
 
 ```bash
-cat .planning/phases/01-*/01-*-SUMMARY.md
-cat .planning/phases/02-*/02-*-SUMMARY.md
-# ... for each phase in milestone
+# For each phase in milestone, extract one-liner
+for summary in .planning/phases/*-*/*-SUMMARY.md; do
+  node ~/.claude/get-shit-done/bin/gsd-tools.js summary-extract "$summary" --fields one_liner | jq -r '.one_liner'
+done
 ```
 
 Extract 4-6 key accomplishments. Present:

--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -47,31 +47,16 @@ From init JSON: `phase_dir`, `plan_count`, `incomplete_count`.
 Report: "Found {plan_count} plans in {phase_dir} ({incomplete_count} incomplete)"
 </step>
 
-<step name="discover_plans">
+<step name="discover_and_group_plans">
+Load plan inventory with wave grouping in one call:
 
 ```bash
-ls -1 "$PHASE_DIR"/*-PLAN.md 2>/dev/null | sort
-ls -1 "$PHASE_DIR"/*-SUMMARY.md 2>/dev/null | sort
+PLAN_INDEX=$(node ~/.claude/get-shit-done/bin/gsd-tools.js phase-plan-index "${PHASE_NUMBER}")
 ```
 
-For each plan, read frontmatter: `wave`, `autonomous`, `gap_closure`.
+Parse JSON for: `phase`, `plans[]` (each with `id`, `wave`, `autonomous`, `objective`, `files_modified`, `task_count`, `has_summary`), `waves` (map of wave number → plan IDs), `incomplete`, `has_checkpoints`.
 
-Build inventory: path, plan ID, wave, autonomous flag, gap_closure flag, completion (SUMMARY exists = complete).
-
-**Filtering:** Skip completed plans. If `--gaps-only`: also skip non-gap_closure plans. If all filtered: "No matching incomplete plans" → exit.
-</step>
-
-<step name="group_by_wave">
-
-```bash
-for plan in $PHASE_DIR/*-PLAN.md; do
-  wave=$(grep "^wave:" "$plan" | cut -d: -f2 | tr -d ' ')
-  autonomous=$(grep "^autonomous:" "$plan" | cut -d: -f2 | tr -d ' ')
-  echo "$plan:$wave:$autonomous"
-done
-```
-
-Group by wave number. **No dependency analysis needed** — waves pre-computed during `/gsd:plan-phase`.
+**Filtering:** Skip plans where `has_summary: true`. If `--gaps-only`: also skip non-gap_closure plans. If all filtered: "No matching incomplete plans" → exit.
 
 Report:
 ```

--- a/get-shit-done/workflows/plan-phase.md
+++ b/get-shit-done/workflows/plan-phase.md
@@ -75,7 +75,8 @@ Display banner:
 ```bash
 PHASE_DESC=$(node ~/.claude/get-shit-done/bin/gsd-tools.js roadmap get-phase "${PHASE}" | jq -r '.section')
 REQUIREMENTS=$(cat .planning/REQUIREMENTS.md 2>/dev/null | grep -A100 "## Requirements" | head -50)
-DECISIONS=$(grep -A20 "### Decisions Made" .planning/STATE.md 2>/dev/null)
+STATE_SNAP=$(node ~/.claude/get-shit-done/bin/gsd-tools.js state-snapshot)
+# Extract decisions from state-snapshot JSON: jq '.decisions[] | "\(.phase): \(.summary) - \(.rationale)"'
 ```
 
 Research prompt:

--- a/get-shit-done/workflows/research-phase.md
+++ b/get-shit-done/workflows/research-phase.md
@@ -38,7 +38,8 @@ If exists: Offer update/view/skip options.
 echo "$PHASE_INFO" | jq -r '.section'
 cat .planning/REQUIREMENTS.md 2>/dev/null
 cat .planning/phases/${PHASE}-*/*-CONTEXT.md 2>/dev/null
-grep -A30 "### Decisions Made" .planning/STATE.md 2>/dev/null
+# Decisions from state-snapshot (structured JSON)
+node ~/.claude/get-shit-done/bin/gsd-tools.js state-snapshot | jq '.decisions'
 ```
 
 ## Step 4: Spawn Researcher


### PR DESCRIPTION
## Summary

- Add three new gsd-tools commands that extract structured JSON from GSD files
- Reduces agent context usage by returning only parsed fields (~2-3%) instead of raw file content (~10-20%)

### New Commands

| Command | Purpose | Replaces |
|---------|---------|----------|
| `phase-plan-index <phase>` | Plans grouped by wave with metadata | `ls` + grep loop in execute-phase |
| `state-snapshot` | Parsed STATE.md fields | `grep -A20 "### Decisions Made"` patterns |
| `summary-extract <path> [--fields]` | SUMMARY.md frontmatter extraction | `cat` + manual parsing |

### Workflow Updates

- `execute-phase.md`: Use `phase-plan-index` instead of ls + grep loop
- `plan-phase.md`: Use `state-snapshot` for decisions
- `research-phase.md`: Use `state-snapshot` for decisions  
- `complete-milestone.md`: Use `summary-extract` for one-liners

## Test plan

- [x] 17 new tests added across 3 test suites
- [x] All 39 tests pass (`npm test`)
- [ ] Manual test with real GSD project

🤖 Generated with [Claude Code](https://claude.com/claude-code)