### PR TITLE
fix: replace invalid commit-docs workflow command

### DIFF
--- a/get-shit-done/workflows/plan-phase.md
+++ b/get-shit-done/workflows/plan-phase.md
@@ -237,7 +237,7 @@ grep -l "## Validation Architecture" "${PHASE_DIR}"/*-RESEARCH.md 2>/dev/null
 test -f "${PHASE_DIR}/${PADDED_PHASE}-VALIDATION.md" && echo "VALIDATION_CREATED=true" || echo "VALIDATION_CREATED=false"
 ```
 5. If `VALIDATION_CREATED=false`: STOP — do not proceed to Step 6
-6. If `commit_docs`: `commit-docs "docs(phase-${PHASE}): add validation strategy"`
+6. If `commit_docs`: `commit "docs(phase-${PHASE}): add validation strategy" --files "${PHASE_DIR}/${PADDED_PHASE}-VALIDATION.md"`
 
 **If not found:** Warn and continue — plans may fail Dimension 8.
 

--- a/get-shit-done/workflows/validate-phase.md
+++ b/get-shit-done/workflows/validate-phase.md
@@ -128,7 +128,7 @@ Handle return:
 git add {test_files}
 git commit -m "test(phase-${PHASE}): add Nyquist validation tests"
 
-node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" commit-docs "docs(phase-${PHASE}): add/update validation strategy"
+node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" commit "docs(phase-${PHASE}): add/update validation strategy" --files "${PHASE_DIR}/${PADDED_PHASE}-VALIDATION.md"
 ```
 
 ## 8. Results + Routing


### PR DESCRIPTION
## What

- replace the invalid `commit-docs` workflow step in `validate-phase` with the supported `commit` command
- pass the generated `VALIDATION.md` path via `--files` so the docs-only commit still targets the intended file
- update the matching `plan-phase` guidance so both workflows stay consistent

Fixes #968.

## Why

- replace the invalid `commit-docs` workflow step in `validate-phase` with the supported `commit` command
- pass the generated `VALIDATION.md` path via `--files` so the docs-only commit still targets the intended file
- update the matching `plan-phase` guidance so both workflows stay consistent

Fixes #968.

## Testing

- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Validation notes:
- `git diff --check`
- `rg -n "commit-docs" get-shit-done/workflows/validate-phase.md get-shit-done/workflows/plan-phase.md`

## Checklist

- [x] Follows GSD style (no enterprise patterns, no filler)
- [ ] Updates CHANGELOG.md for user-facing changes
- [x] No unnecessary dependencies added
- [ ] Works on Windows (backslash paths tested)

## Breaking Changes

None

Fixes #968