### PR TITLE
fix: load model_overrides from config and use resolveModelInternal in CLI

### DIFF
--- a/get-shit-done/bin/lib/commands.cjs
+++ b/get-shit-done/bin/lib/commands.cjs
@@ -204,17 +204,12 @@ function cmdResolveModel(cwd, agentType, raw) {
 
   const config = loadConfig(cwd);
   const profile = config.model_profile || 'balanced';
+  const model = resolveModelInternal(cwd, agentType);
 
   const agentModels = MODEL_PROFILES[agentType];
-  if (!agentModels) {
-    const result = { model: 'sonnet', profile, unknown_agent: true };
-    output(result, raw, 'sonnet');
-    return;
-  }
-
-  const resolved = agentModels[profile] || agentModels['balanced'] || 'sonnet';
-  const model = resolved === 'opus' ? 'inherit' : resolved;
-  const result = { model, profile };
+  const result = agentModels
+    ? { model, profile }
+    : { model, profile, unknown_agent: true };
   output(result, raw, model);
 }
 

--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -104,6 +104,7 @@ function loadConfig(cwd) {
       verifier: get('verifier', { section: 'workflow', field: 'verifier' }) ?? defaults.verifier,
       parallelization,
       brave_search: get('brave_search') ?? defaults.brave_search,
+      model_overrides: parsed.model_overrides || null,
     };
   } catch {
     return defaults;


### PR DESCRIPTION
## Summary

- Added `model_overrides` to `loadConfig()` return object in `core.cjs` so `resolveModelInternal()` can actually read per-agent overrides from `config.json`
- Replaced duplicated model resolution logic in `cmdResolveModel` (`commands.cjs`) with a call to `resolveModelInternal`, which checks overrides before falling back to profile lookup

## Root Cause

`loadConfig()` never returned `model_overrides`, so `resolveModelInternal()` always got `undefined` for `config.model_overrides?.[agentType]`. Per-agent overrides configured in `.planning/config.json` were silently ignored.

Separately, `cmdResolveModel` (the `resolve-model` CLI command) duplicated the profile-based model lookup but skipped the override check entirely — so even if `loadConfig` had returned overrides, the CLI would still ignore them.

## Test plan

- [ ] Set `model_overrides: { "gsd-executor": "haiku" }` in `.planning/config.json`, run `node gsd-tools.cjs resolve-model gsd-executor --raw` — should return `haiku`
- [ ] Without overrides, confirm profile-based resolution still works correctly
- [ ] Confirm `init execute-phase` also respects overrides via `resolveModelInternal`

🤖 Generated with [Claude Code](https://claude.com/claude-code)