### PR TITLE
fix: clamp progress bar percent to prevent RangeError crash

### DIFF
--- a/get-shit-done/bin/gsd-tools.cjs
+++ b/get-shit-done/bin/gsd-tools.cjs
@@ -1294,7 +1294,7 @@ function cmdStateUpdateProgress(cwd, raw) {
     }
   }
 
-  const percent = totalPlans > 0 ? Math.round(totalSummaries / totalPlans * 100) : 0;
+  const percent = totalPlans > 0 ? Math.min(100, Math.round(totalSummaries / totalPlans * 100)) : 0;
   const barWidth = 10;
   const filled = Math.round(percent / 100 * barWidth);
   const bar = '\u2588'.repeat(filled) + '\u2591'.repeat(barWidth - filled);
@@ -3842,7 +3842,7 @@ function cmdProgressRender(cwd, format, raw) {
     }
   } catch {}
 
-  const percent = totalPlans > 0 ? Math.round((totalSummaries / totalPlans) * 100) : 0;
+  const percent = totalPlans > 0 ? Math.min(100, Math.round((totalSummaries / totalPlans) * 100)) : 0;
 
   if (format === 'table') {
     // Render markdown table


### PR DESCRIPTION
## Problem

When `totalSummaries > totalPlans` (e.g., an orphaned `SUMMARY.md` exists after its `PLAN.md` was deleted), the progress percentage exceeds 100%. This causes `filled > barWidth`, making `barWidth - filled` negative. `String.prototype.repeat()` throws `RangeError: Invalid count value` on negative arguments, crashing the progress bar render.

**Affected commands:** `gsd-tools.cjs roadmap update-progress`, `gsd-tools.cjs progress table`, `gsd-tools.cjs progress bar`

## Reproduction

1. Create a phase with a plan and complete it (generates SUMMARY.md)
2. Delete the PLAN.md but keep SUMMARY.md
3. Run `gsd-tools.cjs progress bar` → crashes with `RangeError: Invalid count value`

## Fix

Clamp `percent` to `Math.min(100, ...)` at computation. This is a defensive fix — the percent value should never exceed 100 in normal operation, but orphaned files can cause it. The clamp prevents the crash without changing behavior for valid inputs.

## Scope

Minimal change — only adds `Math.min(100, ...)` wrapper to percent computation in 2 locations (roadmap update + cmdProgressRender).

## Test plan

- [x] Added test case: orphaned SUMMARY.md (2 summaries, 1 plan) — verifies bar, table, and JSON formats don't crash
- [x] All existing progress tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)