### PR TITLE
fix: execute-phase now calls phase complete tool for ROADMAP updates

### DIFF
--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -287,7 +287,15 @@ Gap closure cycle: `/gsd:plan-phase {X} --gaps` reads VERIFICATION.md → create
 </step>
 
 <step name="update_roadmap">
-Mark phase complete in ROADMAP.md (date, status).
+Mark phase complete in ROADMAP.md and advance STATE.md using gsd-tools:
+
+```bash
+node ~/.claude/get-shit-done/bin/gsd-tools.js phase complete {X}
+```
+
+This handles: checkbox flip (`[x]` + date), progress table update, plan count, and STATE.md advancement (current phase, status, last activity).
+
+Extract from result: `completed_phase`, `plans_executed`, `next_phase`, `next_phase_name`, `is_last_phase`.
 
 ```bash
 node ~/.claude/get-shit-done/bin/gsd-tools.js commit "docs(phase-{X}): complete phase execution" --files .planning/ROADMAP.md .planning/STATE.md .planning/phases/{phase_dir}/*-VERIFICATION.md .planning/REQUIREMENTS.md


### PR DESCRIPTION
## What

Adds the missing `gsd-tools.js phase complete {X}` call to `execute-phase.md` `update_roadmap` step.

Fixes #536

## Why

`execute-phase.md` had a vague NL instruction ("Mark phase complete in ROADMAP.md") with no tool call. The LLM inconsistently performed or skipped the manual edit, leaving ROADMAP checkboxes unchecked (`- [ ]`) after successful phase execution. `transition.md` already does this correctly via `gsd-tools.js phase complete` — this PR aligns `execute-phase.md` to the same pattern.

## QA Review

**Root cause confirmed via code audit:**

| File | Behavior |
|------|----------|
| `transition.md` (line 126) | ✅ Calls `gsd-tools.js phase complete` — checkbox flipped, STATE.md advanced |
| `execute-phase.md` `update_roadmap` | ❌ Vague NL instruction, no tool call — LLM guesses, often skips |
| `gsd-tools.js` `cmdPhaseComplete` (line 2930) | ✅ Tool exists and handles: checkbox flip + date, progress table, plan count, STATE.md advancement |

**What the tool handles that the NL instruction left to chance:**
- `- [ ]` → `- [x]` with completion date
- Progress table status → Complete
- Plan count update (e.g., "3/3 plans complete")
- STATE.md: current phase, status, current plan, last activity

**Fix:** One tool call added before the existing commit command. Matches `transition.md` pattern exactly.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

> Workflow-only change (`.md` file). No JS logic modified. The tool call being added (`phase complete`) is already tested and used in production via `transition.md`.

## Checklist

- [x] Follows GSD style (no enterprise patterns, no filler)
- [x] No unnecessary dependencies added
- [x] Works on Windows (no platform-specific changes)