### PR TITLE
feat: add native openclaw runtime support in installer

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -990,7 +990,7 @@ function cleanupOrphanedHooks(settings) {
  */
 function uninstall(isGlobal, runtime = 'claude') {
   const isOpencode = runtime === 'opencode';
-  const isCodex = runtime === 'codex';
+  const isCodex = runtime === 'codex' || runtime === 'openclaw';
   const dirName = getDirName(runtime);
 
   // Get the target directory based on runtime and install type
@@ -1455,7 +1455,7 @@ function generateManifest(dir, baseDir) {
  */
 function writeManifest(configDir, runtime = 'claude') {
   const isOpencode = runtime === 'opencode';
-  const isCodex = runtime === 'codex';
+  const isCodex = runtime === 'codex' || runtime === 'openclaw';
   const gsdDir = path.join(configDir, 'get-shit-done');
   const commandsDir = path.join(configDir, 'commands', 'gsd');
   const opencodeCommandDir = path.join(configDir, 'command');


### PR DESCRIPTION
## Summary
- add `--openclaw` installer flag and include OpenClaw in runtime selection / `--all`
- map OpenClaw runtime to `.openclaw` and support `OPENCLAW_HOME` in global directory resolution
- route OpenClaw through codex-like skills install path
- add OpenClaw labels/commands in completion output and help text
- fix OpenClaw parity gaps in `uninstall()` and `writeManifest()` by treating it as codex-like

## Validation
- `node bin/install.js --openclaw --local`
- `node bin/install.js --openclaw --local --uninstall`
- `node bin/install.js --all --local`
- `npm test --silent` (115 pass, 0 fail)

## Notes
- changes are runtime-scoped and preserve behavior for claude/opencode/gemini/codex
