### PR TITLE
Fix /gsd:update to always install latest package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - `/gsd:update` now installs with `npx get-shit-done-cc@latest` (instead of unpinned `npx get-shit-done-cc`) to prevent stale project-local versions from shadowing updates
 - `/gsd:update` now uses strict package safety checks: only `get-shit-done-cc` is allowed, scoped/user-derived package names are rejected, and install command execution is allowlisted to trusted forms
+- `/gsd:update` install detection now validates local integrity and falls back to global install when local metadata is missing or invalid
 
 ## [1.20.4] - 2026-02-17
 

--- a/get-shit-done/workflows/update.md
+++ b/get-shit-done/workflows/update.md
@@ -9,16 +9,21 @@ Read all files referenced by the invoking prompt's execution_context before star
 <process>
 
 <step name="get_installed_version">
-Detect whether GSD is installed locally or globally by checking both locations:
+Detect whether GSD is installed locally or globally by checking both locations and validating install integrity:
 
 ```bash
-# Check local first (takes priority)
+# Check local first (takes priority only if valid)
 # Paths templated at install time for runtime compatibility
-if [ -f ./.claude/get-shit-done/VERSION ]; then
-  cat ./.claude/get-shit-done/VERSION
+LOCAL_VERSION_FILE="./.claude/get-shit-done/VERSION"
+LOCAL_MARKER_FILE="./.claude/get-shit-done/workflows/update.md"
+GLOBAL_VERSION_FILE="$HOME/.claude/get-shit-done/VERSION"
+GLOBAL_MARKER_FILE="$HOME/.claude/get-shit-done/workflows/update.md"
+
+if [ -f "$LOCAL_VERSION_FILE" ] && [ -f "$LOCAL_MARKER_FILE" ] && grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+' "$LOCAL_VERSION_FILE"; then
+  cat "$LOCAL_VERSION_FILE"
   echo "LOCAL"
-elif [ -f ~/.claude/get-shit-done/VERSION ]; then
-  cat ~/.claude/get-shit-done/VERSION
+elif [ -f "$GLOBAL_VERSION_FILE" ] && [ -f "$GLOBAL_MARKER_FILE" ] && grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+' "$GLOBAL_VERSION_FILE"; then
+  cat "$GLOBAL_VERSION_FILE"
   echo "GLOBAL"
 else
   echo "UNKNOWN"
@@ -26,8 +31,8 @@ fi
 ```
 
 Parse output:
-- If last line is "LOCAL": installed version is first line, use `--local` flag for update
-- If last line is "GLOBAL": installed version is first line, use `--global` flag for update
+- If last line is "LOCAL": local install is valid; installed version is first line; use `--local`
+- If last line is "GLOBAL": local missing/invalid, global install is valid; installed version is first line; use `--global`
 - If "UNKNOWN": proceed to install step (treat as version 0.0.0)
 
 **If VERSION file missing:**


### PR DESCRIPTION
## Summary
- pin `/gsd:update` install commands to `npx -y get-shit-done-cc@latest` for both local and global paths
- keep update behavior deterministic regardless of project-local `node_modules`
- document the fix in `CHANGELOG.md` under Unreleased

## Why
`npx get-shit-done-cc` can resolve to a stale project-local package if one exists, causing update to report success while reinstalling an older version.

## Validation
- reproduced failure mode locally with project dependency `get-shit-done-cc@1.18.0`:
  - `npx get-shit-done-cc --local` -> stayed on `1.18.0`
  - `npx get-shit-done-cc@latest --local` -> upgraded to `1.20.3`
- same behavior reproduced for `--global` when invoked from that cwd

Closes #619
