### PR TITLE
fix workflow auto-advance persistence after --auto setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- `--auto` new-project setup no longer writes `workflow.auto_advance: true` into `.planning/config.json`; the temporary auto-chain now stays ephemeral so later manual `/gsd:execute-phase` runs do not unexpectedly jump into the next phase (#932)
+
 ## [1.22.4] - 2026-03-03
 
 ### Added

--- a/get-shit-done/workflows/new-project.md
+++ b/get-shit-done/workflows/new-project.md
@@ -179,10 +179,12 @@ Create `.planning/config.json` with mode set to "yolo":
     "plan_check": true|false,
     "verifier": true|false,
     "nyquist_validation": depth !== "quick",
-    "auto_advance": true
+    "auto_advance": false
   }
 }
 ```
+
+`--auto` should only drive the current setup chain. Do **not** persist `workflow.auto_advance: true` into project config, or later manual `/gsd:execute-phase` runs can unexpectedly auto-transition into the next phase.
 
 **If commit_docs = No:** Add `.planning/` to `.gitignore`.
 


### PR DESCRIPTION
## What

Stop `--auto` new-project setup from writing `workflow.auto_advance: true` into `.planning/config.json`, and document that auto-chaining should stay scoped to the current setup run.

## Why

Persisting `workflow.auto_advance` from setup can make later manual `/gsd:execute-phase` runs unexpectedly transition into the next phase, which matches the behavior reported in #932.

## Testing

- [ ] Tested on macOS
- [ ] Tested on Windows
- [ ] Tested on Linux
- Ran `git diff --check`
- Verified the new-project workflow now writes `"auto_advance": false`
- Verified CHANGELOG documents the regression fix for #932

## Checklist

- [x] Follows GSD style (no enterprise patterns, no filler)
- [x] Updates CHANGELOG.md for user-facing changes
- [x] No unnecessary dependencies added
- [ ] Works on Windows (backslash paths tested)

## Breaking Changes

None

Fixes #932
