### PR TITLE
fix(milestone): deduplicate phase filter and handle empty MILESTONES.md

### DIFF
--- a/get-shit-done/bin/lib/milestone.cjs
+++ b/get-shit-done/bin/lib/milestone.cjs
@@ -4,7 +4,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { output, error } = require('./core.cjs');
+const { getMilestonePhaseFilter, output, error } = require('./core.cjs');
 const { extractFrontmatter } = require('./frontmatter.cjs');
 const { writeStateMd } = require('./state.cjs');
 
@@ -92,42 +92,10 @@ function cmdMilestoneComplete(cwd, version, options, raw) {
   // Ensure archive directory exists
   fs.mkdirSync(archiveDir, { recursive: true });
 
-  // Extract milestone phase numbers from ROADMAP.md to scope stats.
-  // Only phases listed in the current ROADMAP are counted — phases from
-  // prior milestones that remain on disk are excluded.
-  //
-  // Related upstream PRs (getMilestoneInfo, not milestone complete):
-  //   #756 — fix(core): detect current milestone correctly in getMilestoneInfo
-  //   #783 — fix: getMilestoneInfo() returns wrong version after completion
-  // Those PRs fix *which* milestone is detected; this fix scopes *stats*
-  // and *accomplishments* to only the phases belonging to that milestone.
-  const milestonePhaseNums = new Set();
-  if (fs.existsSync(roadmapPath)) {
-    try {
-      const roadmapContent = fs.readFileSync(roadmapPath, 'utf-8');
-      const phasePattern = /#{2,4}\s*Phase\s+(\d+[A-Z]?(?:\.\d+)*)\s*:/gi;
-      let phaseMatch;
-      while ((phaseMatch = phasePattern.exec(roadmapContent)) !== null) {
-        milestonePhaseNums.add(phaseMatch[1]);
-      }
-    } catch {}
-  }
-
-  // Pre-normalize phase numbers for O(1) lookup — strip leading zeros
-  // and lowercase for case-insensitive matching of letter suffixes (e.g. 3A/3a).
-  const normalizedPhaseNums = new Set(
-    [...milestonePhaseNums].map(num => (num.replace(/^0+/, '') || '0').toLowerCase())
-  );
-
-  // Match a phase directory name to the milestone's phase set.
-  // Handles: "01-foo" → "1", "3A-bar" → "3a", "3.1-baz" → "3.1"
-  // Returns false for non-phase directories (no leading digit).
-  function isDirInMilestone(dirName) {
-    if (normalizedPhaseNums.size === 0) return true; // no scoping
-    const m = dirName.match(/^0*(\d+[A-Za-z]?(?:\.\d+)*)/);
-    if (!m) return false; // not a phase directory
-    return normalizedPhaseNums.has(m[1].toLowerCase());
-  }
+  // Scope stats and accomplishments to only the phases belonging to the
+  // current milestone's ROADMAP.  Uses the shared filter from core.cjs
+  // (same logic used by cmdPhasesList and other callers).
+  const isDirInMilestone = getMilestonePhaseFilter(cwd);
 
   // Gather stats from phases (scoped to current milestone only)
   let phaseCount = 0;
@@ -189,15 +157,20 @@ function cmdMilestoneComplete(cwd, version, options, raw) {
 
   if (fs.existsSync(milestonesPath)) {
     const existing = fs.readFileSync(milestonesPath, 'utf-8');
-    // Insert after the header line(s) for reverse chronological order (newest first)
-    const headerMatch = existing.match(/^(#{1,3}\s+[^\n]*\n\n?)/);
-    if (headerMatch) {
-      const header = headerMatch[1];
-      const rest = existing.slice(header.length);
-      fs.writeFileSync(milestonesPath, header + milestoneEntry + rest, 'utf-8');
+    if (!existing.trim()) {
+      // Empty file — treat like new
+      fs.writeFileSync(milestonesPath, `# Milestones\n\n${milestoneEntry}`, 'utf-8');
     } else {
-      // No recognizable header — prepend the entry
-      fs.writeFileSync(milestonesPath, milestoneEntry + existing, 'utf-8');
+      // Insert after the header line(s) for reverse chronological order (newest first)
+      const headerMatch = existing.match(/^(#{1,3}\s+[^\n]*\n\n?)/);
+      if (headerMatch) {
+        const header = headerMatch[1];
+        const rest = existing.slice(header.length);
+        fs.writeFileSync(milestonesPath, header + milestoneEntry + rest, 'utf-8');
+      } else {
+        // No recognizable header — prepend the entry
+        fs.writeFileSync(milestonesPath, milestoneEntry + existing, 'utf-8');
+      }
     }
   } else {
     fs.writeFileSync(milestonesPath, `# Milestones\n\n${milestoneEntry}`, 'utf-8');


### PR DESCRIPTION
## Summary
- Replace 27 lines of inline `isDirInMilestone` logic in `cmdMilestoneComplete` with a single call to the shared `getMilestonePhaseFilter(cwd)` from `core.cjs` — the inline copy was identical, deduplicating prevents future drift
- Handle empty `MILESTONES.md` files — previously an existing but empty file would fall into the `headerMatch` branch and produce malformed output; now treated the same as a missing file

## Changes
**`get-shit-done/bin/lib/milestone.cjs`**
1. Added `getMilestonePhaseFilter` to the import from `./core.cjs`
2. Replaced lines 104–130 (inline `milestonePhaseNums` set, normalization, and `isDirInMilestone` function) with `const isDirInMilestone = getMilestonePhaseFilter(cwd)`
3. Added `!existing.trim()` guard before the header-match logic in the MILESTONES.md write section — empty files now get the standard `# Milestones` header

Net result: **-27 lines** (45 removed, 18 added)

## Test plan
- [x] Full test suite passes (476/476, 0 failures)
- [ ] Verify milestone complete still scopes stats to current ROADMAP phases
- [ ] Verify empty MILESTONES.md gets proper header + entry
- [ ] Verify existing MILESTONES.md with content inserts in reverse-chronological order

🦊 — Tibsfox ^.^