### PR TITLE
feat: preserve local patches across GSD updates

### DIFF
--- a/commands/gsd/reapply-patches.md
+++ b/commands/gsd/reapply-patches.md
@@ -1,0 +1,110 @@
+---
+description: Reapply local modifications after a GSD update
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep, AskUserQuestion
+---
+
+<purpose>
+After a GSD update wipes and reinstalls files, this command merges user's previously saved local modifications back into the new version. Uses intelligent comparison to handle cases where the upstream file also changed.
+</purpose>
+
+<process>
+
+## Step 1: Detect backed-up patches
+
+Check for local patches directory:
+
+```bash
+# Global install
+PATCHES_DIR="${HOME}/.claude/gsd-local-patches"
+# Local install fallback
+if [ ! -d "$PATCHES_DIR" ]; then
+  PATCHES_DIR="./.claude/gsd-local-patches"
+fi
+```
+
+Read `backup-meta.json` from the patches directory.
+
+**If no patches found:**
+```
+No local patches found. Nothing to reapply.
+
+Local patches are automatically saved when you run /gsd:update
+after modifying any GSD workflow, command, or agent files.
+```
+Exit.
+
+## Step 2: Show patch summary
+
+```
+## Local Patches to Reapply
+
+**Backed up from:** v{from_version}
+**Current version:** {read VERSION file}
+**Files modified:** {count}
+
+| # | File | Status |
+|---|------|--------|
+| 1 | {file_path} | Pending |
+| 2 | {file_path} | Pending |
+```
+
+## Step 3: Merge each file
+
+For each file in `backup-meta.json`:
+
+1. **Read the backed-up version** (user's modified copy from `gsd-local-patches/`)
+2. **Read the newly installed version** (current file after update)
+3. **Compare and merge:**
+
+   - If the new file is identical to the backed-up file: skip (modification was incorporated upstream)
+   - If the new file differs: identify the user's modifications and apply them to the new version
+
+   **Merge strategy:**
+   - Read both versions fully
+   - Identify sections the user added or modified (look for additions, not just differences from path replacement)
+   - Apply user's additions/modifications to the new version
+   - If a section the user modified was also changed upstream: flag as conflict, show both versions, ask user which to keep
+
+4. **Write merged result** to the installed location
+5. **Report status:**
+   - `Merged` — user modifications applied cleanly
+   - `Skipped` — modification already in upstream
+   - `Conflict` — user chose resolution
+
+## Step 4: Update manifest
+
+After reapplying, regenerate the file manifest so future updates correctly detect these as user modifications:
+
+```bash
+# The manifest will be regenerated on next /gsd:update
+# For now, just note which files were modified
+```
+
+## Step 5: Cleanup option
+
+Ask user:
+- "Keep patch backups for reference?" → preserve `gsd-local-patches/`
+- "Clean up patch backups?" → remove `gsd-local-patches/` directory
+
+## Step 6: Report
+
+```
+## Patches Reapplied
+
+| # | File | Status |
+|---|------|--------|
+| 1 | {file_path} | ✓ Merged |
+| 2 | {file_path} | ○ Skipped (already upstream) |
+| 3 | {file_path} | ⚠ Conflict resolved |
+
+{count} file(s) updated. Your local modifications are active again.
+```
+
+</process>
+
+<success_criteria>
+- [ ] All backed-up patches processed
+- [ ] User modifications merged into new version
+- [ ] Conflicts resolved with user input
+- [ ] Status reported for each file
+</success_criteria>

--- a/get-shit-done/workflows/update.md
+++ b/get-shit-done/workflows/update.md
@@ -129,7 +129,7 @@ Your custom files in other locations are preserved:
 - Custom hooks ✓
 - Your CLAUDE.md files ✓
 
-If you've modified any GSD files directly, back them up first.
+If you've modified any GSD files directly, they'll be automatically backed up to `gsd-local-patches/` and can be reapplied with `/gsd:reapply-patches` after the update.
 ```
 
 Use AskUserQuestion:
@@ -183,6 +183,21 @@ Format completion message (changelog was already shown in confirmation step):
 ```
 </step>
 
+
+<step name="check_local_patches">
+After update completes, check if the installer detected and backed up any locally modified files:
+
+Check for gsd-local-patches/backup-meta.json in the config directory.
+
+**If patches found:**
+
+```
+Local patches were backed up before the update.
+Run /gsd:reapply-patches to merge your modifications into the new version.
+```
+
+**If no patches:** Continue normally.
+</step>
 </process>
 
 <success_criteria>


### PR DESCRIPTION
## Summary

- Adds automatic backup and restore of user-modified GSD files across updates
- New `/gsd:reapply-patches` command for LLM-guided merge after update
- No more losing local workarounds, customizations, or bug fixes when running `/gsd:update`

## Problem

When users modify GSD workflow files (e.g., adding workarounds for Claude Code bugs, customizing execution behavior, adjusting failure handling), every `/gsd:update` wipes and replaces all GSD files. Users must manually re-apply their modifications after every update, which is:

- **Error-prone** — easy to forget which files were modified
- **Time-consuming** — must re-read changelogs and merge manually
- **Discouraging** — users avoid updating to keep their patches, missing new features and fixes

## Solution

### Automatic Detection & Backup (install.js)

On first install, writes `gsd-file-manifest.json` with SHA256 hashes of every installed GSD file. On subsequent updates:

1. Compares current files against manifest hashes
2. Files that differ = user-modified → backed up to `gsd-local-patches/`
3. Clean install proceeds normally
4. After install, reports which files were backed up

```
  ⚠  Found 3 locally modified GSD file(s) — backed up to gsd-local-patches/
     get-shit-done/workflows/execute-phase.md
     get-shit-done/workflows/execute-plan.md
     get-shit-done/workflows/quick.md

  📋 Local patches detected (from v1.15.0):
     get-shit-done/workflows/execute-phase.md
     get-shit-done/workflows/execute-plan.md
     get-shit-done/workflows/quick.md

  Your modifications are saved in gsd-local-patches/
  Run /gsd:reapply-patches to merge them into the new version.
```

### LLM-Guided Merge (new command)

`/gsd:reapply-patches` reads backed-up files and intelligently merges modifications into the new version:

- Compares backed-up (user-modified) vs. newly installed version
- Applies user additions/modifications to new file
- Flags conflicts where both user and upstream changed the same section
- Reports per-file status: merged, skipped (already upstream), or conflict resolved

### Update Workflow Integration

- Warning text now mentions automatic backup instead of "back them up first"
- New step after install checks for and reports backed-up patches
- Seamless flow: modify → update → patches auto-saved → reapply

## Files Changed

| File | Change |
|------|--------|
| `bin/install.js` | +145 lines: manifest generation, patch detection, backup, and reporting functions |
| `commands/gsd/reapply-patches.md` | New command for LLM-guided patch merge |
| `get-shit-done/workflows/update.md` | Updated warning text + new check_local_patches step |

## Technical Details

- **Manifest format**: `gsd-file-manifest.json` at config root, contains version, timestamp, and SHA256 hashes for all GSD files
- **Backup location**: `gsd-local-patches/` at config root (outside GSD install dirs, survives clean install)
- **Backup metadata**: `backup-meta.json` records source version, timestamp, and list of modified files
- **Hash scope**: `get-shit-done/**`, `commands/gsd/**`, `agents/gsd-*.md`

## Test Plan

- [ ] Fresh install creates `gsd-file-manifest.json` with correct hashes
- [ ] Modifying a GSD file then running update detects and backs up the modification
- [ ] `gsd-local-patches/` directory survives clean install (it's outside GSD dirs)
- [ ] `/gsd:reapply-patches` correctly merges backed-up modifications
- [ ] Unmodified files are not backed up (hash matches)
- [ ] Missing manifest (first update after feature ships) gracefully skips backup

🤖 Generated with [Claude Code](https://claude.com/claude-code)