### PR TITLE
fix(milestone): make requirements mark-complete idempotent

### DIFF
--- a/get-shit-done/bin/lib/milestone.cjs
+++ b/get-shit-done/bin/lib/milestone.cjs
@@ -33,6 +33,7 @@ function cmdRequirementsMarkComplete(cwd, reqIdsRaw, raw) {
 
   let reqContent = fs.readFileSync(reqPath, 'utf-8');
   const updated = [];
+  const alreadyComplete = [];
   const notFound = [];
 
   for (const reqId of reqIds) {
@@ -60,7 +61,14 @@ function cmdRequirementsMarkComplete(cwd, reqIdsRaw, raw) {
     if (found) {
       updated.push(reqId);
     } else {
-      notFound.push(reqId);
+      // Check if already complete before declaring not_found
+      const doneCheckbox = new RegExp(`-\\s*\\[x\\]\\s*\\*\\*${reqEscaped}\\*\\*`, 'gi');
+      const doneTable = new RegExp(`\\|\\s*${reqEscaped}\\s*\\|[^|]+\\|\\s*Complete\\s*\\|`, 'gi');
+      if (doneCheckbox.test(reqContent) || doneTable.test(reqContent)) {
+        alreadyComplete.push(reqId);
+      } else {
+        notFound.push(reqId);
+      }
     }
   }
 
@@ -71,6 +79,7 @@ function cmdRequirementsMarkComplete(cwd, reqIdsRaw, raw) {
   output({
     updated: updated.length > 0,
     marked_complete: updated,
+    already_complete: alreadyComplete,
     not_found: notFound,
     total: reqIds.length,
   }, raw, `${updated.length}/${reqIds.length} requirements marked complete`);

--- a/tests/milestone.test.cjs
+++ b/tests/milestone.test.cjs
@@ -583,14 +583,43 @@ describe('requirements mark-complete command', () => {
     assert.ok(result.success, `Command failed: ${result.error}`);
 
     const output = JSON.parse(result.output);
-    // Regex only matches [ ] (space), not [x], so TEST-03 goes to not_found
-    assert.ok(output.not_found.includes('TEST-03'), 'already-complete ID should be in not_found');
+    assert.ok(output.already_complete.includes('TEST-03'), 'already-complete ID should be in already_complete');
+    assert.deepStrictEqual(output.not_found, [], 'should not appear in not_found');
 
     const content = readRequirements(tmpDir);
     // File should not be corrupted — no [xx] or doubled markers
     assert.ok(content.includes('- [x] **TEST-03**'), 'existing [x] should remain intact');
     assert.ok(!content.includes('[xx]'), 'should not have doubled x markers');
     assert.ok(!content.includes('- [x] [x]'), 'should not have duplicate checkbox');
+  });
+
+  test('returns already_complete for idempotent calls on completed requirements', () => {
+    writeRequirements(tmpDir, STANDARD_REQUIREMENTS);
+
+    // TEST-03 is already [x] in the fixture
+    const result = runGsdTools('requirements mark-complete TEST-03', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.deepStrictEqual(output.already_complete, ['TEST-03'],
+      'should report TEST-03 as already_complete');
+    assert.deepStrictEqual(output.not_found, [],
+      'should not report already-complete IDs as not_found');
+  });
+
+  test('mixed: updates pending, reports already-complete, and flags missing', () => {
+    writeRequirements(tmpDir, STANDARD_REQUIREMENTS);
+
+    const result = runGsdTools('requirements mark-complete TEST-01,TEST-03,FAKE-99', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.deepStrictEqual(output.marked_complete, ['TEST-01'],
+      'should mark TEST-01 complete');
+    assert.deepStrictEqual(output.already_complete, ['TEST-03'],
+      'should report TEST-03 as already_complete');
+    assert.deepStrictEqual(output.not_found, ['FAKE-99'],
+      'should report FAKE-99 as not_found');
   });
 
   test('missing REQUIREMENTS.md returns expected error structure', () => {


### PR DESCRIPTION
## What

`cmdRequirementsMarkComplete` now returns `already_complete` for requirements that are already checked off, instead of reporting them as `not_found`.

## Why

The function only matched unchecked `[ ]` checkboxes and `Pending` table cells. Already-completed requirements (`[x]` + `Complete`) were silently classified as `not_found`, causing false warnings in execution agent logs and making the command non-idempotent.

## Testing
- [x] Tested on Linux
- [ ] Tested on macOS
- [ ] Tested on Windows

## Checklist
- [x] Follows GSD style (no enterprise patterns, no filler)
- [x] Updates CHANGELOG.md for user-facing changes
- [x] No unnecessary dependencies added
- [x] Works on Windows (no path-sensitive changes)

## Breaking Changes
Output schema adds `already_complete` array. Existing consumers that only check `not_found` will see fewer items there (previously-false-positive IDs move to `already_complete`).