### PR TITLE
Fix /gsd:update to always install latest package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - `gsd-tools state-snapshot` supports `--cwd <path>` so tooling can target a project directory when invoked from outside the repo
 - `/gsd:update` now installs with `npx get-shit-done-cc@latest` (instead of unpinned `npx get-shit-done-cc`) to prevent stale project-local versions from shadowing updates
+- `/gsd:update` now uses strict package safety checks: only `get-shit-done-cc` is allowed, scoped/user-derived package names are rejected, and install command execution is allowlisted to trusted forms
+- `/gsd:update` install detection now validates local integrity and falls back to global install when local metadata is missing or invalid
 
 ## [1.20.6] - 2025-02-23
 

--- a/get-shit-done/workflows/update.md
+++ b/get-shit-done/workflows/update.md
@@ -9,16 +9,21 @@ Read all files referenced by the invoking prompt's execution_context before star
 <process>
 
 <step name="get_installed_version">
-Detect whether GSD is installed locally or globally by checking both locations:
+Detect whether GSD is installed locally or globally by checking both locations and validating install integrity:
 
 ```bash
-# Check local first (takes priority)
+# Check local first (takes priority only if valid)
 # Paths templated at install time for runtime compatibility
-if [ -f ./.claude/get-shit-done/VERSION ]; then
-  cat ./.claude/get-shit-done/VERSION
+LOCAL_VERSION_FILE="./.claude/get-shit-done/VERSION"
+LOCAL_MARKER_FILE="./.claude/get-shit-done/workflows/update.md"
+GLOBAL_VERSION_FILE="$HOME/.claude/get-shit-done/VERSION"
+GLOBAL_MARKER_FILE="$HOME/.claude/get-shit-done/workflows/update.md"
+
+if [ -f "$LOCAL_VERSION_FILE" ] && [ -f "$LOCAL_MARKER_FILE" ] && grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+' "$LOCAL_VERSION_FILE"; then
+  cat "$LOCAL_VERSION_FILE"
   echo "LOCAL"
-elif [ -f ~/.claude/get-shit-done/VERSION ]; then
-  cat ~/.claude/get-shit-done/VERSION
+elif [ -f "$GLOBAL_VERSION_FILE" ] && [ -f "$GLOBAL_MARKER_FILE" ] && grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+' "$GLOBAL_VERSION_FILE"; then
+  cat "$GLOBAL_VERSION_FILE"
   echo "GLOBAL"
 else
   echo "UNKNOWN"
@@ -26,8 +31,8 @@ fi
 ```
 
 Parse output:
-- If last line is "LOCAL": installed version is first line, use `--local` flag for update
-- If last line is "GLOBAL": installed version is first line, use `--global` flag for update
+- If last line is "LOCAL": local install is valid; installed version is first line; use `--local`
+- If last line is "GLOBAL": local missing/invalid, global install is valid; installed version is first line; use `--global`
 - If "UNKNOWN": proceed to install step (treat as version 0.0.0)
 
 **If VERSION file missing:**


### PR DESCRIPTION
## Summary
Rebased version of #620 by @Solvely-Colin (closes #619).

- Pin `/gsd:update` install commands to `npx -y get-shit-done-cc@latest` to prevent stale project-local versions from shadowing updates
- Add strict package safety checks: only `get-shit-done-cc` allowed, scoped/user-derived names rejected
- Install detection validates local integrity and falls back to global when metadata is missing/invalid

Supersedes #620 (rebased to resolve CHANGELOG conflicts with main).

Co-authored-by: Colin <colin@solvely.net>