### PR TITLE
feat: worktree isolation for parallel execution

### DIFF
--- a/agents/gsd-executor.md
+++ b/agents/gsd-executor.md
@@ -51,6 +51,21 @@ If STATE.md missing but .planning/ exists: offer to reconstruct or continue with
 If .planning/ missing: Error — project not initialized.
 </step>
 
+<step name="detect_worktree">
+Check if running in a git worktree:
+
+```bash
+COMMON_DIR=$(git rev-parse --git-common-dir 2>/dev/null)
+GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
+if [ "$COMMON_DIR" != "$GIT_DIR" ] && [ "$COMMON_DIR" != "." ]; then
+  IS_WORKTREE=true
+  WORKTREE_BRANCH=$(git branch --show-current)
+fi
+```
+
+If in worktree: note branch name, all commits go to worktree branch, do NOT switch branches.
+</step>
+
 <step name="load_plan">
 Read the plan file provided in your prompt context.
 
@@ -441,6 +456,7 @@ Separate from per-task commits — captures execution results only.
 ## PLAN COMPLETE
 
 **Plan:** {phase}-{plan}
+**Branch:** {WORKTREE_BRANCH if in worktree, otherwise omit}
 **Tasks:** {completed}/{total}
 **SUMMARY:** {path to SUMMARY.md}
 

--- a/agents/gsd-plan-checker.md
+++ b/agents/gsd-plan-checker.md
@@ -161,6 +161,27 @@ issue:
 - `depends_on: ["01"]` = Wave 2 minimum (must wait for 01)
 - Wave number = max(deps) + 1
 
