### PR TITLE
feat: quality automation — ship-readiness gates, skill system, advisory consensus

### DIFF
--- a/commands/gsd/advisory-consensus.md
+++ b/commands/gsd/advisory-consensus.md
@@ -1,0 +1,35 @@
+---
+name: gsd:advisory-consensus
+description: Run advisory perspectives (PM, UX, Security, etc.) before planning
+argument-hint: "<phase> [--skills <skill1,skill2,...>]"
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+  - Glob
+  - Grep
+  - Task
+---
+<objective>
+Run one or more advisory skill perspectives against a phase to produce acceptance criteria and flags before planning.
+
+Loads all specified skills into a single agent that produces a unified advisory output. This replaces running multiple discuss-phase rounds for users who want structured advisory input.
+
+**Default skills:** product-manager, ux-designer
+**Output:** `{phase_num}-CONTEXT.md` with advisory-derived decisions
+</objective>
+
+<execution_context>
+@~/.claude/get-shit-done/workflows/advisory-consensus.md
+@~/.claude/get-shit-done/references/ui-brand.md
+</execution_context>
+
+<context>
+Phase number: $ARGUMENTS
+@.planning/STATE.md
+@.planning/ROADMAP.md
+</context>
+
+<process>
+Execute the advisory-consensus workflow from @~/.claude/get-shit-done/workflows/advisory-consensus.md end-to-end.
+</process>

--- a/get-shit-done/templates/config.json
+++ b/get-shit-done/templates/config.json
@@ -32,5 +32,10 @@
   "safety": {
     "always_confirm_destructive": true,
     "always_confirm_external_services": true
+  },
+  "quality_gates": {
+    "enabled": false,
+    "commands": [],
+    "fail_action": "warn"
   }
 }

--- a/get-shit-done/templates/skills/product-manager.md
+++ b/get-shit-done/templates/skills/product-manager.md
@@ -1,0 +1,45 @@
+---
+name: product-manager
+description: Writes user stories with Gherkin acceptance criteria, defines milestone goals. Source of truth for what to build and why.
+---
+
+# Product Manager
+
+You are a technical, empathetic product manager.
+
+## Core Responsibility
+
+Ensure the product delivers **user value**. Every feature must trace back to a real person getting something useful done.
+
+## User Stories
+
+Write user stories in this format:
+
+```
+### [Story Title]
+
+**As a** [specific user type]
+**I want** [goal]
+**So that** [reason/value]
+
+#### Acceptance Criteria
+
+Feature: [Feature name]
+
+  Scenario: [Happy path]
+    Given [precondition]
+    When [action]
+    Then [expected outcome]
+
+  Scenario: [Edge case]
+    Given [precondition]
+    When [action]
+    Then [expected outcome]
+```
+
+## When Consulted
+
+- Restate the user value first
+- Point to the specific Gherkin scenario that answers the question
+- If no scenario covers it, write one on the spot
+- Never answer with implementation details — answer with user outcomes

--- a/get-shit-done/templates/skills/production-engineer.md
+++ b/get-shit-done/templates/skills/production-engineer.md
@@ -1,0 +1,34 @@
+---
+name: production-engineer
+description: Testing strategy, code quality gates, and ship-readiness checks. Consult during implementation and review.
+---
+
+# Production Engineer
+
+You are a production engineer responsible for quality gates and ship-readiness.
+
+## Quality Gates
+
+All gates must pass before shipping:
+
+- Test suite passes with adequate coverage
+- Type checking passes (if applicable)
+- No critical linting errors
+- Security review for auth, crypto, or data handling changes
+- No hardcoded secrets or credentials
+
+## Ship-Readiness Checklist
+
+- [ ] All tests pass
+- [ ] Type check passes
+- [ ] No TODO/FIXME in new code
+- [ ] Error handling covers failure modes
+- [ ] Logging is appropriate (not excessive, not missing)
+- [ ] No debug code left in production paths
+
+## When Consulted
+
+- Define what "done" means for a specific feature
+- Evaluate test coverage adequacy
+- Review deployment readiness
+- Identify gaps in quality assurance

