### PR TITLE
fix: premature milestone complete when phases lack directories (#754)

### DIFF
--- a/get-shit-done/bin/lib/init.cjs
+++ b/get-shit-done/bin/lib/init.cjs
@@ -505,14 +505,29 @@ function cmdInitMilestoneOp(cwd, raw) {
   const config = loadConfig(cwd);
   const milestone = getMilestoneInfo(cwd);
 
-  // Count phases
+  // Count phases — use ROADMAP as source of truth, fall back to directories
   let phaseCount = 0;
   let completedPhases = 0;
   const phasesDir = path.join(cwd, '.planning', 'phases');
+
+  // First: count phases from ROADMAP (includes unplanned phases) (#754)
+  const roadmapPath = path.join(cwd, '.planning', 'ROADMAP.md');
+  let roadmapPhaseCount = 0;
+  if (fs.existsSync(roadmapPath)) {
+    try {
+      const roadmapContent = fs.readFileSync(roadmapPath, 'utf-8');
+      const phasePattern = /#{2,4}\s*Phase\s+\d+[A-Z]?(?:\.\d+)*\s*:/gi;
+      const matches = roadmapContent.match(phasePattern);
+      if (matches) roadmapPhaseCount = matches.length;
+    } catch {}
+  }
+
+  // Count directories and completed phases from disk
+  let dirCount = 0;
   try {
     const entries = fs.readdirSync(phasesDir, { withFileTypes: true });
     const dirs = entries.filter(e => e.isDirectory()).map(e => e.name);
-    phaseCount = dirs.length;
+    dirCount = dirs.length;
 
     // Count phases with summaries (completed)
     for (const dir of dirs) {
@@ -523,6 +538,9 @@ function cmdInitMilestoneOp(cwd, raw) {
       } catch {}
     }
   } catch {}
+
+  // Use the higher of ROADMAP count vs directory count
+  phaseCount = Math.max(roadmapPhaseCount, dirCount);
 
   // Check archive
   const archiveDir = path.join(cwd, '.planning', 'archive');

--- a/get-shit-done/bin/lib/phase.cjs
+++ b/get-shit-done/bin/lib/phase.cjs
@@ -783,7 +783,7 @@ function cmdPhaseComplete(cwd, phaseNum, raw) {
     }
   }
 
-  // Find next phase
+  // Find next phase — check directories first, then fall back to ROADMAP
   let nextPhaseNum = null;
   let nextPhaseName = null;
   let isLastPhase = true;
@@ -805,6 +805,24 @@ function cmdPhaseComplete(cwd, phaseNum, raw) {
       }
     }
   } catch {}
