### PR TITLE
fix: emit valid Codex agent TOML

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -563,9 +563,11 @@ function generateCodexAgentToml(agentName, agentContent) {
 
   const lines = [
     `sandbox_mode = "${sandboxMode}"`,
-    `developer_instructions = """`,
+    // Agent prompts contain raw backslashes in regexes and shell snippets.
+    // TOML literal multiline strings preserve them without escape parsing.
+    `developer_instructions = '''`,
     instructions,
-    `"""`,
+    `'''`,
   ];
   return lines.join('\n') + '\n';
 }

--- a/tests/codex-config.test.cjs
+++ b/tests/codex-config.test.cjs
@@ -155,9 +155,9 @@ tools: Read, Grep, Glob
 
   test('includes developer_instructions from body', () => {
     const result = generateCodexAgentToml('gsd-executor', sampleAgent);
-    assert.ok(result.includes('developer_instructions = """'), 'has triple-quoted instructions');
+    assert.ok(result.includes("developer_instructions = '''"), 'has literal triple-quoted instructions');
     assert.ok(result.includes('<role>You are an executor.</role>'), 'body content in instructions');
-    assert.ok(result.includes('"""'), 'has closing triple quotes');
+    assert.ok(result.includes("'''"), 'has closing literal triple quotes');
   });
 
   test('defaults unknown agents to read-only', () => {


### PR DESCRIPTION
# Human Summary
Codex was unable to run gsd-planner subagent with error `agent type is currently not available`.
I was surprised to not see an issue open for this because it completely broke GSD usage within codex for me. Its possible that this may have been a quirk of just my system. 

# Agent Summary
## What happened
Generated Codex agent TOML files used TOML basic multiline strings for `developer_instructions`. Several GSD agents include raw backslashes in regexes, shell snippets, and fenced examples. In TOML basic strings those backslashes are escape sequences, so the generated `.toml` files became invalid and Codex left those agents unavailable at runtime.

## What this changes
- switch generated Codex agent `developer_instructions` to TOML literal multiline strings
- preserve agent prompt content verbatim instead of forcing TOML escape parsing
- update the Codex config test to assert the new delimiter

## Verification
- `node --test tests/codex-config.test.cjs`
- generated and parsed all `gsd-*.toml` files successfully with `tomllib` after the change

## Impact
This makes Codex installs generate valid agent configs for planner, verifier, researcher, mapper, and integration-checker prompts that contain raw backslashes.