### PR TITLE
fix: replace execSync with execFileSync and add path/session validation

### DIFF
--- a/get-shit-done/bin/lib/commands.cjs
+++ b/get-shit-done/bin/lib/commands.cjs
@@ -83,7 +83,12 @@ function cmdVerifyPathExists(cwd, targetPath, raw) {
     error('path required for verification');
   }
 
-  const fullPath = path.isAbsolute(targetPath) ? targetPath : path.join(cwd, targetPath);
+  const fullPath = path.resolve(cwd, targetPath);
+
+  // Prevent path traversal — resolved path must stay within cwd
+  if (!fullPath.startsWith(path.resolve(cwd) + path.sep) && fullPath !== path.resolve(cwd)) {
+    error('path must be within the project directory');
+  }
 
   try {
     const stats = fs.statSync(fullPath);

--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -4,7 +4,8 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
+const crypto = require('crypto');
 
 // ─── Path helpers ────────────────────────────────────────────────────────────
 
@@ -39,7 +40,7 @@ function output(result, raw, rawValue) {
     // Large payloads exceed Claude Code's Bash tool buffer (~50KB).
     // Write to tmpfile and output the path prefixed with @file: so callers can detect it.
     if (json.length > 50000) {
-      const tmpPath = path.join(require('os').tmpdir(), `gsd-${Date.now()}.json`);
+      const tmpPath = path.join(require('os').tmpdir(), `gsd-${crypto.randomUUID()}.json`);
       fs.writeFileSync(tmpPath, json, 'utf-8');
       process.stdout.write('@file:' + tmpPath);
     } else {
@@ -124,7 +125,7 @@ function loadConfig(cwd) {
 
 function isGitIgnored(cwd, targetPath) {
   try {
-    execSync('git check-ignore -q -- ' + targetPath.replace(/[^a-zA-Z0-9._\-/]/g, ''), {
+    execFileSync('git', ['check-ignore', '-q', '--', targetPath], {
       cwd,
       stdio: 'pipe',
     });
@@ -136,11 +137,7 @@ function isGitIgnored(cwd, targetPath) {
 
 function execGit(cwd, args) {
   try {
-    const escaped = args.map(a => {
-      if (/^[a-zA-Z0-9._\-/=:@]+$/.test(a)) return a;
-      return "'" + a.replace(/'/g, "'\\''") + "'";
-    });
-    const stdout = execSync('git ' + escaped.join(' '), {
+    const stdout = execFileSync('git', args, {
       cwd,
       stdio: 'pipe',
       encoding: 'utf-8',

--- a/hooks/gsd-context-monitor.js
+++ b/hooks/gsd-context-monitor.js
@@ -34,7 +34,7 @@ process.stdin.on('end', () => {
     const data = JSON.parse(input);
     const sessionId = data.session_id;
 
-    if (!sessionId) {
+    if (!sessionId || !/^[a-f0-9-]+$/i.test(sessionId)) {
       process.exit(0);
     }
 

--- a/hooks/gsd-statusline.js
+++ b/hooks/gsd-statusline.js
@@ -18,6 +18,9 @@ process.stdin.on('end', () => {
     const session = data.session_id || '';
     const remaining = data.context_window?.remaining_percentage;
 
+    // Validate session_id to prevent path traversal in temp file paths
+    const safeSession = /^[a-f0-9-]+$/i.test(session) ? session : '';
+
     // Context window display (shows USED percentage scaled to 80% limit)
     // Claude Code enforces an 80% context limit, so we scale to show 100% at that point
     let ctx = '';
@@ -29,9 +32,9 @@ process.stdin.on('end', () => {
 
       // Write context metrics to bridge file for the context-monitor PostToolUse hook.
       // The monitor reads this file to inject agent-facing warnings when context is low.
-      if (session) {
+      if (safeSession) {
         try {
-          const bridgePath = path.join(os.tmpdir(), `claude-ctx-${session}.json`);
+          const bridgePath = path.join(os.tmpdir(), `claude-ctx-${safeSession}.json`);
           const bridgeData = JSON.stringify({
             session_id: session,
             remaining_percentage: remaining,


### PR DESCRIPTION
## Security Fixes

Seven security hardening changes across 4 files. All 462 existing tests pass.

### CRITICAL: Shell Injection in `isGitIgnored()` (core.cjs)
**Before:** `execSync('git check-ignore -q -- ' + targetPath.replace(...))` — regex-based sanitization is insufficient; shell metacharacters can bypass it.
**After:** `execFileSync('git', ['check-ignore', '-q', '--', targetPath])` — no shell spawned, arguments passed directly to git as an array.

### HIGH: Shell Injection in `execGit()` (core.cjs)  
**Before:** Manual shell escaping with regex + `execSync('git ' + escaped.join(' '))` — fragile escaping can be bypassed.
**After:** `execFileSync('git', args)` — eliminates the shell entirely. Arguments are passed as an array directly to the git process.

### HIGH: Path Traversal in `cmdVerifyPathExists()` (commands.cjs)
**Before:** `path.isAbsolute(targetPath) ? targetPath : path.join(cwd, targetPath)` — no containment check; `../../../etc/passwd` is resolved outside the project.
**After:** `path.resolve(cwd, targetPath)` with containment check: `fullPath.startsWith(path.resolve(cwd) + path.sep)`. Rejects paths that escape the project directory.

### MEDIUM: Unsanitized Session ID in Context Monitor (gsd-context-monitor.js)
**Before:** Session ID used without validation in file path construction.
**After:** Added `/^[a-f0-9-]+$/i` regex validation — exits on non-UUID session IDs to prevent path injection.

### MEDIUM: Unsanitized Session ID in Statusline (gsd-statusline.js)
**Before:** `session` variable used directly in `claude-ctx-${session}.json` path.
**After:** `safeSession` variable with UUID regex validation. Empty string fallback prevents path injection through malicious session values.

### MEDIUM: Predictable Temp File Names (core.cjs)
**Before:** `gsd-${Date.now()}.json` — predictable names enable symlink attacks.
**After:** `gsd-${crypto.randomUUID()}.json` — cryptographically random, unpredictable names.

### Testing
- All **462 tests** across **88 suites** pass
- Zero regressions
