### PR TITLE
fix(core): complete toPosixPath coverage for Windows output paths

### DIFF
--- a/get-shit-done/bin/lib/commands.cjs
+++ b/get-shit-done/bin/lib/commands.cjs
@@ -4,7 +4,7 @@
 const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
-const { safeReadFile, loadConfig, isGitIgnored, execGit, normalizePhaseName, comparePhaseNum, getArchivedPhaseDirs, generateSlugInternal, getMilestoneInfo, resolveModelInternal, MODEL_PROFILES, output, error, findPhaseInternal } = require('./core.cjs');
+const { safeReadFile, loadConfig, isGitIgnored, execGit, normalizePhaseName, comparePhaseNum, getArchivedPhaseDirs, generateSlugInternal, getMilestoneInfo, resolveModelInternal, MODEL_PROFILES, toPosixPath, output, error, findPhaseInternal } = require('./core.cjs');
 const { extractFrontmatter } = require('./frontmatter.cjs');
 
 function cmdGenerateSlug(text, raw) {
@@ -68,7 +68,7 @@ function cmdListTodos(cwd, area, raw) {
           created: createdMatch ? createdMatch[1].trim() : 'unknown',
           title: titleMatch ? titleMatch[1].trim() : 'Untitled',
           area: todoArea,
-          path: path.join('.planning', 'todos', 'pending', file),
+          path: toPosixPath(path.join('.planning', 'todos', 'pending', file)),
         });
       } catch {}
     }
@@ -528,7 +528,7 @@ function cmdScaffold(cwd, type, options, raw) {
   }
 
   fs.writeFileSync(filePath, content, 'utf-8');
-  const relPath = path.relative(cwd, filePath);
+  const relPath = toPosixPath(path.relative(cwd, filePath));
   output({ created: true, path: relPath }, raw, relPath);
 }
 

--- a/get-shit-done/bin/lib/phase.cjs
+++ b/get-shit-done/bin/lib/phase.cjs
@@ -4,7 +4,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { escapeRegex, normalizePhaseName, comparePhaseNum, findPhaseInternal, getArchivedPhaseDirs, generateSlugInternal, getMilestonePhaseFilter, output, error } = require('./core.cjs');
+const { escapeRegex, normalizePhaseName, comparePhaseNum, findPhaseInternal, getArchivedPhaseDirs, generateSlugInternal, getMilestonePhaseFilter, toPosixPath, output, error } = require('./core.cjs');
 const { extractFrontmatter } = require('./frontmatter.cjs');
 const { writeStateMd } = require('./state.cjs');
 
@@ -180,7 +180,7 @@ function cmdFindPhase(cwd, phase, raw) {
 
     const result = {
       found: true,
-      directory: path.join('.planning', 'phases', match),
+      directory: toPosixPath(path.join('.planning', 'phases', match)),
       phase_number: phaseNumber,
       phase_name: phaseName,
       plans,

--- a/get-shit-done/bin/lib/template.cjs
+++ b/get-shit-done/bin/lib/template.cjs
@@ -4,7 +4,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { normalizePhaseName, findPhaseInternal, generateSlugInternal, output, error } = require('./core.cjs');
+const { normalizePhaseName, findPhaseInternal, generateSlugInternal, toPosixPath, output, error } = require('./core.cjs');
 const { reconstructFrontmatter } = require('./frontmatter.cjs');
 
 function cmdTemplateSelect(cwd, planPath, raw) {
@@ -210,12 +210,12 @@ function cmdTemplateFill(cwd, templateType, options, raw) {
   const outPath = path.join(cwd, phaseInfo.directory, fileName);
 
   if (fs.existsSync(outPath)) {
-    output({ error: 'File already exists', path: path.relative(cwd, outPath) }, raw);
+    output({ error: 'File already exists', path: toPosixPath(path.relative(cwd, outPath)) }, raw);
     return;
   }
 
   fs.writeFileSync(outPath, fullContent, 'utf-8');
-  const relPath = path.relative(cwd, outPath);
+  const relPath = toPosixPath(path.relative(cwd, outPath));
   output({ created: true, path: relPath, template: templateType }, raw, relPath);
 }
 


### PR DESCRIPTION
## Summary
- Three files emit `path.join` or `path.relative` results directly into JSON output without normalizing backslashes on Windows
- Wrap these with `toPosixPath` (already used in `core.cjs` and `init.cjs`) so agents receive consistent forward-slash paths on all platforms

## Changes
**`phase.cjs`** — added `toPosixPath` import, wrapped `path.join` in `cmdPhasesFind` (line 183)

**`commands.cjs`** — added `toPosixPath` import, wrapped:
- `path.join` in `cmdListTodos` todo path (line 71)
- `path.relative` in `cmdScaffold` output (line 531)

**`template.cjs`** — added `toPosixPath` import, wrapped:
- `path.relative` in `cmdTemplateFill` exists branch (line 213)
- `path.relative` in `cmdTemplateFill` created branch (line 218)

## Test plan
- [x] Full test suite passes (476/476, 0 failures)
- [ ] Verify on Windows that output paths use forward slashes
- [ ] Confirm `toPosixPath` is a no-op on Linux/macOS (already forward slashes)

🦊 — Tibsfox ^.^