### PR TITLE
fix: skip no-research nyquist artifact gating

### DIFF
--- a/get-shit-done/bin/lib/config.cjs
+++ b/get-shit-done/bin/lib/config.cjs
@@ -16,6 +16,19 @@ const VALID_CONFIG_KEYS = new Set([
   'planning.commit_docs', 'planning.search_gitignored',
 ]);
 
+const CONFIG_KEY_SUGGESTIONS = {
+  'workflow.nyquist_validation_enabled': 'workflow.nyquist_validation',
+  'agents.nyquist_validation_enabled': 'workflow.nyquist_validation',
+  'nyquist.validation_enabled': 'workflow.nyquist_validation',
+};
+
+function validateKnownConfigKeyPath(keyPath) {
+  const suggested = CONFIG_KEY_SUGGESTIONS[keyPath];
+  if (suggested) {
+    error(`Unknown config key: ${keyPath}. Did you mean ${suggested}?`);
+  }
+}
+
 function cmdConfigEnsureSection(cwd, raw) {
   const configPath = path.join(cwd, '.planning', 'config.json');
   const planningDir = path.join(cwd, '.planning');
@@ -97,6 +110,8 @@ function cmdConfigSet(cwd, keyPath, value, raw) {
   if (!keyPath) {
     error('Usage: config-set <key.path> <value>');
   }
+
+  validateKnownConfigKeyPath(keyPath);
 
   if (!VALID_CONFIG_KEYS.has(keyPath)) {
     error(`Unknown config key: "${keyPath}". Valid keys: ${[...VALID_CONFIG_KEYS].sort().join(', ')}`);

--- a/get-shit-done/workflows/plan-phase.md
+++ b/get-shit-done/workflows/plan-phase.md
@@ -242,6 +242,13 @@ Skip if `nyquist_validation_enabled` is false OR `research_enabled` is false.
 
 If `research_enabled` is false and `nyquist_validation_enabled` is true: warn "Nyquist validation enabled but research disabled — VALIDATION.md cannot be created without RESEARCH.md. Plans will lack validation requirements (Dimension 8)." Continue to step 6.
 
+**But Nyquist is not applicable for this run** when all of the following are true:
+- `research_enabled` is false
+- `has_research` is false
+- no `--research` flag was provided
+
+In that case: **skip validation-strategy creation entirely**. Do **not** expect `RESEARCH.md` or `VALIDATION.md` for this run, and continue to Step 6.
+
 ```bash
 grep -l "## Validation Architecture" "${PHASE_DIR}"/*-RESEARCH.md 2>/dev/null
 ```
@@ -325,13 +332,21 @@ CONTEXT_PATH=$(printf '%s\n' "$INIT" | jq -r '.context_path // empty')
 
 Skip if `nyquist_validation_enabled` is false OR `research_enabled` is false.
 
+Also skip if all of the following are true:
+- `research_enabled` is false
+- `has_research` is false
+- no `--research` flag was provided
+
+In that no-research path, Nyquist artifacts are **not required** for this run.
+
 ```bash
 VALIDATION_EXISTS=$(ls "${PHASE_DIR}"/*-VALIDATION.md 2>/dev/null | head -1)
 ```
 
-If missing and Nyquist enabled — ask user:
-1. Re-run with research: `/gsd:plan-phase {PHASE} --research`
-2. Disable Nyquist: `node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-set workflow.nyquist_validation false`
+If missing and Nyquist is still enabled/applicable — ask user:
+1. Re-run: `/gsd:plan-phase {PHASE} --research`
+2. Disable Nyquist with the exact command:
+   `node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-set workflow.nyquist_validation false`
 3. Continue anyway (plans fail Dimension 8)
 
 Proceed to Step 8 only if user selects 2 or 3.

--- a/tests/config.test.cjs
+++ b/tests/config.test.cjs
@@ -291,6 +291,17 @@ describe('config-set command', () => {
     const result = runGsdTools('config-set', tmpDir);
     assert.strictEqual(result.success, false);
   });
+
+  test('rejects known invalid nyquist alias keys with a suggestion', () => {
+    const result = runGsdTools('config-set workflow.nyquist_validation_enabled false', tmpDir);
+    assert.strictEqual(result.success, false);
+    assert.match(result.error, /Unknown config key: workflow\.nyquist_validation_enabled/);
+    assert.match(result.error, /workflow\.nyquist_validation/);
+
+    const config = readConfig(tmpDir);
+    assert.strictEqual(config.workflow.nyquist_validation_enabled, undefined);
+    assert.strictEqual(config.workflow.nyquist_validation, true);
+  });
 });
 
 // ─── config-get ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

- stop `plan-phase` from treating Nyquist artifacts as required when research is disabled, no research exists yet, and the run was not forced with `--research`
- make the no-research guidance explicit by pointing the disable path at the exact `workflow.nyquist_validation` config key
- reject the known bogus `*_nyquist_validation_enabled` config aliases with a helpful suggestion instead of silently writing dead config

## Why

- stop `plan-phase` from treating Nyquist artifacts as required when research is disabled, no research exists yet, and the run was not forced with `--research`
- make the no-research guidance explicit by pointing the disable path at the exact `workflow.nyquist_validation` config key
- reject the known bogus `*_nyquist_validation_enabled` config aliases with a helpful suggestion instead of silently writing dead config

## Testing

- [x] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux

Validation notes:
- `node --test tests/config.test.cjs tests/init.test.cjs`
- `git diff --check`

Fixes #980

## Checklist

- [x] Follows GSD style (no enterprise patterns, no filler)
- [ ] Updates CHANGELOG.md for user-facing changes
- [x] No unnecessary dependencies added
- [ ] Works on Windows (backslash paths tested)

## Breaking Changes

None

Fixes #980