### PR TITLE
feat: wiring-first planning with integration maps

### DIFF
--- a/agents/gsd-plan-checker.md
+++ b/agents/gsd-plan-checker.md
@@ -171,38 +171,84 @@ issue:
   fix_hint: "Plan 02 depends on 03, but 03 depends on 02"
 ```
 
-## Dimension 4: Key Links Planned
+## Dimension 4: Key Links & Wiring
 
 **Question:** Are artifacts wired together, not just created in isolation?
 
 **Process:**
 1. Identify artifacts in `must_haves.artifacts`
 2. Check that `must_haves.key_links` connects them
-3. Verify tasks actually implement the wiring (not just artifact creation)
+3. **Verify tasks include explicit wiring instructions** (Wire into / Import from / Connect to lines)
+4. If Integration Map exists, verify its entries are addressed in task actions
+5. Check for orphaned files in `files_modified` that aren't imported/used by any other task
+
+**Wiring Line Check (BLOCKING):**
+
+Every task action that creates a new file MUST include at least one of:
+- `Wire into:` — where the artifact is consumed
+- `Import from:` — types/modules the artifact needs
+- `Connect to:` — data flow connections
+
+A task action that creates `src/components/Feed.tsx` without any wiring line is a **blocker** — the component will be orphaned.
 
 **Red flags:**
-- Component created but not imported anywhere
-- API route created but component doesn't call it
+- Component created but no "Wire into" line specifying where it renders → **blocker**
+- API route created but no task has "Connect to" referencing it → **blocker**
+- `key_link` in must_haves without a corresponding wiring instruction in any task action → **blocker**
 - Database model created but API doesn't query it
 - Form created but submit handler is missing or stub
 
+**Integration Map Cross-Reference:**
+
+If `{phase}-INTEGRATION-MAP.md` exists in the verification context:
+1. For each entry in the Integration Map, check if a task action addresses it
+2. Unaddressed Integration Map entries → **warning** (the entry may not be relevant to all plans)
+
+**Orphan Detection:**
+
+For each file in `files_modified` across all plans:
+1. Check if any other task action references importing or using this file
+2. Files that appear in `files_modified` but are never referenced by another task's action → **warning** (potential orphan)
+
 **What to check:**
 ```
-Component -> API: Does action mention fetch/axios call?
-API -> Database: Does action mention Prisma/query?
-Form -> Handler: Does action mention onSubmit implementation?
-State -> Render: Does action mention displaying state?
+Component -> API: Does action include "Connect to: /api/..." or "Wire into: ...fetch..."?
+API -> Database: Does action include "Connect to: prisma..." or mention query?
+Form -> Handler: Does action include "Connect to: onSubmit handler"?
+State -> Render: Does action include "Wire into: ...renders state..."?
 ```
 
-**Example issue:**
+**Example issues:**
 ```yaml
 issue:
   dimension: key_links_planned
-  severity: warning
-  description: "Chat.tsx created but no task wires it to /api/chat"
+  severity: blocker
+  description: "Task creates src/components/Chat.tsx but has no wiring line — component will be orphaned"
+  plan: "01"
+  task: 2
+  fix_hint: "Add 'Wire into: src/app/chat/page.tsx — import and render <Chat>' to task action"
+
+issue:
+  dimension: key_links_planned
+  severity: blocker
+  description: "key_link Chat.tsx -> /api/chat has no corresponding wiring instruction in any task"
   plan: "01"
   artifacts: ["src/components/Chat.tsx", "src/app/api/chat/route.ts"]
