### PR TITLE
fix(milestone): scope stats and archive to current milestone phases

### DIFF
--- a/get-shit-done/bin/lib/milestone.cjs
+++ b/get-shit-done/bin/lib/milestone.cjs
@@ -92,7 +92,44 @@ function cmdMilestoneComplete(cwd, version, options, raw) {
   // Ensure archive directory exists
   fs.mkdirSync(archiveDir, { recursive: true });
 
-  // Gather stats from phases
+  // Extract milestone phase numbers from ROADMAP.md to scope stats.
+  // Only phases listed in the current ROADMAP are counted — phases from
+  // prior milestones that remain on disk are excluded.
+  //
+  // Related upstream PRs (getMilestoneInfo, not milestone complete):
+  //   #756 — fix(core): detect current milestone correctly in getMilestoneInfo
+  //   #783 — fix: getMilestoneInfo() returns wrong version after completion
+  // Those PRs fix *which* milestone is detected; this fix scopes *stats*
+  // and *accomplishments* to only the phases belonging to that milestone.
+  const milestonePhaseNums = new Set();
+  if (fs.existsSync(roadmapPath)) {
+    try {
+      const roadmapContent = fs.readFileSync(roadmapPath, 'utf-8');
+      const phasePattern = /#{2,4}\s*Phase\s+(\d+[A-Z]?(?:\.\d+)*)\s*:/gi;
+      let phaseMatch;
+      while ((phaseMatch = phasePattern.exec(roadmapContent)) !== null) {
+        milestonePhaseNums.add(phaseMatch[1]);
+      }
+    } catch {}
+  }
+
+  // Pre-normalize phase numbers for O(1) lookup — strip leading zeros
+  // and lowercase for case-insensitive matching of letter suffixes (e.g. 3A/3a).
+  const normalizedPhaseNums = new Set(
+    [...milestonePhaseNums].map(num => (num.replace(/^0+/, '') || '0').toLowerCase())
+  );
+
+  // Match a phase directory name to the milestone's phase set.
+  // Handles: "01-foo" → "1", "3A-bar" → "3a", "3.1-baz" → "3.1"
+  // Returns false for non-phase directories (no leading digit).
+  function isDirInMilestone(dirName) {
+    if (normalizedPhaseNums.size === 0) return true; // no scoping
+    const m = dirName.match(/^0*(\d+[A-Za-z]?(?:\.\d+)*)/);
+    if (!m) return false; // not a phase directory
+    return normalizedPhaseNums.has(m[1].toLowerCase());
+  }
+
+  // Gather stats from phases (scoped to current milestone only)
   let phaseCount = 0;
   let totalPlans = 0;
   let totalTasks = 0;
@@ -103,6 +140,8 @@ function cmdMilestoneComplete(cwd, version, options, raw) {
     const dirs = entries.filter(e => e.isDirectory()).map(e => e.name).sort();
 
     for (const dir of dirs) {
+      if (!isDirInMilestone(dir)) continue;
+
       phaseCount++;
       const phaseFiles = fs.readdirSync(path.join(phasesDir, dir));
       const plans = phaseFiles.filter(f => f.endsWith('-PLAN.md') || f === 'PLAN.md');
@@ -182,10 +221,13 @@ function cmdMilestoneComplete(cwd, version, options, raw) {
 
       const phaseEntries = fs.readdirSync(phasesDir, { withFileTypes: true });
       const phaseDirNames = phaseEntries.filter(e => e.isDirectory()).map(e => e.name);
+      let archivedCount = 0;
       for (const dir of phaseDirNames) {
+        if (!isDirInMilestone(dir)) continue;
         fs.renameSync(path.join(phasesDir, dir), path.join(phaseArchiveDir, dir));
+        archivedCount++;
       }
-      phasesArchived = phaseDirNames.length > 0;
+      phasesArchived = archivedCount > 0;
     } catch {}
   }
 


### PR DESCRIPTION
## Summary

`cmdMilestoneComplete` iterates all phase directories in `.planning/phases/` to gather stats (phase count, plan count, task count), extract accomplishments (one-liner frontmatter from summaries), and optionally archive phase directories with `--archive-phases`. **The bug is that it counts every phase directory on disk, not just the phases belonging to the current milestone.**

In projects that span multiple milestones without cleaning up old phase directories, this produces:
- **Inflated stats** — phase/plan/task counts include work from prior milestones
- **Stale accomplishments** — the MILESTONES.md entry lists accomplishments from milestones that already shipped
- **Overbroad archival** — `--archive-phases` moves ALL phase directories, including those from prior milestones

## Root Cause

The stats-gathering loop at line ~105 of `milestone.cjs` iterates every directory in `.planning/phases/` unconditionally:

```javascript
for (const dir of dirs) {
  phaseCount++;  // counts ALL directories
  // ...
}
```

There is no mechanism to determine which phases belong to the current milestone vs. prior ones.

## Fix

This PR adds milestone-scoped filtering by:

1. **Parsing ROADMAP.md** for phase headings (`### Phase N: Name`) to build a set of phase numbers belonging to the current milestone
2. **Pre-normalizing** phase numbers into a `Set` for O(1) lookup — stripping leading zeros and lowercasing letter suffixes
3. **Filtering** via an `isDirInMilestone(dirName)` helper that matches directory names against the milestone's phase set

The helper handles real-world naming conventions:
- Leading zeros: `01-foundation` → matches Phase 1
- Letter suffixes: `3A-hotfix` → matches Phase 3A
- Decimal phases: `3.1-sub-feature` → matches Phase 3.1
- Large numbers: `456-dacp` → matches Phase 456
- Non-phase directories: `notes/`, `misc/` → excluded (no leading digit)
- Prefix collision guard: Phase 1 does NOT match directory `10-something`

When no ROADMAP.md exists (graceful degradation), the filter passes all directories through — preserving backward compatibility.

The same `isDirInMilestone()` filter is applied to both the stats-gathering loop and the `--archive-phases` loop.

## Relationship to Other PRs

This fix complements #756 and #783 which fix `getMilestoneInfo()` in `core.cjs` (detecting *which* milestone is current). This PR fixes what happens *during* milestone completion — scoping the stats and archive operations to only the current milestone's phases. There is no code overlap or merge conflict.

## Testing

Adds 5 new tests:

| Test | What it verifies |
|------|------------------|
| `scopes stats to current milestone phases only` | Phases 3,4 counted; phases 1,2 from prior milestone excluded |
| `archive-phases only archives current milestone phases` | Phase 2 archived, phase 1 stays in place |
| `phase 1 does NOT match directory 10-something` | Prefix collision guard (1 ≠ 10) |
| `non-numeric directory excluded when scoping active` | `notes/` directory not counted as a phase |
| `large phase numbers (456, 457) scope correctly` | 3-digit phases work; phase 45 excluded |

All existing tests continue to pass. Full suite: 424 tests, 0 failures.

## Impact

- **Projects with clean phase dirs** — no change (filter passes all when ROADMAP defines all phases on disk)
- **Projects with leftover phases from prior milestones** — stats now accurately reflect only the current milestone
- **`--archive-phases` users** — only current milestone phases are moved; prior milestone phases remain undisturbed
- **No ROADMAP.md** — graceful fallback to existing behavior (all phases counted)