### PR TITLE
fix: resolve-model returns invalid 'inherit' value instead of 'opus'

### DIFF
--- a/get-shit-done/bin/lib/commands.cjs
+++ b/get-shit-done/bin/lib/commands.cjs
@@ -205,15 +205,8 @@ function cmdResolveModel(cwd, agentType, raw) {
   const config = loadConfig(cwd);
   const profile = config.model_profile || 'balanced';
 
-  const agentModels = MODEL_PROFILES[agentType];
-  if (!agentModels) {
-    const result = { model: 'sonnet', profile, unknown_agent: true };
-    output(result, raw, 'sonnet');
-    return;
-  }
-
-  const resolved = agentModels[profile] || agentModels['balanced'] || 'sonnet';
-  const model = resolved === 'opus' ? 'inherit' : resolved;
+  // Delegate to resolveModelInternal which handles overrides and all profile types
+  const model = resolveModelInternal(cwd, agentType);
   const result = { model, profile };
   output(result, raw, model);
 }

--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -347,15 +347,14 @@ function resolveModelInternal(cwd, agentType) {
   // Check per-agent override first
   const override = config.model_overrides?.[agentType];
   if (override) {
-    return override === 'opus' ? 'inherit' : override;
+    return override;
   }
 
   // Fall back to profile lookup
   const profile = config.model_profile || 'balanced';
   const agentModels = MODEL_PROFILES[agentType];
   if (!agentModels) return 'sonnet';
-  const resolved = agentModels[profile] || agentModels['balanced'] || 'sonnet';
-  return resolved === 'opus' ? 'inherit' : resolved;
+  return agentModels[profile] || agentModels['balanced'] || 'sonnet';
 }
 
 // ─── Misc utilities ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `resolveModelInternal()` converts `"opus"` → `"inherit"` at 2 return points in `core.cjs`
- `cmdResolveModel()` in `commands.cjs` has a 3rd instance of the same conversion
- `"inherit"` is **not a valid value** for the Task tool's `model` parameter (enum: `sonnet`, `opus`, `haiku`)
- When the orchestrator constructs `Task(model="inherit")`, it silently falls back to **sonnet** for every agent that should be running opus

### Impact

Any user with a profile that assigns `opus` to agents (quality profile, custom profile with `opus` roles, or per-agent overrides) gets **all those agents running on sonnet instead**. This burns through sonnet quota unexpectedly and degrades agent quality.

### Fix

- Remove the `opus → inherit` conversion — return actual model names directly
- Consolidate `cmdResolveModel` to delegate to `resolveModelInternal` instead of duplicating incomplete resolution logic (the standalone command was also missing custom profile and override support)

## Test plan

- [x] All 34 existing tests pass (`node --test tests/commands.test.cjs` + `tests/init.test.cjs`)
- [x] `gsd-tools.cjs resolve-model gsd-planner` returns `"opus"` on quality profile (was returning `"inherit"`)
- [x] `gsd-tools.cjs init quick "test"` returns valid enum values for all model fields
- [x] No remaining references to `"inherit"` in `bin/` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)