-  fix_hint: "Add fetch call in Chat.tsx action or create wiring task"
+  fix_hint: "Add 'Connect to: /api/chat via fetch in useEffect' to Chat.tsx task action"
+
+issue:
+  dimension: key_links_planned
+  severity: warning
+  description: "Integration Map entry 'Nav config registration' not addressed by any task"
+  plan: null
+  fix_hint: "Add nav registration step to a task action or confirm it's not needed for this plan"
+
+issue:
+  dimension: key_links_planned
+  severity: warning
+  description: "src/utils/format.ts in files_modified but not imported by any other task"
+  plan: "02"
+  fix_hint: "Add import reference in consuming task or verify it's used by existing code"
 ```
 
 ## Dimension 5: Scope Sanity
@@ -430,11 +476,13 @@ Orchestrator provides CONTEXT.md content in the verification prompt. If provided
 ls "$phase_dir"/*-PLAN.md 2>/dev/null
 # Read research for Nyquist validation data
 cat "$phase_dir"/*-RESEARCH.md 2>/dev/null
+# Read Integration Map for wiring verification
+cat "$phase_dir"/*-INTEGRATION-MAP.md 2>/dev/null
 node ~/.claude/get-shit-done/bin/gsd-tools.cjs roadmap get-phase "$phase_number"
 ls "$phase_dir"/*-BRIEF.md 2>/dev/null
 ```
 
-**Extract:** Phase goal, requirements (decompose goal), locked decisions, deferred ideas.
+**Extract:** Phase goal, requirements (decompose goal), locked decisions, deferred ideas, integration map entries (if exists).
 
 ## Step 2: Load All Plans
 
@@ -530,15 +578,31 @@ done
 
 Validate: all referenced plans exist, no cycles, wave numbers consistent, no forward references. If A -> B -> C -> A, report cycle.
 
-## Step 7: Check Key Links
+## Step 7: Check Key Links & Wiring
 
-For each key_link in must_haves: find source artifact task, check if action mentions the connection, flag missing wiring.
+**7a. Wiring Line Check:**
+For each task that creates a new file (check `<files>` for new paths):
+- Scan `<action>` for wiring lines: `Wire into:`, `Import from:`, `Connect to:`
+- If no wiring line found → **blocker** issue
+
+**7b. Key Link Check:**
+For each key_link in must_haves: find source artifact task, check if action includes a corresponding wiring instruction, flag missing wiring as **blocker**.
 
 ```
 key_link: Chat.tsx -> /api/chat via fetch
+Task 2 action: "Create Chat component... Connect to: /api/chat via fetch in useEffect"
+✓ Wiring planned
+
+key_link: Chat.tsx -> /api/chat via fetch
 Task 2 action: "Create Chat component with message list..."
-Missing: No mention of fetch/API call → Issue: Key link not planned
+✗ No wiring instruction → blocker
 ```
+
+**7c. Integration Map Cross-Reference (if exists):**
+Load `{phase}-INTEGRATION-MAP.md`. For each entry, check if any task action addresses it. Unaddressed entries → **warning**.
+
+**7d. Orphan Detection:**
+Collect all files from `files_modified` across all plans. For each file, check if any other task's `<action>` references importing or using it. Unreferenced files → **warning**.
 
 ## Step 8: Assess Scope
 
@@ -627,11 +691,14 @@ issue:
 - Missing required task fields
 - Circular dependencies
 - Scope > 5 tasks per plan
+- New file created without wiring line in task action
+- key_link without corresponding wiring instruction
 
 **warning** - Should fix, execution may work
 - Scope 4 tasks (borderline)
 - Implementation-focused truths
-- Minor wiring missing
+- Integration Map entry unaddressed
+- Orphaned file in files_modified (not imported by any other task)
 
 **info** - Suggestions for improvement
 - Could split for better parallelization

--- a/agents/gsd-planner.md
+++ b/agents/gsd-planner.md
@@ -575,6 +575,53 @@ must_haves:
 
 </goal_backward>
 
