### PR TITLE
fix(core): respect .gitignore for tracked files in isGitIgnored (#703)

### DIFF
--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -124,7 +124,11 @@ function loadConfig(cwd) {
 
 function isGitIgnored(cwd, targetPath) {
   try {
-    execSync('git check-ignore -q -- ' + targetPath.replace(/[^a-zA-Z0-9._\-/]/g, ''), {
+    // --no-index checks .gitignore rules regardless of whether the file is tracked.
+    // Without it, git check-ignore returns "not ignored" for tracked files even when
+    // .gitignore explicitly lists them — a common source of confusion when .planning/
+    // was committed before being added to .gitignore.
+    execSync('git check-ignore -q --no-index -- ' + targetPath.replace(/[^a-zA-Z0-9._\-/]/g, ''), {
       cwd,
       stdio: 'pipe',
     });


### PR DESCRIPTION
## What This Fixes

When `.planning/` files have been committed to a repo and `.planning/` is later added to `.gitignore`, the `isGitIgnored()` function in `core.cjs` incorrectly reports them as "not ignored." This means the automatic `commit_docs: false` safety net — designed to prevent unwanted `.planning/` commits — silently fails.

This is a subtle interaction between git's index and `.gitignore` that can catch people off guard. Once files enter git's tracked index, `git check-ignore` considers them "not ignored" regardless of what `.gitignore` says. It's standard git behavior, but it breaks the assumption that `.gitignore` entries are always respected.

## The Fix

A one-word addition: `--no-index` on the `git check-ignore` call.

```diff
- execSync('git check-ignore -q -- ' + targetPath...
+ execSync('git check-ignore -q --no-index -- ' + targetPath...
```

The `--no-index` flag tells git to evaluate `.gitignore` rules without consulting the index, which matches what users expect: if `.planning/` is in `.gitignore`, treat it as ignored regardless of tracking history.

## Why It Matters

This is especially relevant for projects that started with `commit_docs: true` (the default) and later decided to stop committing planning docs. Without this fix, the transition is silent — `.planning/` files keep getting committed even after adding them to `.gitignore`, and the auto-detection safety net that's supposed to catch this never triggers.

The issue reporter also noted this compounds with the auto-advance nesting behavior (#668/#686), where agents doing raw `git add` bypass the `commit_docs` config entirely. This fix addresses the `isGitIgnored()` detection half of that problem.

## Test Plan

- [ ] Project with `.planning/` tracked + `.planning/` in `.gitignore`: `isGitIgnored` should return `true`
- [ ] Project with `.planning/` untracked + `.planning/` in `.gitignore`: `isGitIgnored` should return `true` (unchanged behavior)
- [ ] Project with `.planning/` tracked + `.planning/` NOT in `.gitignore`: `isGitIgnored` should return `false` (unchanged behavior)

## Recovery Note for Affected Users

If `.planning/` files are already committed and you want to stop tracking them:
```bash
git rm -r --cached .planning/
git commit -m "chore: stop tracking .planning/ (now gitignored)"
```

Closes #703

🤖 Generated with [Claude Code](https://claude.com/claude-code)