### PR TITLE
fix: replace echo with printf to prevent jq parse errors

### DIFF
--- a/get-shit-done/references/decimal-phase-calculation.md
+++ b/get-shit-done/references/decimal-phase-calculation.md
@@ -33,8 +33,8 @@ With existing decimals:
 
 ```bash
 DECIMAL_INFO=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" phase next-decimal "${AFTER_PHASE}")
-DECIMAL_PHASE=$(echo "$DECIMAL_INFO" | jq -r '.next')
-BASE_PHASE=$(echo "$DECIMAL_INFO" | jq -r '.base_phase')
+DECIMAL_PHASE=$(printf '%s\n' "$DECIMAL_INFO" | jq -r '.next')
+BASE_PHASE=$(printf '%s\n' "$DECIMAL_INFO" | jq -r '.base_phase')
 ```
 
 Or with --raw flag:

--- a/get-shit-done/references/phase-argument-parsing.md
+++ b/get-shit-done/references/phase-argument-parsing.md
@@ -46,7 +46,7 @@ Use `roadmap get-phase` to validate phase exists:
 
 ```bash
 PHASE_CHECK=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" roadmap get-phase "${PHASE}")
-if [ "$(echo "$PHASE_CHECK" | jq -r '.found')" = "false" ]; then
+if [ "$(printf '%s\n' "$PHASE_CHECK" | jq -r '.found')" = "false" ]; then
   echo "ERROR: Phase ${PHASE} not found in roadmap"
   exit 1
 fi

--- a/get-shit-done/workflows/plan-milestone-gaps.md
+++ b/get-shit-done/workflows/plan-milestone-gaps.md
@@ -66,7 +66,7 @@ Find highest existing phase:
 ```bash
 # Get sorted phase list, extract last one
 PHASES=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" phases list)
-HIGHEST=$(echo "$PHASES" | jq -r '.directories[-1]')
+HIGHEST=$(printf '%s\n' "$PHASES" | jq -r '.directories[-1]')
 ```
 
 New phases continue from there:

--- a/get-shit-done/workflows/plan-phase.md
+++ b/get-shit-done/workflows/plan-phase.md
@@ -257,13 +257,13 @@ ls "${PHASE_DIR}"/*-PLAN.md 2>/dev/null
 Extract from INIT JSON:
 
 ```bash
-STATE_PATH=$(echo "$INIT" | jq -r '.state_path // empty')
-ROADMAP_PATH=$(echo "$INIT" | jq -r '.roadmap_path // empty')
-REQUIREMENTS_PATH=$(echo "$INIT" | jq -r '.requirements_path // empty')
-RESEARCH_PATH=$(echo "$INIT" | jq -r '.research_path // empty')
-VERIFICATION_PATH=$(echo "$INIT" | jq -r '.verification_path // empty')
-UAT_PATH=$(echo "$INIT" | jq -r '.uat_path // empty')
-CONTEXT_PATH=$(echo "$INIT" | jq -r '.context_path // empty')
+STATE_PATH=$(printf '%s\n' "$INIT" | jq -r '.state_path // empty')
+ROADMAP_PATH=$(printf '%s\n' "$INIT" | jq -r '.roadmap_path // empty')
+REQUIREMENTS_PATH=$(printf '%s\n' "$INIT" | jq -r '.requirements_path // empty')
+RESEARCH_PATH=$(printf '%s\n' "$INIT" | jq -r '.research_path // empty')
+VERIFICATION_PATH=$(printf '%s\n' "$INIT" | jq -r '.verification_path // empty')
+UAT_PATH=$(printf '%s\n' "$INIT" | jq -r '.uat_path // empty')
+CONTEXT_PATH=$(printf '%s\n' "$INIT" | jq -r '.context_path // empty')
 ```
 
 ## 8. Spawn gsd-planner Agent


### PR DESCRIPTION
## Summary

- Replace all `echo "$VAR" | jq` patterns with `printf '%s\n' "$VAR" | jq` across workflows and references
- Fixes jq parse error: `control characters from U+0000 through U+001F must be escaped`

## Root Cause

zsh's built-in `echo` interprets `\n` escape sequences. When `JSON.stringify` properly escapes a newline as `\\n` in a string value (e.g., the `section` field from `roadmap get-phase` containing raw markdown), the shell round-trip through `$()` + `echo` converts `\\n` back into a literal newline (0x0A), producing invalid JSON.

`printf '%s\n'` does not interpret escape sequences and preserves JSON verbatim.

## Files Changed

- `get-shit-done/workflows/plan-phase.md` — 7 occurrences (INIT JSON path extraction)
- `get-shit-done/workflows/plan-milestone-gaps.md` — 1 occurrence
- `get-shit-done/references/decimal-phase-calculation.md` — 2 occurrences
- `get-shit-done/references/phase-argument-parsing.md` — 1 occurrence

## Test plan

- [x] Verified `printf '%s\n'` preserves JSON with escaped newlines through jq
- [x] Verified `echo` breaks the same JSON (reproduces the original error)
- [x] Existing roadmap tests pass (24/24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)