### PR TITLE
fix: auto-advance chain broken — Skills don't resolve inside Task subagents

### DIFF
--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -381,6 +381,29 @@ node ~/.claude/get-shit-done/bin/gsd-tools.cjs commit "docs(phase-{X}): complete
 
 **Exception:** If `gaps_found`, the `verify_phase_goal` step already presents the gap-closure path (`/gsd:plan-phase {X} --gaps`). No additional routing needed — skip auto-advance.
 
+**No-transition check (spawned by auto-advance chain):**
+
+Parse `--no-transition` flag from $ARGUMENTS.
+
+**If `--no-transition` flag present:**
+
+Execute-phase was spawned by plan-phase's auto-advance. Do NOT run transition.md.
+After verification passes and roadmap is updated, return completion status to parent:
+
+```
+## PHASE COMPLETE
+
+Phase: ${PHASE_NUMBER} - ${PHASE_NAME}
+Plans: ${completed_count}/${total_count}
+Verification: {Passed | Gaps Found}
+
+[Include aggregate_results output]
+```
+
+STOP. Do not proceed to auto-advance or transition.
+
+**If `--no-transition` flag is NOT present:**
+
 **Auto-advance detection:**
 
 1. Parse `--auto` flag from $ARGUMENTS

--- a/get-shit-done/workflows/plan-phase.md
+++ b/get-shit-done/workflows/plan-phase.md
@@ -366,10 +366,36 @@ Display banner:
 Plans ready. Spawning execute-phase...
 ```
 
-Spawn execute-phase as Task:
+Spawn execute-phase as Task with direct workflow file reference (do NOT use Skill tool — Skills don't resolve inside Task subagents):
 ```
 Task(
-  prompt="Run /gsd:execute-phase ${PHASE} --auto",
+  prompt="
+    <objective>
+    You are the execute-phase orchestrator. Execute all plans for Phase ${PHASE}: ${PHASE_NAME}.
+    </objective>
+
+    <execution_context>
+    @~/.claude/get-shit-done/workflows/execute-phase.md
+    @~/.claude/get-shit-done/references/checkpoints.md
+    @~/.claude/get-shit-done/references/tdd.md
+    @~/.claude/get-shit-done/references/model-profile-resolution.md
+    </execution_context>
+
+    <arguments>
+    PHASE=${PHASE}
+    ARGUMENTS='${PHASE} --auto --no-transition'
+    </arguments>
+
+    <instructions>
+    1. Read execute-phase.md from execution_context for your complete workflow
+    2. Follow ALL steps: initialize, handle_branching, validate_phase, discover_and_group_plans, execute_waves, aggregate_results, close_parent_artifacts, verify_phase_goal, update_roadmap
+    3. The --no-transition flag means: after verification + roadmap update, STOP and return status. Do NOT run transition.md.
+    4. When spawning executor agents, use subagent_type='gsd-executor' with the existing @file pattern from the workflow
+    5. When spawning verifier agents, use subagent_type='gsd-verifier'
+    6. Preserve the classifyHandoffIfNeeded workaround (spot-check on that specific error)
+    7. Do NOT use the Skill tool or /gsd: commands
+    </instructions>
+  ",
   subagent_type="general-purpose",
   description="Execute Phase ${PHASE}"
 )


### PR DESCRIPTION
## Summary

- **Bug:** The `--auto` flag on `discuss-phase` and `plan-phase` chains stages automatically (discuss → plan → execute), but the chain is **completely broken** because auto-advance spawns `Task(prompt="Run /gsd:plan-phase --auto")` which requires the Skill tool — **Skills don't resolve inside Task subagents**.
- **Fix:** Replace `Task(prompt="Run /gsd:XXX")` with Task calls that tell the subagent to **read the workflow `.md` file directly** via `@file` references — the same pattern that already works for gsd-executor spawning in `execute-phase`.
- **New flag:** `--no-transition` on `execute-phase` prevents it from running `transition.md` when spawned as a child of `plan-phase`'s auto-advance (the parent controls the chain boundary).

## Root Cause

Claude Code's Task tool spawns subagents that do **not** have access to the Skill tool. When auto-advance tells a subagent `"Run /gsd:plan-phase --auto"`, the subagent cannot resolve the `/gsd:` skill prefix, so:

1. `discuss-phase --auto` → spawns Task → tries `Run /gsd:plan-phase` → **fails silently**
2. `plan-phase --auto` → spawns Task → tries `Run /gsd:execute-phase` → **fails silently**
3. The entire auto-advance pipeline is dead code

## Fix Details

| File | Change |
|------|--------|
| `execute-phase.md` | Add `--no-transition` flag: when present, return status to parent instead of running `transition.md`. Existing auto-advance logic becomes the else branch. |
| `plan-phase.md` | Replace `"Run /gsd:execute-phase"` with direct `@file` reference to `execute-phase.md` + `--no-transition` flag |
| `discuss-phase.md` | Replace `"Run /gsd:plan-phase"` with direct `@file` reference to `plan-phase.md` + richer return status handling (PHASE COMPLETE, PLANNING COMPLETE, INCONCLUSIVE, GAPS FOUND) |

## How It Works Now

**Before (broken):**
```
Subagent told to "Run /gsd:plan-phase" → needs Skill tool → Skill doesn't resolve → chain fails
```

**After (fixed):**
```
Subagent told to "Read plan-phase.md and follow it" → reads file directly → follows workflow → spawns sub-agents → chain works
```

**Nesting depth:** discuss → Task(plan) → Task(execute) → Task(executor) = 3 levels max. Each level gets a clean 200k context window.

## Test plan

- [ ] Run `/gsd:plan-phase N --auto` on any planned phase → confirm execute-phase spawns with gsd-executor subagents
- [ ] Run `/gsd:discuss-phase N --auto` → confirm full chain: discuss → plan → execute
- [ ] Verify each stage gets clean context (subagents read files fresh, not inheriting parent context)
- [ ] Verify `--no-transition` prevents execute-phase from chaining to next phase
- [ ] Run `/gsd:plan-phase N` (no --auto) → confirm manual mode unchanged
- [ ] Run `/gsd:execute-phase N` (no --no-transition) → confirm transition still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)