### PR TITLE
docs: show optional [area] arg for /gsd:map-codebase in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,7 +488,7 @@ You're never locked in. The system adapts.
 
 | Command | What it does |
 |---------|--------------|
-| `/gsd:map-codebase` | Analyze existing codebase before new-project |
+| `/gsd:map-codebase [area]` | Analyze existing codebase before new-project |
 
 ### Phase Management
 


### PR DESCRIPTION
The `map-codebase` command accepts an optional area argument (defined in its `argument-hint` frontmatter), but the Brownfield commands table in the README didn't reflect this.

Updated to `/gsd:map-codebase [area]` to match the pattern used by other commands in the table (e.g. `/gsd:add-todo [desc]`, `/gsd:debug [desc]`).