### PR TITLE
feat: extract ROADMAP Success Criteria for verifier baseline truths

### DIFF
--- a/get-shit-done/bin/gsd-tools.js
+++ b/get-shit-done/bin/gsd-tools.js
@@ -863,12 +863,28 @@ function cmdRoadmapGetPhase(cwd, phaseNum, raw) {
     const goalMatch = section.match(/\*\*Goal:\*\*\s*([^\n]+)/i);
     const goal = goalMatch ? goalMatch[1].trim() : null;
 
+    // Extract Success Criteria as structured array
+    const successCriteria = [];
+    // Match Success Criteria block — terminate at next field (**Key:** pattern at line start) or next section
+    // Match Success Criteria block — terminate at next field header, next section, or end of string
+    const scMatch = section.match(/\*\*Success Criteria\*\*[^:]*:\s*\n([\s\S]*?)(?=\n\*\*[A-Z][^*]+\*\*|\n###|$)/i);
+    if (scMatch) {
+      const lines = scMatch[1].split('\n');
+      for (const line of lines) {
+        const itemMatch = line.match(/^\s*(?:\d+[.)]\s*|-\s*|\*\s*)(.+)/);
+        if (itemMatch) {
+          successCriteria.push(itemMatch[1].trim());
+        }
+      }
+    }
+
     output(
       {
         found: true,
         phase_number: phaseNum,
         phase_name: phaseName,
         goal,
+        success_criteria: successCriteria,
         section,
       },
       raw,

--- a/get-shit-done/workflows/verify-phase.md
+++ b/get-shit-done/workflows/verify-phase.md
@@ -44,7 +44,13 @@ Extract **phase goal** from ROADMAP.md (the outcome to verify, not tasks) and **
 </step>
 
 <step name="establish_must_haves">
-**Option A: Must-haves in PLAN frontmatter**
+**Step 1: ROADMAP Success Criteria (mandatory baseline)**
+
+The `roadmap get-phase` result includes `success_criteria` — an array of observable behaviors that must be TRUE for the phase to pass. These are **non-negotiable truths**. Each criterion becomes a mandatory verification item.
+
+If `success_criteria` is non-empty, use each item as a truth to verify. These take priority over derived truths.
+
+**Step 2: PLAN frontmatter must_haves (supplemental)**
 
 Use gsd-tools to extract must_haves from each PLAN:
 
@@ -57,11 +63,11 @@ done
 
 Returns JSON: `{ truths: [...], artifacts: [...], key_links: [...] }`
 
-Aggregate all must_haves across plans for phase-level verification.
+Aggregate all must_haves across plans. These supplement the ROADMAP Success Criteria — they add detail but do not replace them.
 
-**Option B: Derive from phase goal**
+**Step 3: Derive from phase goal (fallback only)**
 
-If no must_haves in frontmatter (MUST_HAVES returns error or empty):
+If BOTH `success_criteria` is empty AND no must_haves in frontmatter:
 1. State the goal from ROADMAP.md
 2. Derive **truths** (3-7 observable behaviors, each testable)
 3. Derive **artifacts** (concrete file paths for each truth)
@@ -212,7 +218,7 @@ Orchestrator routes: `passed` → update_roadmap | `gaps_found` → create/execu
 </process>
 
 <success_criteria>
-- [ ] Must-haves established (from frontmatter or derived)
+- [ ] Must-haves established (from ROADMAP Success Criteria, PLAN frontmatter, or derived)
 - [ ] All truths verified with status and evidence
 - [ ] All artifacts checked at all three levels
 - [ ] All key links verified


### PR DESCRIPTION
Fixes #538

## What

1. `cmdRoadmapGetPhase` now returns `success_criteria` as a structured array, parsed from the ROADMAP phase section
2. `verify-phase.md` updated to use these criteria as mandatory baseline truths

## Why

The verifier derived truths from Goal text or PLAN frontmatter `must_haves`, but ignored explicit ROADMAP Success Criteria. This allowed partial implementations to pass verification — e.g., a health endpoint checking 2 of 5 dependencies passed when the Success Criteria explicitly required all 5.

## How

**gsd-tools.js** — Regex extracts numbered or bulleted items after the `**Success Criteria**` header. Terminates at the next field header (`**Plans:**`, etc.), next section (`###`), or end of string. Returns empty array when no criteria present.

**verify-phase.md** — Restructured `establish_must_haves` into three prioritized steps:
1. **ROADMAP Success Criteria** (mandatory baseline) — each criterion becomes a non-negotiable truth
2. **PLAN frontmatter must_haves** (supplemental) — adds detail but does not replace criteria
3. **Goal derivation** (fallback only) — used only when both above are empty

Backward compatible — projects without Success Criteria fall through to existing behavior.

## Testing

3 new tests:
- Numbered list extraction (3 criteria parsed correctly)
- Empty criteria (returns `[]`)
- Bullet-style criteria (dash format)


## Checklist

- [x] Follows GSD style (no enterprise patterns, no filler)
- [x] No unnecessary dependencies added
- [x] Works on Windows (no platform-specific changes)
- [x] Backward compatible (empty array when no criteria present)