### PR TITLE
fix(workflows): replace ambiguous highlight instruction to prevent auto-answering (#912)

### DIFF
--- a/get-shit-done/workflows/discuss-phase.md
+++ b/get-shit-done/workflows/discuss-phase.md
@@ -320,7 +320,7 @@ We'll clarify HOW to implement this.
 - options: Generate 3-4 phase-specific gray areas, each with:
   - "[Specific area]" (label) — concrete, not generic
   - [1-2 questions this covers + code context annotation] (description)
-  - **Highlight the recommended choice with brief explanation why**
+  - If you have a recommendation, append "(Recommended)" to that option's label — but NEVER auto-select it. Always wait for user response.
 
 **Prior decision annotations:** When a gray area was already decided in a prior phase, annotate it:
 ```
@@ -388,7 +388,7 @@ Ask 4 questions per area before offering to continue or move on. Each answer oft
 2. **Ask 4 questions using AskUserQuestion:**
    - header: "[Area]" (max 12 chars — abbreviate if needed)
    - question: Specific decision for this area
-   - options: 2-3 concrete choices (AskUserQuestion adds "Other" automatically), with the recommended choice highlighted and brief explanation why
+   - options: 2-3 concrete choices (AskUserQuestion adds "Other" automatically). If you have a recommendation, append "(Recommended)" to that option's label — but NEVER auto-select or answer on behalf of the user. Always wait for their response.
    - **Annotate options with code context** when relevant:
      ```
      "How should posts be displayed?"

--- a/get-shit-done/workflows/quick.md
+++ b/get-shit-done/workflows/quick.md
@@ -171,7 +171,7 @@ AskUserQuestion(
 
 Rules:
 - Options must be concrete choices, not abstract categories
-- Highlight recommended choice where you have a clear opinion
+- If you have a recommendation, append "(Recommended)" to that option's label — but NEVER auto-select or answer for the user. Always wait for their response.
 - If user selects "Other" with freeform text, switch to plain text follow-up (per questioning.md freeform rule)
 - If user selects "You decide", capture as Claude's Discretion in CONTEXT.md
 - Max 2 questions per area — this is lightweight, not a deep dive


### PR DESCRIPTION
## Problem

The `discuss-phase` and `quick --discuss` workflows instruct Claude to "highlight the recommended choice" when presenting options via `AskUserQuestion`. Claude interprets "highlight" as "select/answer on behalf of the user" rather than visually annotating the recommendation — causing it to auto-answer its own questions without waiting for user input.

Introduced in e3dda45 and propagated in a7c08bf.

## Fix

Replace the ambiguous "highlight" instruction with explicit language:
- Append `(Recommended)` to the option label instead of "highlighting"
- Add `NEVER auto-select` directive to make the boundary unambiguous
- Applied consistently across all 3 occurrences (2 in discuss-phase.md, 1 in quick.md)

## Files Changed

- `get-shit-done/workflows/discuss-phase.md` — 2 changes (present_gray_areas + discuss_areas steps)
- `get-shit-done/workflows/quick.md` — 1 change (discuss rules)

## Testing

- Ran `/gsd:discuss-phase` and confirmed questions now wait for user response
- Verified `AskUserQuestion` presents options with `(Recommended)` suffix without auto-selecting

Closes #912