--- a/get-shit-done/templates/skills/security-auditor.md
+++ b/get-shit-done/templates/skills/security-auditor.md
@@ -1,0 +1,25 @@
+---
+name: security-auditor
+description: Reviews code for security vulnerabilities. Covers OWASP Top 10, auth, crypto, injection, and data exposure.
+---
+
+# Security Auditor
+
+You are a security auditor. You review code for vulnerabilities during development.
+
+## What to Review
+
+1. **Authentication & Authorization**: Broken access controls, missing auth checks, privilege escalation
+2. **Injection**: SQL injection, XSS, command injection, template injection
+3. **Cryptography**: Weak algorithms, static keys, missing key rotation, plaintext secrets
+4. **Data Exposure**: Sensitive data in logs, error messages leaking internals, PII in URLs
+5. **Input Validation**: Missing validation at system boundaries, type coercion attacks
+6. **Dependencies**: Known CVEs in dependencies, outdated packages
+7. **Configuration**: Debug mode in production, default credentials, permissive CORS
+
+## When Consulted
+
+- Flag the specific code pattern that's vulnerable
+- Explain the attack vector (how it could be exploited)
+- Provide a concrete fix, not just "be more secure"
+- Rate severity: Critical / High / Medium / Low

--- a/get-shit-done/templates/skills/ux-designer.md
+++ b/get-shit-done/templates/skills/ux-designer.md
@@ -1,0 +1,36 @@
+---
+name: ux-designer
+description: Turns user stories into clear flows, grades milestones 1-10, enforces WCAG 2.1 AA and human-centered design.
+---
+
+# UX Designer
+
+You are a pragmatic UX designer.
+
+## Design Philosophy
+
+1. **Simplicity Over Features**: Prioritize core functionality over feature bloat
+2. **Transparency and Control**: Clear explanations for all user-facing behavior
+3. **Friction with Purpose**: Intentional friction for high-stakes actions, minimal for everyday use
+
+## Responsibilities
+
+### User Stories to User Flows
+- Turn product manager's stories into clear, simple user flows
+- Challenge vague acceptance criteria, missing edge cases
+- Push back when a story optimizes for the system instead of the person
+
+### Milestone Grading
+At each milestone release, grade the UX on a scale of **1-10** evaluating:
+- Clarity of user flows
+- Consistency of interaction patterns
+- Accessibility (WCAG 2.1 AA)
+- Error handling and recovery
+- First-use experience
+
+## Accessibility (WCAG 2.1 AA)
+
+- Color contrast: minimum 4.5:1 for normal text, 3:1 for large text
+- Keyboard navigation: all interactive elements reachable via keyboard
+- Screen reader compatibility: all UI states announced appropriately
+- Focus indicators: visible, high-contrast focus rings

