### PR TITLE
fix: map requirements-completed frontmatter in summary-extract

### DIFF
--- a/get-shit-done/bin/lib/commands.cjs
+++ b/get-shit-done/bin/lib/commands.cjs
@@ -304,6 +304,7 @@ function cmdSummaryExtract(cwd, summaryPath, fields, raw) {
     tech_added: (fm['tech-stack'] && fm['tech-stack'].added) || [],
     patterns: fm['patterns-established'] || [],
     decisions: parseDecisions(fm['key-decisions']),
+    requirements_completed: fm['requirements-completed'] || [],
   };
 
   // If fields specified, filter to only those fields

--- a/tests/commands.test.cjs
+++ b/tests/commands.test.cjs
@@ -303,6 +303,9 @@ patterns-established:
 key-decisions:
   - Use Prisma over Drizzle: Better DX and ecosystem
   - Single database: Start simple, shard later
+requirements-completed:
+  - AUTH-01
+  - AUTH-02
 ---
 
 # Summary
@@ -321,6 +324,7 @@ Full summary content here.
     assert.deepStrictEqual(output.tech_added, ['prisma', 'zod'], 'tech added extracted');
     assert.deepStrictEqual(output.patterns, ['Repository pattern', 'Dependency injection'], 'patterns extracted');
     assert.strictEqual(output.decisions.length, 2, 'decisions extracted');
+    assert.deepStrictEqual(output.requirements_completed, ['AUTH-01', 'AUTH-02'], 'requirements completed extracted');
   });
 
   test('selective extraction with --fields', () => {
@@ -340,16 +344,19 @@ patterns-established:
   - Repository pattern
 key-decisions:
   - Use Prisma: Better DX
+requirements-completed:
+  - AUTH-01
 ---
 `
     );
 
-    const result = runGsdTools('summary-extract .planning/phases/01-foundation/01-01-SUMMARY.md --fields one_liner,key_files', tmpDir);
+    const result = runGsdTools('summary-extract .planning/phases/01-foundation/01-01-SUMMARY.md --fields one_liner,key_files,requirements_completed', tmpDir);
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
     assert.strictEqual(output.one_liner, 'Set up database', 'one_liner included');
     assert.deepStrictEqual(output.key_files, ['prisma/schema.prisma'], 'key_files included');
+    assert.deepStrictEqual(output.requirements_completed, ['AUTH-01'], 'requirements_completed included');
     assert.strictEqual(output.tech_added, undefined, 'tech_added excluded');
     assert.strictEqual(output.patterns, undefined, 'patterns excluded');
     assert.strictEqual(output.decisions, undefined, 'decisions excluded');
@@ -378,6 +385,7 @@ one-liner: Minimal summary
     assert.deepStrictEqual(output.tech_added, [], 'tech_added defaults to empty');
     assert.deepStrictEqual(output.patterns, [], 'patterns defaults to empty');
     assert.deepStrictEqual(output.decisions, [], 'decisions defaults to empty');
+    assert.deepStrictEqual(output.requirements_completed, [], 'requirements_completed defaults to empty');
   });
 
   test('parses key-decisions with rationale', () => {


### PR DESCRIPTION
## Summary
- Map SUMMARY frontmatter `requirements-completed` → `requirements_completed` in `summary-extract`
- Default to empty array when field is missing
- Test coverage for full extraction, `--fields requirements_completed`, and missing-field defaults

## Why
`/gsd:audit-milestone` step 5c relies on `summary-extract --fields requirements_completed`. Without this mapping, the SUMMARY source in the 3-source cross-check silently contributes no data.

## Replaces #631
PR #631 by @Solvely-Colin had the correct fix but couldn't rebase cleanly — `gsd-tools.cjs` was split into `lib/commands.cjs` and `gsd-tools.test.cjs` was split into `tests/commands.test.cjs` on main. This PR re-applies the same logic against the refactored codebase.

Closes #627

## Validation
- `node --test tests/commands.test.cjs` → 22 passing, 0 failing

## Credit
Original fix by @Solvely-Colin in #631.

🤖 Generated with [Claude Code](https://claude.com/claude-code)