### PR TITLE
fix: statusline migration regex too broad, clobbers third-party statuslines

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -787,16 +787,16 @@ function cleanupOrphanedHooks(settings) {
     console.log(`  ${green}✓${reset} Removed orphaned hook registrations`);
   }
 
-  // Fix #330: Update statusLine if it points to old statusline.js path
+  // Fix #330: Update statusLine if it points to old GSD statusline.js path
+  // Only match the specific old GSD path pattern (hooks/statusline.js),
+  // not third-party statusline scripts that happen to contain 'statusline.js'
   if (settings.statusLine && settings.statusLine.command &&
-      settings.statusLine.command.includes('statusline.js') &&
-      !settings.statusLine.command.includes('gsd-statusline.js')) {
-    // Replace old path with new path
+      /hooks[\/\\]statusline\.js/.test(settings.statusLine.command)) {
     settings.statusLine.command = settings.statusLine.command.replace(
-      /statusline\.js/,
-      'gsd-statusline.js'
+      /hooks([\/\\])statusline\.js/,
+      'hooks$1gsd-statusline.js'
     );
-    console.log(`  ${green}✓${reset} Updated statusline path (statusline.js → gsd-statusline.js)`);
+    console.log(`  ${green}✓${reset} Updated statusline path (hooks/statusline.js → hooks/gsd-statusline.js)`);
   }
 
   return settings;


### PR DESCRIPTION
## Summary

- The `#330` migration in `cleanupOrphanedHooks()` renames `statusline.js` → `gsd-statusline.js` using `.includes('statusline.js')`, which matches **any** file containing that substring
- A user's custom statusline (e.g. `ted-statusline.js`) gets silently rewritten to `ted-gsd-statusline.js` (which doesn't exist), breaking the statusline
- This runs **before** the interactive "Keep existing / Replace" prompt, so choosing "Keep existing" doesn't prevent the damage

## Fix

Narrow the regex to only match the specific old GSD path pattern `hooks/statusline.js` (or `hooks\statusline.js` on Windows), not any file that happens to contain `statusline.js` in its name.

**Before:**
```js
settings.statusLine.command.includes('statusline.js') &&
!settings.statusLine.command.includes('gsd-statusline.js')
```

**After:**
```js
/hooks[\/\]statusline\.js/.test(settings.statusLine.command)
```

## Test plan

- [ ] User with custom `my-statusline.js` → should NOT be renamed
- [ ] User with old GSD `hooks/statusline.js` → should be renamed to `hooks/gsd-statusline.js`
- [ ] User with current GSD `hooks/gsd-statusline.js` → should be left as-is

🤖 Generated with [Claude Code](https://claude.com/claude-code)