### PR TITLE
Fix phase complete crash on nested decimal phases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- `gsd-tools phase complete` now handles multi-level decimal phases (e.g. `03.2.1`) and safely escapes requirement IDs when building regex patterns, preventing `Invalid regular expression` crashes
+
 ## [1.20.3] - 2026-02-16
 
 ### Fixed


### PR DESCRIPTION
## Summary
- fix phase-number parsing to support multi-level decimals (e.g. `03.2.1`) in normalization and directory matching
- replace first-dot escaping with full regex escaping for phase numbers used in dynamic regexes
- escape requirement IDs before interpolating into regex patterns during REQUIREMENTS.md updates
- improve phase sorting/comparison logic to handle nested decimals when finding next phases
- add regression test for `phase complete 03.2.1` with downstream requirements containing parentheses

## Root cause
`phase complete` used one-decimal parsing and unescaped regex interpolation. In specific ROADMAP layouts this could select the wrong requirements line and crash with:
`SyntaxError: Invalid regular expression: Unterminated group`

## Validation
- ran: `node --test get-shit-done/bin/gsd-tools.test.cjs`
- result: 84 passing, 0 failing
- includes new regression test: `handles multi-level decimal phase without regex crash`

Closes #621
