### PR TITLE
fix: phase-plan-index canonical format — 3 field extraction bugs

### DIFF
--- a/get-shit-done/bin/lib/phase.cjs
+++ b/get-shit-done/bin/lib/phase.cjs
@@ -192,6 +192,11 @@ function cmdFindPhase(cwd, phase, raw) {
   }
 }
 
+function extractObjective(content) {
+  const m = content.match(/<objective>\s*\n?\s*(.+)/);
+  return m ? m[1].trim() : null;
+}
+
 function cmdPhasePlanIndex(cwd, phase, raw) {
   if (!phase) {
     error('phase required for phase-plan-index');
@@ -241,9 +246,10 @@ function cmdPhasePlanIndex(cwd, phase, raw) {
     const content = fs.readFileSync(planPath, 'utf-8');
     const fm = extractFrontmatter(content);
 
-    // Count tasks (## Task N patterns)
-    const taskMatches = content.match(/##\s*Task\s*\d+/gi) || [];
-    const taskCount = taskMatches.length;
+    // Count tasks: XML <task> tags (canonical) or ## Task N markdown (legacy)
+    const xmlTasks = content.match(/<task[\s>]/gi) || [];
+    const mdTasks = content.match(/##\s*Task\s*\d+/gi) || [];
+    const taskCount = xmlTasks.length || mdTasks.length;
 
     // Parse wave as integer
     const wave = parseInt(fm.wave, 10) || 1;
@@ -258,10 +264,11 @@ function cmdPhasePlanIndex(cwd, phase, raw) {
       hasCheckpoints = true;
     }
 
-    // Parse files-modified
+    // Parse files_modified (underscore is canonical; also accept hyphenated for compat)
     let filesModified = [];
-    if (fm['files-modified']) {
-      filesModified = Array.isArray(fm['files-modified']) ? fm['files-modified'] : [fm['files-modified']];
+    const fmFiles = fm['files_modified'] || fm['files-modified'];
+    if (fmFiles) {
+      filesModified = Array.isArray(fmFiles) ? fmFiles : [fmFiles];
     }
 
     const hasSummary = completedPlanIds.has(planId);
@@ -273,7 +280,7 @@ function cmdPhasePlanIndex(cwd, phase, raw) {
       id: planId,
       wave,
       autonomous,
-      objective: fm.objective || null,
+      objective: extractObjective(content) || fm.objective || null,
       files_modified: filesModified,
       task_count: taskCount,
       has_summary: hasSummary,


### PR DESCRIPTION
## Summary

- **files_modified**: code checked `fm['files-modified']` (hyphen) but canonical plans use `files_modified` (underscore). Now checks underscore first with hyphen fallback.
- **objective**: code read `fm.objective` from YAML frontmatter but canonical plans put objective in `<objective>` XML tag in the body. Now extracts first content line from the tag, falls back to frontmatter.
- **task_count**: code matched `## Task N` markdown headings but canonical plans use `<task>` XML tags. Now counts XML tags first, markdown headings as fallback.

All three fixes preserve backward compatibility with legacy markdown-style plans — existing tests (6) still pass alongside 4 new canonical-format tests.

## Test plan

- [x] TDD: stash fixes → write 4 red tests against buggy code → stash pop → all 4 green
- [x] Backward compat: all 6 existing `phase-plan-index` tests still pass
- [x] Full suite: `node --test tests/phase.test.cjs` — 10/10 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)