### PR TITLE
feat(hooks): add quality gate hooks for plan format and roadmap sync

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -852,7 +852,11 @@ function uninstall(isGlobal, runtime = 'claude') {
   // 4. Remove GSD hooks
   const hooksDir = path.join(targetDir, 'hooks');
   if (fs.existsSync(hooksDir)) {
-    const gsdHooks = ['gsd-statusline.js', 'gsd-check-update.js', 'gsd-check-update.sh'];
+    const gsdHooks = [
+      'gsd-statusline.js', 'gsd-check-update.js', 'gsd-check-update.sh',
+      'check-plan-format.js', 'check-roadmap-sync.js',
+      'check-phase-boundary.js', 'check-subagent-output.js'
+    ];
     let hookCount = 0;
     for (const hook of gsdHooks) {
       const hookPath = path.join(hooksDir, hook);

--- a/get-shit-done/bin/gsd-tools.js
+++ b/get-shit-done/bin/gsd-tools.js
@@ -168,6 +168,7 @@ function loadConfig(cwd) {
     verifier: true,
     parallelization: true,
     brave_search: false,
+    hooks: {},
   };
 
   try {
@@ -201,6 +202,7 @@ function loadConfig(cwd) {
       verifier: get('verifier', { section: 'workflow', field: 'verifier' }) ?? defaults.verifier,
       parallelization,
       brave_search: get('brave_search') ?? defaults.brave_search,
+      hooks: parsed.hooks || {},
     };
   } catch {
     return defaults;
@@ -608,6 +610,12 @@ function cmdConfigEnsureSection(cwd, raw) {
     },
     parallelization: true,
     brave_search: hasBraveSearch,
+    hooks: {
+      checkPlanFormat: true,
+      checkRoadmapSync: true,
+      enforcePhaseBoundaries: false,
+      checkSubagentOutput: true,
+    },
   };
 
   try {

--- a/get-shit-done/templates/config.json
+++ b/get-shit-done/templates/config.json
@@ -31,5 +31,11 @@
   "safety": {
     "always_confirm_destructive": true,
     "always_confirm_external_services": true
+  },
+  "hooks": {
+    "checkPlanFormat": true,
+    "checkRoadmapSync": true,
+    "enforcePhaseBoundaries": false,
+    "checkSubagentOutput": true
   }
 }

--- a/hooks/check-phase-boundary.js
+++ b/hooks/check-phase-boundary.js
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+// PreToolUse(Write/Edit) hook — warns or blocks writes outside current phase directory
+// Reads current phase from .planning/STATE.md and checks if the target file
+// is inside the expected phase directory.
+//
+// Behavior:
+//   - Planning files (.planning/**) are always allowed
+//   - Files inside current phase directory are allowed
+//   - Files outside phase dir: warn by default, block if enforcePhaseBoundaries: true
+//   - Config toggle: config.hooks.enforcePhaseBoundaries (default: false = warn only)
+//
+// Input: JSON on stdin with { tool_name, tool_input, cwd }
+// Output: JSON { decision: "allow" } or { decision: "block", reason: "..." }
+
+const fs = require('fs');
+const path = require('path');
+
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', chunk => input += chunk);
+process.stdin.on('end', () => {
+  try {
+    const data = JSON.parse(input);
+    const cwd = data.cwd || process.cwd();
+
+    // Only handle Write and Edit tools
+    if (data.tool_name !== 'Write' && data.tool_name !== 'Edit') {
+      process.stdout.write(JSON.stringify({ decision: 'allow' }));
+      process.exit(0);
+    }
+
+    // Check config toggle
+    const config = loadHookConfig(cwd);
+    // If explicitly set to false by name, skip entirely
+    if (config.enforcePhaseBoundaries === false && config.checkPhaseBoundary === false) {
+      process.stdout.write(JSON.stringify({ decision: 'allow' }));
+      process.exit(0);
+    }
+
+    const filePath = (data.tool_input && (data.tool_input.file_path || data.tool_input.path)) || '';
+    if (!filePath) {
+      process.stdout.write(JSON.stringify({ decision: 'allow' }));
+      process.exit(0);
+    }
+
+    // Normalize paths
+    const normalizedFile = filePath.replace(/\\/g, '/');
+    const normalizedCwd = cwd.replace(/\\/g, '/');
+
+    // Planning files are always allowed
+    if (normalizedFile.includes('.planning/')) {
+      process.stdout.write(JSON.stringify({ decision: 'allow' }));
+      logEvent(cwd, filePath, 'allow', 'planning-file');
+      process.exit(0);
+    }
+
+    // Read STATE.md to get current phase
+    const statePath = path.join(cwd, '.planning', 'STATE.md');
+    let stateContent = '';
+    try {
+      stateContent = fs.readFileSync(statePath, 'utf8');
+    } catch (e) {
+      // No STATE.md — can't check boundaries, allow
+      process.stdout.write(JSON.stringify({ decision: 'allow' }));
+      process.exit(0);
+    }
+
+    const phaseMatch = stateContent.match(/\*\*Current Phase:\*\*\s*(\S+)/);
+    if (!phaseMatch) {
+      // No phase info — allow
+      process.stdout.write(JSON.stringify({ decision: 'allow' }));
+      process.exit(0);
+    }
+
+    const currentPhase = phaseMatch[1].replace(/^0+/, '') || '0';
+    const paddedPhase = currentPhase.padStart(2, '0');
+
+    // Find the current phase directory
+    const phasesDir = path.join(cwd, '.planning', 'phases');
+    let phaseDir = null;
+    try {
+      if (fs.existsSync(phasesDir)) {
+        const dirs = fs.readdirSync(phasesDir);
+        const match = dirs.find(d =>
+          d.startsWith(paddedPhase + '-') || d.startsWith(paddedPhase + '.')
+        );
+        if (match) {
+          phaseDir = path.join(phasesDir, match).replace(/\\/g, '/');
+        }
+      }
+    } catch (e) {
+      // Can't read phases dir — allow
+      process.stdout.write(JSON.stringify({ decision: 'allow' }));
+      process.exit(0);
+    }
+
+    if (!phaseDir) {
+      // No phase directory found — allow
+      process.stdout.write(JSON.stringify({ decision: 'allow' }));
+      process.exit(0);
+    }
+
+    // Check if the file is inside the phase directory
+    const absoluteFile = path.isAbsolute(filePath)
+      ? filePath.replace(/\\/g, '/')
+      : path.resolve(cwd, filePath).replace(/\\/g, '/');
+
+    if (absoluteFile.startsWith(phaseDir + '/') || absoluteFile === phaseDir) {
+      process.stdout.write(JSON.stringify({ decision: 'allow' }));
+      logEvent(cwd, filePath, 'allow', 'in-phase');
+      process.exit(0);
+    }
+
+    // File is outside phase directory
+    const enforce = config.enforcePhaseBoundaries === true;
+
+    if (enforce) {
+      const reason = `File "${path.basename(filePath)}" is outside the current phase directory (phase ${currentPhase}). Phase boundary enforcement is enabled.`;
+      process.stdout.write(JSON.stringify({ decision: 'block', reason }));
+      logEvent(cwd, filePath, 'block', 'out-of-phase');
+      process.exit(0);
+    }
+
+    // Warn only (default behavior)
+    process.stderr.write(
+      `[check-phase-boundary] Warning: "${path.basename(filePath)}" is outside the current phase ${currentPhase} directory\n`
+    );
+    process.stdout.write(JSON.stringify({ decision: 'allow' }));
+    logEvent(cwd, filePath, 'warn', 'out-of-phase');
+
+  } catch (e) {
+    // Silent fail — never block on hook bugs
+    process.stdout.write(JSON.stringify({ decision: 'allow' }));
+  }
+  process.exit(0);
+});
+
+function loadHookConfig(cwd) {
+  try {
+    const configPath = path.join(cwd, '.planning', 'config.json');
+    if (fs.existsSync(configPath)) {
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+      return config.hooks || {};
+    }
+  } catch (e) { /* ignore parse errors */ }
+  return {};
+}
+
+function logEvent(cwd, filePath, decision, reason) {
+  try {
+    const logsDir = path.join(cwd, '.planning', 'logs');
+    const logFile = path.join(logsDir, 'hooks.jsonl');
+
+    if (!fs.existsSync(logsDir)) {
+      fs.mkdirSync(logsDir, { recursive: true });
+    }
+
+    const entry = {
+      timestamp: new Date().toISOString(),
+      hook: 'check-phase-boundary',
+      event: 'PreToolUse',
+      decision,
+      file: path.basename(filePath),
+      reason,
+    };
+
+    fs.appendFileSync(logFile, JSON.stringify(entry) + '\n');
+  } catch (e) { /* ignore logging errors */ }
+}

--- a/hooks/check-plan-format.js
+++ b/hooks/check-plan-format.js
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+// PostToolUse(Write/Edit) hook — validates PLAN.md and SUMMARY.md structure
+// Activates when file matches PLAN*.md or SUMMARY*.md in .planning/ directory
+//
+// Checks for PLAN files:
+//   - Frontmatter exists (between --- markers)
+//   - Required frontmatter fields: phase, plan
+//   - Task sections exist (## Task N or ### Task N headings)
+//   - Task count: warn if >3, error if >5
+//
+// Checks for SUMMARY files:
+//   - Frontmatter exists
+//   - Required fields: phase, plan, status
+//
+// Input: JSON on stdin with { tool_name, tool_input, tool_result, cwd }
+// Output: Informational only (PostToolUse hooks cannot block)
+
+const fs = require('fs');
+const path = require('path');
+
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', chunk => input += chunk);
+process.stdin.on('end', () => {
+  try {
+    const data = JSON.parse(input);
+    const cwd = data.cwd || process.cwd();
+
+    // Only handle Write and Edit tools
+    if (data.tool_name !== 'Write' && data.tool_name !== 'Edit') {
+      process.exit(0);
+    }
+
+    // Check config toggle
+    const config = loadHookConfig(cwd);
+    if (config.checkPlanFormat === false) {
+      process.exit(0);
+    }
+
+    const filePath = (data.tool_input && (data.tool_input.file_path || data.tool_input.path)) || '';
+    if (!filePath) {
+      process.exit(0);
+    }
+
+    // Normalize path separators for cross-platform matching
+    const normalizedPath = filePath.replace(/\\/g, '/');
+
+    // Only activate for files in .planning/ directory
+    if (!normalizedPath.includes('.planning/')) {
+      process.exit(0);
+    }
+
+    const basename = path.basename(filePath);
+
+    // Determine file type
+    const isPlan = /^.*PLAN.*\.md$/i.test(basename) && !basename.includes('SUMMARY');
+    const isSummary = /^.*SUMMARY.*\.md$/i.test(basename);
+
+    if (!isPlan && !isSummary) {
+      process.exit(0);
+    }
+
+    // Read the file content
+    let content = '';
+    try {
+      const resolvedPath = path.isAbsolute(filePath)
+        ? filePath
+        : path.resolve(cwd, filePath);
+      content = fs.readFileSync(resolvedPath, 'utf8');
+    } catch (e) {
+      // File may not exist yet or be unreadable — skip silently
+      process.exit(0);
+    }
+
+    const warnings = [];
+
+    // Extract frontmatter
+    const frontmatter = extractFrontmatter(content);
+
+    if (isPlan) {
+      validatePlan(content, frontmatter, basename, warnings);
+    } else if (isSummary) {
+      validateSummary(frontmatter, basename, warnings);
+    }
+
+    // Output warnings to stderr (PostToolUse is informational)
+    if (warnings.length > 0) {
+      process.stderr.write(`[check-plan-format] ${basename}:\n`);
+      for (const w of warnings) {
+        process.stderr.write(`  - ${w}\n`);
+      }
+    }
+
+    // Log event
+    logEvent(cwd, isPlan ? 'plan' : 'summary', basename, warnings);
+
+  } catch (e) {
+    // Silent fail — never block on hook bugs
+  }
+  process.exit(0);
+});
+
+function extractFrontmatter(content) {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return null;
+
+  const fields = {};
+  const lines = match[1].split(/\r?\n/);
+  for (const line of lines) {
+    const kvMatch = line.match(/^(\S[^:]*?):\s*(.*)/);
+    if (kvMatch) {
+      fields[kvMatch[1].trim()] = kvMatch[2].trim();
+    }
+  }
+  return fields;
+}
+
+function validatePlan(content, frontmatter, basename, warnings) {
+  // Check frontmatter exists
+  if (!frontmatter) {
+    warnings.push('Missing frontmatter (expected --- delimited YAML block)');
+    return;
+  }
+
+  // Check required fields
+  if (!frontmatter.phase) {
+    warnings.push('Missing required frontmatter field: phase');
+  }
+  if (!frontmatter.plan) {
+    warnings.push('Missing required frontmatter field: plan');
+  }
+
+  // Count tasks (headings like ## Task N or ### Task N)
+  const taskPattern = /^#{2,3}\s+Task\s+\d+/gim;
+  const tasks = content.match(taskPattern) || [];
+  const taskCount = tasks.length;
+
+  if (taskCount === 0) {
+    warnings.push('No task sections found (expected ## Task N or ### Task N headings)');
+  } else if (taskCount > 5) {
+    warnings.push(`Too many tasks: ${taskCount} (maximum 5 per plan, consider splitting)`);
+  } else if (taskCount > 3) {
+    warnings.push(`High task count: ${taskCount} (recommended maximum is 3 per plan)`);
+  }
+}
+
+function validateSummary(frontmatter, basename, warnings) {
+  // Check frontmatter exists
+  if (!frontmatter) {
+    warnings.push('Missing frontmatter (expected --- delimited YAML block)');
+    return;
+  }
+
+  // Check required fields
+  if (!frontmatter.phase) {
+    warnings.push('Missing required frontmatter field: phase');
+  }
+  if (!frontmatter.plan) {
+    warnings.push('Missing required frontmatter field: plan');
+  }
+  if (!frontmatter.status) {
+    warnings.push('Missing required frontmatter field: status');
+  }
+}
+
+function loadHookConfig(cwd) {
+  try {
+    const configPath = path.join(cwd, '.planning', 'config.json');
+    if (fs.existsSync(configPath)) {
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+      return config.hooks || {};
+    }
+  } catch (e) { /* ignore parse errors */ }
+  return {};
+}
+
+function logEvent(cwd, fileType, filename, warnings) {
+  try {
+    const logsDir = path.join(cwd, '.planning', 'logs');
+    const logFile = path.join(logsDir, 'hooks.jsonl');
+
+    if (!fs.existsSync(logsDir)) {
+      fs.mkdirSync(logsDir, { recursive: true });
+    }
+
+    const entry = {
+      timestamp: new Date().toISOString(),
+      hook: 'check-plan-format',
+      event: 'PostToolUse',
+      decision: warnings.length > 0 ? 'warn' : 'allow',
+      fileType,
+      file: filename,
+      warnings: warnings.length > 0 ? warnings : undefined,
+    };
+
+    fs.appendFileSync(logFile, JSON.stringify(entry) + '\n');
+  } catch (e) { /* ignore logging errors */ }
+}

--- a/hooks/check-roadmap-sync.js
+++ b/hooks/check-roadmap-sync.js
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+// PostToolUse(Write/Edit) hook — validates STATE.md stays in sync with ROADMAP.md
+// Activates when written file is STATE.md in .planning/ directory
+//
+// Checks:
+//   - Reads current phase from STATE.md
+//   - Reads ROADMAP.md and finds matching phase entry
+//   - Warns if STATE.md says phase is "executing"/"in progress" but ROADMAP shows "planned"
+//   - Warns if phase referenced in STATE.md doesn't exist in ROADMAP.md
+//
+// Input: JSON on stdin with { tool_name, tool_input, tool_result, cwd }
+// Output: Informational only (PostToolUse hooks cannot block)
+
+const fs = require('fs');
+const path = require('path');
+
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', chunk => input += chunk);
+process.stdin.on('end', () => {
+  try {
+    const data = JSON.parse(input);
+    const cwd = data.cwd || process.cwd();
+
+    // Only handle Write and Edit tools
+    if (data.tool_name !== 'Write' && data.tool_name !== 'Edit') {
+      process.exit(0);
+    }
+
+    // Check config toggle
+    const config = loadHookConfig(cwd);
+    if (config.checkRoadmapSync === false) {
+      process.exit(0);
+    }
+
+    const filePath = (data.tool_input && (data.tool_input.file_path || data.tool_input.path)) || '';
+    if (!filePath) {
+      process.exit(0);
+    }
+
+    // Normalize and check if this is STATE.md in .planning/
+    const normalizedPath = filePath.replace(/\\/g, '/');
+    const basename = path.basename(filePath);
+
+    if (basename !== 'STATE.md' || !normalizedPath.includes('.planning/')) {
+      process.exit(0);
+    }
+
+    // Read STATE.md
+    const statePath = path.join(cwd, '.planning', 'STATE.md');
+    let stateContent = '';
+    try {
+      stateContent = fs.readFileSync(statePath, 'utf8');
+    } catch (e) {
+      process.exit(0);
+    }
+
+    // Read ROADMAP.md
+    const roadmapPath = path.join(cwd, '.planning', 'ROADMAP.md');
+    let roadmapContent = '';
+    try {
+      roadmapContent = fs.readFileSync(roadmapPath, 'utf8');
+    } catch (e) {
+      // No ROADMAP.md — nothing to sync against
+      process.exit(0);
+    }
+
+    const warnings = [];
+
+    // Extract current phase from STATE.md
+    const phaseMatch = stateContent.match(/\*\*Current Phase:\*\*\s*(\S+)/);
+    const statusMatch = stateContent.match(/\*\*Status:\*\*\s*(.+)/);
+
+    if (!phaseMatch) {
+      // No phase info — skip
+      process.exit(0);
+    }
+
+    const currentPhase = phaseMatch[1].replace(/^0+/, '') || '0';
+    const stateStatus = statusMatch ? statusMatch[1].trim().toLowerCase() : '';
+
+    // Find this phase in ROADMAP.md
+    const phasePattern = new RegExp(
+      `###\\s+Phase\\s+${escapeRegex(currentPhase)}[.:]\\s*(.+)`,
+      'i'
+    );
+    const roadmapMatch = roadmapContent.match(phasePattern);
+
+    if (!roadmapMatch) {
+      warnings.push(
+        `Phase ${currentPhase} referenced in STATE.md not found in ROADMAP.md`
+      );
+    } else {
+      // Check if ROADMAP has a checkbox status for this phase
+      const checkboxPattern = new RegExp(
+        `-\\s+\\[([ x])\\]\\s+Phase\\s+${escapeRegex(currentPhase)}`,
+        'i'
+      );
+      const checkboxMatch = roadmapContent.match(checkboxPattern);
+
+      if (checkboxMatch) {
+        const isChecked = checkboxMatch[1] === 'x';
+        const isActive = stateStatus.includes('progress') || stateStatus.includes('executing');
+
+        if (isActive && isChecked) {
+          warnings.push(
+            `Phase ${currentPhase} is marked complete in ROADMAP.md but STATE.md says "${statusMatch[1].trim()}"`
+          );
+        }
+      }
+
+      // Check if state says executing but no phase directory exists on disk
+      if (stateStatus.includes('progress') || stateStatus.includes('executing')) {
+        const phasesDir = path.join(cwd, '.planning', 'phases');
+        if (fs.existsSync(phasesDir)) {
+          const padded = currentPhase.padStart(2, '0');
+          const dirs = fs.readdirSync(phasesDir);
+          const hasDir = dirs.some(d => d.startsWith(padded + '-') || d.startsWith(padded + '.'));
+          if (!hasDir) {
+            warnings.push(
+              `Phase ${currentPhase} is "in progress" but no phase directory exists on disk`
+            );
+          }
+        }
+      }
+    }
+
+    // Output warnings to stderr
+    if (warnings.length > 0) {
+      process.stderr.write(`[check-roadmap-sync] STATE.md:\n`);
+      for (const w of warnings) {
+        process.stderr.write(`  - ${w}\n`);
+      }
+    }
+
+    // Log event
+    logEvent(cwd, warnings);
+
+  } catch (e) {
+    // Silent fail — never block on hook bugs
+  }
+  process.exit(0);
+});
+
+function escapeRegex(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function loadHookConfig(cwd) {
+  try {
+    const configPath = path.join(cwd, '.planning', 'config.json');
+    if (fs.existsSync(configPath)) {
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+      return config.hooks || {};
+    }
+  } catch (e) { /* ignore parse errors */ }
+  return {};
+}
+
+function logEvent(cwd, warnings) {
+  try {
+    const logsDir = path.join(cwd, '.planning', 'logs');
+    const logFile = path.join(logsDir, 'hooks.jsonl');
+
+    if (!fs.existsSync(logsDir)) {
+      fs.mkdirSync(logsDir, { recursive: true });
+    }
+
+    const entry = {
+      timestamp: new Date().toISOString(),
+      hook: 'check-roadmap-sync',
+      event: 'PostToolUse',
+      decision: warnings.length > 0 ? 'warn' : 'allow',
+      warnings: warnings.length > 0 ? warnings : undefined,
+    };
+
+    fs.appendFileSync(logFile, JSON.stringify(entry) + '\n');
+  } catch (e) { /* ignore logging errors */ }
+}

--- a/hooks/check-subagent-output.js
+++ b/hooks/check-subagent-output.js
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+// PostToolUse(Task) hook — validates expected artifacts exist after agent completion
+// Activates when tool_name === 'Task'
+//
+// Checks for expected artifacts based on agent type indicators in the result:
+//   - gsd-executor / execute → SUMMARY*.md must exist
+//   - gsd-planner / plan → PLAN*.md must exist
+//   - gsd-verifier / verify → VERIFICATION.md must exist
+//
+// Input: JSON on stdin with { tool_name, tool_input, tool_result, cwd }
+// Output: Informational only (PostToolUse hooks cannot block)
+
+const fs = require('fs');
+const path = require('path');
+
+let input = '';
+process.stdin.setEncoding('utf8');
+process.stdin.on('data', chunk => input += chunk);
+process.stdin.on('end', () => {
+  try {
+    const data = JSON.parse(input);
+    const cwd = data.cwd || process.cwd();
+
+    // Only handle Task tool
+    if (data.tool_name !== 'Task') {
+      process.exit(0);
+    }
+
+    // Check config toggle
+    const config = loadHookConfig(cwd);
+    if (config.checkSubagentOutput === false) {
+      process.exit(0);
+    }
+
+    // Get the task result (may be string or object)
+    const result = typeof data.tool_result === 'string'
+      ? data.tool_result
+      : JSON.stringify(data.tool_result || '');
+
+    // Also check tool_input for agent type hints
+    const taskInput = typeof data.tool_input === 'string'
+      ? data.tool_input
+      : JSON.stringify(data.tool_input || '');
+
+    const combinedText = (result + ' ' + taskInput).toLowerCase();
+
+    const warnings = [];
+
+    // Detect agent type and check for expected artifacts
+    const phasesDir = path.join(cwd, '.planning', 'phases');
+
+    if (combinedText.includes('gsd-executor') || combinedText.includes('execute-plan')) {
+      // Executor should produce SUMMARY*.md
+      if (!hasArtifact(phasesDir, /SUMMARY.*\.md$/i)) {
+        warnings.push(
+          'gsd-executor completed but no SUMMARY.md found in .planning/phases/'
+        );
+      }
+    }
+
+    if (combinedText.includes('gsd-planner') || combinedText.includes('plan-phase')) {
+      // Planner should produce PLAN*.md
+      if (!hasArtifact(phasesDir, /PLAN.*\.md$/i)) {
+        warnings.push(
+          'gsd-planner completed but no PLAN.md found in .planning/phases/'
+        );
+      }
+    }
+
+    if (combinedText.includes('gsd-verifier') || combinedText.includes('verify-phase')) {
+      // Verifier should produce VERIFICATION.md
+      if (!hasArtifact(phasesDir, /VERIFICATION.*\.md$/i)) {
+        warnings.push(
+          'gsd-verifier completed but no VERIFICATION.md found in .planning/phases/'
+        );
+      }
+    }
+
+    // Output warnings to stderr
+    if (warnings.length > 0) {
+      process.stderr.write(`[check-subagent-output]:\n`);
+      for (const w of warnings) {
+        process.stderr.write(`  - ${w}\n`);
+      }
+    }
+
+    // Log event
+    logEvent(cwd, warnings);
+
+  } catch (e) {
+    // Silent fail — never block on hook bugs
+  }
+  process.exit(0);
+});
+
+/**
+ * Check if any file matching pattern exists recursively in phases directory
+ */
+function hasArtifact(phasesDir, pattern) {
+  try {
+    if (!fs.existsSync(phasesDir)) return false;
+
+    const dirs = fs.readdirSync(phasesDir);
+    for (const dir of dirs) {
+      const fullDir = path.join(phasesDir, dir);
+      if (!fs.statSync(fullDir).isDirectory()) continue;
+
+      const files = fs.readdirSync(fullDir);
+      if (files.some(f => pattern.test(f))) {
+        return true;
+      }
+    }
+    return false;
+  } catch (e) {
+    return false;
+  }
+}
+
+function loadHookConfig(cwd) {
+  try {
+    const configPath = path.join(cwd, '.planning', 'config.json');
+    if (fs.existsSync(configPath)) {
+      const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+      return config.hooks || {};
+    }
+  } catch (e) { /* ignore parse errors */ }
+  return {};
+}
+
+function logEvent(cwd, warnings) {
+  try {
+    const logsDir = path.join(cwd, '.planning', 'logs');
+    const logFile = path.join(logsDir, 'hooks.jsonl');
+
+    if (!fs.existsSync(logsDir)) {
+      fs.mkdirSync(logsDir, { recursive: true });
+    }
+
+    const entry = {
+      timestamp: new Date().toISOString(),
+      hook: 'check-subagent-output',
+      event: 'PostToolUse',
+      decision: warnings.length > 0 ? 'warn' : 'allow',
+      warnings: warnings.length > 0 ? warnings : undefined,
+    };
+
+    fs.appendFileSync(logFile, JSON.stringify(entry) + '\n');
+  } catch (e) { /* ignore logging errors */ }
+}

--- a/scripts/build-hooks.js
+++ b/scripts/build-hooks.js
@@ -12,7 +12,11 @@ const DIST_DIR = path.join(HOOKS_DIR, 'dist');
 // Hooks to copy (pure Node.js, no bundling needed)
 const HOOKS_TO_COPY = [
   'gsd-check-update.js',
-  'gsd-statusline.js'
+  'gsd-statusline.js',
+  'check-plan-format.js',
+  'check-roadmap-sync.js',
+  'check-phase-boundary.js',
+  'check-subagent-output.js'
 ];
 
 function build() {


### PR DESCRIPTION
## What
Adds 4 quality enforcement hooks:
- `check-plan-format.js` — validates PLAN.md frontmatter and task count (warn >3, block >5)
- `check-roadmap-sync.js` — detects STATE.md/ROADMAP.md desynchronization on write
- `check-phase-boundary.js` — warns/blocks writes outside current phase directory
- `check-subagent-output.js` — validates expected artifacts after agent completion (executor->SUMMARY, planner->PLAN, verifier->VERIFICATION)

## Why
GSD already has validation commands but they only run when manually invoked. These hooks convert manual checks into automatic enforcement. Plan format hook prevents the most common mistake (too many tasks), subagent output hook catches silent agent failures.

**Depends on:** `feat/hook-infrastructure` (Branch 2).

## Testing
- 94/94 tests pass (19 new quality gate tests)

## Breaking Changes
None — hooks respect config toggles.