### PR TITLE
fix: clear both local and global update caches after update

### DIFF
--- a/get-shit-done/workflows/update.md
+++ b/get-shit-done/workflows/update.md
@@ -159,16 +159,12 @@ Capture output. If install fails, show error and exit.
 
 Clear the update cache so statusline indicator disappears:
 
-**If LOCAL install:**
 ```bash
 rm -f ./.claude/cache/gsd-update-check.json
-```
-
-**If GLOBAL install:**
-```bash
 rm -f ~/.claude/cache/gsd-update-check.json
 ```
-(Paths are templated at install time for runtime compatibility)
+
+The SessionStart hook (`gsd-check-update.js`) always writes to `~/.claude/cache/` via `os.homedir()` regardless of install type, so both paths must be cleared to prevent stale update indicators.
 </step>
 
 <step name="display_result">


### PR DESCRIPTION
## Summary

- Clear **both** `./.claude/cache/` and `~/.claude/cache/` after update, instead of only the install-type-specific path

## Root Cause

The `SessionStart` hook (`gsd-check-update.js:12`) always writes cache to `~/.claude/cache/` via `os.homedir()`, regardless of install type. The update workflow previously cleared only the install-type-specific path:

- **Local install** cleared `./.claude/cache/gsd-update-check.json` - but the file was never there
- **Global install** cleared `~/.claude/cache/gsd-update-check.json` - this one worked

For local installs, the stale `~/.claude/cache/gsd-update-check.json` was never removed, causing the statusline "update available" indicator to persist indefinitely.

## Fix

Replace the conditional (local OR global) cache clearing with unconditional (BOTH always). Two `rm -f` lines - idempotent and safe.

## Why not a CLI command

A dedicated `clear-update-cache` command would work but is overkill for this. `update.md` is a workflow doc read by Claude as instructions - two `rm -f` lines are simpler, universally understood, and have no dependency on gsd-tools. The deeper issue (install.js templating the hook to use the correct path) is tracked separately.

## Test plan

- [ ] Run `/gsd:update` with a local install
- [ ] Verify `~/.claude/cache/gsd-update-check.json` is removed after update
- [ ] Verify `./.claude/cache/gsd-update-check.json` is also removed (or was never there)
- [ ] Statusline indicator should not persist after successful update

Fixes #663