--- a/get-shit-done/workflows/advisory-consensus.md
+++ b/get-shit-done/workflows/advisory-consensus.md
@@ -1,0 +1,192 @@
+<purpose>
+Run advisory skill perspectives against a phase goal to produce structured context for planning. Loads all specified skills into a single agent that produces acceptance criteria, UX flags, and security concerns in one pass.
+
+Inspired by Weaveto.do's "Phase 1: Consensus + Plan" pattern — one agent, multiple perspectives, one output.
+</purpose>
+
+<process>
+
+## 1. Initialize
+
+```bash
+INIT=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs init phase-op "${PHASE}")
+```
+
+Parse JSON for phase details. Extract phase goal from ROADMAP.md.
+
+## 2. Parse Arguments
+
+Extract from $ARGUMENTS: phase number, `--skills <list>` flag.
+
+Default skills if none specified: `product-manager,ux-designer`
+
+## 3. Load Skills
+
+For each skill name, look for skill files in order:
+1. `.planning/skills/{name}.md` (project-specific skills)
+2. `~/.claude/get-shit-done/templates/skills/{name}.md` (built-in skills)
+
+```bash
+SKILL_CONTENT=""
+for skill in $(echo "$SKILLS" | tr ',' ' '); do
+  if [ -f ".planning/skills/${skill}.md" ]; then
+    SKILL_CONTENT="$SKILL_CONTENT\n$(cat .planning/skills/${skill}.md)"
+  elif [ -f "$HOME/.claude/get-shit-done/templates/skills/${skill}.md" ]; then
+    SKILL_CONTENT="$SKILL_CONTENT\n$(cat $HOME/.claude/get-shit-done/templates/skills/${skill}.md)"
+  else
+    echo "Warning: Skill '${skill}' not found"
+  fi
+done
+```
+
+## 4. Spawn Advisory Agent
+
+Display banner:
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ GSD ► ADVISORY CONSENSUS
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Phase {X}: {Name}
+Skills: {skill list}
+
+◆ Spawning advisory agent...
+```
+
+```
+Task(
+  prompt="""
+You are an advisory agent loaded with multiple skill perspectives. Analyze the phase goal and produce structured advisory output.
+
+<skills>
+{skill_content}
+</skills>
+
+<phase>
+Phase: {phase_number}
+Name: {phase_name}
+Goal: {phase_goal}
+</phase>
+
+<project_context>
+{roadmap_content}
+{requirements_content}
+</project_context>
+
+<instructions>
+For each loaded skill perspective, analyze the phase goal and produce:
+
+1. **Acceptance Criteria** (PM perspective): User stories with Gherkin acceptance criteria for this phase
+2. **UX Flags** (UX perspective): Flow concerns, accessibility requirements, edge cases
+3. **Security Concerns** (Security perspective, if loaded): Vulnerabilities to watch for, auth requirements
+4. **Quality Gates** (Production Engineer perspective, if loaded): What must pass before shipping
+
+Produce a unified advisory output that combines all perspectives. Flag any conflicts between perspectives and recommend a resolution.
+
+Write the output to: {phase_dir}/{padded_phase}-CONTEXT.md
+
+Use this structure:
+```markdown
+# Phase [X]: [Name] - Context
+
+**Gathered:** [date]
+**Status:** Ready for planning
+**Source:** Advisory Consensus ({skill list})
+
+<domain>
+## Phase Boundary
+
+[What this phase delivers — derived from phase goal]
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Acceptance Criteria
+{Gherkin acceptance criteria from PM perspective}
+
+### UX Requirements
+{Flow requirements, accessibility, edge cases from UX perspective}
+
+### Security Requirements
+{Security concerns, if security-auditor skill loaded}
+
+### Quality Requirements
+{Quality gates, if production-engineer skill loaded}
+
+### Claude's Discretion
+[Technical implementation details not specified by any advisory perspective]
+
+</decisions>
+
+<specifics>
+## Specific Ideas
+
+[Concrete requirements, specific behaviors, examples from advisory output]
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+None — advisory consensus covers phase scope
+
+</deferred>
+
+---
+
+*Phase: XX-name*
+*Context gathered: [date] via Advisory Consensus*
+```
+""",
+  subagent_type="general-purpose",
+  model="sonnet",
+  description="Advisory Consensus Phase {phase}"
+)
+```
+
+## 5. Commit Context
+
+```bash
+node ~/.claude/get-shit-done/bin/gsd-tools.cjs commit "docs(${padded_phase}): advisory consensus context" --files "${phase_dir}/${padded_phase}-CONTEXT.md"
+```
+
+## 6. Present Results
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ GSD ► ADVISORY CONSENSUS COMPLETE ✓
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Phase {X}: {Name}
+Skills consulted: {skill list}
+Output: {phase_dir}/{padded_phase}-CONTEXT.md
+
+## ▶ Next Up
+
+**Plan Phase {X}** — create execution plans
+
+/gsd:plan-phase {X}
+
+<sub>/clear first → fresh context window</sub>
+
+---
+
+**Also available:**
+- /gsd:discuss-phase {X} — interactive discussion instead
+- cat {phase_dir}/{padded_phase}-CONTEXT.md — review advisory output
+```
+
+</process>
+
+<success_criteria>
+- [ ] Skills loaded from project or built-in templates
+- [ ] Single agent spawned with all skill perspectives
+- [ ] CONTEXT.md created with advisory-derived decisions
+- [ ] Acceptance criteria in Gherkin format (if PM skill loaded)
+- [ ] UX flags included (if UX skill loaded)
+- [ ] Security concerns included (if security skill loaded)
+- [ ] Committed to git
+- [ ] User knows next steps
+</success_criteria>

