### PR TITLE
fix: add codebase conventions to phase prompt template for brownfield executors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Brownfield projects: phase prompt template now includes codebase CONVENTIONS.md in context — executors follow existing coding patterns
+
 ## [1.22.4] - 2026-03-03
 
 ### Added

--- a/get-shit-done/templates/phase-prompt.md
+++ b/get-shit-done/templates/phase-prompt.md
@@ -49,6 +49,9 @@ Output: [What artifacts will be created]
 @.planning/ROADMAP.md
 @.planning/STATE.md
 
+# If .planning/codebase/ exists — follow existing conventions:
+# @.planning/codebase/CONVENTIONS.md
+
 # Only reference prior plan SUMMARYs if genuinely needed:
 # - This plan uses types/exports from prior plan
 # - Prior plan made decision that affects this plan
@@ -211,6 +214,9 @@ Wave 3 runs after Waves 1 and 2. Pauses at checkpoint, orchestrator presents to 
 @.planning/PROJECT.md
 @.planning/ROADMAP.md
 @.planning/STATE.md
+
+# If .planning/codebase/ exists — follow existing conventions:
+# @.planning/codebase/CONVENTIONS.md
 
 # Only include SUMMARY refs if genuinely needed:
 # - This plan imports types from prior plan


### PR DESCRIPTION
## What

Add conditional `.planning/codebase/CONVENTIONS.md` reference to the phase prompt template's `<context>` section for brownfield projects.

## Why

The executor agent that runs PLAN.md files never sees codebase conventions — it may violate existing coding patterns during implementation. This is the last line of defense after questioning (#935) and planning (#936).

## Details

- **phase-prompt.md template:** Add conditional CONVENTIONS.md to `<context>` section
- **phase-prompt.md docs:** Update "Parallel-aware context" example to match

Follows the template's existing pattern for conditional context (commented with `# If .planning/codebase/ exists`).

**Pros:** Last backstop — even if planning misses conventions, executor sees them. Minimal change (3 lines each in template + docs).
**Cons:** Lowest impact of the three PRs — if planner already respects conventions, executor inherits through well-written tasks. Template comments are guidance for the planner, not enforced.

**Related:** #935 (new-project questioning), #936 (planner agent) — together these ensure CONVENTIONS.md flows through questioning → planning → execution.

## Testing

- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

## Checklist

- [x] Follows GSD style (no enterprise patterns, no filler)
- [x] Updates CHANGELOG.md for user-facing changes
- [x] No unnecessary dependencies added
- [ ] Works on Windows (backslash paths tested)

## Breaking Changes

None