+<wiring_protocol>
+
+## The Wiring Line Rule
+
+**Every task action that creates a new file MUST include at least one explicit wiring instruction.** This prevents orphaned code — files that exist but aren't imported, rendered, or connected anywhere.
+
+### Required Wiring Lines
+
+Task actions that create new files must include one or more of:
+
+- **`Wire into:`** — Specifies the exact file and mechanism where this artifact is consumed
+- **`Import from:`** — Specifies types, utilities, or modules this artifact needs
+- **`Connect to:`** — Specifies data flow connections (API calls, store subscriptions, event handlers)
+
+### Example Transformation
+
+```
+BAD:  "Create FeedItem component that displays a post."
+
+GOOD: "Create src/components/feed/FeedItem.tsx that displays a post.
+       Import from: src/types/user.ts (User type), src/types/post.ts (Post type)
+       Wire into: src/app/(main)/feed/page.tsx — import and render <FeedItem> in feed list
+       Connect to: /api/posts — fetch post data via useEffect on mount"
+```
+
+### Integration Map Usage
+
+If an Integration Map exists (`{phase}-INTEGRATION-MAP.md`), use its entries as wiring targets:
+
+1. **Entry Points** → your component/page wires into these routes
+2. **Registration Points** → your feature registers in these configs
+3. **Data Flow** → your code connects to these stores/APIs
+4. **Type Connections** → your code imports these types (don't redefine)
+
+### Self-Check Before Returning
+
+After creating all plans, verify:
+
+- [ ] Every artifact in `must_haves.artifacts` has a "Wire into" line in a task action
+- [ ] Every `key_link` in `must_haves.key_links` has a corresponding wiring instruction in a task action
+- [ ] No artifact is created without being imported/used somewhere (no orphans)
+- [ ] If Integration Map exists, every relevant entry has a corresponding task action
+
+**If self-check fails:** Fix the plan before returning. Add missing wiring lines to task actions or create additional wiring tasks.
+
+</wiring_protocol>
+
 <checkpoints>
 
 ## Checkpoint Types

--- a/agents/gsd-verifier.md
+++ b/agents/gsd-verifier.md
@@ -57,11 +57,14 @@ Set `is_re_verification = false`, proceed with Step 1.
 ```bash
 ls "$PHASE_DIR"/*-PLAN.md 2>/dev/null
 ls "$PHASE_DIR"/*-SUMMARY.md 2>/dev/null
+cat "$PHASE_DIR"/*-INTEGRATION-MAP.md 2>/dev/null
 node ~/.claude/get-shit-done/bin/gsd-tools.cjs roadmap get-phase "$PHASE_NUM"
 grep -E "^| $PHASE_NUM" .planning/REQUIREMENTS.md 2>/dev/null
 ```
 
 Extract phase goal from ROADMAP.md — this is the outcome to verify, not the tasks.
+
+**Integration Map:** If `{phase}-INTEGRATION-MAP.md` exists, load it as an additional verification reference. In Step 5 (Key Links), cross-check that every integration point from the map was addressed in the codebase. Unaddressed integration points should be flagged as gaps.
 
 ## Step 2: Establish Must-Haves (Initial Mode Only)
 

--- a/get-shit-done/bin/lib/init.cjs
+++ b/get-shit-done/bin/lib/init.cjs
@@ -137,6 +137,10 @@ function cmdInitPlanPhase(cwd, phase, raw) {
       if (uatFile) {
         result.uat_path = path.join(phaseInfo.directory, uatFile);
       }
+      const integrationMapFile = files.find(f => f.endsWith('-INTEGRATION-MAP.md') || f === 'INTEGRATION-MAP.md');
+      if (integrationMapFile) {
+        result.integration_map_path = path.join(phaseInfo.directory, integrationMapFile);
+      }
     } catch {}
   }
 
@@ -419,6 +423,10 @@ function cmdInitPhaseOp(cwd, phase, raw) {
       const uatFile = files.find(f => f.endsWith('-UAT.md') || f === 'UAT.md');
       if (uatFile) {
         result.uat_path = path.join(phaseInfo.directory, uatFile);
+      }
+      const integrationMapFile = files.find(f => f.endsWith('-INTEGRATION-MAP.md') || f === 'INTEGRATION-MAP.md');
+      if (integrationMapFile) {
+        result.integration_map_path = path.join(phaseInfo.directory, integrationMapFile);
       }
     } catch {}
   }

