### PR TITLE
fix(routing): smart next-step routing based on phase state

### DIFF
--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -404,7 +404,52 @@ Read and follow `~/.claude/get-shit-done/workflows/transition.md`, passing throu
 
 **If neither `--auto` nor `AUTO_CFG` is true:**
 
-The workflow ends. The user runs `/gsd:progress` or invokes the transition workflow manually.
+Probe next phase state to determine routing:
+```bash
+NEXT_INFO=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs init phase-op "${next_phase}")
+```
+
+Parse `has_context`, `has_plans`, `is_last_phase` from result.
+
+**If `is_last_phase` is true (milestone complete):**
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ GSD ► MILESTONE COMPLETE
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+All {N} phases executed.
+
+`/gsd:complete-milestone`
+```
+
+**If more phases remain**, select primary command based on state:
+- `has_plans: true` → primary = `/gsd:execute-phase {next_phase}`
+- `has_context: true` AND `has_plans: false` → primary = `/gsd:plan-phase {next_phase}`
+- `has_context: false` → primary = `/gsd:discuss-phase {next_phase}`
+
+Present:
+```
+## ▶ Next Up
+
+**Phase {next_phase}: {next_phase_name}** — {goal from ROADMAP.md}
+
+`{primary command}`
+
+<sub>`/clear` first → fresh context window</sub>
+
+---
+
+**Also available:**
+- `{alt command 1}` — {description}
+- `{alt command 2}` — {description}
+
+---
+```
+
+Where `{alt command 1}` and `{alt command 2}` are the two commands NOT selected as primary:
+- `/gsd:discuss-phase {next_phase}` — gather context first
+- `/gsd:plan-phase {next_phase}` — create execution plans
+- `/gsd:execute-phase {next_phase}` — run existing plans
 </step>
 
 </process>

--- a/get-shit-done/workflows/transition.md
+++ b/get-shit-done/workflows/transition.md
@@ -358,46 +358,34 @@ This returns all phases with goals, disk status, and completion info.
 
 Read ROADMAP.md to get the next phase's name and goal.
 
-**Check if next phase has CONTEXT.md:**
+**If next phase exists:**
 
+Probe next phase state to determine routing:
 ```bash
-ls .planning/phases/*[X+1]*/*-CONTEXT.md 2>/dev/null
+NEXT_INFO=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs init phase-op "${next_phase}")
 ```
 
-**If next phase exists:**
+Parse `has_context`, `has_plans` from result. Select primary command:
+- `has_plans: true` → primary = `/gsd:execute-phase [X+1]`
+- `has_context: true` AND `has_plans: false` → primary = `/gsd:plan-phase [X+1]`
+- `has_context: false` → primary = `/gsd:discuss-phase [X+1]`
 
 <if mode="yolo">
 
-**If CONTEXT.md exists:**
-
 ```
 Phase [X] marked complete.
 
 Next: Phase [X+1] — [Name]
 
-⚡ Auto-continuing: Plan Phase [X+1] in detail
+⚡ Auto-continuing: {primary command description}
 ```
 
-Exit skill and invoke SlashCommand("/gsd:plan-phase [X+1] --auto")
-
-**If CONTEXT.md does NOT exist:**
-
-```
-Phase [X] marked complete.
-
-Next: Phase [X+1] — [Name]
-
-⚡ Auto-continuing: Discuss Phase [X+1] first
-```
-
-Exit skill and invoke SlashCommand("/gsd:discuss-phase [X+1] --auto")
+Exit skill and invoke the primary command with `--auto` flag (e.g., SlashCommand("/gsd:discuss-phase [X+1]") if `has_context: false`).
 
 </if>
 
 <if mode="interactive" OR="custom with gates.confirm_transition true">
 
-**If CONTEXT.md does NOT exist:**
-
 ```
 ## ✓ Phase [X] Complete
 
@@ -407,43 +395,23 @@ Exit skill and invoke SlashCommand("/gsd:discuss-phase [X+1] --auto")
 
 **Phase [X+1]: [Name]** — [Goal from ROADMAP.md]
 
-`/gsd:discuss-phase [X+1]` — gather context and clarify approach
+`{primary command}`
 
 <sub>`/clear` first → fresh context window</sub>
 
 ---
 
 **Also available:**
-- `/gsd:plan-phase [X+1]` — skip discussion, plan directly
-- `/gsd:research-phase [X+1]` — investigate unknowns
+- `{alt command 1}` — {description}
+- `{alt command 2}` — {description}
 
 ---
 ```
 
-**If CONTEXT.md exists:**
-
-```
-## ✓ Phase [X] Complete
-
----
-
-## ▶ Next Up
-
-**Phase [X+1]: [Name]** — [Goal from ROADMAP.md]
-<sub>✓ Context gathered, ready to plan</sub>
-
-`/gsd:plan-phase [X+1]`
-
-<sub>`/clear` first → fresh context window</sub>
-
----
-
-**Also available:**
-- `/gsd:discuss-phase [X+1]` — revisit context
-- `/gsd:research-phase [X+1]` — investigate unknowns
-
----
-```
+Where `{alt command 1}` and `{alt command 2}` are the two commands NOT selected as primary:
+- `/gsd:discuss-phase [X+1]` — gather context first
+- `/gsd:plan-phase [X+1]` — create execution plans
+- `/gsd:execute-phase [X+1]` — run existing plans
 
 </if>
 


### PR DESCRIPTION
## Summary

- Replace static next-phase routing with dynamic `init phase-op` state detection
- Routes to `discuss-phase`, `plan-phase`, or `execute-phase` based on actual phase state (has_context, has_plans)
- Previously, routing always defaulted to `plan-phase` regardless of whether the phase had been discussed or already had plans

## Problem

After completing a phase, the Next Up block always suggested `/gsd:plan-phase` — even when the next phase had no CONTEXT.md (should route to `discuss-phase`) or already had plans (should route to `execute-phase`).

## Changes

**execute-phase.md** — Added `init phase-op` probe to the non-auto-advance path with:
- Milestone-complete detection via `is_last_phase`
- 3-state routing: discuss -> plan -> execute based on phase artifacts
- Also available alternatives block

**transition.md** — Replaced `ls` CONTEXT.md check with `init phase-op` probe:
- Unified yolo and interactive routing through same 3-state logic
- Removed duplicate CONTEXT.md exists / does not exist blocks
- Both modes now use dynamic primary command selection

## Test plan

- [ ] Complete a phase where next phase has no CONTEXT.md -> should suggest `discuss-phase`
- [ ] Complete a phase where next phase has CONTEXT.md but no plans -> should suggest `plan-phase`
- [ ] Complete a phase where next phase already has plans -> should suggest `execute-phase`
- [ ] Complete last phase -> should suggest `complete-milestone`

Generated with [Claude Code](https://claude.com/claude-code)