### PR TITLE
fix: normalize Windows backslashes in gsd-tools path prefix

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -1063,7 +1063,7 @@ function configureOpencodePermissions() {
   const defaultConfigDir = path.join(os.homedir(), '.config', 'opencode');
   const gsdPath = opencodeConfigDir === defaultConfigDir
     ? '~/.config/opencode/get-shit-done/*'
-    : `${opencodeConfigDir}/get-shit-done/*`;
+    : `${opencodeConfigDir.replace(/\\/g, '/')}/get-shit-done/*`;
   
   let modified = false;
 
@@ -1150,7 +1150,7 @@ function install(isGlobal, runtime = 'claude') {
   // For global installs: use full path
   // For local installs: use relative
   const pathPrefix = isGlobal
-    ? `${targetDir}/`
+    ? `${targetDir.replace(/\\/g, '/')}/`
     : `./${dirName}/`;
 
   let runtimeLabel = 'Claude Code';


### PR DESCRIPTION
On Windows, path.join(os.homedir(), '.cursor') produces backslash paths (e.g. C:\Users\user\.cursor). When appended with forward slashes to build pathPrefix, this creates mixed-separator paths that break gsd-tools invocations:

  Bash(node C:\Users\user\.claude/get-shit-done/bin/gsd-tools.js init map-codebase)

Normalize targetDir and opencodeConfigDir to forward slashes before concatenation so Node.js receives consistent paths on all platforms.

## Testing

- [ V ] Tested on Windows

## Breaking Changes

None
