### PR TITLE
fix: universal phase number parsing with comparePhaseNum helper

### DIFF
--- a/get-shit-done/bin/gsd-tools.test.cjs
+++ b/get-shit-done/bin/gsd-tools.test.cjs
@@ -2344,3 +2344,88 @@ describe('scaffold command', () => {
     assert.strictEqual(output.reason, 'already_exists');
   });
 });
+
+// Unit tests for comparePhaseNum and normalizePhaseName (imported directly)
+const { comparePhaseNum, normalizePhaseName } = require('./gsd-tools.cjs');
+
+describe('comparePhaseNum', () => {
+  test('sorts integer phases numerically', () => {
+    assert.ok(comparePhaseNum('2', '10') < 0);
+    assert.ok(comparePhaseNum('10', '2') > 0);
+    assert.strictEqual(comparePhaseNum('5', '5'), 0);
+  });
+
+  test('sorts decimal phases correctly', () => {
+    assert.ok(comparePhaseNum('12', '12.1') < 0);
+    assert.ok(comparePhaseNum('12.1', '12.2') < 0);
+    assert.ok(comparePhaseNum('12.2', '13') < 0);
+  });
+
+  test('sorts letter-suffix phases correctly', () => {
+    assert.ok(comparePhaseNum('12', '12A') < 0);
+    assert.ok(comparePhaseNum('12A', '12B') < 0);
+    assert.ok(comparePhaseNum('12B', '13') < 0);
+  });
+
+  test('sorts hybrid phases correctly', () => {
+    assert.ok(comparePhaseNum('12A', '12A.1') < 0);
+    assert.ok(comparePhaseNum('12A.1', '12A.2') < 0);
+    assert.ok(comparePhaseNum('12A.2', '12B') < 0);
+  });
+
+  test('handles full sort order', () => {
+    const phases = ['13', '12B', '12A.2', '12', '12.1', '12A', '12A.1', '12.2'];
+    phases.sort(comparePhaseNum);
+    assert.deepStrictEqual(phases, ['12', '12.1', '12.2', '12A', '12A.1', '12A.2', '12B', '13']);
+  });
+
+  test('handles directory names with slugs', () => {
+    const dirs = ['13-deploy', '12B-hotfix', '12A.1-bugfix', '12-foundation', '12.1-inserted', '12A-split'];
+    dirs.sort(comparePhaseNum);
+    assert.deepStrictEqual(dirs, [
+      '12-foundation', '12.1-inserted', '12A-split', '12A.1-bugfix', '12B-hotfix', '13-deploy'
+    ]);
+  });
+
+  test('case insensitive letter matching', () => {
+    assert.ok(comparePhaseNum('12a', '12B') < 0);
+    assert.ok(comparePhaseNum('12A', '12b') < 0);
+    assert.strictEqual(comparePhaseNum('12a', '12A'), 0);
+  });
+
+  test('falls back to localeCompare for non-phase strings', () => {
+    const result = comparePhaseNum('abc', 'def');
+    assert.strictEqual(typeof result, 'number');
+  });
+});
+
+describe('normalizePhaseName', () => {
+  test('pads single-digit integers', () => {
+    assert.strictEqual(normalizePhaseName('3'), '03');
+    assert.strictEqual(normalizePhaseName('12'), '12');
+  });
+
+  test('handles decimal phases', () => {
+    assert.strictEqual(normalizePhaseName('3.1'), '03.1');
+    assert.strictEqual(normalizePhaseName('12.2'), '12.2');
+  });
+
+  test('handles letter-suffix phases', () => {
+    assert.strictEqual(normalizePhaseName('3A'), '03A');
+    assert.strictEqual(normalizePhaseName('12B'), '12B');
+  });
+
+  test('handles hybrid phases', () => {
+    assert.strictEqual(normalizePhaseName('3A.1'), '03A.1');
+    assert.strictEqual(normalizePhaseName('12A.2'), '12A.2');
+  });
+
+  test('uppercases letters', () => {
+    assert.strictEqual(normalizePhaseName('3a'), '03A');
+    assert.strictEqual(normalizePhaseName('12b.1'), '12B.1');
+  });
+
+  test('returns non-matching input unchanged', () => {
+    assert.strictEqual(normalizePhaseName('abc'), 'abc');
+  });
+});


### PR DESCRIPTION
## Problem

Phase number parsing crashes on multi-format phase numbers (#621). The current code uses `parseFloat()` and `/^(\d+(?:\.\d+)?)/` regex which only handles integers and decimals. This fails for letter-suffix phases (`12A`), hybrids (`12A.1`), and multi-level decimals (`03.2.1`).

## Approach

This is an **alternative to #624** with broader scope. While #624 fixes the decimal parsing specifically, this PR introduces a universal `comparePhaseNum()` helper that handles ALL phase number formats:

| Format | Example | Use Case |
|--------|---------|----------|
| Integer | `12` | Standard planned phases |
| Decimal | `12.1` | Inserted phases (`/gsd:insert-phase`) |
| Letter-suffix | `12A`, `12B` | Split phases (`/gsd:split-phase`) |
| Hybrid | `12A.1` | Insertion into a split phase |

**Sort order:** `12 → 12.1 → 12.2 → 12A → 12A.1 → 12A.2 → 12B → 13`

## Changes

1. **`normalizePhaseName()`** — New regex `/^(\d+)([A-Z])?(\.\d+)?/i` handles all formats
2. **`comparePhaseNum()`** — New helper function for correct phase ordering
3. **All `.sort()` calls** — Replaced `parseFloat` and bare `.sort()` with `comparePhaseNum`
4. **All phase-matching regexes** — Added `[A-Z]?` for letter-suffix support
5. **`cmdPhaseComplete`** — Uses `comparePhaseNum` instead of `parseFloat` for next-phase detection
6. **Exports** — `comparePhaseNum` and `normalizePhaseName` exported via `module.exports` for unit testing
7. **14 new unit tests** — 8 for `comparePhaseNum`, 6 for `normalizePhaseName` (all 97 tests pass)

## Why Not Just Fix Decimals?

The decimal-only fix (#624) solves the immediate crash but leaves the codebase unprepared for phase splitting (`/gsd:split-phase`), which creates letter-suffix phases. This PR provides forward-compatible parsing that handles the full phase number taxonomy.

## Battle-Tested

This logic has been running as a local customization (16-patch script) for several weeks across 20+ phases with mixed integer, decimal, and letter-suffix numbering. The `comparePhaseNum` helper was specifically designed to handle the full sort order.

## Test Results

```
# tests 97
# suites 20
# pass 97
# fail 0
```

All existing tests pass without modification. 14 new tests cover:
- Integer sorting (numeric, not lexicographic)
- Decimal phase ordering
- Letter-suffix phase ordering  
- Hybrid phase ordering
- Full sort order validation
- Directory names with slugs
- Case-insensitive letter matching
- Fallback for non-phase strings
- `normalizePhaseName` padding, letter, decimal, and hybrid handling

## Relationship to #624

Both PRs fix #621. Key differences:
- **#624**: Minimal fix — extends decimal regex to handle multi-level decimals
- **This PR**: Comprehensive fix — universal `comparePhaseNum` helper that handles all formats including letter-suffix phases

The maintainer should choose whichever approach best fits the project direction. If letter-suffix phases are not planned upstream, #624 may be sufficient.

Fixes #621

🤖 Generated with [Claude Code](https://claude.com/claude-code)