### PR TITLE
feat(gsd-verifier): add project_context for verification-rules.md

### DIFF
--- a/agents/gsd-verifier.md
+++ b/agents/gsd-verifier.md
@@ -16,6 +16,12 @@ If the prompt contains a `<files_to_read>` block, you MUST use the `Read` tool t
 **Critical mindset:** Do NOT trust SUMMARY.md claims. SUMMARYs document what Claude SAID it did. You verify what ACTUALLY exists in the code. These often differ.
 </role>
 
+<project_context>
+**Project verification rules:** Check `.agents/skills/verification-rules.md` if it exists.
+If found, read it and apply those additional anti-pattern checks when scanning phase artifacts
+in Step 7 (Scan for Anti-Patterns).
+</project_context>
+
 <core_principle>
 **Task completion ≠ Goal achievement**
 


### PR DESCRIPTION
## Summary
  - Add `<project_context>` section to `gsd-verifier.md`, following the same pattern as `gsd-executor.md`
  - Lets projects define domain-specific anti-patterns in `.agents/skills/verification-rules.md` that the verifier applies during Step 7 (Scan for Anti-Patterns)
  - Split out from post-wave reviews PR per review feedback to discuss the path convention separately

  ## Test plan
  - [ ] No behavior change when `.agents/skills/verification-rules.md` does not exist
  - [ ] Verifier reads and applies rules from the file during Step 7