### PR TITLE
fix: align resolve-model variable names with template placeholders

### DIFF
--- a/commands/gsd/debug.md
+++ b/commands/gsd/debug.md
@@ -36,7 +36,7 @@ INIT=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs state load)
 
 Extract `commit_docs` from init JSON. Resolve debugger model:
 ```bash
-DEBUGGER_MODEL=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs resolve-model gsd-debugger --raw)
+debugger_model=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs resolve-model gsd-debugger --raw)
 ```
 
 ## 1. Check Active Sessions

--- a/get-shit-done/workflows/audit-milestone.md
+++ b/get-shit-done/workflows/audit-milestone.md
@@ -18,7 +18,7 @@ Extract from init JSON: `milestone_version`, `milestone_name`, `phase_count`, `c
 
 Resolve integration checker model:
 ```bash
-CHECKER_MODEL=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs resolve-model gsd-integration-checker --raw)
+integration_checker_model=$(node ~/.claude/get-shit-done/bin/gsd-tools.cjs resolve-model gsd-integration-checker --raw)
 ```
 
 ## 1. Determine Milestone Scope


### PR DESCRIPTION
## Summary

- In `commands/gsd/debug.md`, renamed `DEBUGGER_MODEL` → `debugger_model` to match the `{debugger_model}` placeholder used in Task calls
- In `get-shit-done/workflows/audit-milestone.md`, renamed `CHECKER_MODEL` → `integration_checker_model` to match the `{integration_checker_model}` placeholder used in Task calls

## Root Cause

Both workflows resolved the model via `resolve-model --raw` and stored the result in an uppercase bash-style variable (`DEBUGGER_MODEL`, `CHECKER_MODEL`). However, the downstream Task() calls referenced the model using lowercase template placeholder syntax (`{debugger_model}`, `{integration_checker_model}`). The name mismatch meant Claude couldn't reliably substitute the computed value — causing it to fall back to the parent session model regardless of the configured GSD profile.

## Test plan

- [ ] Run `/gsd:debug` with profile set to `budget` — verify gsd-debugger spawns with `haiku` instead of parent session model
- [ ] Run `/gsd:audit-milestone` with profile set to `budget` — verify gsd-integration-checker spawns with `haiku`
- [ ] Confirm `quality` and `balanced` profiles still use `inherit` for these agents (expected behaviour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)