### PR TITLE
Add human-verify gate before debug session resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+- `/gsd:debug` flow now requires a `human-verify` checkpoint after self-verification before marking debug sessions `resolved` and moving files to `.planning/debug/resolved/`
+
 ## [1.20.3] - 2026-02-16
 
 ### Fixed

--- a/commands/gsd/debug.md
+++ b/commands/gsd/debug.md
@@ -110,6 +110,9 @@ Task(
 **If `## CHECKPOINT REACHED`:**
 - Present checkpoint details to user
 - Get user response
+- If checkpoint type is `human-verify`:
+  - If user confirms fixed: continue so agent can finalize/resolve/archive
+  - If user reports issues: continue so agent returns to investigation/fixing
 - Spawn continuation agent (see step 5)
 
 **If `## INVESTIGATION INCONCLUSIVE`:**

--- a/get-shit-done/templates/DEBUG.md
+++ b/get-shit-done/templates/DEBUG.md
@@ -8,7 +8,7 @@ Template for `.planning/debug/[slug].md` — active debug session tracking.
 
 ```markdown
 ---
-status: gathering | investigating | fixing | verifying | resolved
+status: gathering | investigating | fixing | verifying | awaiting_human_verify | resolved
 trigger: "[verbatim user input]"
 created: [ISO timestamp]
 updated: [ISO timestamp]
@@ -127,9 +127,14 @@ files_changed: []
 - Update Resolution.verification with results
 - If verification fails: status → "investigating", try again
 
+**After self-verification passes:**
+- status -> "awaiting_human_verify"
+- Request explicit user confirmation in a checkpoint
+- Do NOT move file to resolved yet
+
 **On resolution:**
 - status → "resolved"
-- Move file to .planning/debug/resolved/
+- Move file to .planning/debug/resolved/ (only after user confirms fix)
 
 </lifecycle>
 


### PR DESCRIPTION
## Summary
- add `awaiting_human_verify` state to debugger session lifecycle
- require a `human-verify` checkpoint after self-verification passes
- prevent auto-moving debug files to `resolved/` before explicit user confirmation
- align `/gsd:debug` command guidance with this checkpoint gate
- document behavior in `CHANGELOG.md`

## Why
`/gsd:debug` currently allows the debugger agent to self-verify and immediately archive to `resolved`, which can bypass human confirmation for real-world behavior checks.

## Behavior after this change
- Agent can still self-verify automated checks.
- Agent must then return `## CHECKPOINT REACHED` (`Type: human-verify`).
- Only after user confirms fix should session transition to `resolved` and archive.
- If user reports remaining issues, flow returns to investigation/fixing.

Closes #630
