### PR TITLE
Fix summary-extract requirements_completed mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- `summary-extract` now maps SUMMARY frontmatter `requirements-completed` to `requirements_completed`, enabling milestone audit cross-check extraction
+
 ## [1.20.3] - 2026-02-16
 
 ### Fixed

--- a/get-shit-done/bin/gsd-tools.cjs
+++ b/get-shit-done/bin/gsd-tools.cjs
@@ -2095,6 +2095,7 @@ function cmdSummaryExtract(cwd, summaryPath, fields, raw) {
     tech_added: (fm['tech-stack'] && fm['tech-stack'].added) || [],
     patterns: fm['patterns-established'] || [],
     decisions: parseDecisions(fm['key-decisions']),
+    requirements_completed: fm['requirements-completed'] || [],
   };
 
   // If fields specified, filter to only those fields

--- a/get-shit-done/bin/gsd-tools.test.cjs
+++ b/get-shit-done/bin/gsd-tools.test.cjs
@@ -995,6 +995,9 @@ patterns-established:
 key-decisions:
   - Use Prisma over Drizzle: Better DX and ecosystem
   - Single database: Start simple, shard later
+requirements-completed:
+  - AUTH-01
+  - AUTH-02
 ---
 
 # Summary
@@ -1013,6 +1016,7 @@ Full summary content here.
     assert.deepStrictEqual(output.tech_added, ['prisma', 'zod'], 'tech added extracted');
     assert.deepStrictEqual(output.patterns, ['Repository pattern', 'Dependency injection'], 'patterns extracted');
     assert.strictEqual(output.decisions.length, 2, 'decisions extracted');
+    assert.deepStrictEqual(output.requirements_completed, ['AUTH-01', 'AUTH-02'], 'requirements completed extracted');
   });
 
   test('selective extraction with --fields', () => {
@@ -1032,16 +1036,19 @@ patterns-established:
   - Repository pattern
 key-decisions:
   - Use Prisma: Better DX
+requirements-completed:
+  - AUTH-01
 ---
 `
     );
 
-    const result = runGsdTools('summary-extract .planning/phases/01-foundation/01-01-SUMMARY.md --fields one_liner,key_files', tmpDir);
+    const result = runGsdTools('summary-extract .planning/phases/01-foundation/01-01-SUMMARY.md --fields one_liner,key_files,requirements_completed', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
     assert.strictEqual(output.one_liner, 'Set up database', 'one_liner included');
     assert.deepStrictEqual(output.key_files, ['prisma/schema.prisma'], 'key_files included');
+    assert.deepStrictEqual(output.requirements_completed, ['AUTH-01'], 'requirements_completed included');
     assert.strictEqual(output.tech_added, undefined, 'tech_added excluded');
     assert.strictEqual(output.patterns, undefined, 'patterns excluded');
     assert.strictEqual(output.decisions, undefined, 'decisions excluded');
@@ -1070,6 +1077,7 @@ one-liner: Minimal summary
     assert.deepStrictEqual(output.tech_added, [], 'tech_added defaults to empty');
     assert.deepStrictEqual(output.patterns, [], 'patterns defaults to empty');
     assert.deepStrictEqual(output.decisions, [], 'decisions defaults to empty');
+    assert.deepStrictEqual(output.requirements_completed, [], 'requirements_completed defaults to empty');
   });
 
   test('parses key-decisions with rationale', () => {


### PR DESCRIPTION
## Summary
- map SUMMARY frontmatter `requirements-completed` to `requirements_completed` in `summary-extract`
- keep missing field behavior safe by defaulting to an empty array
- add test coverage for full extraction and `--fields requirements_completed`

## Why
`/gsd:audit-milestone` step 5c relies on:
`summary-extract --fields requirements_completed`

Without this mapping, the field is silently omitted, so the SUMMARY frontmatter source in the 3-source cross-check never contributes data.

## Validation
- ran: `node --test get-shit-done/bin/gsd-tools.test.cjs`
- result: 83 passing, 0 failing

Closes #627