--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -309,6 +309,66 @@ Create VERIFICATION.md.",
 )
 ```
 
+**Quality Gates (if configured):**
+
+```bash
+QG_ENABLED=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs config-get quality_gates.enabled 2>/dev/null || echo "false")
+QG_FAIL_ACTION=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs config-get quality_gates.fail_action 2>/dev/null || echo "warn")
+```
+
+If `QG_ENABLED` is `"true"`:
+
+Display banner:
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ GSD ► RUNNING QUALITY GATES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+Read commands from config:
+```bash
+QG_COMMANDS=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs config-get quality_gates.commands 2>/dev/null)
+```
+
+For each command in the `QG_COMMANDS` array:
+1. Display: `Running: {command}...`
+2. Execute the command via Bash, capturing start time
+3. Capture exit code
+4. Calculate duration
+5. Display: `✓ Passed` or `✗ Failed (exit code N)`
+
+Track all results (command, pass/fail, duration, exit code).
+
+Present results table:
+```
+## Quality Gate Results
+
+| Command | Status | Duration |
+|---------|--------|----------|
+| npm run test | ✓ Passed | 12s |
+| npm run check | ✗ Failed | 3s |
+```
+
+**If any failed and `QG_FAIL_ACTION` is `"block"`:**
+```
+⚠ Quality gates failed. Phase cannot be marked complete.
+Fix the issues and re-run /gsd:execute-phase {phase}
+```
+
+**If any failed and `QG_FAIL_ACTION` is `"warn"`:**
+```
+⚠ Quality gates failed but configured as warn-only. Continuing.
+```
+
+**If all passed:**
+```
+✓ All quality gates passed.
+```
+
+Append a `## Quality Gates` section to the VERIFICATION.md output with the results table and overall status.
+
+If `QG_FAIL_ACTION` is `"block"` and any command failed, override the verification status to `gaps_found` regardless of the verifier's result.
+
 Read status:
 ```bash
 grep "^status:" "$PHASE_DIR"/*-VERIFICATION.md | cut -d: -f2 | tr -d ' '

--- a/get-shit-done/workflows/help.md
+++ b/get-shit-done/workflows/help.md
@@ -69,6 +69,18 @@ Help articulate your vision for a phase before planning.
 
 Usage: `/gsd:discuss-phase 2`
 
+**`/gsd:advisory-consensus <number>`**
+Run advisory skill perspectives before planning.
+
+- Loads PM, UX, Security, or custom skills into one agent
+- Produces acceptance criteria, UX flags, and security concerns
+- Creates CONTEXT.md — same output as discuss-phase but automated
+- One agent, multiple perspectives, one pass (efficient alternative to discuss-phase)
+- Custom skills: add `.md` files to `.planning/skills/`
+
+Usage: `/gsd:advisory-consensus 3`
+Usage: `/gsd:advisory-consensus 3 --skills product-manager,security-auditor`
+
 **`/gsd:research-phase <number>`**
 Comprehensive ecosystem research for niche/complex domains.
 
@@ -299,6 +311,8 @@ Configure workflow toggles and model profile interactively.
 - Select model profile (quality/balanced/budget)
 - Updates `.planning/config.json`
 
+Includes quality gates configuration — run shell commands (tests, lints, type checks) after execution with warn or block behavior.
+
 Usage: `/gsd:settings`
 
 **`/gsd:set-profile <profile>`**
@@ -355,6 +369,9 @@ Usage: `/gsd:join-discord`
 ├── todos/                # Captured ideas and tasks
 │   ├── pending/          # Todos waiting to be worked on
 │   └── done/             # Completed todos
+├── skills/               # Custom advisory skill definitions
+│   ├── product-manager.md
+│   └── domain-expert.md
 ├── debug/                # Active debug sessions
 │   └── resolved/         # Archived resolved issues
 ├── milestones/
@@ -421,6 +438,25 @@ Example config:
   "planning": {
     "commit_docs": false,
     "search_gitignored": true
+  }
+}
+```
+
+**Quality Gates** (configured via `/gsd:settings`)
+
+Run shell commands (tests, lints, type checks) automatically after phase execution and verification:
+
+- `quality_gates.enabled` — `true` to activate (default: `false`)
+- `quality_gates.commands` — array of shell commands to run (e.g., `["npm test", "npm run lint"]`)
+- `quality_gates.fail_action` — `"warn"` (report but continue) or `"block"` (prevent phase completion)
+
+Example:
+```json
+{
+  "quality_gates": {
+    "enabled": true,
+    "commands": ["npm run test", "npm run check", "npm run lint"],
+    "fail_action": "block"
   }
 }
 ```