+**Worktree Isolation File Overlap Guard:**
+
+Check if `parallelization.isolation` is `"worktree"` in `.planning/config.json`:
+
+```bash
+node ~/.claude/get-shit-done/bin/gsd-tools.cjs config-get parallelization.isolation 2>/dev/null || echo "none"
+```
+
+**If `"worktree"`:** Plans in the same wave MUST NOT share `files_modified` entries. Each executor gets an isolated git worktree — file overlaps within a wave would cause merge conflicts.
+
+For each wave, collect all `files_modified` from plans in that wave. If any file appears in multiple plans within the same wave → **blocker** (move overlapping plan to a later wave).
+
+```yaml
+issue:
+  dimension: dependency_correctness
+  severity: blocker
+  description: "Plans 01 and 02 (both Wave 1) share files_modified entry 'src/types/index.ts' — will conflict in worktree mode"
+  plans: ["01", "02"]
+  fix_hint: "Move plan 02 to Wave 2 with depends_on: ['01'], or consolidate shared file into one plan"
+```
+
 **Example issue:**
 ```yaml
 issue:
@@ -627,6 +648,7 @@ issue:
 - Missing required task fields
 - Circular dependencies
 - Scope > 5 tasks per plan
+- Same-wave file overlap in worktree mode
 
 **warning** - Should fix, execution may work
 - Scope 4 tasks (borderline)

--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -88,7 +88,10 @@ function loadConfig(cwd) {
     const parallelization = (() => {
       const val = get('parallelization');
       if (typeof val === 'boolean') return val;
-      if (typeof val === 'object' && val !== null && 'enabled' in val) return val.enabled;
+      if (typeof val === 'object' && val !== null) {
+        if ('enabled' in val && !val.enabled) return false;
+        return val;  // Preserve full object with sub-fields like isolation
+      }
       return defaults.parallelization;
     })();
 

--- a/get-shit-done/bin/lib/init.cjs
+++ b/get-shit-done/bin/lib/init.cjs
@@ -43,6 +43,9 @@ function cmdInitExecutePhase(cwd, phase, raw) {
     plan_count: phaseInfo?.plans?.length || 0,
     incomplete_count: phaseInfo?.incomplete_plans?.length || 0,
 
+    // Isolation mode
+    isolation: config.parallelization?.isolation || 'none',
+
     // Branch name (pre-computed)
     branch_name: config.branching_strategy === 'phase' && phaseInfo
       ? config.phase_branch_template

--- a/get-shit-done/references/planning-config.md
+++ b/get-shit-done/references/planning-config.md
@@ -193,4 +193,54 @@ Squash merge is recommended — keeps main branch history clean while preserving
 
 </branching_strategy_behavior>
 
+<parallelization_isolation>
+
+**Worktree Isolation for Parallel Execution:**
+
+When multiple executor agents run in parallel (same wave), they share the same git working tree by default. This can cause:
+- Lint-staged picking up changes from other agents
+- File write conflicts between concurrent agents
+- Test runners seeing partial changes from parallel work
+
+**Configuration:**
+
+```json
+"parallelization": {
+  "enabled": true,
+  "plan_level": true,
+  "isolation": "worktree",
+  "max_concurrent_agents": 3
+}
+```
+
+| Value | Behavior |
+|-------|----------|
+| `"none"` (default) | All agents share the same working tree (current behavior) |
+| `"worktree"` | Each parallel agent gets an isolated git worktree via Claude Code's `isolation: "worktree"` Task parameter |
+
+**How it works:**
+
+1. Plan-checker enforces no `files_modified` overlap between plans in the same wave (blocker severity)
+2. Execute-phase adds `isolation: "worktree"` to Task calls when spawning multiple agents in a wave
+3. Each agent works in an isolated copy of the repo
+4. After wave completes, worktree branches are merged back sequentially
+5. If merge conflict occurs (shouldn't with file overlap guard), user is prompted
+
+**Requirements:**
+- Git repository (worktrees require git)
+- Plans in same wave must NOT share `files_modified` entries
+- Sufficient disk space for temporary worktree copies
+
+**When to use:**
+- Projects with lint-staged or pre-commit hooks that scan all staged files
+- Large phases with 3+ parallel plans modifying many files
+- When experiencing flaky parallel execution due to file conflicts
+
+**When NOT to use:**
+- Single-plan waves (no benefit, adds overhead)
+- Small projects where parallel conflicts are rare
+- Non-git projects
+
+</parallelization_isolation>
+
 </planning_config>

--- a/get-shit-done/templates/config.json
+++ b/get-shit-done/templates/config.json
@@ -18,7 +18,8 @@
     "task_level": false,
     "skip_checkpoints": true,
     "max_concurrent_agents": 3,
-    "min_plans_for_parallel": 2
+    "min_plans_for_parallel": 2,
+    "isolation": "none"
   },
   "gates": {
     "confirm_project": true,

--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -99,10 +99,18 @@ Execute each wave in sequence. Within a wave: parallel if `PARALLELIZATION=true`
    Pass paths only — executors read files themselves with their fresh 200k context.
    This keeps orchestrator context lean (~10-15%).
 
+   **Worktree isolation (when configured):**
+   When `parallelization.isolation` is `"worktree"` AND there are multiple plans in the current wave,
+   add `isolation: "worktree"` to the Task call. This gives each executor an isolated copy of the repo,
+   preventing lint-staged cross-contamination and file conflicts between parallel agents.
+
+   Single-plan waves do NOT need isolation (no parallel conflict possible).
+
    ```
    Task(
      subagent_type="gsd-executor",
      model="{executor_model}",
+     isolation: (ISOLATION === "worktree" && wave_plan_count > 1) ? "worktree" : undefined,
      prompt="
        <objective>
        Execute plan {plan_number} of phase {phase_number}-{phase_name}.
@@ -137,6 +145,27 @@ Execute each wave in sequence. Within a wave: parallel if `PARALLELIZATION=true`
    ```
 
 3. **Wait for all agents in wave to complete.**
+
+   Store each Task result. When `isolation: "worktree"` was used,
+   the result includes the worktree branch name for post-wave merging.
+
+3.5. **Merge worktree branches (if isolation was used):**
+
+   When `parallelization.isolation` is `"worktree"` AND multiple agents ran in the wave,
+   each agent's work lives on a separate branch in a temporary worktree. After all agents
+   in the wave complete, merge their branches back:
+
+   ```bash
+   # For each completed worktree agent that returned a branch name:
+   for branch in $WAVE_BRANCHES; do
+     git merge "$branch" --no-edit
+   done
+   ```
+
+   If a merge conflict occurs (should not happen when plan-checker enforces no file overlap):
+   - Report the conflicting files to the user
+   - Ask: "Resolve manually?" or "Abort wave?"
+   - Do NOT auto-resolve — file ownership violation indicates a planning error
 
 4. **Report completion — spot-check claims first:**
 

--- a/tests/init.test.cjs
+++ b/tests/init.test.cjs
@@ -97,6 +97,87 @@ describe('init commands', () => {
     assert.strictEqual(output.context_path, undefined);
     assert.strictEqual(output.research_path, undefined);
   });
+  test('init execute-phase returns isolation mode from config', () => {
+    const phaseDir = path.join(tmpDir, '.planning', 'phases', '03-api');
+    fs.mkdirSync(phaseDir, { recursive: true });
+    fs.writeFileSync(path.join(phaseDir, '03-01-PLAN.md'), '# Plan');
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'config.json'), JSON.stringify({
+      parallelization: { enabled: true, plan_level: true, isolation: 'worktree' }
+    }));
+
+    const result = runGsdTools('init execute-phase 03', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.isolation, 'worktree');
+  });
+
+  test('init execute-phase defaults isolation to none', () => {
+    const phaseDir = path.join(tmpDir, '.planning', 'phases', '03-api');
+    fs.mkdirSync(phaseDir, { recursive: true });
+    fs.writeFileSync(path.join(phaseDir, '03-01-PLAN.md'), '# Plan');
+
+    const result = runGsdTools('init execute-phase 03', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.isolation, 'none');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// loadConfig parallelization preservation
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('loadConfig parallelization', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('preserves parallelization object with isolation sub-field', () => {
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'config.json'), JSON.stringify({
+      parallelization: { enabled: true, plan_level: true, isolation: 'worktree' }
+    }));
+
+    const result = runGsdTools('init execute-phase 03', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    // parallelization should be the full object, not coerced to boolean
+    assert.strictEqual(typeof output.parallelization, 'object');
+    assert.strictEqual(output.parallelization.isolation, 'worktree');
+    assert.strictEqual(output.parallelization.enabled, true);
+  });
+
+  test('returns false when parallelization.enabled is false', () => {
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'config.json'), JSON.stringify({
+      parallelization: { enabled: false, isolation: 'worktree' }
+    }));
+
+    const result = runGsdTools('init execute-phase 03', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.parallelization, false);
+  });
+
+  test('preserves boolean true/false unchanged', () => {
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'config.json'), JSON.stringify({
+      parallelization: true
+    }));
+
+    const result = runGsdTools('init execute-phase 03', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.parallelization, true);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **Structural fix**: `loadConfig()` in `core.cjs` was coercing parallelization objects to booleans, dropping sub-fields like `isolation`. Now preserves the full object when `enabled` is truthy, returns `false` when `enabled` is false, and handles plain booleans unchanged.
- Execute-phase workflow passes `isolation: "worktree"` to Task calls when configured and wave has multiple plans
- **Step ordering fix**: wait for agents to complete FIRST, then merge worktree branches (original PR had merge before wait)
- Executor detects worktree environment and reports branch name in completion format
- Plan-checker enforces no `files_modified` overlap between same-wave plans in worktree mode (blocker severity)

## Why split from #712

This PR extracts worktree isolation from #712 (which combined 3 concepts). The critical structural fix — `loadConfig()` dropping the `isolation` sub-field — would have made worktree mode silently non-functional. Additionally, the original PR merged branches before waiting for agents to complete, which would race.

## Files changed (8)

| File | Change |
|------|--------|
| `get-shit-done/bin/lib/core.cjs` | **Structural fix**: preserve parallelization object sub-fields |
| `get-shit-done/bin/lib/init.cjs` | Expose isolation field in execute-phase init |
| `get-shit-done/workflows/execute-phase.md` | Worktree isolation param + step ordering fix |
| `agents/gsd-executor.md` | **New**: worktree detection step + branch in completion |
| `agents/gsd-plan-checker.md` | Dimension 3: worktree file overlap guard |
| `get-shit-done/templates/config.json` | Add isolation field |
| `get-shit-done/references/planning-config.md` | Document isolation options |
| `tests/init.test.cjs` | Tests for config preservation and isolation field |

## Shared file note

`gsd-plan-checker.md` is also touched by the wiring-first planning PR (#728), but in a different section (Dimension 3 vs Dimension 4). Clean merge if #728 lands first.

## Test plan

- [x] `loadConfig()` with parallelization object preserves `.isolation`
- [x] `loadConfig()` with `enabled: false` returns `false`
- [x] `loadConfig()` with boolean `true`/`false` unchanged
- [x] `init execute-phase` returns isolation mode from config
- [x] `init execute-phase` defaults isolation to `"none"`
- [ ] Run `/gsd:execute-phase` with `isolation: "worktree"` — verify isolation param passed, branches merged after wait

🤖 Generated with [Claude Code](https://claude.com/claude-code)