### PR TITLE
fix: workaround for Claude Code classifyHandoffIfNeeded bug

### DIFF
--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -169,7 +169,11 @@ Execute each wave in sequence. Within a wave: parallel if `PARALLELIZATION=true`
    - Bad: "Wave 2 complete. Proceeding to Wave 3."
    - Good: "Terrain system complete — 3 biome types, height-based texturing, physics collision meshes. Vehicle physics (Wave 3) can now reference ground surfaces."
 
-5. **Handle failures:** Report which plan failed → ask "Continue?" or "Stop?" → if continue, dependent plans may also fail. If stop, partial completion report.
+5. **Handle failures:**
+
+   **Known Claude Code bug (classifyHandoffIfNeeded):** If an agent reports "failed" with error containing `classifyHandoffIfNeeded is not defined`, this is a Claude Code runtime bug — not a GSD or agent issue. The error fires in the completion handler AFTER all tool calls finish. In this case: run the same spot-checks as step 4 (SUMMARY.md exists, git commits present, no Self-Check: FAILED). If spot-checks PASS → treat as **successful**. If spot-checks FAIL → treat as real failure below.
+
+   For real failures: report which plan failed → ask "Continue?" or "Stop?" → if continue, dependent plans may also fail. If stop, partial completion report.
 
 6. **Execute checkpoint plans between waves** — see `<checkpoint_handling>`.
 
@@ -329,6 +333,7 @@ Orchestrator: ~10-15% context. Subagents: fresh 200k each. No polling (Task bloc
 </context_efficiency>
 
 <failure_handling>
+- **classifyHandoffIfNeeded false failure:** Agent reports "failed" but error is `classifyHandoffIfNeeded is not defined` → Claude Code bug, not GSD. Spot-check (SUMMARY exists, commits present) → if pass, treat as success
 - **Agent fails mid-plan:** Missing SUMMARY.md → report, ask user how to proceed
 - **Dependency chain breaks:** Wave 1 fails → Wave 2 dependents likely fail → user chooses attempt or skip
 - **All agents in wave fail:** Systemic issue → stop, report for investigation

--- a/get-shit-done/workflows/execute-plan.md
+++ b/get-shit-done/workflows/execute-plan.md
@@ -111,6 +111,12 @@ Pattern B only (verify-only checkpoints). Skip for A/C.
    - Verify key-files.created exist on disk with `[ -f ]`
    - Check `git log --oneline --all --grep="{phase}-{plan}"` returns ≥1 commit
    - Append `## Self-Check: PASSED` or `## Self-Check: FAILED` to SUMMARY
+
+   **Known Claude Code bug (classifyHandoffIfNeeded):** If any segment agent reports "failed" with `classifyHandoffIfNeeded is not defined`, this is a Claude Code runtime bug — not a real failure. Run spot-checks; if they pass, treat as successful.
+
+
+
+
 </step>
 
 <step name="load_prompt">

--- a/get-shit-done/workflows/quick.md
+++ b/get-shit-done/workflows/quick.md
@@ -141,6 +141,8 @@ After executor returns:
 2. Extract commit hash from executor output
 3. Report completion status
 
+**Known Claude Code bug (classifyHandoffIfNeeded):** If executor reports "failed" with error `classifyHandoffIfNeeded is not defined`, this is a Claude Code runtime bug — not a real failure. Check if summary file exists and git log shows commits. If so, treat as successful.
+
 If summary not found, error: "Executor failed to create ${next_num}-SUMMARY.md"
 
 Note: For quick tasks producing multiple plans (rare), spawn executors in parallel waves per execute-phase patterns.


### PR DESCRIPTION
## Summary

- Adds workaround to `execute-phase.md`, `execute-plan.md`, and `quick.md` for the `classifyHandoffIfNeeded is not defined` bug in Claude Code v2.1.27+
- All Task tool agents report `status: failed` despite completing work successfully — the error fires in Claude Code's internal completion handler AFTER all tool calls finish
- Workaround: when agent reports this specific failure, run spot-checks (SUMMARY.md exists, git commits present, no Self-Check: FAILED). If spot-checks pass, treat as successful

## The Bug

`classifyHandoffIfNeeded` is called but never defined in Claude Code's `cli.js` bundle. This causes **100% of Task tool agents** to report "failed" even though all work completes correctly. It affects every agent type, every model, every platform.

**Tracked upstream:** [anthropics/claude-code#24181](https://github.com/anthropics/claude-code/issues/24181) + related [#22087](https://github.com/anthropics/claude-code/issues/22087), [#22544](https://github.com/anthropics/claude-code/issues/22544)

## Impact on GSD

Without this workaround:
- `execute-phase` triggers the failure handler for every wave, asking users "Retry plan?" or "Continue?" — even though all work completed
- Parallel execution workflows are most affected — every wave reports multiple failures
- Users must manually dismiss false failures for each agent in each wave

With this workaround:
- Orchestrators recognize the specific error pattern and fall back to spot-checks
- Spot-checks verify work on disk (SUMMARY.md exists, git commits present)
- False failures are silently promoted to success; real failures still trigger the failure handler

## Files Changed

| File | Change |
|------|--------|
| `get-shit-done/workflows/execute-phase.md` | Step 5 failure handler + `<failure_handling>` section |
| `get-shit-done/workflows/execute-plan.md` | Segment aggregation step |
| `get-shit-done/workflows/quick.md` | Executor return handling |

## Test Plan

- [ ] Run `/gsd:execute-phase` with a phase containing parallel plans — agents should no longer trigger failure handler
- [ ] Run `/gsd:quick` — executor should complete without false failure prompt
- [ ] Verify real failures (e.g., missing SUMMARY.md) still trigger the failure handler correctly

## Removal Criteria

This workaround should be removed when Claude Code ships a fix for `classifyHandoffIfNeeded`. Watch [anthropics/claude-code#24181](https://github.com/anthropics/claude-code/issues/24181).

🤖 Generated with [Claude Code](https://claude.com/claude-code)