### PR TITLE
feat: wiring-first planning, code-aware discuss, worktree isolation

### DIFF
--- a/agents/gsd-plan-checker.md
+++ b/agents/gsd-plan-checker.md
@@ -161,6 +161,27 @@ issue:
 - `depends_on: ["01"]` = Wave 2 minimum (must wait for 01)
 - Wave number = max(deps) + 1
 
+**Worktree Isolation File Overlap Guard:**
+
+Check if `parallelization.isolation` is `"worktree"` in `.planning/config.json`:
+
+```bash
+node ~/.claude/get-shit-done/bin/gsd-tools.cjs config-get parallelization.isolation 2>/dev/null || echo "none"
+```
+
+**If `"worktree"`:** Plans in the same wave MUST NOT share `files_modified` entries. Each executor gets an isolated git worktree — file overlaps within a wave would cause merge conflicts.
+
+For each wave, collect all `files_modified` from plans in that wave. If any file appears in multiple plans within the same wave → **blocker** (move overlapping plan to a later wave).
+
+```yaml
+issue:
+  dimension: dependency_correctness
+  severity: blocker
+  description: "Plans 01 and 02 (both Wave 1) share files_modified entry 'src/types/index.ts' — will conflict in worktree mode"
+  plans: ["01", "02"]
+  fix_hint: "Move plan 02 to Wave 2 with depends_on: ['01'], or consolidate shared file into one plan"
+```
+
 **Example issue:**
 ```yaml
 issue:
@@ -171,38 +192,84 @@ issue:
   fix_hint: "Plan 02 depends on 03, but 03 depends on 02"
 ```
 
-## Dimension 4: Key Links Planned
+## Dimension 4: Key Links & Wiring
 
 **Question:** Are artifacts wired together, not just created in isolation?
 
 **Process:**
 1. Identify artifacts in `must_haves.artifacts`
 2. Check that `must_haves.key_links` connects them
-3. Verify tasks actually implement the wiring (not just artifact creation)
+3. **Verify tasks include explicit wiring instructions** (Wire into / Import from / Connect to lines)
+4. If Integration Map exists, verify its entries are addressed in task actions
+5. Check for orphaned files in `files_modified` that aren't imported/used by any other task
+
+**Wiring Line Check (BLOCKING):**
+
+Every task action that creates a new file MUST include at least one of:
+- `Wire into:` — where the artifact is consumed
+- `Import from:` — types/modules the artifact needs
+- `Connect to:` — data flow connections
+
+A task action that creates `src/components/Feed.tsx` without any wiring line is a **blocker** — the component will be orphaned.
 
 **Red flags:**
-- Component created but not imported anywhere
-- API route created but component doesn't call it
+- Component created but no "Wire into" line specifying where it renders → **blocker**
+- API route created but no task has "Connect to" referencing it → **blocker**
+- `key_link` in must_haves without a corresponding wiring instruction in any task action → **blocker**
 - Database model created but API doesn't query it
 - Form created but submit handler is missing or stub
 
+**Integration Map Cross-Reference:**
+
+If `{phase}-INTEGRATION-MAP.md` exists in the verification context:
+1. For each entry in the Integration Map, check if a task action addresses it
+2. Unaddressed Integration Map entries → **warning** (the entry may not be relevant to all plans)
+
+**Orphan Detection:**
+
+For each file in `files_modified` across all plans:
+1. Check if any other task action references importing or using this file
+2. Files that appear in `files_modified` but are never referenced by another task's action → **warning** (potential orphan)
+
 **What to check:**
 ```
-Component -> API: Does action mention fetch/axios call?
-API -> Database: Does action mention Prisma/query?
-Form -> Handler: Does action mention onSubmit implementation?
-State -> Render: Does action mention displaying state?
+Component -> API: Does action include "Connect to: /api/..." or "Wire into: ...fetch..."?
+API -> Database: Does action include "Connect to: prisma..." or mention query?
+Form -> Handler: Does action include "Connect to: onSubmit handler"?
+State -> Render: Does action include "Wire into: ...renders state..."?
 ```
 
-**Example issue:**
+**Example issues:**
 ```yaml
 issue:
   dimension: key_links_planned
-  severity: warning
-  description: "Chat.tsx created but no task wires it to /api/chat"
+  severity: blocker
+  description: "Task creates src/components/Chat.tsx but has no wiring line — component will be orphaned"
+  plan: "01"
+  task: 2
+  fix_hint: "Add 'Wire into: src/app/chat/page.tsx — import and render <Chat>' to task action"
+
+issue:
+  dimension: key_links_planned
+  severity: blocker
+  description: "key_link Chat.tsx -> /api/chat has no corresponding wiring instruction in any task"
   plan: "01"
   artifacts: ["src/components/Chat.tsx", "src/app/api/chat/route.ts"]
-  fix_hint: "Add fetch call in Chat.tsx action or create wiring task"
+  fix_hint: "Add 'Connect to: /api/chat via fetch in useEffect' to Chat.tsx task action"
+
+issue:
+  dimension: key_links_planned
+  severity: warning
+  description: "Integration Map entry 'Nav config registration' not addressed by any task"
+  plan: null
+  fix_hint: "Add nav registration step to a task action or confirm it's not needed for this plan"
+
+issue:
+  dimension: key_links_planned
+  severity: warning
+  description: "src/utils/format.ts in files_modified but not imported by any other task"
+  plan: "02"
+  fix_hint: "Add import reference in consuming task or verify it's used by existing code"
 ```
 
 ## Dimension 5: Scope Sanity
