### PR TITLE
docs: add /gsd:add-tests to help, README, and user guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,6 +516,7 @@ You're never locked in. The system adapts.
 | `/gsd:add-todo [desc]` | Capture idea for later |
 | `/gsd:check-todos` | List pending todos |
 | `/gsd:debug [desc]` | Systematic debugging with persistent state |
+| `/gsd:add-tests <N> [instructions]` | Generate unit and E2E tests for completed phase |
 | `/gsd:quick [--full]` | Execute ad-hoc task with GSD guarantees (`--full` adds plan-checking and verification) |
 | `/gsd:health [--repair]` | Validate `.planning/` directory integrity, auto-repair with `--repair` |
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -202,6 +202,7 @@ rapid prototyping phases where test infrastructure isn't the focus.
 | `/gsd:check-todos` | List pending todos | Review captured ideas |
 | `/gsd:settings` | Configure workflow toggles and model profile | Change model, toggle agents |
 | `/gsd:set-profile <profile>` | Quick profile switch | Change cost/quality tradeoff |
+| `/gsd:add-tests <N> [instructions]` | Generate unit and E2E tests for completed phase | After execution, before milestone completion |
 | `/gsd:reapply-patches` | Restore local modifications after update | After `/gsd:update` if you had local edits |
 
 ---

--- a/get-shit-done/workflows/help.md
+++ b/get-shit-done/workflows/help.md
@@ -270,6 +270,20 @@ Validate built features through conversational UAT.
 
 Usage: `/gsd:verify-work 3`
 
+### Test Generation
+
+**`/gsd:add-tests <phase> [additional instructions]`**
+Generate unit and E2E tests for a completed phase.
+
+- Reads phase SUMMARY.md, CONTEXT.md, and VERIFICATION.md
+- Classifies changed files into TDD (unit), E2E (browser), or Skip
+- Presents classification for approval before generating
+- Runs tests after generation — flags bugs but doesn't fix them
+- Commits passing tests
+
+Usage: `/gsd:add-tests 3`
+Usage: `/gsd:add-tests 3 focus on edge cases for auth`
+
 ### Milestone Auditing
 
 **`/gsd:audit-milestone [version]`**
@@ -438,6 +452,7 @@ Example config:
 /gsd:plan-phase 1       # Create plans for first phase
 /clear
 /gsd:execute-phase 1    # Execute all plans in phase
+/gsd:add-tests 1        # Generate tests for completed phase
 ```
 
 **Resuming work after a break:**


### PR DESCRIPTION
## What

Add `/gsd:add-tests` to all three documentation surfaces: help.md, README.md, and USER-GUIDE.md.

## Why

`/gsd:add-tests` shipped in a92512a (v1.21.0) but was never added to help docs. 20 users upvoted #302 — they can't discover the command because `/gsd:help` doesn't list it.

Closes #302

## Testing

- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Checklist

- [x] Follows GSD style (no enterprise patterns, no filler)
- [ ] Updates CHANGELOG.md for user-facing changes
- [x] No unnecessary dependencies added
- [x] Works on Windows (backslash paths tested)

## Breaking Changes

None