### PR TITLE
feat(execute-phase): add configurable post-wave domain review hooks

### DIFF
--- a/agents/gsd-verifier.md
+++ b/agents/gsd-verifier.md
@@ -16,12 +16,6 @@ If the prompt contains a `<files_to_read>` block, you MUST use the `Read` tool t
 **Critical mindset:** Do NOT trust SUMMARY.md claims. SUMMARYs document what Claude SAID it did. You verify what ACTUALLY exists in the code. These often differ.
 </role>
 
-<project_context>
-**Project verification rules:** Check `.agents/skills/verification-rules.md` if it exists.
-If found, read it and apply those additional anti-pattern checks when scanning phase artifacts
-in Step 7 (Scan for Anti-Patterns).
-</project_context>
-
 <core_principle>
 **Task completion ≠ Goal achievement**
 

--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -181,6 +181,12 @@ Execute each wave in sequence. Within a wave: parallel if `PARALLELIZATION=true`
 
    For each review entry where `enabled: true` and at least one file matches `trigger_glob`:
 
+   **Verify agent file exists first:**
+   ```bash
+   ls .claude/agents/{review.agent}.md 2>/dev/null
+   ```
+   If missing → log `"Review '{name}' skipped: agent file .claude/agents/{review.agent}.md not found"` and skip this review entry.
+
    ```
    Task(
      subagent_type="general-purpose",


### PR DESCRIPTION
## Summary

  Adds a configurable mechanism for running domain-specific review agents after each execution wave. Projects can define review hooks in `config.json` that trigger specialized   
  agents (e.g., SQL migration reviewers, workflow validators) based on file patterns in SUMMARY.md `key-files`.

  - New `post_wave_reviews` config section with per-review `trigger_glob`, `agent`, `blocking`, and `model` fields
  - Step 4b in execute-phase: matches wave output files against configured globs, spawns review agents, handles blocking/non-blocking results
  - Auto-advance aware: integrates with `workflow.auto_advance` to avoid breaking automated pipelines
  - Verifier enhancement: new `<project_context>` section reads `.agents/skills/verification-rules.md` for project-local anti-pattern checks
  - Fully backward compatible — no behavior change when `post_wave_reviews` is absent

  ## Motivation

  The execute-phase orchestrator spot-checks (step 4) verify files exist and commits were made, but can't catch domain-specific quality issues. Projects that maintain specialized
   review agents in `.claude/agents/` currently have no way to wire them into the execution pipeline automatically.

  This feature closes that gap with a generic, config-driven approach that works for any domain — SQL migrations, IaC templates, API specs, workflow JSON, etc.

  ## Files changed

  | File | Change |
  |------|--------|
  | `workflows/execute-phase.md` | Added step 4b (post-wave domain reviews) inside `execute_waves` |
  | `agents/gsd-verifier.md` | Added `<project_context>` for project-local verification rules |
  | `references/planning-config.md` | Documented `post_wave_reviews` config schema |

  ## Config example

  ```json
  {
    "post_wave_reviews": {
      "sql_migrations": {
        "enabled": true,
        "trigger_glob": "db/migrations/*.sql",
        "agent": "sql-migration-reviewer",
        "blocking": true,
        "model": "sonnet"
      }
    }
  }
  ```

  ## Test plan

  - [ ] Run `/gsd:execute-phase` on a phase WITHOUT `post_wave_reviews` in config — verify identical behavior to current framework
  - [ ] Add `post_wave_reviews` config with a trigger glob matching phase output files — verify review agent spawns after wave
  - [ ] Test with `blocking: false` — verify results logged but execution continues
  - [ ] Test with `auto_advance: true` — verify auto-fix cycle runs without user prompt
  - [ ] Test with non-existent agent name — verify graceful error, not crash
