### PR TITLE
fix: create feature branch before first commit in discuss/plan workflows

### DIFF
--- a/get-shit-done/bin/gsd-tools.js
+++ b/get-shit-done/bin/gsd-tools.js
@@ -3652,6 +3652,7 @@ function cmdInitPlanPhase(cwd, phase, includes, raw) {
     research_enabled: config.research,
     plan_checker_enabled: config.plan_checker,
     commit_docs: config.commit_docs,
+    branching_strategy: config.branching_strategy,
 
     // Phase info
     phase_found: !!phaseInfo,
@@ -3660,6 +3661,17 @@ function cmdInitPlanPhase(cwd, phase, includes, raw) {
     phase_name: phaseInfo?.phase_name || null,
     phase_slug: phaseInfo?.phase_slug || null,
     padded_phase: phaseInfo?.phase_number?.padStart(2, '0') || null,
+
+    // Branch name (pre-computed) — ensures early branching before first commit
+    branch_name: config.branching_strategy === 'phase' && phaseInfo
+      ? config.phase_branch_template
+          .replace('{phase}', phaseInfo.phase_number)
+          .replace('{slug}', phaseInfo.phase_slug || 'phase')
+      : config.branching_strategy === 'milestone'
+        ? config.milestone_branch_template
+            .replace('{milestone}', getMilestoneInfo(cwd).version)
+            .replace('{slug}', generateSlugInternal(getMilestoneInfo(cwd).name) || 'milestone')
+        : null,
 
     // Existing artifacts
     has_research: phaseInfo?.has_research || false,
@@ -3919,11 +3931,13 @@ function cmdInitVerifyWork(cwd, phase, raw) {
 function cmdInitPhaseOp(cwd, phase, raw) {
   const config = loadConfig(cwd);
   const phaseInfo = findPhaseInternal(cwd, phase);
+  const milestone = getMilestoneInfo(cwd);
 
   const result = {
     // Config
     commit_docs: config.commit_docs,
     brave_search: config.brave_search,
+    branching_strategy: config.branching_strategy,
 
     // Phase info
     phase_found: !!phaseInfo,
@@ -3932,6 +3946,17 @@ function cmdInitPhaseOp(cwd, phase, raw) {
     phase_name: phaseInfo?.phase_name || null,
     phase_slug: phaseInfo?.phase_slug || null,
     padded_phase: phaseInfo?.phase_number?.padStart(2, '0') || null,
+
+    // Branch name (pre-computed) — ensures early branching before first commit
+    branch_name: config.branching_strategy === 'phase' && phaseInfo
+      ? config.phase_branch_template
+          .replace('{phase}', phaseInfo.phase_number)
+          .replace('{slug}', phaseInfo.phase_slug || 'phase')
+      : config.branching_strategy === 'milestone'
+        ? config.milestone_branch_template
+            .replace('{milestone}', milestone.version)
+            .replace('{slug}', generateSlugInternal(milestone.name) || 'milestone')
+        : null,
 
     // Existing artifacts
     has_research: phaseInfo?.has_research || false,

--- a/get-shit-done/workflows/discuss-phase.md
+++ b/get-shit-done/workflows/discuss-phase.md
@@ -114,7 +114,7 @@ Phase number from argument (required).
 INIT=$(node ~/.claude/get-shit-done/bin/gsd-tools.js init phase-op "${PHASE}")
 ```
 
-Parse JSON for: `commit_docs`, `phase_found`, `phase_dir`, `phase_number`, `phase_name`, `phase_slug`, `padded_phase`, `has_research`, `has_context`, `has_plans`, `has_verification`, `plan_count`, `roadmap_exists`, `planning_exists`.
+Parse JSON for: `commit_docs`, `branching_strategy`, `branch_name`, `phase_found`, `phase_dir`, `phase_number`, `phase_name`, `phase_slug`, `padded_phase`, `has_research`, `has_context`, `has_plans`, `has_verification`, `plan_count`, `roadmap_exists`, `planning_exists`.
 
 **If `phase_found` is false:**
 ```
@@ -124,7 +124,22 @@ Use /gsd:progress to see available phases.
 ```
 Exit workflow.
 
-**If `phase_found` is true:** Continue to check_existing.
+**If `phase_found` is true:** Continue to handle_branching.
+</step>
+
+<step name="handle_branching">
+Check `branching_strategy` from init:
+
+**"none":** Skip, continue on current branch.
+
+**"phase" or "milestone":** Use pre-computed `branch_name` from init:
+```bash
+git checkout -b "$BRANCH_NAME" 2>/dev/null || git checkout "$BRANCH_NAME"
+```
+
+This ensures all phase documentation commits (context, research, plans) go to the feature branch, not main.
+
+Continue to check_existing.
 </step>
 
 <step name="check_existing">

--- a/get-shit-done/workflows/plan-phase.md
+++ b/get-shit-done/workflows/plan-phase.md
@@ -18,11 +18,24 @@ Load all context in one call (include file contents to avoid redundant reads):
 INIT=$(node ~/.claude/get-shit-done/bin/gsd-tools.js init plan-phase "$PHASE" --include state,roadmap,requirements,context,research,verification,uat)
 ```
 
-Parse JSON for: `researcher_model`, `planner_model`, `checker_model`, `research_enabled`, `plan_checker_enabled`, `commit_docs`, `phase_found`, `phase_dir`, `phase_number`, `phase_name`, `phase_slug`, `padded_phase`, `has_research`, `has_context`, `has_plans`, `plan_count`, `planning_exists`, `roadmap_exists`.
+Parse JSON for: `researcher_model`, `planner_model`, `checker_model`, `research_enabled`, `plan_checker_enabled`, `commit_docs`, `branching_strategy`, `branch_name`, `phase_found`, `phase_dir`, `phase_number`, `phase_name`, `phase_slug`, `padded_phase`, `has_research`, `has_context`, `has_plans`, `plan_count`, `planning_exists`, `roadmap_exists`.
 
 **File contents (from --include):** `state_content`, `roadmap_content`, `requirements_content`, `context_content`, `research_content`, `verification_content`, `uat_content`. These are null if files don't exist.
 
 **If `planning_exists` is false:** Error — run `/gsd:new-project` first.
+
+## 1.5. Handle Branching
+
+Check `branching_strategy` from init:
+
+**"none":** Skip, continue on current branch.
+
+**"phase" or "milestone":** Use pre-computed `branch_name` from init:
+```bash
+git checkout -b "$BRANCH_NAME" 2>/dev/null || git checkout "$BRANCH_NAME"
+```
+
+This ensures research and planning commits go to the feature branch, not main. If `/gsd:discuss-phase` already created the branch, the `git checkout` fallback switches to it.
 
 ## 2. Parse and Normalize Arguments
 


### PR DESCRIPTION
## Summary

- **Bug:** When `branching_strategy` is set to `"phase"`, the feature branch is only created in `execute-phase`. But `discuss-phase` and `plan-phase` both commit docs (`CONTEXT.md`, `RESEARCH.md`, `PLAN.md`) *before* execution, landing those commits on `main`. This causes `main` to diverge from `origin/main` when other PRs (e.g., dependency bumps) merge remotely.
- **Fix:** Move branch creation earlier — add a `handle_branching` step to both `discuss-phase` and `plan-phase` workflows, and expose `branching_strategy` + `branch_name` in their init outputs (`cmdInitPhaseOp`, `cmdInitPlanPhase`).
- The `execute-phase` workflow's existing `handle_branching` step gracefully handles the branch already existing (via `git checkout -b ... || git checkout ...`), so no changes needed there.

## Files Changed

| File | Change |
|------|--------|
| `get-shit-done/bin/gsd-tools.js` | Add `branching_strategy` and `branch_name` to `cmdInitPhaseOp` and `cmdInitPlanPhase` |
| `get-shit-done/workflows/discuss-phase.md` | Add `handle_branching` step after `initialize`, before any commits |
| `get-shit-done/workflows/plan-phase.md` | Add step 1.5 `Handle Branching` after initialize |

## Reproduction

1. Start a new phase with `branching_strategy: "phase"` in config
2. Run `/gsd:discuss-phase N` — commits `CONTEXT.md` to `main`
3. Run `/gsd:plan-phase N` — commits `RESEARCH.md` and `PLAN.md` to `main`
4. Meanwhile, a dependency bump PR merges to `origin/main`
5. Local `main` is now diverged from `origin/main`

## Test plan

- [ ] Run `/gsd:discuss-phase` with `branching_strategy: "phase"` — verify branch is created before CONTEXT.md commit
- [ ] Run `/gsd:plan-phase` (skipping discuss) — verify branch is created before research/planning
- [ ] Run `/gsd:execute-phase` after discuss+plan — verify it switches to the already-existing branch without error
- [ ] Run with `branching_strategy: "none"` — verify no branching behavior (no regression)