### PR TITLE
fix(milestone): insert MILESTONES.md entries in reverse chronological order

### DIFF
--- a/get-shit-done/bin/lib/milestone.cjs
+++ b/get-shit-done/bin/lib/milestone.cjs
@@ -150,7 +150,16 @@ function cmdMilestoneComplete(cwd, version, options, raw) {
 
   if (fs.existsSync(milestonesPath)) {
     const existing = fs.readFileSync(milestonesPath, 'utf-8');
-    fs.writeFileSync(milestonesPath, existing + '\n' + milestoneEntry, 'utf-8');
+    // Insert after the header line(s) for reverse chronological order (newest first)
+    const headerMatch = existing.match(/^(#{1,3}\s+[^\n]*\n\n?)/);
+    if (headerMatch) {
+      const header = headerMatch[1];
+      const rest = existing.slice(header.length);
+      fs.writeFileSync(milestonesPath, header + milestoneEntry + rest, 'utf-8');
+    } else {
+      // No recognizable header — prepend the entry
+      fs.writeFileSync(milestonesPath, milestoneEntry + existing, 'utf-8');
+    }
   } else {
     fs.writeFileSync(milestonesPath, `# Milestones\n\n${milestoneEntry}`, 'utf-8');
   }


### PR DESCRIPTION
## Summary

`cmdMilestoneComplete` appends new milestone entries at the **end** of `MILESTONES.md`. Over successive milestones, this produces chronological order (oldest first). The expected convention is **reverse chronological** — newest milestone at the top, matching patterns like CHANGELOG.md and git log.

## Root Cause

The existing code concatenates the new entry after the existing content:

```javascript
if (fs.existsSync(milestonesPath)) {
  const existing = fs.readFileSync(milestonesPath, 'utf-8');
  fs.writeFileSync(milestonesPath, existing + '\n' + milestoneEntry, 'utf-8');
}
```

This unconditionally appends, so after milestones v1.0 → v1.1 → v1.2, the file reads:
```
# Milestones
## v1.0 ...    ← oldest at top
## v1.1 ...
## v1.2 ...    ← newest buried at bottom
```

## Fix

This PR detects the file header (h1 through h3) using a regex and **inserts** the new entry immediately after it, pushing older entries down:

```javascript
const headerMatch = existing.match(/^(#{1,3}\s+[^\n]*\n\n?)/);
if (headerMatch) {
  const header = headerMatch[1];
  const rest = existing.slice(header.length);
  fs.writeFileSync(milestonesPath, header + milestoneEntry + rest, 'utf-8');
} else {
  // No recognizable header — prepend the entry
  fs.writeFileSync(milestonesPath, milestoneEntry + existing, 'utf-8');
}
```

After v1.0 → v1.1 → v1.2, the file now reads:
```
# Milestones
## v1.2 ...    ← newest at top
## v1.1 ...
## v1.0 ...    ← oldest at bottom
```

Edge cases handled:
- **No header line** — entry is prepended to the file
- **New file** — still uses `# Milestones\n\n` as the header (unchanged)
- **h1, h2, h3 headers** — regex matches `#{1,3}` to handle different MILESTONES.md formatting styles

## Testing

Updates 1 existing test and adds 1 new test:

| Test | What it verifies |
|------|------------------|
| `prepends to existing MILESTONES.md (reverse chronological)` | Updated from `appends` — asserts new entry appears before old entry in file |
| `three sequential completions maintain reverse-chronological order` | Runs 3 milestone completions (v1.0 pre-existing, v1.1, v1.2) and verifies file order is v1.2 < v1.1 < v1.0 |

All existing tests continue to pass. Full suite: 420 tests, 0 failures.

## Impact

- **New projects** — no visible change (first milestone creates the file normally)
- **Multi-milestone projects** — each `milestone complete` now places the newest entry at the top
- **Existing MILESTONES.md files** — the first completion after this fix will correctly insert at the top; existing entries remain in their current order (no reordering of history)
- **Backward compatibility** — the `# Milestones` default header and file creation logic are unchanged