--- a/get-shit-done/workflows/settings.md
+++ b/get-shit-done/workflows/settings.md
@@ -92,9 +92,38 @@ AskUserQuestion([
       { label: "Per Phase", description: "Create branch for each phase (gsd/phase-{N}-{name})" },
       { label: "Per Milestone", description: "Create branch for entire milestone (gsd/{version}-{name})" }
     ]
+  },
+  {
+    question: "Run quality gate commands after execution? (e.g., npm test, npm run check)",
+    header: "Gates",
+    multiSelect: false,
+    options: [
+      { label: "Off", description: "No automated quality gates (default)" },
+      { label: "Warn", description: "Run commands, report results but don't block" },
+      { label: "Block", description: "Run commands, block phase completion on failure" }
+    ]
   }
 ])
 ```
+
+**If user selected "Warn" or "Block" for quality gates:**
+
+Follow up with:
+
+```
+AskUserQuestion([
+  {
+    question: "Which commands should run as quality gates? (comma-separated)",
+    header: "Commands",
+    multiSelect: false,
+    options: [
+      { label: "Other", description: "Type your commands (e.g., npm test, npm run check, npm run lint)" }
+    ]
+  }
+])
+```
+
+Parse the comma-separated response into an array of trimmed command strings.
 </step>
 
 <step name="update_config">
@@ -112,9 +141,18 @@ Merge new settings into existing config.json:
   },
   "git": {
     "branching_strategy": "none" | "phase" | "milestone"
+  },
+  "quality_gates": {
+    "enabled": true/false,
+    "commands": ["cmd1", "cmd2", ...],
+    "fail_action": "warn" | "block"
   }
 }
 ```
+
+- If user selected "Off": `enabled: false`, `commands: []`, `fail_action: "warn"`
+- If user selected "Warn": `enabled: true`, `commands: [parsed commands]`, `fail_action: "warn"`
+- If user selected "Block": `enabled: true`, `commands: [parsed commands]`, `fail_action: "block"`
 
 Write updated config to `.planning/config.json`.
 </step>
@@ -177,6 +215,8 @@ Display:
 | Execution Verifier   | {On/Off} |
 | Auto-Advance         | {On/Off} |
 | Git Branching        | {None/Per Phase/Per Milestone} |
+| Quality Gates        | {Off/Warn/Block} |
+| Gate Commands        | {comma-separated list or "—"} |
 | Saved as Defaults    | {Yes/No} |
 
 These settings apply to future /gsd:plan-phase and /gsd:execute-phase runs.
@@ -193,8 +233,8 @@ Quick commands:
 
 <success_criteria>
 - [ ] Current config read
-- [ ] User presented with 6 settings (profile + 4 workflow toggles + git branching)
-- [ ] Config updated with model_profile, workflow, and git sections
+- [ ] User presented with 7 settings (profile + 4 workflow toggles + git branching + quality gates)
+- [ ] Config updated with model_profile, workflow, git, and quality_gates sections
 - [ ] User offered to save as global defaults (~/.gsd/defaults.json)
 - [ ] Changes confirmed to user
 </success_criteria>

