### PR TITLE
fix: load nyquist_validation from config

### DIFF
--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -69,6 +69,7 @@ function loadConfig(cwd) {
     research: true,
     plan_checker: true,
     verifier: true,
+    nyquist_validation: false,
     parallelization: true,
     brave_search: false,
   };
@@ -102,6 +103,7 @@ function loadConfig(cwd) {
       research: get('research', { section: 'workflow', field: 'research' }) ?? defaults.research,
       plan_checker: get('plan_checker', { section: 'workflow', field: 'plan_check' }) ?? defaults.plan_checker,
       verifier: get('verifier', { section: 'workflow', field: 'verifier' }) ?? defaults.verifier,
+      nyquist_validation: get('nyquist_validation', { section: 'workflow', field: 'nyquist_validation' }) ?? defaults.nyquist_validation,
       parallelization,
       brave_search: get('brave_search') ?? defaults.brave_search,
     };


### PR DESCRIPTION
## Summary

- Added `nyquist_validation` to `loadConfig()` defaults and return object in `core.cjs`
- Reads from top-level `nyquist_validation` or nested `workflow.nyquist_validation`, defaulting to `false`

## Root Cause

`loadConfig()` didn't return `nyquist_validation`, so `cmdInitPlanPhase` in `init.cjs:107` always got `undefined` for `config.nyquist_validation`. The `plan-phase` workflow couldn't detect whether Nyquist validation was enabled or disabled.

## Test plan

- [ ] Set `workflow.nyquist_validation: true` in `.planning/config.json`, run `init plan-phase` — verify `nyquist_validation_enabled` is `true`
- [ ] With default config (no setting), verify it defaults to `false`
- [ ] Run `/gsd:plan-phase` with Nyquist enabled — verify step 5.5 (validation strategy) executes

🤖 Generated with [Claude Code](https://claude.com/claude-code)