--- a/get-shit-done/templates/integration-map.md
+++ b/get-shit-done/templates/integration-map.md
@@ -1,0 +1,81 @@
+# Integration Map Template
+
+Template for `.planning/phases/XX-name/{phase_num}-INTEGRATION-MAP.md` — maps where new code must connect to existing codebase.
+
+**Purpose:** Ensure planners know exactly where to wire new features. Prevents orphaned code by making integration points explicit before planning.
+
+**Downstream consumers:**
+- `gsd-planner` — Uses integration points to write explicit "Wire into" instructions in task actions
+- `gsd-plan-checker` — Cross-references plan tasks against integration map entries
+- `gsd-verifier` — Validates that integration points were actually addressed
+
+---
+
+## File Template
+
+```markdown
+# Phase [X]: [Name] - Integration Map
+
+**Generated:** [date]
+**Phase Goal:** [goal from ROADMAP.md]
+
+## Entry Points
+
+Where users/system reach this feature:
+
+| Entry Point | File | Type | How to Wire |
+|-------------|------|------|-------------|
+| [Route/page] | [file path] | routing/page/layout | [Add route, import component, etc.] |
+
+## Registration Points
+
+Where new code must register itself to be discovered:
+
+| Registration | File | Mechanism | How to Wire |
+|-------------|------|-----------|-------------|
+| [Nav item, provider, export] | [file path] | [config array, wrapper, barrel export] | [Add entry, wrap component, export from index] |
+
+## Data Flow
+
+Where data enters, transforms, and persists:
+
+| Endpoint | File | Direction | How to Wire |
+|----------|------|-----------|-------------|
+| [Store/API/DB] | [file path] | [read/write/both] | [Import store, call API, add model] |
+
+## Type Connections
+
+Existing types the phase should import (not redefine):
+
+| Type | Defined In | Used For | Import As |
+|------|-----------|----------|-----------|
+| [TypeName] | [file path] | [purpose] | [import statement] |
+
+---
+
+*Phase: XX-name*
+*Integration map generated: [date]*
+```
+
+<guidelines>
+**Each row = one wiring instruction for the planner.**
+
+The map answers: "To add feature X, wire into Y at Z."
+
+**Good entries (actionable):**
+- Entry: "Dashboard page" | `src/app/dashboard/page.tsx` | page | "Import and render `<NewWidget>` in grid"
+- Registration: "Nav config" | `src/config/navigation.ts` | config array | "Add `{ label: 'Feature', href: '/feature', icon: Icon }` to `navItems`"
+- Type: "User" | `src/types/user.ts` | author display | `import type { User } from '@/types/user'`
+
+**Bad entries (vague):**
+- "Add to the app somewhere"
+- "Connect to database"
+- "Use existing types"
+
+**Generation protocol:**
+1. Grep for routing files, page files, layout files → Entry Points
+2. Grep for nav configs, provider wrappers, barrel exports → Registration Points
+3. Grep for state stores, DB schema, API client → Data Flow
+4. Grep for type definitions relevant to phase goal → Type Connections
+5. Only include entries relevant to this phase's goal — not every file in the codebase
+</guidelines>

--- a/get-shit-done/workflows/plan-phase.md
+++ b/get-shit-done/workflows/plan-phase.md
@@ -60,8 +60,60 @@ Use AskUserQuestion:
   - "Continue without context" — Plan using research + requirements only
   - "Run discuss-phase first" — Capture design decisions before planning
 
-If "Continue without context": Proceed to step 5.
+If "Continue without context": Proceed to step 4.5.
 If "Run discuss-phase first": Display `/gsd:discuss-phase {X}` and exit workflow.
