### PR TITLE
fix: read codebase conventions during new-project for brownfield projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Fixed
-- Brownfield projects: `/gsd:new-project` now reads CONVENTIONS.md and STRUCTURE.md during questioning and PROJECT.md creation — prevents re-asking questions already answered by existing codebase conventions
+- Brownfield projects: `/gsd:new-project` now reads CONVENTIONS.md during questioning and PROJECT.md creation — prevents re-asking questions already answered by existing codebase conventions
 
 ## [1.22.4] - 2026-03-03
 

--- a/get-shit-done/workflows/new-project.md
+++ b/get-shit-done/workflows/new-project.md
@@ -215,10 +215,7 @@ Proceed to Step 4 (skip Steps 3 and 5).
 
 **If `has_codebase_map` is true:** Load existing codebase context before questioning.
 
-Read from `.planning/codebase/` (if they exist):
-- `CONVENTIONS.md` — coding standards, file organization, naming patterns
-- `STRUCTURE.md` — directory layout, where things live
-- `STACK.md` — technology choices already in use
+Read `.planning/codebase/CONVENTIONS.md` (if it exists) — coding standards, file organization, naming patterns.
 
 Use this context to avoid re-asking questions already answered by existing conventions and to ground follow-up questions in established patterns.
 
@@ -301,7 +298,7 @@ All Active requirements are hypotheses until shipped and validated.
 
 Infer Validated requirements from existing code:
 
-1. Read `.planning/codebase/ARCHITECTURE.md`, `STACK.md`, `CONVENTIONS.md`, and `STRUCTURE.md`
+1. Read `.planning/codebase/ARCHITECTURE.md`, `STACK.md`, and `CONVENTIONS.md`
 2. Identify what the codebase already does
 3. These become the initial Validated set
 


### PR DESCRIPTION
## What

Read `.planning/codebase/CONVENTIONS.md` during `/gsd:new-project` questioning (Step 3) and PROJECT.md creation (Step 4) for brownfield projects.

## Why

Brownfield projects have conventions already documented but new-project never reads them — leading to redundant questions (e.g., "where should modules live?" when conventions already specify `/lib`).

## Details

- **Step 3:** When `has_codebase_map` is true, read CONVENTIONS.md before opening the conversation
- **Step 4:** Expand brownfield file reads to include CONVENTIONS.md alongside ARCHITECTURE.md and STACK.md
- Conditional on `has_codebase_map` — zero cost for greenfield projects

**Pros:** Fixes the root cause at the earliest decision point. Prevents redundant questions.
**Cons:** Adds context to orchestrator window during questioning. Only helps if `/gsd:map-codebase` was run first (expected brownfield flow).

**Related:** #936 (planner agent), #937 (phase prompt template) — together these ensure CONVENTIONS.md flows through questioning → planning → execution.

## Testing

- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Checklist

- [x] Follows GSD style (no enterprise patterns, no filler)
- [x] Updates CHANGELOG.md for user-facing changes
- [x] No unnecessary dependencies added
- [ ] Works on Windows (backslash paths tested)

## Breaking Changes

None