### PR TITLE
feat: add Mistral Vibe  and Qwen Code support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # GET SHIT DONE
 
-**A light-weight and powerful meta-prompting, context engineering and spec-driven development system for Claude Code, OpenCode, Gemini CLI, Codex, and Qwen Code.**
+**A light-weight and powerful meta-prompting, context engineering and spec-driven development system for Claude Code, OpenCode, Gemini CLI, Codex, Qwen Code, and Mistral Vibe.**
 
 **Solves context rot — the quality degradation that happens as Claude fills its context window.**
 
@@ -80,16 +80,16 @@ npx get-shit-done-cc@latest
 ```
 
 The installer prompts you to choose:
-1. **Runtime** — Claude Code, OpenCode, Gemini, Codex, Qwen Code, or all
+1. **Runtime** — Claude Code, OpenCode, Gemini, Codex, Qwen Code, Mistral Vibe, or all
 2. **Location** — Global (all projects) or local (current project only)
 
 Verify with:
-- Claude Code / Gemini: `/gsd:help`
-- OpenCode: `/gsd-help`
+- Claude Code / Gemini / Qwen Code: `/gsd:help`
+- OpenCode / Mistral Vibe: `/gsd-help`
 - Codex: `$gsd-help`
 
 > [!NOTE]
-> Codex installation uses skills (`skills/gsd-*/SKILL.md`) rather than custom prompts.
+> Codex and Mistral Vibe installations use skills (`skills/gsd-*/`) rather than custom prompts.
 
 ### Staying Updated
 
@@ -121,12 +121,16 @@ npx get-shit-done-cc --codex --local     # Install to ./.codex/
 npx get-shit-done-cc --qwen --global     # Install to ~/.qwen/
 npx get-shit-done-cc --qwen --local      # Install to ./.qwen/
 
+# Mistral Vibe (Mistral AI coding assistant)
+npx get-shit-done-cc --mistral --global  # Install to ~/.vibe/
+npx get-shit-done-cc --mistral --local   # Install to ./.vibe/
+
 # All runtimes
 npx get-shit-done-cc --all --global      # Install to all directories
 ```
 
 Use `--global` (`-g`) or `--local` (`-l`) to skip the location prompt.
-Use `--claude`, `--opencode`, `--gemini`, `--codex`, or `--all` to skip the runtime prompt.
+Use `--claude`, `--opencode`, `--gemini`, `--codex`, `--qwen`, `--mistral`, or `--all` to skip the runtime prompt.
 
 </details>
 

--- a/bin/install.js
+++ b/bin/install.js
@@ -42,6 +42,7 @@ const hasClaude = args.includes('--claude');
 const hasGemini = args.includes('--gemini');
 const hasCodex = args.includes('--codex');
 const hasQwen = args.includes('--qwen');
+const hasMistral = args.includes('--mistral');
 const hasBoth = args.includes('--both'); // Legacy flag, keeps working
 const hasAll = args.includes('--all');
 const hasUninstall = args.includes('--uninstall') || args.includes('-u');