+
+## 4.5. Generate Integration Map
+
+**Purpose:** Scan the codebase for integration points BEFORE planning. Produces a concrete table of "to add feature X, wire into Y at Z" that prevents orphaned code.
+
+**Skip if:** `--gaps` flag (gap closure already knows what to wire).
+
+**Check for existing map:**
+```bash
+ls "${PHASE_DIR}"/*-INTEGRATION-MAP.md 2>/dev/null
+```
+
+**If exists and no `--research` flag:** Use existing, skip to step 5.
+
+**If missing OR `--research` flag:**
+
+Display: `◆ Scanning codebase for integration points...`
+
+Run targeted greps to discover file PATHS relevant to the phase goal. Only collect paths — keep orchestrator context lean (~10-15%).
+
+```bash
+# 1. Entry points — routing files, page files, layout files
+grep -rl "Route\|router\|page\|layout" src/ app/ --include="*.ts" --include="*.tsx" --include="*.js" --include="*.jsx" 2>/dev/null | head -10
+
+# 2. Registration points — nav configs, provider wrappers, barrel exports
+grep -rl "nav\|menu\|sidebar\|provider\|Provider\|export \*\|export {" src/ --include="*.ts" --include="*.tsx" 2>/dev/null | head -10
+
+# 3. Data flow — state stores, DB schema, API client
+grep -rl "createContext\|useContext\|zustand\|prisma\|schema\|model \|api/" src/ prisma/ --include="*.ts" --include="*.tsx" --include="*.prisma" 2>/dev/null | head -10
+
+# 4. Type connections — types relevant to phase goal keywords
+grep -rl "type \|interface \|export type" src/ --include="*.ts" --include="*.tsx" 2>/dev/null | head -10
+```
+
+**Filter by relevance:** Only include files related to the phase goal.
+
+**Write skeleton Integration Map** using template from `~/.claude/get-shit-done/templates/integration-map.md`. Populate the tables with discovered file paths and set "How to Wire" to TBD — the planner will fill in wiring details when reading the referenced files with its fresh 200k context.
+
+```bash
+# Write to phase directory
+INTEGRATION_MAP_PATH="${PHASE_DIR}/${PADDED_PHASE}-INTEGRATION-MAP.md"
+```
+
+**Commit (if commit_docs):**
+```bash
+node ~/.claude/get-shit-done/bin/gsd-tools.cjs commit "docs(${PADDED_PHASE}): generate integration map" --files "${INTEGRATION_MAP_PATH}"
+```
+
+**Store path for later steps:**
+```bash
+INTEGRATION_MAP_PATH="${PHASE_DIR}/${PADDED_PHASE}-INTEGRATION-MAP.md"
+```
 
 ## 5. Handle Research
 
@@ -199,6 +251,7 @@ Planner prompt:
 - {requirements_path} (Requirements)
 - {context_path} (USER DECISIONS from /gsd:discuss-phase)
 - {research_path} (Technical Research)
+- {integration_map_path} (Integration Map — wiring targets for new code)
 - {verification_path} (Verification Gaps - if --gaps)
 - {uat_path} (UAT Gaps - if --gaps)
 </files_to_read>
@@ -266,6 +319,7 @@ Checker prompt:
 - {requirements_path} (Requirements)
 - {context_path} (USER DECISIONS from /gsd:discuss-phase)
 - {research_path} (Technical Research — includes Validation Architecture)
+- {integration_map_path} (Integration Map — verify wiring coverage)
 </files_to_read>
 
 **Phase requirement IDs (MUST ALL be covered):** {phase_req_ids}
@@ -466,6 +520,7 @@ Verification: {Passed | Passed with override | Skipped}
 - [ ] Phase validated against roadmap
 - [ ] Phase directory created if needed
 - [ ] CONTEXT.md loaded early (step 4) and passed to ALL agents
+- [ ] Integration Map generated (step 4.5) and passed to planner + checker
 - [ ] Research completed (unless --skip-research or --gaps or exists)
 - [ ] gsd-phase-researcher spawned with CONTEXT.md
 - [ ] Existing plans checked

