### PR TITLE
Correct escape characters in grep command

### DIFF
--- a/agents/gsd-planner.md
+++ b/agents/gsd-planner.md
@@ -494,7 +494,7 @@ After determining `files_modified`, extract the key interfaces/types/exports fro
 
 ```bash
 # Extract type definitions, interfaces, and exports from relevant files
-grep -n "export\|interface\|type\|class\|function" {relevant_source_files} 2>/dev/null | head -50
+grep -n "export\\|interface\\|type\\|class\\|function" {relevant_source_files} 2>/dev/null | head -50
 ```
 
 Embed these in the plan's `<context>` section as an `<interfaces>` block:


### PR DESCRIPTION
Fix escape characters in grep command for extracting code interfaces.

## What

Fix invalid TOML escape sequences in GSD agent prompts by properly escaping backslashes in embedded `grep` examples, so planning/research roles load correctly.

## Why

Unescaped backslashes made multiple `gsd-*.toml` files fail parsing, which caused roles like `gsd-planner` to be unavailable and forced fallback behavior.

## Testing

- [ ] Tested on macOS
- [x] Tested on Windows
- [ ] Tested on Linux

## Checklist

- [x] Follows GSD style (no enterprise patterns, no filler)
- [ ] Updates CHANGELOG.md for user-facing changes
- [x] No unnecessary dependencies added
- [x] Works on Windows (backslash paths tested)

## Breaking Changes

None