### PR TITLE
feat(debug): add persistent knowledge base for resolved sessions

### DIFF
--- a/agents/gsd-debugger.md
+++ b/agents/gsd-debugger.md
@@ -735,6 +735,48 @@ Can I observe the behavior directly?
 
 </research_vs_reasoning>
 
+<knowledge_base_protocol>
+
+## Purpose
+
+The knowledge base is a persistent, append-only record of resolved debug sessions. It lets future debugging sessions skip straight to high-probability hypotheses when symptoms match a known pattern.
+
+## File Location
+
+```
+.planning/debug/knowledge-base.md
+```
+
+## Entry Format
+
+Each resolved session appends one entry:
+
+```markdown
+## {slug} — {one-line description}
+- **Date:** {ISO date}
+- **Error patterns:** {comma-separated keywords extracted from symptoms.errors and symptoms.actual}
+- **Root cause:** {from Resolution.root_cause}
+- **Fix:** {from Resolution.fix}
+- **Files changed:** {from Resolution.files_changed}
+---
+```
+
+## When to Read
+
+At the **start of `investigation_loop` Phase 0**, before any file reading or hypothesis formation.
+
+## When to Write
+
+At the **end of `archive_session`**, after the session file is moved to `resolved/` and the fix is confirmed by the user.
+
+## Matching Logic
+
+Matching is keyword overlap, not semantic similarity. Extract nouns and error substrings from `Symptoms.errors` and `Symptoms.actual`. Scan each knowledge base entry's `Error patterns` field for overlapping tokens (case-insensitive, 2+ word overlap = candidate match).
+
+**Important:** A match is a **hypothesis candidate**, not a confirmed diagnosis. Surface it in Current Focus and test it first — but do not skip other hypotheses or assume correctness.
+
+</knowledge_base_protocol>
+
 <debug_file_protocol>
 
 ## File Location
@@ -884,6 +926,16 @@ Gather symptoms through questioning. Update file after EACH answer.
 
 <step name="investigation_loop">
 **Autonomous investigation. Update file continuously.**
+
+**Phase 0: Check knowledge base**
+- If `.planning/debug/knowledge-base.md` exists, read it
+- Extract keywords from `Symptoms.errors` and `Symptoms.actual` (nouns, error substrings, identifiers)
+- Scan knowledge base entries for 2+ keyword overlap (case-insensitive)
+- If match found:
+  - Note in Current Focus: `known_pattern_candidate: "{matched slug} — {description}"`
+  - Add to Evidence: `found: Knowledge base match on [{keywords}] → Root cause was: {root_cause}. Fix was: {fix}.`
+  - Test this hypothesis FIRST in Phase 2 — but treat it as one hypothesis, not a certainty
+- If no match: proceed normally
 
 **Phase 1: Initial evidence gathering**
 - Update Current Focus with "gathering initial evidence"
@@ -1056,6 +1108,37 @@ Root cause: {root_cause}"
 Then commit planning docs via CLI (respects `commit_docs` config automatically):
 ```bash
 node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" commit "docs: resolve debug {slug}" --files .planning/debug/resolved/{slug}.md
+```
+
+**Append to knowledge base:**
+
+Read `.planning/debug/resolved/{slug}.md` to extract final `Resolution` values. Then append to `.planning/debug/knowledge-base.md` (create file with header if it doesn't exist):
+
+If creating for the first time, write this header first:
+```markdown
+# GSD Debug Knowledge Base
+
+Resolved debug sessions. Used by `gsd-debugger` to surface known-pattern hypotheses at the start of new investigations.
+
+---
+
+```
+
+Then append the entry:
+```markdown
+## {slug} — {one-line description of the bug}
+- **Date:** {ISO date}
+- **Error patterns:** {comma-separated keywords from Symptoms.errors + Symptoms.actual}
+- **Root cause:** {Resolution.root_cause}
+- **Fix:** {Resolution.fix}
+- **Files changed:** {Resolution.files_changed joined as comma list}
+---
+
+```
+
+Commit the knowledge base update alongside the resolved session:
+```bash
+node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" commit "docs: update debug knowledge base with {slug}" --files .planning/debug/knowledge-base.md
 ```
 
 Report completion and offer next steps.


### PR DESCRIPTION
## Problem

Every debug session starts cold. If you've debugged the same `Prisma client not initialized` error three times across three sessions, GSD has no memory of the solution. You pay the full investigation cost every time.

## Solution

Add a **project-scoped knowledge base** at `.planning/debug/knowledge-base.md` that builds automatically as sessions resolve.

### How it works

**On session archive** (`archive_session` step):
After the user confirms a fix, the debugger appends a structured entry to the knowledge base:
```markdown
## {slug} — {one-line description}
- **Date:** {ISO date}
- **Error patterns:** {keywords from symptoms}
- **Root cause:** {what was wrong}
- **Fix:** {what was changed}
- **Files changed:** {list}
---
```

**On new investigation** (new `Phase 0` in `investigation_loop`):
Before any file reading or hypothesis formation, the debugger:
1. Loads the knowledge base (if it exists)
2. Checks for 2+ keyword overlap between current symptoms and past entries
3. If a match is found, surfaces it as a **hypothesis candidate** to test first

The match is treated as one hypothesis among many — not a guaranteed answer. This prevents false positives from derailing investigations while still saving time when patterns genuinely recur.

### What changes

- `agents/gsd-debugger.md` only (1 file, 83 lines added)
  - New `<knowledge_base_protocol>` section documenting the format and matching logic
  - New **Phase 0** at the start of `investigation_loop`
  - Knowledge base append step at the end of `archive_session`

### No breaking changes

- Knowledge base file is optional — if it doesn't exist, Phase 0 is a no-op
- No changes to debug file format, status transitions, checkpoint behavior, or orchestrator (`commands/gsd/debug.md`)
- Works with all existing debug modes (`find_root_cause_only`, `find_and_fix`, `symptoms_prefilled`)

## Test plan
- [ ] Run `/gsd:debug` on a new project (no knowledge base) — Phase 0 skips silently
- [ ] Resolve a debug session — verify entry appears in `.planning/debug/knowledge-base.md`
- [ ] Trigger a similar issue in a later session — verify Phase 0 surfaces the known pattern in Evidence
- [ ] Verify the match is listed as a hypothesis candidate, not an auto-applied fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)