@@ -430,11 +497,13 @@ Orchestrator provides CONTEXT.md content in the verification prompt. If provided
 ls "$phase_dir"/*-PLAN.md 2>/dev/null
 # Read research for Nyquist validation data
 cat "$phase_dir"/*-RESEARCH.md 2>/dev/null
+# Read Integration Map for wiring verification
+cat "$phase_dir"/*-INTEGRATION-MAP.md 2>/dev/null
 node ~/.claude/get-shit-done/bin/gsd-tools.cjs roadmap get-phase "$phase_number"
 ls "$phase_dir"/*-BRIEF.md 2>/dev/null
 ```
 
-**Extract:** Phase goal, requirements (decompose goal), locked decisions, deferred ideas.
+**Extract:** Phase goal, requirements (decompose goal), locked decisions, deferred ideas, integration map entries (if exists).
 
 ## Step 2: Load All Plans
 
@@ -530,15 +599,31 @@ done
 
 Validate: all referenced plans exist, no cycles, wave numbers consistent, no forward references. If A -> B -> C -> A, report cycle.
 
-## Step 7: Check Key Links
+## Step 7: Check Key Links & Wiring
 
-For each key_link in must_haves: find source artifact task, check if action mentions the connection, flag missing wiring.
+**7a. Wiring Line Check:**
+For each task that creates a new file (check `<files>` for new paths):
+- Scan `<action>` for wiring lines: `Wire into:`, `Import from:`, `Connect to:`
+- If no wiring line found → **blocker** issue
+
+**7b. Key Link Check:**
+For each key_link in must_haves: find source artifact task, check if action includes a corresponding wiring instruction, flag missing wiring as **blocker**.
 
 ```
 key_link: Chat.tsx -> /api/chat via fetch
+Task 2 action: "Create Chat component... Connect to: /api/chat via fetch in useEffect"
+✓ Wiring planned
+
+key_link: Chat.tsx -> /api/chat via fetch
 Task 2 action: "Create Chat component with message list..."
-Missing: No mention of fetch/API call → Issue: Key link not planned
+✗ No wiring instruction → blocker
 ```
+
+**7c. Integration Map Cross-Reference (if exists):**
+Load `{phase}-INTEGRATION-MAP.md`. For each entry, check if any task action addresses it. Unaddressed entries → **warning**.
+
+**7d. Orphan Detection:**
+Collect all files from `files_modified` across all plans. For each file, check if any other task's `<action>` references importing or using it. Unreferenced files → **warning**.
 
 ## Step 8: Assess Scope
 
@@ -627,11 +712,15 @@ issue:
 - Missing required task fields
 - Circular dependencies
 - Scope > 5 tasks per plan
+- New file created without wiring line in task action
+- key_link without corresponding wiring instruction
+- Same-wave file overlap in worktree mode
 
 **warning** - Should fix, execution may work
 - Scope 4 tasks (borderline)
 - Implementation-focused truths
-- Minor wiring missing
+- Integration Map entry unaddressed
+- Orphaned file in files_modified (not imported by any other task)
 
 **info** - Suggestions for improvement
 - Could split for better parallelization

--- a/agents/gsd-planner.md
+++ b/agents/gsd-planner.md
@@ -575,6 +575,53 @@ must_haves:
 
 </goal_backward>
 
+<wiring_protocol>
+
+## The Wiring Line Rule
+
+**Every task action that creates a new file MUST include at least one explicit wiring instruction.** This prevents orphaned code — files that exist but aren't imported, rendered, or connected anywhere.
+
+### Required Wiring Lines
+
+Task actions that create new files must include one or more of:
+
+- **`Wire into:`** — Specifies the exact file and mechanism where this artifact is consumed
+- **`Import from:`** — Specifies types, utilities, or modules this artifact needs
+- **`Connect to:`** — Specifies data flow connections (API calls, store subscriptions, event handlers)
+
+### Example Transformation
+
+```
+BAD:  "Create FeedItem component that displays a post."
+
+GOOD: "Create src/components/feed/FeedItem.tsx that displays a post.
+       Import from: src/types/user.ts (User type), src/types/post.ts (Post type)
+       Wire into: src/app/(main)/feed/page.tsx — import and render <FeedItem> in feed list
+       Connect to: /api/posts — fetch post data via useEffect on mount"
+```
+
+### Integration Map Usage
+
+If an Integration Map exists (`{phase}-INTEGRATION-MAP.md`), use its entries as wiring targets:
+
+1. **Entry Points** → your component/page wires into these routes
+2. **Registration Points** → your feature registers in these configs
+3. **Data Flow** → your code connects to these stores/APIs
+4. **Type Connections** → your code imports these types (don't redefine)
+
+### Self-Check Before Returning
+
+After creating all plans, verify:
+
+- [ ] Every artifact in `must_haves.artifacts` has a "Wire into" line in a task action
+- [ ] Every `key_link` in `must_haves.key_links` has a corresponding wiring instruction in a task action
+- [ ] No artifact is created without being imported/used somewhere (no orphans)
+- [ ] If Integration Map exists, every relevant entry has a corresponding task action
+
+**If self-check fails:** Fix the plan before returning. Add missing wiring lines to task actions or create additional wiring tasks.
+
+</wiring_protocol>
+
 <checkpoints>
 
 ## Checkpoint Types

--- a/agents/gsd-verifier.md
+++ b/agents/gsd-verifier.md
@@ -57,11 +57,14 @@ Set `is_re_verification = false`, proceed with Step 1.
 ```bash
 ls "$PHASE_DIR"/*-PLAN.md 2>/dev/null
 ls "$PHASE_DIR"/*-SUMMARY.md 2>/dev/null
+cat "$PHASE_DIR"/*-INTEGRATION-MAP.md 2>/dev/null
 node ~/.claude/get-shit-done/bin/gsd-tools.cjs roadmap get-phase "$PHASE_NUM"
 grep -E "^| $PHASE_NUM" .planning/REQUIREMENTS.md 2>/dev/null
 ```
 
 Extract phase goal from ROADMAP.md — this is the outcome to verify, not the tasks.
+
+**Integration Map:** If `{phase}-INTEGRATION-MAP.md` exists, load it as an additional verification reference. In Step 5 (Key Links), cross-check that every integration point from the map was addressed in the codebase. Unaddressed integration points should be flagged as gaps.
 
 ## Step 2: Establish Must-Haves (Initial Mode Only)
 

--- a/commands/gsd/discuss-phase.md
+++ b/commands/gsd/discuss-phase.md
@@ -10,6 +10,8 @@ allowed-tools:
   - Grep
   - AskUserQuestion
   - Task
+  - mcp__context7__resolve-library-id
+  - mcp__context7__query-docs
 ---
 
 <objective>
@@ -38,11 +40,12 @@ Context files are resolved in-workflow using `init phase-op` and roadmap/state t
 <process>
 1. Validate phase number (error if missing or not in roadmap)
 2. Check if CONTEXT.md exists (offer update/view/skip if yes)
-3. **Analyze phase** — Identify domain and generate phase-specific gray areas
-4. **Present gray areas** — Multi-select: which to discuss? (NO skip option)
-5. **Deep-dive each area** — 4 questions per area, then offer more/next
-6. **Write CONTEXT.md** — Sections match areas discussed
-7. Offer next steps (research or plan)
+3. **Scout codebase** — Find reusable assets, patterns, and integration points
+4. **Analyze phase** — Identify domain and generate code-informed gray areas
+5. **Present gray areas** — Multi-select: which to discuss? (NO skip option)
+6. **Deep-dive each area** — 4 questions per area, code-informed options, Context7 for library choices
+7. **Write CONTEXT.md** — Sections match areas discussed + code_context section
+8. Offer next steps (research or plan)
 
 **CRITICAL: Scope guardrail**
 - Phase boundary from ROADMAP.md is FIXED

--- a/get-shit-done/bin/lib/init.cjs
+++ b/get-shit-done/bin/lib/init.cjs
@@ -43,6 +43,9 @@ function cmdInitExecutePhase(cwd, phase, raw) {
     plan_count: phaseInfo?.plans?.length || 0,
     incomplete_count: phaseInfo?.incomplete_plans?.length || 0,
 
+    // Isolation mode
+    isolation: config.parallelization?.isolation || 'none',
+
     // Branch name (pre-computed)
     branch_name: config.branching_strategy === 'phase' && phaseInfo
       ? config.phase_branch_template

--- a/get-shit-done/references/planning-config.md
+++ b/get-shit-done/references/planning-config.md
@@ -193,4 +193,54 @@ Squash merge is recommended — keeps main branch history clean while preserving
 
 </branching_strategy_behavior>
 
+<parallelization_isolation>
+
+**Worktree Isolation for Parallel Execution:**
+
+When multiple executor agents run in parallel (same wave), they share the same git working tree by default. This can cause:
+- Lint-staged picking up changes from other agents
+- File write conflicts between concurrent agents
+- Test runners seeing partial changes from parallel work
+
+**Configuration:**
+
+```json
+"parallelization": {
+  "enabled": true,
+  "plan_level": true,
+  "isolation": "worktree",
+  "max_concurrent_agents": 3
+}
+```
+
+| Value | Behavior |
+|-------|----------|
+| `"none"` (default) | All agents share the same working tree (current behavior) |
+| `"worktree"` | Each parallel agent gets an isolated git worktree via Claude Code's `isolation: "worktree"` Task parameter |
+
+**How it works:**
+
+1. Plan-checker enforces no `files_modified` overlap between plans in the same wave (blocker severity)
+2. Execute-phase adds `isolation: "worktree"` to Task calls when spawning multiple agents in a wave
+3. Each agent works in an isolated copy of the repo
+4. After wave completes, worktree branches are merged back sequentially
+5. If merge conflict occurs (shouldn't with file overlap guard), user is prompted
+
+**Requirements:**
+- Git repository (worktrees require git)
+- Plans in same wave must NOT share `files_modified` entries
+- Sufficient disk space for temporary worktree copies
+
+**When to use:**
+- Projects with lint-staged or pre-commit hooks that scan all staged files
+- Large phases with 3+ parallel plans modifying many files
+- When experiencing flaky parallel execution due to file conflicts
+
+**When NOT to use:**
+- Single-plan waves (no benefit, adds overhead)
+- Small projects where parallel conflicts are rare
+- Non-git projects
+
+</parallelization_isolation>
+
 </planning_config>

--- a/get-shit-done/templates/config.json
+++ b/get-shit-done/templates/config.json
@@ -18,7 +18,8 @@
     "task_level": false,
     "skip_checkpoints": true,
     "max_concurrent_agents": 3,
-    "min_plans_for_parallel": 2
+    "min_plans_for_parallel": 2,
+    "isolation": "none"
   },
   "gates": {
     "confirm_project": true,

--- a/get-shit-done/templates/context.md
+++ b/get-shit-done/templates/context.md
@@ -54,6 +54,20 @@ Template for `.planning/phases/XX-name/{phase_num}-CONTEXT.md` - captures implem
 
 </specifics>
 
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+- [Component/hook/utility]: [How it could be used in this phase]
+
+### Established Patterns
+- [Pattern]: [How it constrains/enables this phase]
+
+### Integration Points
+- [Where new code connects to existing system]
+
+</code_context>
+
 <deferred>
 ## Deferred Ideas
 

--- a/get-shit-done/templates/integration-map.md
+++ b/get-shit-done/templates/integration-map.md
@@ -1,0 +1,81 @@
+# Integration Map Template
+
+Template for `.planning/phases/XX-name/{phase_num}-INTEGRATION-MAP.md` — maps where new code must connect to existing codebase.
+
+**Purpose:** Ensure planners know exactly where to wire new features. Prevents orphaned code by making integration points explicit before planning.
+
+**Downstream consumers:**
+- `gsd-planner` — Uses integration points to write explicit "Wire into" instructions in task actions
+- `gsd-plan-checker` — Cross-references plan tasks against integration map entries
+- `gsd-verifier` — Validates that integration points were actually addressed
+
+---
+
+## File Template
+
+```markdown
+# Phase [X]: [Name] - Integration Map
+
+**Generated:** [date]
+**Phase Goal:** [goal from ROADMAP.md]
+
+## Entry Points
+
+Where users/system reach this feature:
+
+| Entry Point | File | Type | How to Wire |
+|-------------|------|------|-------------|
+| [Route/page] | [file path] | routing/page/layout | [Add route, import component, etc.] |
+
+## Registration Points
+
+Where new code must register itself to be discovered:
+
+| Registration | File | Mechanism | How to Wire |
+|-------------|------|-----------|-------------|
+| [Nav item, provider, export] | [file path] | [config array, wrapper, barrel export] | [Add entry, wrap component, export from index] |
+
+## Data Flow
+
+Where data enters, transforms, and persists:
+
+| Endpoint | File | Direction | How to Wire |
+|----------|------|-----------|-------------|
+| [Store/API/DB] | [file path] | [read/write/both] | [Import store, call API, add model] |
+
+## Type Connections
+
+Existing types the phase should import (not redefine):
+
+| Type | Defined In | Used For | Import As |
+|------|-----------|----------|-----------|
+| [TypeName] | [file path] | [purpose] | [import statement] |
+
+---
+
+*Phase: XX-name*
+*Integration map generated: [date]*
+```
+
+<guidelines>
+**Each row = one wiring instruction for the planner.**
+
+The map answers: "To add feature X, wire into Y at Z."
+
+**Good entries (actionable):**
+- Entry: "Dashboard page" | `src/app/dashboard/page.tsx` | page | "Import and render `<NewWidget>` in grid"
+- Registration: "Nav config" | `src/config/navigation.ts` | config array | "Add `{ label: 'Feature', href: '/feature', icon: Icon }` to `navItems`"
+- Type: "User" | `src/types/user.ts` | author display | `import type { User } from '@/types/user'`
+
+**Bad entries (vague):**
+- "Add to the app somewhere"
+- "Connect to database"
+- "Use existing types"
+
+**Generation protocol:**
+1. Grep for routing files, page files, layout files → Entry Points
+2. Grep for nav configs, provider wrappers, barrel exports → Registration Points
+3. Grep for state stores, DB schema, API client → Data Flow
+4. Grep for type definitions relevant to phase goal → Type Connections
+5. Only include entries relevant to this phase's goal — not every file in the codebase
+</guidelines>

--- a/get-shit-done/workflows/discuss-phase.md
+++ b/get-shit-done/workflows/discuss-phase.md
@@ -166,27 +166,70 @@ If "Cancel": Exit workflow.
 **If `has_plans` is false:** Continue to analyze_phase.
 </step>
 
+<step name="scout_codebase">
+Lightweight scan of existing code to inform gray area identification and discussion. Uses ~10% context — acceptable for an interactive session.
+
+**Step 1: Check for existing codebase maps**
+```bash
+ls .planning/codebase/*.md 2>/dev/null
+```
+
+**If codebase maps exist:** Read the most relevant ones (CONVENTIONS.md, STRUCTURE.md, STACK.md based on phase type). Extract:
+- Reusable components/hooks/utilities
+- Established patterns (state management, styling, data fetching)
+- Integration points (where new code would connect)
+
+Skip to Step 3 below.
+
+**Step 2: If no codebase maps, do targeted grep**
+
+Extract key terms from the phase goal (e.g., "feed" → "post", "card", "list"; "auth" → "login", "session", "token").
+
+```bash
+# Find files related to phase goal terms
+grep -rl "{term1}\|{term2}" src/ app/ --include="*.ts" --include="*.tsx" --include="*.js" --include="*.jsx" 2>/dev/null | head -10
+
+# Find existing components/hooks
+ls src/components/ 2>/dev/null
+ls src/hooks/ 2>/dev/null
+ls src/lib/ src/utils/ 2>/dev/null
+```
+
+Read the 3-5 most relevant files to understand existing patterns.
+
+**Step 3: Build internal codebase_context**
+
+From the scan, identify:
+- **Reusable assets** — existing components, hooks, utilities that could be used in this phase
+- **Established patterns** — how the codebase does state management, styling, data fetching
+- **Integration points** — where new code would connect (routes, nav, providers)
+- **Creative options** — approaches the existing architecture enables or constrains
+
+Store as internal `<codebase_context>` for use in analyze_phase and present_gray_areas. This is NOT written to a file — it's used within this session only.
+</step>
+
 <step name="analyze_phase">
-Analyze the phase to identify gray areas worth discussing.
+Analyze the phase to identify gray areas worth discussing. **Use codebase_context from scout step to ground the analysis.**
 
 **Read the phase description from ROADMAP.md and determine:**
 
 1. **Domain boundary** — What capability is this phase delivering? State it clearly.
 
-2. **Gray areas by category** — For each relevant category (UI, UX, Behavior, Empty States, Content), identify 1-2 specific ambiguities that would change implementation.
+2. **Gray areas by category** — For each relevant category (UI, UX, Behavior, Empty States, Content), identify 1-2 specific ambiguities that would change implementation. **Annotate with code context where relevant** (e.g., "You already have a Card component" or "No existing pattern for this").
 
 3. **Skip assessment** — If no meaningful gray areas exist (pure infrastructure, clear-cut implementation), the phase may not need discussion.
 
 **Output your analysis internally, then present to user.**
 
-Example analysis for "Post Feed" phase:
+Example analysis for "Post Feed" phase (with code context):
 ```
 Domain: Displaying posts from followed users
+Existing: Card component (src/components/ui/Card.tsx), useInfiniteQuery hook, Tailwind CSS
 Gray areas:
-- UI: Layout style (cards vs timeline vs grid)
-- UI: Information density (full posts vs previews)
-- Behavior: Loading pattern (infinite scroll vs pagination)
-- Empty State: What shows when no posts exist
+- UI: Layout style (cards vs timeline vs grid) — Card component exists with shadow/rounded variants
+- UI: Information density (full posts vs previews) — no existing density patterns
+- Behavior: Loading pattern (infinite scroll vs pagination) — useInfiniteQuery already set up
+- Empty State: What shows when no posts exist — EmptyState component exists in ui/
 - Content: What metadata displays (time, author, reactions count)
 ```
 </step>
@@ -208,17 +251,23 @@ We'll clarify HOW to implement this.
 - question: "Which areas do you want to discuss for [phase name]?"
 - options: Generate 3-4 phase-specific gray areas, each with:
   - "[Specific area]" (label) — concrete, not generic
-  - [1-2 questions this covers] (description)
+  - [1-2 questions this covers + code context annotation] (description)
   - **Highlight the recommended choice with brief explanation why**
+
+**Code context annotations:** When the scout found relevant existing code, annotate the gray area description:
+```
+☐ Layout style — Cards vs list vs timeline?
+  (You already have a Card component with shadow/rounded variants. Reusing it keeps the app consistent.)
+```
 
 **Do NOT include a "skip" or "you decide" option.** User ran this command to discuss — give them real choices.
 
-**Examples by domain:**
+**Examples by domain (with code context):**
 
 For "Post Feed" (visual feature):
 ```
-☐ Layout style — Cards vs list vs timeline? Information density?
-☐ Loading behavior — Infinite scroll or pagination? Pull to refresh?
+☐ Layout style — Cards vs list vs timeline? (Card component exists with variants)
+☐ Loading behavior — Infinite scroll or pagination? (useInfiniteQuery hook available)
 ☐ Content ordering — Chronological, algorithmic, or user choice?
 ☐ Post metadata — What info per post? Timestamps, reactions, author?
 ```
@@ -260,7 +309,15 @@ Ask 4 questions per area before offering to continue or move on. Each answer oft
    - header: "[Area]" (max 12 chars — abbreviate if needed)
    - question: Specific decision for this area
    - options: 2-3 concrete choices (AskUserQuestion adds "Other" automatically), with the recommended choice highlighted and brief explanation why
+   - **Annotate options with code context** when relevant:
+     ```
+     "How should posts be displayed?"
+     - Cards (reuses existing Card component — consistent with Messages)
+     - List (simpler, would be a new pattern)
+     - Timeline (needs new Timeline component — none exists yet)
+     ```
    - Include "You decide" as an option when reasonable — captures Claude discretion
+   - **Context7 for library choices:** When a gray area involves library selection (e.g., "magic links" → query next-auth docs) or API approach decisions, use `mcp__context7__*` tools to fetch current documentation and inform the options. Don't use Context7 for every question — only when library-specific knowledge improves the options.
 
 3. **After 4 questions, check:**
    - header: "[Area]" (max 12 chars)
@@ -343,6 +400,20 @@ mkdir -p ".planning/phases/${padded_phase}-${phase_slug}"
 [Areas where user said "you decide" — note that Claude has flexibility here]
 
 </decisions>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+- [Component/hook/utility]: [How it could be used in this phase]
+
+### Established Patterns
+- [Pattern]: [How it constrains/enables this phase]
+
+### Integration Points
+- [Where new code connects to existing system]
+
+</code_context>
 
 <specifics>
 ## Specific Ideas
@@ -529,11 +600,13 @@ Route to `confirm_creation` step (existing behavior — show manual next steps).
 
 <success_criteria>
 - Phase validated against roadmap
-- Gray areas identified through intelligent analysis (not generic questions)
+- Codebase scouted for reusable assets, patterns, and integration points
+- Gray areas identified through intelligent analysis with code context annotations
 - User selected which areas to discuss
-- Each selected area explored until user satisfied
+- Each selected area explored until user satisfied (with code-informed options)
 - Scope creep redirected to deferred ideas
 - CONTEXT.md captures actual decisions, not vague vision
+- CONTEXT.md includes code_context section with reusable assets and patterns
 - Deferred ideas preserved for future phases
 - STATE.md updated with session info
 - User knows next steps

--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -99,10 +99,18 @@ Execute each wave in sequence. Within a wave: parallel if `PARALLELIZATION=true`
    Pass paths only — executors read files themselves with their fresh 200k context.
    This keeps orchestrator context lean (~10-15%).
 
+   **Worktree isolation (when configured):**
+   When `parallelization.isolation` is `"worktree"` AND there are multiple plans in the current wave,
+   add `isolation: "worktree"` to the Task call. This gives each executor an isolated copy of the repo,
+   preventing lint-staged cross-contamination and file conflicts between parallel agents.
+
+   Single-plan waves do NOT need isolation (no parallel conflict possible).
+
    ```
    Task(
      subagent_type="gsd-executor",
      model="{executor_model}",
+     isolation: (ISOLATION === "worktree" && wave_plan_count > 1) ? "worktree" : undefined,
      prompt="
        <objective>
        Execute plan {plan_number} of phase {phase_number}-{phase_name}.
@@ -136,7 +144,25 @@ Execute each wave in sequence. Within a wave: parallel if `PARALLELIZATION=true`
    )
    ```
 
-3. **Wait for all agents in wave to complete.**
+3. **Merge worktree branches (if isolation was used):**
+
+   When `parallelization.isolation` is `"worktree"` AND multiple agents ran in the wave,
+   each agent's work lives on a separate branch in a temporary worktree. After all agents
+   in the wave complete, merge their branches back:
+
+   ```bash
+   # For each completed worktree agent that returned a branch name:
+   for branch in $WAVE_BRANCHES; do
+     git merge "$branch" --no-edit
+   done
+   ```
+
+   If a merge conflict occurs (should not happen when plan-checker enforces no file overlap):
+   - Report the conflicting files to the user
+   - Ask: "Resolve manually?" or "Abort wave?"
+   - Do NOT auto-resolve — file ownership violation indicates a planning error
+
+3.5. **Wait for all agents in wave to complete.**
 
 4. **Report completion — spot-check claims first:**
 

--- a/get-shit-done/workflows/plan-phase.md
+++ b/get-shit-done/workflows/plan-phase.md
@@ -63,6 +63,58 @@ Use AskUserQuestion:
 If "Continue without context": Proceed to step 5.
 If "Run discuss-phase first": Display `/gsd:discuss-phase {X}` and exit workflow.
 
+## 4.5. Generate Integration Map
+
+**Purpose:** Scan the codebase for integration points BEFORE planning. Produces a concrete table of "to add feature X, wire into Y at Z" that prevents orphaned code.
+
+**Skip if:** `--gaps` flag (gap closure already knows what to wire).
+
+**Check for existing map:**
+```bash
+ls "${PHASE_DIR}"/*-INTEGRATION-MAP.md 2>/dev/null
+```
+
+**If exists and no `--research` flag:** Use existing, skip to step 5.
+
+**If missing OR `--research` flag:**
+
+Display: `◆ Scanning codebase for integration points...`
+
+Run targeted greps to identify integration points relevant to the phase goal. Use terms from the phase goal/description to focus the scan.
+
+```bash
+# 1. Entry points — routing files, page files, layout files
+grep -rl "Route\|router\|page\|layout" src/ app/ --include="*.ts" --include="*.tsx" --include="*.js" --include="*.jsx" 2>/dev/null | head -10
+
+# 2. Registration points — nav configs, provider wrappers, barrel exports
+grep -rl "nav\|menu\|sidebar\|provider\|Provider\|export \*\|export {" src/ --include="*.ts" --include="*.tsx" 2>/dev/null | head -10
+
+# 3. Data flow — state stores, DB schema, API client
+grep -rl "createContext\|useContext\|zustand\|prisma\|schema\|model \|api/" src/ prisma/ --include="*.ts" --include="*.tsx" --include="*.prisma" 2>/dev/null | head -10
+
+# 4. Type connections — types relevant to phase goal keywords
+grep -rl "type \|interface \|export type" src/ --include="*.ts" --include="*.tsx" 2>/dev/null | head -10
+```
+
+**Filter by relevance:** Only include files related to the phase goal. Read the top 5-8 most relevant files to extract specific integration instructions.
+
+**Write Integration Map** using template from `~/.claude/get-shit-done/templates/integration-map.md`:
+
+```bash
+# Write to phase directory
+INTEGRATION_MAP_PATH="${PHASE_DIR}/${PADDED_PHASE}-INTEGRATION-MAP.md"
+```
+
+**Commit (if commit_docs):**
+```bash
+node ~/.claude/get-shit-done/bin/gsd-tools.cjs commit "docs(${PADDED_PHASE}): generate integration map" --files "${INTEGRATION_MAP_PATH}"
+```
+
+**Store path for later steps:**
+```bash
+INTEGRATION_MAP_PATH="${PHASE_DIR}/${PADDED_PHASE}-INTEGRATION-MAP.md"
+```
+
 ## 5. Handle Research
 
 **Skip if:** `--gaps` flag, `--skip-research` flag, or `research_enabled` is false (from init) without `--research` override.
@@ -199,6 +251,7 @@ Planner prompt:
 - {requirements_path} (Requirements)
 - {context_path} (USER DECISIONS from /gsd:discuss-phase)
 - {research_path} (Technical Research)
+- {integration_map_path} (Integration Map — wiring targets for new code)
 - {verification_path} (Verification Gaps - if --gaps)
 - {uat_path} (UAT Gaps - if --gaps)
 </files_to_read>
@@ -266,6 +319,7 @@ Checker prompt:
 - {requirements_path} (Requirements)
 - {context_path} (USER DECISIONS from /gsd:discuss-phase)
 - {research_path} (Technical Research — includes Validation Architecture)
+- {integration_map_path} (Integration Map — verify wiring coverage)
 </files_to_read>
 
 **Phase requirement IDs (MUST ALL be covered):** {phase_req_ids}
@@ -466,6 +520,7 @@ Verification: {Passed | Passed with override | Skipped}
 - [ ] Phase validated against roadmap
 - [ ] Phase directory created if needed
 - [ ] CONTEXT.md loaded early (step 4) and passed to ALL agents
+- [ ] Integration Map generated (step 4.5) and passed to planner + checker
 - [ ] Research completed (unless --skip-research or --gaps or exists)
 - [ ] gsd-phase-researcher spawned with CONTEXT.md
 - [ ] Existing plans checked


### PR DESCRIPTION
## Summary

Three targeted improvements to GSD's discuss → plan → execute → verify pipeline, each addressing a specific gap observed during real-world usage:

- **Wiring-First Planning** — prevents orphaned code by making integration instructions mandatory in plans
- **Code-Aware Discuss Phase** — grounds user decisions in what the codebase already has
- **Worktree Isolation** — eliminates parallel execution conflicts (lint-staged cross-contamination, file collisions)

---

## Phase 1: Wiring-First Planning (Correctness Fix)

### The Problem

Planner creates tasks like *"Create FeedItem component that displays a post"* — but never specifies WHERE it gets imported. The component gets built, passes its own checks, but is never wired into the app. Verifier catches this post-execution, triggering gap-closure cycles that burn context.

### The Solution

**Integration Map** — New pre-planning artifact (`{phase}-INTEGRATION-MAP.md`) that scans the codebase for concrete wiring targets BEFORE the planner runs. The plan-phase orchestrator greps for entry points, registration points, data flow endpoints, and type connections, then passes this map to the planner.

**Wiring Line Rule** — Every task action that creates a new file MUST include at least one explicit wiring instruction:

```
BAD:  "Create FeedItem component that displays a post."

GOOD: "Create src/components/feed/FeedItem.tsx that displays a post.
       Import: User type from src/types/user.ts
       Wire into: src/app/(main)/feed/page.tsx imports and renders <FeedItem>"
```

**Blocker Severity** — Plan-checker Dimension 4 escalated from `warning` to `blocker`. Unwired plans cannot proceed to execution. This catches the problem at the cheapest possible point in the pipeline.

### Files Changed (Phase 1)

| File | Change |
|------|--------|
| `get-shit-done/workflows/plan-phase.md` | Integration Map generation step + pass to planner/checker |
| `agents/gsd-planner.md` | `<wiring_protocol>` section with Wiring Line Rule |
| `agents/gsd-plan-checker.md` | Dimension 4 → blocker + orphan detection + worktree guard |
| `agents/gsd-verifier.md` | Load Integration Map in Step 1 |
| `get-shit-done/templates/integration-map.md` | **NEW** — template with generation protocol |

---

## Phase 2: Code-Aware Discuss Phase (UX Enhancement)

### The Problem

Discuss phase generates gray areas from ROADMAP.md text only. Users choose between options like "Cards vs list vs timeline?" without knowing they already HAVE a Card component with shadow/rounded variants. This leads to decisions that miss reuse opportunities or contradict established patterns.

### The Solution

**Code-Scout Step** — Lightweight codebase scan (~10% context) inserted between `check_existing` and `analyze_phase`. Checks for existing codebase maps first (`.planning/codebase/*.md`), falls back to targeted greps for phase-relevant terms. Identifies reusable assets, established patterns, and integration points.

**Code-Informed Gray Areas** — Gray areas now include code context annotations:

```
Before: "Layout style — Cards vs list vs timeline?"
After:  "Layout style — Cards vs list vs timeline?
         (You already have a Card component with shadow/rounded variants.
          Reusing it keeps the app consistent.)"
```

**Code Context in CONTEXT.md** — New `<code_context>` section captures reusable assets, established patterns, and integration points. This flows directly to researcher and planner, giving them concrete files to reference.

**Context7 Integration** — `mcp__context7__*` tools added to discuss-phase for library-choice gray areas. When discussing "magic links vs passwords?", the orchestrator can query next-auth docs in real-time.

### Files Changed (Phase 2)

| File | Change |
|------|--------|
| `get-shit-done/workflows/discuss-phase.md` | Scout step + code-informed gray areas + Context7 usage |
| `get-shit-done/templates/context.md` | `<code_context>` section |
| `commands/gsd/discuss-phase.md` | `mcp__context7__*` in allowed-tools + updated process steps |

---

## Phase 3: Worktree Isolation for Parallel Execution

### The Problem

Parallel executor agents share a git working tree. When Agent A stages files for commit, Agent B's lint-staged hooks pick up Agent A's changes. File writes can collide. This was documented as a real-world issue during civic-test-2025 development.

### The Solution

**Config Option** — `parallelization.isolation: "worktree"` in config.json. Default `"none"` preserves current behavior.

**Isolated Execution** — When worktree mode is active and a wave has multiple plans, execute-phase adds `isolation: "worktree"` to Task calls. Each executor gets an isolated copy of the repo via Claude Code's built-in worktree support.

**File Overlap Guard** — Plan-checker blocks plans in the same wave that share `files_modified` entries (blocker severity in worktree mode). Prevents merge conflicts.

**Post-Wave Merge** — After all agents in a wave complete, worktree branches merge back sequentially. Conflict detection routes to user (shouldn't happen with the overlap guard).

### Files Changed (Phase 3)

| File | Change |
|------|--------|
| `get-shit-done/templates/config.json` | `parallelization.isolation` field |
| `get-shit-done/workflows/execute-phase.md` | Isolation param + post-wave merge logic |
| `agents/gsd-plan-checker.md` | File overlap guard in Dimension 3 |
| `get-shit-done/bin/lib/init.cjs` | Return `isolation` setting |
| `get-shit-done/references/planning-config.md` | Full documentation |

---

## Design Principles

1. **Fix at the cheapest point** — Wiring errors caught at plan-check (minutes) not verification (hours)
2. **No new agents** — Code-scout is a workflow step using existing tools. Integration Map is generated by the orchestrator. Zero new subagent types.
3. **Opt-in isolation** — Worktree mode is behind a config flag. Existing behavior unchanged unless explicitly enabled.
4. **Pipeline-native** — Every change flows through the existing discuss → plan → execute → verify pipeline. No new workflow stages or commands.

## Impact Summary

| Improvement | Mechanism | What it prevents |
|------------|-----------|------------------|
| Wiring-First Planning | Integration Map + Wiring Line Rule + Blocker severity | Orphaned code → gap-closure context burn |
| Code-Aware Discuss | Code-scout + annotated gray areas + code_context | Decisions that ignore existing code |
| Worktree Isolation | `isolation: "worktree"` + file overlap guard + post-wave merge | lint-staged cross-contamination + file collisions |

## Test Plan

- [ ] Run `/gsd:plan-phase` — verify Integration Map generated, planner includes "Wire into" lines, checker blocks unwired plans
- [ ] Run `/gsd:discuss-phase` on a project with existing code — verify scout finds components, gray areas show code context
- [ ] Run `/gsd:execute-phase` with 2+ parallel plans and `isolation: "worktree"` — verify isolated execution and clean merge
- [ ] Verify backward compatibility — all changes are additive, no existing behavior altered without new config

🤖 Generated with [Claude Code](https://claude.com/claude-code)