### PR TITLE
fix: prevent auto-advance without --auto flag

### DIFF
--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -28,8 +28,9 @@ Parse JSON for: `executor_model`, `verifier_model`, `commit_docs`, `parallelizat
 
 When `parallelization` is false, plans within a wave execute sequentially.
 
-**Sync chain flag with intent** — if user invoked manually (no `--auto`), clear the ephemeral chain flag from any previous interrupted `--auto` chain. This does NOT touch `workflow.auto_advance` (the user's persistent settings preference). Must happen before any config reads (checkpoint handling also reads auto-advance flags):
+**REQUIRED — Sync chain flag with intent.** If user invoked manually (no `--auto`), clear the ephemeral chain flag from any previous interrupted `--auto` chain. This prevents stale `_auto_chain_active: true` from causing unwanted auto-advance. This does NOT touch `workflow.auto_advance` (the user's persistent settings preference). You MUST execute this bash block before any config reads:
 ```bash
+# REQUIRED: prevents stale auto-chain from previous --auto runs
 if [[ ! "$ARGUMENTS" =~ --auto ]]; then
   node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-set workflow._auto_chain_active false 2>/dev/null
 fi
@@ -433,9 +434,17 @@ Execute the transition workflow inline (do NOT use Task — orchestrator context
 
 Read and follow `~/.claude/get-shit-done/workflows/transition.md`, passing through the `--auto` flag so it propagates to the next phase invocation.
 
-**If neither `--auto` nor `AUTO_CFG` is true:**
+**If none of `--auto`, `AUTO_CHAIN`, or `AUTO_CFG` is true:**
 
-The workflow ends. The user runs `/gsd:progress` or invokes the transition workflow manually.
+**STOP. Do not auto-advance. Do not execute transition. Do not plan next phase. Present options to the user and wait.**
+
+```
+## ✓ Phase {X}: {Name} Complete
+
+/gsd:progress — see updated roadmap
+/gsd:transition — plan next phase transition
+/gsd:execute-phase {next} — execute next phase
+```
 </step>
 
 </process>


### PR DESCRIPTION
## Summary
- Fixed asymmetric stop-guard in `offer_next` step that omitted `AUTO_CHAIN` check
- Strengthened STOP instruction to prevent LLM misinterpretation
- Made chain flag clearing more prominent in initialize step

Closes #1026, closes #932

## Test plan
- [ ] Run `/gsd:execute-phase` without `--auto` — should stop and present options after completion
- [ ] Run `/gsd:execute-phase --auto` — should auto-advance as before
- [ ] Run `/gsd:execute-phase` after a previously interrupted `--auto` run — should NOT auto-advance

🤖 Generated with [Claude Code](https://claude.com/claude-code)