### PR TITLE
fix: feed codebase conventions to planner agent for brownfield projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Brownfield projects: planner agent now reads CONVENTIONS.md from codebase map — plans respect existing file organization and coding patterns
+
 ## [1.22.4] - 2026-03-03
 
 ### Added

--- a/get-shit-done/bin/lib/init.cjs
+++ b/get-shit-done/bin/lib/init.cjs
@@ -125,6 +125,7 @@ function cmdInitPlanPhase(cwd, phase, raw) {
     // Environment
     planning_exists: pathExistsInternal(cwd, '.planning'),
     roadmap_exists: pathExistsInternal(cwd, '.planning/ROADMAP.md'),
+    has_codebase_map: pathExistsInternal(cwd, '.planning/codebase'),
 
     // File paths
     state_path: '.planning/STATE.md',

--- a/get-shit-done/templates/planner-subagent-prompt.md
+++ b/get-shit-done/templates/planner-subagent-prompt.md
@@ -31,6 +31,9 @@ Template for spawning gsd-planner agent. The agent contains all planning experti
 @.planning/phases/{phase_dir}/{phase_num}-VERIFICATION.md
 @.planning/phases/{phase_dir}/{phase_num}-UAT.md
 
+**Codebase Conventions (if .planning/codebase/ exists):**
+@.planning/codebase/CONVENTIONS.md
+
 </planning_context>
 
 <downstream_consumer>

--- a/get-shit-done/workflows/plan-phase.md
+++ b/get-shit-done/workflows/plan-phase.md
@@ -19,7 +19,7 @@ INIT=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" init plan-phase "$PH
 if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 ```
 
-Parse JSON for: `researcher_model`, `planner_model`, `checker_model`, `research_enabled`, `plan_checker_enabled`, `nyquist_validation_enabled`, `commit_docs`, `phase_found`, `phase_dir`, `phase_number`, `phase_name`, `phase_slug`, `padded_phase`, `has_research`, `has_context`, `has_plans`, `plan_count`, `planning_exists`, `roadmap_exists`, `phase_req_ids`.
+Parse JSON for: `researcher_model`, `planner_model`, `checker_model`, `research_enabled`, `plan_checker_enabled`, `nyquist_validation_enabled`, `commit_docs`, `phase_found`, `phase_dir`, `phase_number`, `phase_name`, `phase_slug`, `padded_phase`, `has_research`, `has_context`, `has_plans`, `plan_count`, `planning_exists`, `roadmap_exists`, `has_codebase_map`, `phase_req_ids`.
 
 **File paths (for <files_to_read> blocks):** `state_path`, `roadmap_path`, `requirements_path`, `context_path`, `research_path`, `verification_path`, `uat_path`. These are null if files don't exist.
 
@@ -305,6 +305,14 @@ Planner prompt:
 - {verification_path} (Verification Gaps - if --gaps)
 - {uat_path} (UAT Gaps - if --gaps)
 </files_to_read>
+
+[If `has_codebase_map` is true, add:]
+<codebase_context>
+Existing codebase conventions — plans MUST respect these:
+<files_to_read>
+- .planning/codebase/CONVENTIONS.md (Coding standards, file organization, naming patterns)
+</files_to_read>
+</codebase_context>
 
 **Phase requirement IDs (every ID MUST appear in a plan's `requirements` field):** {phase_req_ids}
 


### PR DESCRIPTION
## What

Feed `.planning/codebase/CONVENTIONS.md` to the planner agent during `/gsd:plan-phase` for brownfield projects.

## Why

The planner creates PLAN.md files without knowledge of existing conventions — plans may specify wrong directories or ignore established patterns. This is critical because `/gsd:discuss-phase` (which does read conventions) is optional.

## Details

- **init.cjs:** Add `has_codebase_map` to `cmdInitPlanPhase` result
- **plan-phase.md:** Parse `has_codebase_map` from init; conditionally add `<codebase_context>` with CONVENTIONS.md to planner prompt
- **planner-subagent-prompt.md:** Add CONVENTIONS.md to template's `<planning_context>`

**Pros:** Safety net when discuss-phase is skipped. Plans reference established patterns. Conditional — zero cost for greenfield.
**Cons:** Adds one file to planner context. Partial overlap with discuss-phase's codebase scout (but discuss-phase is optional).

**Related:** #935 (new-project questioning), #937 (phase prompt template) — together these ensure CONVENTIONS.md flows through questioning → planning → execution.

## Testing

- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Checklist

- [x] Follows GSD style (no enterprise patterns, no filler)
- [x] Updates CHANGELOG.md for user-facing changes
- [x] No unnecessary dependencies added
- [ ] Works on Windows (backslash paths tested)

## Breaking Changes

None