### PR TITLE
fix: escape regex metacharacters in stateExtractField

### DIFF
--- a/get-shit-done/bin/lib/state.cjs
+++ b/get-shit-done/bin/lib/state.cjs
@@ -150,7 +150,8 @@ function cmdStateUpdate(cwd, field, value) {
 // ─── State Progression Engine ────────────────────────────────────────────────
 
 function stateExtractField(content, fieldName) {
-  const pattern = new RegExp(`\\*\\*${fieldName}:\\*\\*\\s*(.+)`, 'i');
+  const escaped = fieldName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const pattern = new RegExp(`\\*\\*${escaped}:\\*\\*\\s*(.+)`, 'i');
   const match = content.match(pattern);
   return match ? match[1].trim() : null;
 }


### PR DESCRIPTION
## Summary

- Added regex escaping for `fieldName` in `stateExtractField` to match the pattern already used in `stateReplaceField`

## Root Cause

`stateReplaceField` properly escapes `fieldName` before building a regex (`fieldName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')`), but `stateExtractField` injected `fieldName` directly into the regex without escaping. This inconsistency could cause incorrect matches or regex errors if a field name ever contained metacharacters.

## Test plan

- [ ] Existing callers (`Current Plan`, `Total Plans in Phase`) continue to work
- [ ] Field names with special characters (if any) are handled safely

🤖 Generated with [Claude Code](https://claude.com/claude-code)