@@ -49,7 +50,7 @@ const hasUninstall = args.includes('--uninstall') || args.includes('-u');
 // Runtime selection - can be set by flags or interactive prompt
 let selectedRuntimes = [];
 if (hasAll) {
-  selectedRuntimes = ['claude', 'opencode', 'gemini', 'codex', 'qwen'];
+  selectedRuntimes = ['claude', 'opencode', 'gemini', 'codex', 'qwen', 'mistral'];
 } else if (hasBoth) {
   selectedRuntimes = ['claude', 'opencode'];
 } else {
@@ -58,6 +59,7 @@ if (hasAll) {
   if (hasGemini) selectedRuntimes.push('gemini');
   if (hasCodex) selectedRuntimes.push('codex');
   if (hasQwen) selectedRuntimes.push('qwen');
+  if (hasMistral) selectedRuntimes.push('mistral');
 }
 
 /**
@@ -81,6 +83,7 @@ function getDirName(runtime) {
   if (runtime === 'gemini') return '.gemini';
   if (runtime === 'codex') return '.codex';
   if (runtime === 'qwen') return '.qwen';
+  if (runtime === 'mistral') return '.vibe';
   return '.claude';
 }
 
@@ -133,7 +136,7 @@ function getOpencodeGlobalDir() {
 
 /**
  * Get the global config directory for a runtime
- * @param {string} runtime - 'claude', 'opencode', 'gemini', or 'codex'
+ * @param {string} runtime - 'claude', 'opencode', 'gemini', 'codex', 'qwen', or 'mistral'
  * @param {string|null} explicitDir - Explicit directory from --config-dir flag
  */
 function getGlobalDir(runtime, explicitDir = null) {
@@ -144,7 +147,7 @@ function getGlobalDir(runtime, explicitDir = null) {
     }
     return getOpencodeGlobalDir();
   }
-  
+
   if (runtime === 'gemini') {
     // Gemini: --config-dir > GEMINI_CONFIG_DIR > ~/.gemini
     if (explicitDir) {
@@ -166,7 +169,29 @@ function getGlobalDir(runtime, explicitDir = null) {
     }
     return path.join(os.homedir(), '.codex');
   }
-  
+
+  if (runtime === 'qwen') {
+    // Qwen Code: --config-dir > QWEN_CONFIG_DIR > ~/.qwen
+    if (explicitDir) {
+      return expandTilde(explicitDir);
+    }
+    if (process.env.QWEN_CONFIG_DIR) {
+      return expandTilde(process.env.QWEN_CONFIG_DIR);
+    }
+    return path.join(os.homedir(), '.qwen');
+  }
+
+  if (runtime === 'mistral') {
+    // Mistral Vibe: --config-dir > VIBE_CONFIG_DIR > ~/.vibe
+    if (explicitDir) {
+      return expandTilde(explicitDir);
+    }
+    if (process.env.VIBE_CONFIG_DIR) {
+      return expandTilde(process.env.VIBE_CONFIG_DIR);
+    }
+    return path.join(os.homedir(), '.vibe');
+  }
+
   // Claude Code: --config-dir > CLAUDE_CONFIG_DIR > ~/.claude
   if (explicitDir) {
     return expandTilde(explicitDir);
@@ -221,7 +246,7 @@ console.log(banner);
 
 // Show help if requested
 if (hasHelp) {
-  console.log(`  ${yellow}Usage:${reset} npx get-shit-done-cc [options]\n\n  ${yellow}Options:${reset}\n    ${cyan}-g, --global${reset}              Install globally (to config directory)\n    ${cyan}-l, --local${reset}               Install locally (to current directory)\n    ${cyan}--claude${reset}                  Install for Claude Code only\n    ${cyan}--opencode${reset}                Install for OpenCode only\n    ${cyan}--gemini${reset}                  Install for Gemini only\n    ${cyan}--codex${reset}                   Install for Codex only\n    ${cyan}--qwen${reset}                    Install for Qwen Code only\n    ${cyan}--all${reset}                     Install for all runtimes\n    ${cyan}-u, --uninstall${reset}           Uninstall GSD (remove all GSD files)\n    ${cyan}-c, --config-dir <path>${reset}   Specify custom config directory\n    ${cyan}-h, --help${reset}                Show this help message\n    ${cyan}--force-statusline${reset}        Replace existing statusline config\n\n  ${yellow}Examples:${reset}\n    ${dim}# Interactive install (prompts for runtime and location)${reset}\n    npx get-shit-done-cc\n\n    ${dim}# Install for Claude Code globally${reset}\n    npx get-shit-done-cc --claude --global\n\n    ${dim}# Install for Qwen Code globally${reset}\n    npx get-shit-done-cc --qwen --global\n\n    ${dim}# Install for Gemini globally${reset}\n    npx get-shit-done-cc --gemini --global\n\n    ${dim}# Install for Codex globally${reset}\n    npx get-shit-done-cc --codex --global\n\n    ${dim}# Install for all runtimes globally${reset}\n    npx get-shit-done-cc --all --global\n\n    ${dim}# Install to custom config directory${reset}\n    npx get-shit-done-cc --codex --global --config-dir ~/.codex-work\n\n    ${dim}# Install to current project only${reset}\n    npx get-shit-done-cc --claude --local\n\n    ${dim}# Uninstall GSD from Codex globally${reset}\n    npx get-shit-done-cc --codex --global --uninstall\n\n  ${yellow}Notes:${reset}\n    The --config-dir option is useful when you have multiple configurations.\n    It takes priority over CLAUDE_CONFIG_DIR / GEMINI_CONFIG_DIR / CODEX_HOME / QWEN_CONFIG_DIR environment variables.\n`);
+  console.log(`  ${yellow}Usage:${reset} npx get-shit-done-cc [options]\n\n  ${yellow}Options:${reset}\n    ${cyan}-g, --global${reset}              Install globally (to config directory)\n    ${cyan}-l, --local${reset}               Install locally (to current directory)\n    ${cyan}--claude${reset}                  Install for Claude Code only\n    ${cyan}--opencode${reset}                Install for OpenCode only\n    ${cyan}--gemini${reset}                  Install for Gemini only\n    ${cyan}--codex${reset}                   Install for Codex only\n    ${cyan}--qwen${reset}                    Install for Qwen Code only\n    ${cyan}--mistral${reset}                 Install for Mistral Vibe only\n    ${cyan}--all${reset}                     Install for all runtimes\n    ${cyan}-u, --uninstall${reset}           Uninstall GSD (remove all GSD files)\n    ${cyan}-c, --config-dir <path>${reset}   Specify custom config directory\n    ${cyan}-h, --help${reset}                Show this help message\n    ${cyan}--force-statusline${reset}        Replace existing statusline config\n\n  ${yellow}Examples:${reset}\n    ${dim}# Interactive install (prompts for runtime and location)${reset}\n    npx get-shit-done-cc\n\n    ${dim}# Install for Claude Code globally${reset}\n    npx get-shit-done-cc --claude --global\n\n    ${dim}# Install for Qwen Code globally${reset}\n    npx get-shit-done-cc --qwen --global\n\n    ${dim}# Install for Mistral Vibe globally${reset}\n    npx get-shit-done-cc --mistral --global\n\n    ${dim}# Install for Gemini globally${reset}\n    npx get-shit-done-cc --gemini --global\n\n    ${dim}# Install for Codex globally${reset}\n    npx get-shit-done-cc --codex --global\n\n    ${dim}# Install for all runtimes globally${reset}\n    npx get-shit-done-cc --all --global\n\n    ${dim}# Install to custom config directory${reset}\n    npx get-shit-done-cc --codex --global --config-dir ~/.codex-work\n\n    ${dim}# Install to current project only${reset}\n    npx get-shit-done-cc --claude --local\n\n    ${dim}# Uninstall GSD from Codex globally${reset}\n    npx get-shit-done-cc --codex --global --uninstall\n\n  ${yellow}Notes:${reset}\n    The --config-dir option is useful when you have multiple configurations.\n    It takes priority over CLAUDE_CONFIG_DIR / GEMINI_CONFIG_DIR / CODEX_HOME / QWEN_CONFIG_DIR / VIBE_CONFIG_DIR environment variables.\n`);
   process.exit(0);
 }
 
@@ -964,7 +989,7 @@ function convertClaudeToGeminiToml(content) {
 
   const frontmatter = content.substring(3, endIndex).trim();
   const body = content.substring(endIndex + 3).trim();
-  
+
   // Extract description from frontmatter
   let description = '';
   const lines = frontmatter.split('\n');
@@ -981,9 +1006,55 @@ function convertClaudeToGeminiToml(content) {
   if (description) {
     toml += `description = ${JSON.stringify(description)}\n`;
   }
-  
+
   toml += `prompt = ${JSON.stringify(body)}\n`;
-  
+
+  return toml;
+}
+
+/**
+ * Convert Claude Code markdown command to Mistral Vibe skill format
+ * Mistral Vibe uses TOML config files with prompt field
+ * @param {string} content - Markdown file content with YAML frontmatter
+ * @param {string} skillName - Name of the skill (e.g., 'gsd-help')
+ * @returns {string} - TOML content for Mistral Vibe skill
+ */
+function convertClaudeToMistralVibeToml(content, skillName) {
+  // Check if content has frontmatter
+  if (!content.startsWith('---')) {
+    // No frontmatter - use entire content as prompt
+    const description = `Run GSD workflow ${skillName}.`;
+    return `description = ${JSON.stringify(description)}\nprompt = ${JSON.stringify(content)}\n`;
+  }
+
+  const endIndex = content.indexOf('---', 3);
+  if (endIndex === -1) {
+    const description = `Run GSD workflow ${skillName}.`;
+    return `description = ${JSON.stringify(description)}\nprompt = ${JSON.stringify(content)}\n`;
+  }
+
+  const frontmatter = content.substring(3, endIndex).trim();
+  const body = content.substring(endIndex + 3).trim();
+
+  // Extract description from frontmatter
+  let description = `Run GSD workflow ${skillName}.`;
+  const lines = frontmatter.split('\n');
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith('description:')) {
+      description = trimmed.substring(12).trim();
+      break;
+    }
+  }
+
+  // Construct TOML
+  let toml = '';
+  if (description) {
+    toml += `description = ${JSON.stringify(description)}\n`;
+  }
+
+  toml += `prompt = ${JSON.stringify(body)}\n`;
+
   return toml;
 }
 
@@ -1056,6 +1127,23 @@ function listCodexSkillNames(skillsDir, prefix = 'gsd-') {
     .sort();
 }
 
+/**
+ * List Mistral Vibe skill names from skills directory
+ * Looks for directories starting with prefix that contain config.toml
+ * @param {string} skillsDir - Skills directory path
+ * @param {string} prefix - Skill name prefix (default 'gsd-')
+ * @returns {string[]} Array of skill names
+ */
+function listMistralVibeSkillNames(skillsDir, prefix = 'gsd-') {
+  if (!fs.existsSync(skillsDir)) return [];
+  const entries = fs.readdirSync(skillsDir, { withFileTypes: true });
+  return entries
+    .filter(entry => entry.isDirectory() && entry.name.startsWith(prefix))
+    .filter(entry => fs.existsSync(path.join(skillsDir, entry.name, 'config.toml')))
+    .map(entry => entry.name)
+    .sort();
+}
+
 function copyCommandsAsCodexSkills(srcDir, skillsDir, prefix, pathPrefix, runtime) {
   if (!fs.existsSync(srcDir)) {
     return;
@@ -1103,6 +1191,73 @@ function copyCommandsAsCodexSkills(srcDir, skillsDir, prefix, pathPrefix, runtim
       content = convertClaudeCommandToCodexSkill(content, skillName);
 
       fs.writeFileSync(path.join(skillDir, 'SKILL.md'), content);
+    }
+  }
+
+  recurse(srcDir, prefix);
+}
+
+/**
+ * Copy commands to Mistral Vibe skills directory
+ * Mistral Vibe expects: skills/gsd-help/config.toml (invoked as /gsd-help)
+ * Source structure: commands/gsd/help.md
+ *
+ * @param {string} srcDir - Source directory (e.g., commands/gsd/)
+ * @param {string} skillsDir - Destination directory (e.g., skills/)
+ * @param {string} prefix - Prefix for skill names (e.g., 'gsd')
+ * @param {string} pathPrefix - Path prefix for file references
+ * @param {string} runtime - Target runtime ('mistral')
+ */
+function copyCommandsAsMistralVibeSkills(srcDir, skillsDir, prefix, pathPrefix, runtime) {
+  if (!fs.existsSync(srcDir)) {
+    return;
+  }
+
+  fs.mkdirSync(skillsDir, { recursive: true });
+
+  // Remove previous GSD Mistral skills to avoid stale skills
+  const existing = fs.readdirSync(skillsDir, { withFileTypes: true });
+  for (const entry of existing) {
+    if (entry.isDirectory() && entry.name.startsWith(`${prefix}-`)) {
+      fs.rmSync(path.join(skillsDir, entry.name), { recursive: true });
+    }
+  }
+
+  function recurse(currentSrcDir, currentPrefix) {
+    const entries = fs.readdirSync(currentSrcDir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const srcPath = path.join(currentSrcDir, entry.name);
+      if (entry.isDirectory()) {
+        recurse(srcPath, `${currentPrefix}-${entry.name}`);
+        continue;
+      }
+
+      if (!entry.name.endsWith('.md')) {
+        continue;
+      }
+
+      const baseName = entry.name.replace('.md', '');
+      const skillName = `${currentPrefix}-${baseName}`;
+      const skillDir = path.join(skillsDir, skillName);
+      fs.mkdirSync(skillDir, { recursive: true });
+
+      let content = fs.readFileSync(srcPath, 'utf8');
+      const globalClaudeRegex = /~\/\.claude\//g;
+      const globalClaudeHomeRegex = /\$HOME\/\.claude\//g;
+      const localClaudeRegex = /\.\/\.claude\//g;
+      const vibeDirRegex = /~\/\.vibe\//g;
+      content = content.replace(globalClaudeRegex, pathPrefix);
+      content = content.replace(globalClaudeHomeRegex, toHomePrefix(pathPrefix));
+      content = content.replace(localClaudeRegex, `./${getDirName(runtime)}/`);
+      content = content.replace(vibeDirRegex, pathPrefix);
+      content = processAttribution(content, getCommitAttribution(runtime));
+      
+      // Convert slash commands in content: /gsd:help -> /gsd-help
+      content = content.replace(/\/gsd:/g, '/gsd-');
+      
+      const tomlContent = convertClaudeToMistralVibeToml(content, skillName);
+      fs.writeFileSync(path.join(skillDir, 'config.toml'), tomlContent);
     }
   }
 
@@ -1253,12 +1408,13 @@ function cleanupOrphanedHooks(settings) {
  * Uninstall GSD from the specified directory for a specific runtime
  * Removes only GSD-specific files/directories, preserves user content
  * @param {boolean} isGlobal - Whether to uninstall from global or local
- * @param {string} runtime - Target runtime ('claude', 'opencode', 'gemini', 'codex', 'qwen')
+ * @param {string} runtime - Target runtime ('claude', 'opencode', 'gemini', 'codex', 'qwen', 'mistral')
  */
 function uninstall(isGlobal, runtime = 'claude') {
   const isOpencode = runtime === 'opencode';
   const isCodex = runtime === 'codex';
   const isQwen = runtime === 'qwen';
+  const isMistral = runtime === 'mistral';
   const dirName = getDirName(runtime);
 
   // Get the target directory based on runtime and install type
@@ -1275,6 +1431,7 @@ function uninstall(isGlobal, runtime = 'claude') {
   if (runtime === 'gemini') runtimeLabel = 'Gemini';
   if (runtime === 'codex') runtimeLabel = 'Codex';
   if (runtime === 'qwen') runtimeLabel = 'Qwen Code';
+  if (runtime === 'mistral') runtimeLabel = 'Mistral Vibe';
 
   console.log(`  Uninstalling GSD from ${cyan}${runtimeLabel}${reset} at ${cyan}${locationLabel}${reset}\n`);
 
@@ -1350,6 +1507,23 @@ function uninstall(isGlobal, runtime = 'claude') {
         fs.writeFileSync(configPath, cleaned);
         removedCount++;
         console.log(`  ${green}✓${reset} Cleaned GSD sections from config.toml`);
+      }
+    }
+  } else if (isMistral) {
+    // Mistral Vibe: remove skills/gsd-*/config.toml skill directories
+    const skillsDir = path.join(targetDir, 'skills');
+    if (fs.existsSync(skillsDir)) {
+      let skillCount = 0;
+      const entries = fs.readdirSync(skillsDir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (entry.isDirectory() && entry.name.startsWith('gsd-')) {
+          fs.rmSync(path.join(skillsDir, entry.name), { recursive: true });
+          skillCount++;
+        }
+      }
+      if (skillCount > 0) {
+        removedCount++;
+        console.log(`  ${green}✓${reset} Removed ${skillCount} Mistral Vibe skills`);
       }
     }
   } else {
@@ -1882,6 +2056,7 @@ function install(isGlobal, runtime = 'claude') {
   const isGemini = runtime === 'gemini';
   const isCodex = runtime === 'codex';
   const isQwen = runtime === 'qwen';
+  const isMistral = runtime === 'mistral';
   const dirName = getDirName(runtime);
   const src = path.join(__dirname, '..');
 
@@ -1906,6 +2081,7 @@ function install(isGlobal, runtime = 'claude') {
   if (isGemini) runtimeLabel = 'Gemini';
   if (isCodex) runtimeLabel = 'Codex';
   if (isQwen) runtimeLabel = 'Qwen Code';
+  if (isMistral) runtimeLabel = 'Mistral Vibe';
 
   console.log(`  Installing for ${cyan}${runtimeLabel}${reset} to ${cyan}${locationLabel}${reset}\n`);
 
@@ -1943,11 +2119,22 @@ function install(isGlobal, runtime = 'claude') {
     } else {
       failures.push('skills/gsd-*');
     }
+  } else if (isMistral) {
+    // Mistral Vibe: skills structure in skills/ directory
+    const skillsDir = path.join(targetDir, 'skills');
+    const gsdSrc = path.join(src, 'commands', 'gsd');
+    copyCommandsAsMistralVibeSkills(gsdSrc, skillsDir, 'gsd', pathPrefix, runtime);
+    const installedSkillNames = listMistralVibeSkillNames(skillsDir);
+    if (installedSkillNames.length > 0) {
+      console.log(`  ${green}✓${reset} Installed ${installedSkillNames.length} skills to skills/`);
+    } else {
+      failures.push('skills/gsd-*');
+    }
   } else {
-    // Claude Code & Gemini: nested structure in commands/ directory
+    // Claude Code, Gemini, Qwen Code: nested structure in commands/ directory
     const commandsDir = path.join(targetDir, 'commands');
     fs.mkdirSync(commandsDir, { recursive: true });
-    
+
     const gsdSrc = path.join(src, 'commands', 'gsd');
     const gsdDest = path.join(commandsDir, 'gsd');
     copyWithPathReplacement(gsdSrc, gsdDest, pathPrefix, runtime, true);
@@ -2315,15 +2502,18 @@ function promptRuntime(callback) {
   ${cyan}3${reset}) Gemini      ${dim}(~/.gemini)${reset}
   ${cyan}4${reset}) Codex       ${dim}(~/.codex)${reset}
   ${cyan}5${reset}) Qwen Code   ${dim}(~/.qwen)${reset} - optimized for Qwen3-Coder
-  ${cyan}6${reset}) All
+  ${cyan}6${reset}) Mistral Vibe${dim}(~/.vibe)${reset} - Mistral AI coding assistant
+  ${cyan}7${reset}) All
 `);
 
   rl.question(`  Choice ${dim}[1]${reset}: `, (answer) => {
     answered = true;
     rl.close();
     const choice = answer.trim() || '1';
-    if (choice === '6') {
-      callback(['claude', 'opencode', 'gemini', 'codex', 'qwen']);
+    if (choice === '7') {
+      callback(['claude', 'opencode', 'gemini', 'codex', 'qwen', 'mistral']);
+    } else if (choice === '6') {
+      callback(['mistral']);
     } else if (choice === '5') {
       callback(['qwen']);
     } else if (choice === '4') {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "get-shit-done-cc",
   "version": "1.22.4",
-  "description": "A meta-prompting, context engineering and spec-driven development system for Claude Code, OpenCode, Gemini, Codex, and Qwen Code by TÂCHES.",
+  "description": "A meta-prompting, context engineering and spec-driven development system for Claude Code, OpenCode, Gemini, Codex, Qwen Code, and Mistral Vibe by TÂCHES.",
   "bin": {
     "get-shit-done-cc": "bin/install.js"
   },
@@ -26,7 +26,10 @@
     "codex-cli",
     "qwen",
     "qwen-code",
-    "qwen3-coder"
+    "qwen3-coder",
+    "mistral",
+    "mistral-vibe",
+    "mistral-ai"
   ],
   "author": "TÂCHES",
   "license": "MIT",


### PR DESCRIPTION
## Summary

This PR adds support for **Mistral Vibe** and completes **Qwen Code** support in the GSD (Get Shit Done) system.

## Changes

### Mistral Vibe Support (New)
- Added `--mistral` flag for Mistral Vibe installation
- Added Mistral Vibe to `--all` runtime option
- Added `.vibe` directory mapping for local installs
- Added `~/.vibe` global config directory with `VIBE_CONFIG_DIR` env var support
- Updated interactive menu with Mistral Vibe option (option 6)

### Qwen Code Support (Completed)
- Added `--qwen` flag support
- Added `~/.qwen` global config directory with `QWEN_CONFIG_DIR` env var support
- Added Qwen Code to interactive menu (option 5)
- Added uninstall support for Qwen Code commands

### Conversion Functions
- `convertClaudeToMistralVibeToml()` - Converts Claude Code commands to Mistral Vibe skill TOML format
- `copyCommandsAsMistralVibeSkills()` - Copies commands to Mistral Vibe skills directory structure
- `listMistralVibeSkillNames()` - Lists installed Mistral Vibe skills for verification

### Installation Flow
- **Mistral Vibe**: Uses skills-based approach with `skills/gsd-*/config.toml`
- **Qwen Code**: Uses commands-based approach with `commands/gsd/*.md`
- Slash commands converted: `/gsd:help` → `/gsd-help` (Mistral Vibe)
- Path replacements for `~/.vibe/`, `~/.qwen/`, and `/home/ubuntu/.vibe/`, `/home/ubuntu/.qwen/`

### Documentation
- Updated README.md with Mistral Vibe and Qwen Code installation instructions
- Updated package.json with mistral and qwen keywords

## Usage

```bash
# Install for Mistral Vibe globally
npx get-shit-done-cc --mistral --global

# Install for Qwen Code globally
npx get-shit-done-cc --qwen --global

# Install for both Mistral Vibe and Qwen Code locally
npx get-shit-done-cc --mistral --qwen --local

# Install for all runtimes (Claude, OpenCode, Gemini, Codex, Qwen, Mistral)
npx get-shit-done-cc --all --global

# Interactive install (select option 5 for Qwen, 6 for Mistral, 7 for All)
npx get-shit-done-cc
```

## Testing

All installation tests pass:
- ✓ Qwen Code installation works (commands in `commands/gsd/`)
- ✓ Mistral Vibe installation works (32 skills in `skills/gsd-*/`)
- ✓ Qwen Code uninstall works cleanly
- ✓ Mistral Vibe uninstall works cleanly

## Related

- Mistral Vibe: https://github.com/mistralai/mistral-vibe
- Qwen Code: https://github.com/QwenLM/qwen-code