--- a/get-shit-done/workflows/verify-work.md
+++ b/get-shit-done/workflows/verify-work.md
@@ -311,9 +311,79 @@ Present summary:
 [List from Issues section]
 ```
 
-**If issues > 0:** Proceed to `diagnose_issues`
+**If issues > 0:** Proceed to `run_quality_gates`
 
-**If issues == 0:**
+**If issues == 0:** Proceed to `run_quality_gates`
+</step>
+
+<step name="run_quality_gates">
+**Run quality gates if configured (after UAT, before diagnosis):**
+
+```bash
+QG_ENABLED=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs config-get quality_gates.enabled 2>/dev/null || echo "false")
+QG_FAIL_ACTION=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs config-get quality_gates.fail_action 2>/dev/null || echo "warn")
+```
+
+**If `QG_ENABLED` is `"true"`:**
+
+Display banner:
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ GSD ► RUNNING QUALITY GATES
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+Read commands from config:
+```bash
+QG_COMMANDS=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs config-get quality_gates.commands 2>/dev/null)
+```
+
+For each command in the `QG_COMMANDS` array:
+1. Display: `Running: {command}...`
+2. Execute the command via Bash, capturing start time
+3. Capture exit code
+4. Calculate duration
+5. Display: `✓ Passed` or `✗ Failed (exit code N)`
+
+Track all results (command, pass/fail, duration, exit code).
+
+Present results table:
+```
+## Quality Gate Results
+
+| Command | Status | Duration |
+|---------|--------|----------|
+| npm run test | ✓ Passed | 12s |
+| npm run check | ✗ Failed | 3s |
+```
+
+**If any failed and `QG_FAIL_ACTION` is `"block"`:**
+```
+⚠ Quality gates failed. Phase cannot be marked complete.
+Fix the issues and re-run /gsd:verify-work {phase}
+```
+
+**If any failed and `QG_FAIL_ACTION` is `"warn"`:**
+```
+⚠ Quality gates failed but configured as warn-only. Continuing.
+```
+
+**If all passed:**
+```
+✓ All quality gates passed.
+```
+
+Append a `## Quality Gates` section to the UAT.md file with the results table and overall status.
+
+If `QG_FAIL_ACTION` is `"block"` and any command failed, add quality gate failures as additional issues (treat each failed command as a blocker-severity issue in the Gaps section).
+
+**If `QG_ENABLED` is not `"true"`:** Skip this step silently.
+
+**After quality gates (or if skipped):**
+
+If UAT issues > 0 OR (quality gate failures with `fail_action: "block"`): Proceed to `diagnose_issues`
+
+**If issues == 0 and no blocking quality gate failures:**
 ```
 All tests passed. Ready to continue.
 


### PR DESCRIPTION
## What This Is

Three features that automate quality verification, extracted from building [Weaveto.do](https://github.com/smledbetter/Weaveto.do) with GSD. Manual verification was the biggest friction point — these replace it with verifiable, repeatable checks.

## What's Included

### 1. Ship-Readiness Gate
Automated quality gates (`npm test`, `tsc --noEmit`, linters) that run after plan execution and during `/gsd:verify-work`. Configurable per-project via `config.json` with three modes:
- **off** — No gates (default, backwards compatible)
- **warn** — Run commands, report results, continue on failure
- **block** — Run commands, stop execution on failure

Results are appended to VERIFICATION.md and UAT.md for traceability.

### 2. Skill System
Four advisory role templates (Product Manager, UX Designer, Security Auditor, Production Engineer) that provide specialized review perspectives. Each is a markdown file in `templates/skills/` — users can add custom skills to `.planning/skills/`.

### 3. Advisory Consensus
`/gsd:advisory-consensus` runs all skill perspectives in one agent pass, producing a CONTEXT.md with acceptance criteria, UX flags, and security concerns. An efficient alternative to discuss-phase when you want structured feedback without interactive Q&A.

## Files Changed (11 files)

| File | What Changed |
|------|-------------|
| `commands/gsd/advisory-consensus.md` | New command entry point |
| `get-shit-done/workflows/advisory-consensus.md` | New workflow (192 lines) |
| `get-shit-done/templates/skills/*.md` | 4 new advisory role templates |
| `get-shit-done/templates/config.json` | Added `quality_gates` section |
| `get-shit-done/workflows/execute-phase.md` | Quality gates after verification |
| `get-shit-done/workflows/verify-work.md` | Quality gates after UAT |
| `get-shit-done/workflows/settings.md` | Quality gates configuration UI |
| `get-shit-done/workflows/help.md` | Advisory consensus docs + quality gates config + skills directory |

## Context

This is 2 of 4 PRs from my fork, split by theme:
1. Planning improvements — PRD express path, interface-first planning, living retrospective (#644)
2. **Quality automation** (this PR)
3. Execution modes — consolidated workflow, sprint mode
4. Token metrics — JSONL session log parsing for verified token tracking

These came from building a full project with GSD. Weaveto.do isn't deployed yet, so these are tested on one project, not across many. Happy to adjust anything.

GSD is the best system I've found for building with Claude Code. The core architecture — context engineering, fresh subagent windows, atomic commits, goal-backward verification — is genuinely brilliant. These additions are only possible because the foundation is so solid. Thank you for building it and sharing it with the community.