--- a/tests/init.test.cjs
+++ b/tests/init.test.cjs
@@ -97,6 +97,47 @@ describe('init commands', () => {
     assert.strictEqual(output.context_path, undefined);
     assert.strictEqual(output.research_path, undefined);
   });
+
+  test('init plan-phase discovers integration map when present', () => {
+    const phaseDir = path.join(tmpDir, '.planning', 'phases', '03-api');
+    fs.mkdirSync(phaseDir, { recursive: true });
+    fs.writeFileSync(path.join(phaseDir, '03-INTEGRATION-MAP.md'), '# Integration Map');
+
+    const result = runGsdTools('init plan-phase 03', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(
+      output.integration_map_path.replace(/\\/g, '/'),
+      '.planning/phases/03-api/03-INTEGRATION-MAP.md'
+    );
+  });
+
+  test('init plan-phase omits integration_map_path when file missing', () => {
+    const phaseDir = path.join(tmpDir, '.planning', 'phases', '03-api');
+    fs.mkdirSync(phaseDir, { recursive: true });
+
+    const result = runGsdTools('init plan-phase 03', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.integration_map_path, undefined);
+  });
+
+  test('init phase-op discovers integration map when present', () => {
+    const phaseDir = path.join(tmpDir, '.planning', 'phases', '03-api');
+    fs.mkdirSync(phaseDir, { recursive: true });
+    fs.writeFileSync(path.join(phaseDir, '03-INTEGRATION-MAP.md'), '# Integration Map');
+
+    const result = runGsdTools('init phase-op 03', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(
+      output.integration_map_path.replace(/\\/g, '/'),
+      '.planning/phases/03-api/03-INTEGRATION-MAP.md'
+    );
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Adds integration map generation (Step 4.5) to plan-phase workflow — scans codebase for entry points, registration points, data flow, and type connections before planning
- **Structural fix**: `init.cjs` now discovers `INTEGRATION-MAP.md` files in `cmdInitPlanPhase()` and `cmdInitPhaseOp()` (was missing from #712, causing `{integration_map_path}` to always be empty)
- Planner enforces wiring protocol: every new file must include `Wire into:`, `Import from:`, or `Connect to:` lines
- Plan-checker Dimension 4 upgraded from "Key Links Planned" to "Key Links & Wiring" with blocker severity for unwired artifacts

## Why split from #712

This PR extracts wiring-first planning from #712 (which combined 3 concepts). The key structural fix — `integration_map_path` discovery in `init.cjs` — was missing from the original PR, which would have made the integration map invisible to downstream agents.

## Files changed (7)

| File | Change |
|------|--------|
| `get-shit-done/bin/lib/init.cjs` | **Structural fix**: add INTEGRATION-MAP.md discovery |
| `get-shit-done/workflows/plan-phase.md` | New Step 4.5: integration map generation |
| `agents/gsd-planner.md` | Wiring protocol with Wire into/Import from/Connect to |
| `agents/gsd-plan-checker.md` | Dimension 4: wiring line check, orphan detection, integration map cross-ref |
| `agents/gsd-verifier.md` | Integration map cross-check in verification |
| `get-shit-done/templates/integration-map.md` | New template file |
| `tests/init.test.cjs` | Tests for integration_map_path discovery |

## Shared file note

`gsd-plan-checker.md` is also touched by the worktree isolation PR (#3), but in a different section (Dimension 3 vs Dimension 4). Clean merge if this lands first.

## Test plan

- [x] `init plan-phase` discovers integration map when present
- [x] `init plan-phase` omits integration_map_path when file missing
- [x] `init phase-op` discovers integration map when present
- [ ] Run `/gsd:plan-phase` — verify integration map generated
- [ ] Verify planner includes wiring lines in task actions
- [ ] Verify checker blocks plans with unwired artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)