### PR TITLE
feat: add Novita AI as optional LLM provider

### DIFF
--- a/get-shit-done/references/checkpoints.md
+++ b/get-shit-done/references/checkpoints.md
@@ -457,8 +457,8 @@ const model = process.env.LLM_MODEL || (
 
 // Novita examples:
 // - deepseek/deepseek-v3.2
-// - minimax-minimax-m2.5
-// - zai-org-glm-5
+// - minimax/minimax-m2.5
+// - zai-org/glm-5
 const response = await client.chat.completions.create({
   model,
   messages: [{ role: "user", content: "Hello from GSD" }],


### PR DESCRIPTION
## What this PR does

Adds [Novita AI](https://novita.ai) as an optional, drop-in replacement for OpenAI usage in the Convex checkpoint automation guidance.

**Usage:** Set `NOVITA_API_KEY` in your environment and use OpenAI SDK with Novita's OpenAI-compatible endpoint (`https://api.novita.ai/openai`).

## Changes

- `get-shit-done/references/checkpoints.md`
  - Added Convex env var automation examples for `NOVITA_API_KEY` alongside existing `OPENAI_API_KEY`.
  - Updated checkpoint examples so users can provide either OpenAI or Novita API keys.
  - Added a drop-in OpenAI SDK code pattern using `baseURL: \"https://api.novita.ai/openai\"` when `NOVITA_API_KEY` is set.
  - Included Novita model examples:
    - `deepseek/deepseek-v3.2`
    - `minimax-minimax-m2.5`
    - `zai-org-glm-5`

<details>
<summary>Integration analysis</summary>

- **Architecture**: single_provider
- **Pattern reference**: `get-shit-done/references/checkpoints.md` env automation + SDK pattern examples
- **Pattern followed**: true
- **Deviations**: none
- **Concerns**: Repository does not instantiate LLM SDKs in runtime code; integration is applied to canonical workflow/code-reference templates consumed by generated project implementations.

</details>

## Testing

- Ran: `npm test`
- Result: all tests passed (476 passed, 0 failed)