### PR TITLE
fix(codex): avoid duplicate [agents] header in config merge

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -687,6 +687,13 @@ function mergeCodexConfig(configPath, gsdBlock) {
   let content = existing;
   const featuresRegex = /^\[features\]\s*$/m;
   const hasFeatures = featuresRegex.test(content);
+  const hasAgentsHeader = /^\[agents\]\s*$/m.test(content);
+  const agentsBlock = gsdBlock.substring(gsdBlock.indexOf('[agents]'));
+  const agentSubsections = agentsBlock
+    .split('\n')
+    .slice(4)
+    .join('\n')
+    .trim();
 
   if (hasFeatures) {
     if (!content.includes('multi_agent')) {
@@ -695,11 +702,23 @@ function mergeCodexConfig(configPath, gsdBlock) {
     if (!content.includes('default_mode_request_user_input')) {
       content = content.replace(/^\[features\].*$/m, '$&\ndefault_mode_request_user_input = true');
     }
-    // Append agents block (skip the [features] section from gsdBlock)
-    const agentsBlock = gsdBlock.substring(gsdBlock.indexOf('[agents]'));
-    content = content.trimEnd() + '\n\n' + GSD_CODEX_MARKER + '\n' + agentsBlock + '\n';
+    if (hasAgentsHeader && agentSubsections) {
+      content = content.trimEnd() + '\n\n' + GSD_CODEX_MARKER + '\n' + agentSubsections + '\n';
+    } else {
+      // Append agents block (skip the [features] section from gsdBlock)
+      content = content.trimEnd() + '\n\n' + GSD_CODEX_MARKER + '\n' + agentsBlock + '\n';
+    }
   } else {
-    content = content.trimEnd() + '\n\n' + gsdBlock + '\n';
+    if (hasAgentsHeader && agentSubsections) {
+      content = content.trimEnd() + '\n\n' +
+        GSD_CODEX_MARKER + '\n' +
+        '[features]\n' +
+        'multi_agent = true\n' +
+        'default_mode_request_user_input = true\n\n' +
+        agentSubsections + '\n';
+    } else {
+      content = content.trimEnd() + '\n\n' + gsdBlock + '\n';
+    }
   }
 
   fs.writeFileSync(configPath, content);

--- a/tests/codex-config.test.cjs
+++ b/tests/codex-config.test.cjs
@@ -443,6 +443,34 @@ describe('mergeCodexConfig', () => {
     assert.strictEqual(first, second, 'idempotent after 2nd merge');
     assert.strictEqual(second, third, 'idempotent after 3rd merge');
   });
+
+  test('case 3 with existing [agents]: does not duplicate [agents] header', () => {
+    const configPath = path.join(tmpDir, 'config.toml');
+    fs.writeFileSync(
+      configPath,
+      [
+        '[model]',
+        'name = "o3"',
+        '',
+        '[agents]',
+        'max_threads = 2',
+        '',
+        '[agents.custom-helper]',
+        'description = "custom helper"',
+        'config_file = "agents/custom-helper.toml"',
+        '',
+      ].join('\n'),
+    );
+
+    mergeCodexConfig(configPath, sampleBlock);
+
+    const content = fs.readFileSync(configPath, 'utf8');
+    const agentsCount = (content.match(/^\[agents\]\s*$/gm) || []).length;
+    assert.strictEqual(agentsCount, 1, 'exactly one [agents] section');
+    assert.ok(content.includes('[agents.custom-helper]'), 'preserves existing custom agent');
+    assert.ok(content.includes('[agents.gsd-executor]'), 'adds GSD agents');
+    assert.ok(content.includes(GSD_CODEX_MARKER), 'adds managed marker');
+  });
 });
 
 // ─── Integration: installCodexConfig ────────────────────────────────────────────


### PR DESCRIPTION
## What This PR Fixes

This PR carries forward only the remaining Codex installer fix from superseded PR #914.

- `mergeCodexConfig` now avoids adding a second `[agents]` header when one already exists in `config.toml`.
- The Codex config merge path remains idempotent across repeated installs.

## Why This Is Separate

The Gemini `skills:` frontmatter issue from PR #914 was already fixed upstream in PR #971, so this replacement PR intentionally excludes all Gemini changes and keeps scope to the unresolved Codex behavior only.

## Implementation Scope

- `bin/install.js`
- `tests/codex-config.test.cjs`

## Validation

- `GSD_TEST_MODE=1 node --test tests/codex-config.test.cjs`
- `npm test`
