### PR TITLE
fix: use roadmap_complete checkbox to override disk_status

### DIFF
--- a/get-shit-done/bin/lib/roadmap.cjs
+++ b/get-shit-done/bin/lib/roadmap.cjs
@@ -157,6 +157,13 @@ function cmdRoadmapAnalyze(cwd, raw) {
     const checkboxMatch = content.match(checkboxPattern);
     const roadmapComplete = checkboxMatch ? checkboxMatch[1] === 'x' : false;
 
+    // If roadmap marks phase complete, trust that over disk file structure.
+    // Phases completed before GSD tracking (or via external tools) may lack
+    // the standard PLAN/SUMMARY pairs but are still done.
+    if (roadmapComplete && diskStatus !== 'complete') {
+      diskStatus = 'complete';
+    }
+
     phases.push({
       number: phaseNum,
       name: phaseName,


### PR DESCRIPTION
## Summary
- When ROADMAP.md marks a phase `[x]` complete, override `disk_status` to `"complete"` regardless of file structure
- One-line fix in `bin/lib/roadmap.cjs` — the `roadmap_complete` field was already parsed but never used

## Problem
Phases completed before GSD tracking (or via external tools) lack standard `-PLAN.md`/`-SUMMARY.md` pairs. They get `disk_status: "discussed"` or `"planned"` even though `roadmap_complete: true`. This causes:
- `/gsd:progress` routing to these phases as if they need work
- `progress bar` showing incorrect completion percentages
- `/ax:status` reporting stale phase status

## Fix
After the `roadmap_complete` checkbox is parsed (~line 158), add:
```js
if (roadmapComplete && diskStatus !== 'complete') {
  diskStatus = 'complete';
}
```

## Related
- Fixes #977
- Related to #689 (same class of disk-vs-roadmap mismatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)