### PR TITLE
Fix STATE.md decision duplication/corruption and preserve dollar text

### DIFF
--- a/get-shit-done/bin/gsd-tools.cjs
+++ b/get-shit-done/bin/gsd-tools.cjs
@@ -102,7 +102,9 @@
  *   state update-progress              Recalculate progress bar
  *   state add-decision --summary "..."  Add decision to STATE.md
  *     [--phase N] [--rationale "..."]
+ *     [--summary-file path] [--rationale-file path]
  *   state add-blocker --text "..."     Add blocker
+ *     [--text-file path]
  *   state resolve-blocker --text "..." Remove blocker
  *   state record-session               Update session continuity
  *     --stopped-at "..."
@@ -187,15 +189,23 @@ async function main() {
       } else if (subcommand === 'add-decision') {
         const phaseIdx = args.indexOf('--phase');
         const summaryIdx = args.indexOf('--summary');
+        const summaryFileIdx = args.indexOf('--summary-file');
         const rationaleIdx = args.indexOf('--rationale');
+        const rationaleFileIdx = args.indexOf('--rationale-file');
         state.cmdStateAddDecision(cwd, {
           phase: phaseIdx !== -1 ? args[phaseIdx + 1] : null,
           summary: summaryIdx !== -1 ? args[summaryIdx + 1] : null,
+          summary_file: summaryFileIdx !== -1 ? args[summaryFileIdx + 1] : null,
           rationale: rationaleIdx !== -1 ? args[rationaleIdx + 1] : '',
+          rationale_file: rationaleFileIdx !== -1 ? args[rationaleFileIdx + 1] : null,
         }, raw);
       } else if (subcommand === 'add-blocker') {
         const textIdx = args.indexOf('--text');
-        state.cmdStateAddBlocker(cwd, textIdx !== -1 ? args[textIdx + 1] : null, raw);
+        const textFileIdx = args.indexOf('--text-file');
+        state.cmdStateAddBlocker(cwd, {
+          text: textIdx !== -1 ? args[textIdx + 1] : null,
+          text_file: textFileIdx !== -1 ? args[textFileIdx + 1] : null,
+        }, raw);
       } else if (subcommand === 'resolve-blocker') {
         const textIdx = args.indexOf('--text');
         state.cmdStateResolveBlocker(cwd, textIdx !== -1 ? args[textIdx + 1] : null, raw);

--- a/get-shit-done/workflows/execute-plan.md
+++ b/get-shit-done/workflows/execute-plan.md
@@ -349,11 +349,12 @@ From SUMMARY: Extract decisions and add to STATE.md:
 
 ```bash
 # Add each decision from SUMMARY key-decisions
+# Prefer file inputs for shell-safe text (preserves `$`, `*`, etc. exactly)
 node ~/.claude/get-shit-done/bin/gsd-tools.cjs state add-decision \
-  --phase "${PHASE}" --summary "${DECISION_TEXT}" --rationale "${RATIONALE}"
+  --phase "${PHASE}" --summary-file "${DECISION_TEXT_FILE}" --rationale-file "${RATIONALE_FILE}"
 
 # Add blockers if any found
-node ~/.claude/get-shit-done/bin/gsd-tools.cjs state add-blocker "Blocker description"
+node ~/.claude/get-shit-done/bin/gsd-tools.cjs state add-blocker --text-file "${BLOCKER_TEXT_FILE}"
 ```
 </step>
 


### PR DESCRIPTION
Fixes #692

This addresses two separate failure modes behind the reported `STATE.md` corruption / decision text breakage:

1. Regex replacement backreference injection in `state` mutators
   - `String.replace(regex, replacementString)` treated `$1/$2/$&` in decision/blocker text as backreferences
   - This could splice captured section content into the replacement and corrupt/duplicate `STATE.md`

2. Shell interpolation risk for inline `state add-decision` / `state add-blocker` text
   - Added file-based inputs to preserve shell-sensitive text exactly:
   - `--summary-file`, `--rationale-file`, `--text-file`

Changes included:
- callback replacers for state mutation paths in `bin/lib/state.cjs`
- CLI parsing for new file-based flags in `bin/gsd-tools.cjs`
- workflow docs update in `workflows/execute-plan.md` to prefer file inputs
- regression tests covering `$0.50/$2.00/$5.00` and file-based inputs

Verification:
- `node --test tests/state.test.cjs` (10/10 passing)