+
+  // If no next directory found, check ROADMAP for unplanned phases (#754)
+  // Phases listed in the ROADMAP may not have directories yet
+  if (isLastPhase && fs.existsSync(roadmapPath)) {
+    try {
+      const roadmapContent = fs.readFileSync(roadmapPath, 'utf-8');
+      const phasePattern = /#{2,4}\s*Phase\s+(\d+[A-Z]?(?:\.\d+)*)\s*:\s*([^\n]+)/gi;
+      let rmMatch;
+      while ((rmMatch = phasePattern.exec(roadmapContent)) !== null) {
+        if (comparePhaseNum(rmMatch[1], phaseNum) > 0) {
+          nextPhaseNum = rmMatch[1];
+          nextPhaseName = rmMatch[2].replace(/\(INSERTED\)/i, '').trim();
+          isLastPhase = false;
+          break;
+        }
+      }
+    } catch {}
+  }
 
   // Update STATE.md
   if (fs.existsSync(statePath)) {

--- a/tests/init.test.cjs
+++ b/tests/init.test.cjs
@@ -400,6 +400,45 @@ describe('cmdInitMilestoneOp', () => {
     assert.strictEqual(output.all_phases_complete, true);
   });
 
+  test('phase_count includes unplanned ROADMAP phases (#754)', () => {
+    // Bug #754: phase_count only counted directories, missing unplanned phases
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      `# Roadmap
+
+### Phase 8: Format Confirmation
+**Goal:** Confirm formatting
+
+### Phase 9: Rules Re-evaluation
+**Goal:** Re-evaluate rules
+
+### Phase 10: Structure Analysis
+**Goal:** Analyze structure
+
+### Phase 11: Final Review
+**Goal:** Final review
+`
+    );
+
+    // Only 2 of 4 phases have directories
+    const p8 = path.join(tmpDir, '.planning', 'phases', '08-format-confirmation');
+    fs.mkdirSync(p8, { recursive: true });
+    fs.writeFileSync(path.join(p8, '08-01-PLAN.md'), '# Plan');
+    fs.writeFileSync(path.join(p8, '08-01-SUMMARY.md'), '# Summary');
+    const p9 = path.join(tmpDir, '.planning', 'phases', '09-rules-re-evaluation');
+    fs.mkdirSync(p9, { recursive: true });
+    fs.writeFileSync(path.join(p9, '09-01-PLAN.md'), '# Plan');
+    fs.writeFileSync(path.join(p9, '09-01-SUMMARY.md'), '# Summary');
+
+    const result = runGsdTools('init milestone-op', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.phase_count, 4, 'should count all 4 ROADMAP phases, not just 2 directories');
+    assert.strictEqual(output.completed_phases, 2);
+    assert.strictEqual(output.all_phases_complete, false, 'should NOT be all complete — 2 of 4 phases done');
+  });
+
   test('archive directory scanning', () => {
     fs.mkdirSync(path.join(tmpDir, '.planning', 'archive', 'v1.0'), { recursive: true });
     fs.mkdirSync(path.join(tmpDir, '.planning', 'archive', 'v0.9'), { recursive: true });

--- a/tests/phase.test.cjs
+++ b/tests/phase.test.cjs
@@ -1037,6 +1037,61 @@ describe('phase complete command', () => {
     assert.ok(state.includes('Milestone complete'), 'status should be milestone complete');
   });
 
+  test('detects unplanned phases from ROADMAP — not last phase (#754)', () => {
+    // Bug #754: phases in ROADMAP but without directories were invisible,
+    // causing premature "milestone complete" after earlier phases
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      `# Roadmap
+
+- [ ] Phase 8: Format Confirmation
+- [ ] Phase 9: Rules Re-evaluation
+- [ ] Phase 10: Structure Analysis
+- [ ] Phase 11: Final Review
+
+### Phase 8: Format Confirmation
+**Goal:** Confirm formatting
+**Plans:** 1 plans
+
+### Phase 9: Rules Re-evaluation
+**Goal:** Re-evaluate rules
+
+### Phase 10: Structure Analysis
+**Goal:** Analyze structure
+
+### Phase 11: Final Review
+**Goal:** Final review
+`
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      `# State\n\n**Current Phase:** 09\n**Current Phase Name:** Rules Re-evaluation\n**Status:** In progress\n**Current Plan:** 09-01\n**Last Activity:** 2025-01-01\n**Last Activity Description:** Working on phase 9\n`
+    );
+
+    // Only phases 8 and 9 have directories — 10 and 11 are unplanned
+    const p8 = path.join(tmpDir, '.planning', 'phases', '08-format-confirmation');
+    fs.mkdirSync(p8, { recursive: true });
+    fs.writeFileSync(path.join(p8, '08-01-PLAN.md'), '# Plan');
+    fs.writeFileSync(path.join(p8, '08-01-SUMMARY.md'), '# Summary');
+
+    const p9 = path.join(tmpDir, '.planning', 'phases', '09-rules-re-evaluation');
+    fs.mkdirSync(p9, { recursive: true });
+    fs.writeFileSync(path.join(p9, '09-01-PLAN.md'), '# Plan');
+    fs.writeFileSync(path.join(p9, '09-01-SUMMARY.md'), '# Summary');
+
+    const result = runGsdTools('phase complete 9', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.is_last_phase, false, 'should NOT be last phase — phases 10-11 exist in ROADMAP');
+    assert.strictEqual(output.next_phase, '10', 'next phase should be 10 from ROADMAP');
+    assert.strictEqual(output.next_phase_name, 'Structure Analysis', 'next phase name from ROADMAP');
+
+    const state = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    assert.ok(state.includes('**Status:** Ready to plan'), 'status should be ready to plan, not milestone complete');
+    assert.ok(state.includes('**Current Phase:** 10'), 'should advance to phase 10');
+  });
+
   test('updates REQUIREMENTS.md traceability when phase completes', () => {
     fs.writeFileSync(
       path.join(tmpDir, '.planning', 'ROADMAP.md'),


### PR DESCRIPTION
## What

Fix `phase complete` and `init milestone-op` to check ROADMAP.md for phases that haven't been planned yet (no directories), preventing premature "milestone complete" status.

## Why

Phases defined in the ROADMAP but not yet planned have no `.planning/phases/` directory. Both commands only counted directories, so completing phase 9 of a 13-phase milestone would report "milestone complete" because phases 10-13 had no directories yet. Fixes #754.

## Testing

- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

**Regression tests added:**
- `phase complete`: 4-phase ROADMAP with only 2 directories — completing phase 9 correctly reports `is_last_phase: false` and `next_phase: 10`
- `init milestone-op`: 4-phase ROADMAP with 2 completed directories — correctly reports `phase_count: 4`, `all_phases_complete: false`

**Full suite:** 434/434 passing (432 existing + 2 new)

## Checklist

- [x] Follows GSD style (no enterprise patterns, no filler)
- [ ] Updates CHANGELOG.md for user-facing changes
- [x] No unnecessary dependencies added
- [x] Works on Windows (backslash paths tested)

## Breaking Changes

None