### PR TITLE
feat: Add OpenHands CLI support

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -769,11 +769,11 @@ function installOpenHandsSkills(targetDir, agentsSrc) {
   for (const file of agentEntries) {
     const content = fs.readFileSync(path.join(agentsSrc, file), 'utf8');
     const { frontmatter, body } = extractFrontmatterAndBody(content);
-    const name = extractFrontmatterField(frontmatter, 'name') || file.replace('.md', '');
+    const name = extractFrontmatterField(frontmatter, 'name') || file.replace('.md', '').replace(/^gsd-/, '');
     const description = extractFrontmatterField(frontmatter, 'description') || '';
     
-    // Create skill directory
-    const skillDir = path.join(skillsDir, `gsd-${name}`);
+    // Create skill directory (use name directly, already has gsd- prefix)
+    const skillDir = path.join(skillsDir, name);
     fs.mkdirSync(skillDir, { recursive: true });
 
     // Generate SKILL.md content for OpenHands
@@ -796,7 +796,7 @@ function generateOpenHandsSkillMd(name, description, body, pathPrefix) {
     .replace(/\$HOME\/\.claude\//g, pathPrefix.replace('$HOME', os.homedir()));
 
   return `---
-name: gsd-${name}
+name: ${name}
 description: ${description || 'GSD agent for ' + name}
 ---
 
@@ -2275,8 +2275,9 @@ function install(isGlobal, runtime = 'claude') {
 function finishInstall(settingsPath, settings, statuslineCommand, shouldInstallStatusline, runtime = 'claude', isGlobal = true) {
   const isOpencode = runtime === 'opencode';
   const isCodex = runtime === 'codex';
+  const isOpenHands = runtime === 'openhands';
 
-  if (shouldInstallStatusline && !isOpencode && !isCodex) {
+  if (shouldInstallStatusline && !isOpencode && !isCodex && !isOpenHands) {
     settings.statusLine = {
       type: 'command',
       command: statuslineCommand
@@ -2285,7 +2286,7 @@ function finishInstall(settingsPath, settings, statuslineCommand, shouldInstallS
   }
 
   // Write settings when runtime supports settings.json
-  if (!isCodex) {
+  if (!isCodex && !isOpenHands) {
     writeSettings(settingsPath, settings);
   }
 
@@ -2298,6 +2299,7 @@ function finishInstall(settingsPath, settings, statuslineCommand, shouldInstallS
   if (runtime === 'opencode') program = 'OpenCode';
   if (runtime === 'gemini') program = 'Gemini';
   if (runtime === 'codex') program = 'Codex';
+  if (runtime === 'openhands') program = 'OpenHands';
 
   let command = '/gsd:new-project';
   if (runtime === 'opencode') command = '/gsd-new-project';
@@ -2465,6 +2467,9 @@ function installAllRuntimes(runtimes, isGlobal, isInteractive) {
 
   const finalize = (shouldInstallStatusline) => {
     for (const result of results) {
+      // Skip finalize for OpenHands (no settings.json needed)
+      if (result.runtime === 'openhands') continue;
+      
       const useStatusline = statuslineRuntimes.includes(result.runtime) && shouldInstallStatusline;
       finishInstall(
         result.settingsPath,
@@ -2479,8 +2484,16 @@ function installAllRuntimes(runtimes, isGlobal, isInteractive) {
 
   if (primaryStatuslineResult) {
     handleStatusline(primaryStatuslineResult.settings, isInteractive, finalize);
-  } else {
+  } else if (results.length > 0 && results.some(r => r.runtime !== 'openhands')) {
+    // Has other runtimes besides OpenHands
     finalize(false);
+  } else {
+    // Only OpenHands - no statusline needed, just print done message
+    console.log(`
+  ${green}Done!${reset} GSD skills installed for OpenHands.
+
+  ${cyan}Join the community:${reset} https://discord.gg/gsd
+`);
   }
 }
 


### PR DESCRIPTION

## Summary

This PR adds support for installing GSD (Get Shit Done) with OpenHands CLI.

### Changes

1. **OpenHands skill generation** ( function)
   - Generates OpenHands-compatible skills in  directory
   - Creates SKILL.md files for each GSD agent (planner, executor, verifier, etc.)
   - Converts  paths to OpenHands config paths

2. **Runtime detection**
   - Added  detection throughout the installer
   - Added  variable to handle runtime-specific behavior

3. **Settings handling**
   - OpenHands doesn't use , so we skip writing settings for it
   - Statusline is also skipped for OpenHands (no support)

4. **Commands installation**
   - Installs 32 GSD commands to 
   - Commands follow the  format

### Installation

```bash
node bin/install.js --openhands --global
```

### What gets installed

- **12 GSD Skills**: gsd-planner, gsd-executor, gsd-verifier, gsd-debugger, gsd-phase-researcher, gsd-project-researcher, gsd-codebase-mapper, gsd-roadmapper, gsd-plan-checker, gsd-research-synthesizer, gsd-integration-checker, gsd-nyquist-auditor
- **32 GSD Commands**: /gsd:new-project, /gsd:plan-phase, /gsd:execute-phase, etc.
- **Project data**: In ~/.agents/get-shit-done/

### Testing

Verified installation works correctly:
- Skills are created with proper naming (e.g.,  not )
- Commands are installed to the correct location
- Completion message shows "GSD skills installed for OpenHands"

Co-authored-by: openhands <openhands@all-hands.dev>