### PR TITLE
fix(workflow): use Skill instead of Task for auto-advance phase transitions

### DIFF
--- a/get-shit-done/workflows/discuss-phase.md
+++ b/get-shit-done/workflows/discuss-phase.md
@@ -530,41 +530,15 @@ Display banner:
  GSD ► AUTO-ADVANCING TO PLAN
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Context captured. Spawning plan-phase...
+Context captured. Launching plan-phase...
 ```
 
-Spawn plan-phase as Task with direct workflow file reference (do NOT use Skill tool — Skills don't resolve inside Task subagents):
+Launch plan-phase using the Skill tool to avoid nested Task sessions (which cause runtime freezes due to deep agent nesting — see #686):
 ```
-Task(
-  prompt="
-    <objective>
-    You are the plan-phase orchestrator. Create executable plans for Phase ${PHASE}: ${PHASE_NAME}, then auto-advance to execution.
-    </objective>
-
-    <execution_context>
-    @~/.claude/get-shit-done/workflows/plan-phase.md
-    @~/.claude/get-shit-done/references/ui-brand.md
-    @~/.claude/get-shit-done/references/model-profile-resolution.md
-    </execution_context>
-
-    <arguments>
-    PHASE=${PHASE}
-    ARGUMENTS='${PHASE} --auto'
-    </arguments>
-
-    <instructions>
-    1. Read plan-phase.md from execution_context for your complete workflow
-    2. Follow ALL steps: initialize, validate, load context, research, plan, verify, auto-advance
-    3. When spawning agents (gsd-phase-researcher, gsd-planner, gsd-plan-checker), use Task with specified subagent_type and model
-    4. For step 14 (auto-advance to execute): spawn execute-phase as a Task with DIRECT file reference — tell it to read execute-phase.md. Include @file refs to execute-phase.md, checkpoints.md, tdd.md, model-profile-resolution.md. Pass --no-transition flag so execute-phase returns results instead of chaining further.
-    5. Do NOT use the Skill tool or /gsd: commands. Read workflow .md files directly.
-    6. Return: PHASE COMPLETE (full pipeline success), PLANNING COMPLETE (planning done but execute failed/skipped), PLANNING INCONCLUSIVE, or GAPS FOUND
-    </instructions>
-  ",
-  subagent_type="general-purpose",
-  description="Plan Phase ${PHASE}"
-)
+Skill(skill="gsd:plan-phase", args="${PHASE} --auto")
 ```
+
+This keeps the auto-advance chain flat — discuss, plan, and execute all run at the same nesting level rather than spawning increasingly deep Task agents.
 
 **Handle plan-phase return:**
 - **PHASE COMPLETE** → Full chain succeeded. Display:


### PR DESCRIPTION
## Summary

The auto-advance chain (`discuss → plan → execute` triggered by `--auto`) was spawning each subsequent phase as a `Task(subagent_type="general-purpose")`, creating 3-4 levels of nested agent sessions. At that depth, the Claude Code runtime hits resource limits or stdio contention, causing the execute-phase to either freeze indefinitely or attempt to shell out to `claude` as a subprocess — which is explicitly blocked with "Claude Code cannot be launched inside another Claude Code session."

The nesting looks like this:
```
discuss-phase (level 0)
  └─ Task(general-purpose) → plan-phase (level 1)
       └─ Task(general-purpose) → execute-phase (level 2)
            └─ Task(gsd-executor) → executor agents (level 3)
                 └─ ...potential further nesting (level 4)
```

By level 2-3, the `general-purpose` agent loses context about the execute-phase orchestration protocol and falls back to shelling out to `claude --print`, which triggers the nested session error.

## The Fix

Replace `Task(general-purpose)` with `Skill()` invocations for phase transitions:

```
discuss-phase (level 0)
  └─ Skill("gsd:plan-phase") → plan-phase (level 0, same context)
       └─ Skill("gsd:execute-phase") → execute-phase (level 0, same context)
            └─ Task(gsd-executor) → executor agents (level 1)
```

The `Skill` tool runs in the same process context as the caller — it doesn't create a subprocess or new agent session. This keeps the entire orchestration chain flat at level 0, with only the actual worker agents (gsd-executor, gsd-verifier, etc.) spawning as Task subagents at level 1.

## Changes

- **`workflows/plan-phase.md`** (step 14): Replace 30-line `Task(general-purpose)` block with `Skill("gsd:execute-phase", args="${PHASE} --auto --no-transition")`
- **`workflows/discuss-phase.md`** (auto_advance step): Replace 30-line `Task(general-purpose)` block with `Skill("gsd:plan-phase", args="${PHASE} --auto")`

Net effect: -67 lines of complex Task prompt engineering, +13 lines of clean Skill invocations.

## Verification

1. Run `/gsd:discuss-phase <phase> --auto`
2. Complete the discussion flow
3. Auto-advance should trigger plan-phase (via Skill, not Task)
4. Plan-phase should auto-advance to execute-phase (via Skill, not Task)
5. Execute-phase should spawn gsd-executor agents normally
6. No "nested session" errors, no freezes

## Why Skill Instead of Task?

The previous code had a comment: _"do NOT use Skill tool — Skills don't resolve inside Task subagents"_. This was correct for the original architecture where each phase ran inside a Task. But the fix here changes the architecture: phases now chain via Skill at the top level, so the resolution concern doesn't apply. Each Skill invocation runs with full access to the command registry.

Closes #686

🤖 Generated with [Claude Code](https://claude.com/claude-code)