### PR TITLE
fix(gemini): use AfterTool instead of PostToolUse for Gemini CLI hooks

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -1403,24 +1403,26 @@ function uninstall(isGlobal, runtime = 'claude') {
       }
     }
 
-    // Remove GSD hooks from PostToolUse
-    if (settings.hooks && settings.hooks.PostToolUse) {
-      const before = settings.hooks.PostToolUse.length;
-      settings.hooks.PostToolUse = settings.hooks.PostToolUse.filter(entry => {
-        if (entry.hooks && Array.isArray(entry.hooks)) {
-          const hasGsdHook = entry.hooks.some(h =>
-            h.command && h.command.includes('gsd-context-monitor')
-          );
-          return !hasGsdHook;
+    // Remove GSD hooks from PostToolUse and AfterTool (Gemini uses AfterTool)
+    for (const eventName of ['PostToolUse', 'AfterTool']) {
+      if (settings.hooks && settings.hooks[eventName]) {
+        const before = settings.hooks[eventName].length;
+        settings.hooks[eventName] = settings.hooks[eventName].filter(entry => {
+          if (entry.hooks && Array.isArray(entry.hooks)) {
+            const hasGsdHook = entry.hooks.some(h =>
+              h.command && h.command.includes('gsd-context-monitor')
+            );
+            return !hasGsdHook;
+          }
+          return true;
+        });
+        if (settings.hooks[eventName].length < before) {
+          settingsModified = true;
+          console.log(`  ${green}✓${reset} Removed context monitor hook from settings`);
         }
-        return true;
-      });
-      if (settings.hooks.PostToolUse.length < before) {
-        settingsModified = true;
-        console.log(`  ${green}✓${reset} Removed context monitor hook from settings`);
-      }
-      if (settings.hooks.PostToolUse.length === 0) {
-        delete settings.hooks.PostToolUse;
+        if (settings.hooks[eventName].length === 0) {
+          delete settings.hooks[eventName];
+        }
       }
     }
 
@@ -2031,7 +2033,8 @@ function install(isGlobal, runtime = 'claude') {
   }
 
   // Configure statusline and hooks in settings.json
-  // Gemini shares same hook system as Claude Code for now
+  // Gemini uses AfterTool instead of PostToolUse for post-tool hooks
+  const postToolEvent = runtime === 'gemini' ? 'AfterTool' : 'PostToolUse';
   const settingsPath = path.join(targetDir, 'settings.json');
   const settings = cleanupOrphanedHooks(readSettings(settingsPath));
   const statuslineCommand = isGlobal
@@ -2080,17 +2083,17 @@ function install(isGlobal, runtime = 'claude') {
       console.log(`  ${green}✓${reset} Configured update check hook`);
     }
 
-    // Configure PostToolUse hook for context window monitoring
-    if (!settings.hooks.PostToolUse) {
-      settings.hooks.PostToolUse = [];
+    // Configure post-tool hook for context window monitoring
+    if (!settings.hooks[postToolEvent]) {
+      settings.hooks[postToolEvent] = [];
     }
 
-    const hasContextMonitorHook = settings.hooks.PostToolUse.some(entry =>
+    const hasContextMonitorHook = settings.hooks[postToolEvent].some(entry =>
       entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-context-monitor'))
     );
 
     if (!hasContextMonitorHook) {
-      settings.hooks.PostToolUse.push({
+      settings.hooks[postToolEvent].push({
         hooks: [
           {
             type: 'command',

--- a/docs/context-monitor.md
+++ b/docs/context-monitor.md
@@ -1,6 +1,6 @@
 # Context Window Monitor
 
-A PostToolUse hook that warns the agent when context window usage is high.
+A post-tool hook (`PostToolUse` for Claude Code, `AfterTool` for Gemini CLI) that warns the agent when context window usage is high.
 
 ## Problem
 
@@ -37,7 +37,7 @@ Statusline Hook (gsd-statusline.js)
 /tmp/claude-ctx-{session_id}.json
     ^ reads
     |
-Context Monitor (gsd-context-monitor.js, PostToolUse)
+Context Monitor (gsd-context-monitor.js, PostToolUse/AfterTool)
     | injects
     v
 additionalContext -> Agent sees warning
@@ -63,9 +63,9 @@ GSD's `/gsd:pause-work` command saves execution state. The WARNING message sugge
 Both hooks are automatically registered during `npx get-shit-done-cc` installation:
 
 - **Statusline** (writes bridge file): Registered as `statusLine` in settings.json
-- **Context Monitor** (reads bridge file): Registered as `PostToolUse` hook in settings.json
+- **Context Monitor** (reads bridge file): Registered as `PostToolUse` hook in settings.json (`AfterTool` for Gemini)
 
-Manual registration in `~/.claude/settings.json`:
+Manual registration in `~/.claude/settings.json` (Claude Code):
 
 ```json
 {
@@ -80,6 +80,25 @@ Manual registration in `~/.claude/settings.json`:
           {
             "type": "command",
             "command": "node ~/.claude/hooks/gsd-context-monitor.js"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+For Gemini CLI (`~/.gemini/settings.json`), use `AfterTool` instead of `PostToolUse`:
+
+```json
+{
+  "hooks": {
+    "AfterTool": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ~/.gemini/hooks/gsd-context-monitor.js"
           }
         ]
       }

--- a/hooks/gsd-context-monitor.js
+++ b/hooks/gsd-context-monitor.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Context Monitor - PostToolUse hook
+// Context Monitor - PostToolUse/AfterTool hook (Gemini uses AfterTool)
 // Reads context metrics from the statusline bridge file and injects
 // warnings when context usage is high. This makes the AGENT aware of
 // context limits (the statusline only shows the user).
@@ -109,7 +109,7 @@ process.stdin.on('end', () => {
 
     const output = {
       hookSpecificOutput: {
-        hookEventName: "PostToolUse",
+        hookEventName: process.env.GEMINI_API_KEY ? "AfterTool" : "PostToolUse",
         additionalContext: message
       }
     };


### PR DESCRIPTION
## Summary

Gemini CLI uses `AfterTool` as the post-tool hook event name, not `PostToolUse` (which is Claude Code's event name). The installer was registering the context monitor under `PostToolUse` for all runtimes, causing Gemini to print an "Invalid hook event name" warning on every run and silently disabling the context monitor hook.

The comment at install.js:2034 even noted the assumption: _"Gemini shares same hook system as Claude Code for now"_ — this turned out to be incorrect for hook event names.

## Changes

- **`bin/install.js`**: Introduce `postToolEvent` variable that resolves to `AfterTool` when `runtime === 'gemini'`, `PostToolUse` otherwise. Used for both the install and registration paths.
- **`bin/install.js` (uninstall)**: Clean up both `PostToolUse` and `AfterTool` entries for backward compatibility — users who installed with the old `PostToolUse` key need their stale entries removed on uninstall/reinstall.
- **`hooks/gsd-context-monitor.js`**: Runtime-aware `hookEventName` in output metadata (detects Gemini via `GEMINI_API_KEY` env var).
- **`docs/context-monitor.md`**: Document both event names, add Gemini-specific manual registration example.

## Verification

1. Install GSD for Gemini: `npx get-shit-done-cc --gemini --global`
2. Check `~/.gemini/settings.json` — context monitor should be under `hooks.AfterTool`, not `hooks.PostToolUse`
3. Run `gemini -p "ping" --output-format text` — no "Invalid hook event name" warning
4. Uninstall — both `AfterTool` and `PostToolUse` entries cleaned up

## Backward Compatibility

- Existing Gemini installs with `PostToolUse` entries: The uninstall path now cleans up both event names, so reinstalling will migrate to `AfterTool` automatically.
- Claude Code / OpenCode installs: No change — they continue using `PostToolUse`.

Closes #750

🤖 Generated with [Claude Code](https://claude.com/claude-code)