### PR TITLE
fix: replace invalid commit-docs with commit command

### DIFF
--- a/get-shit-done/workflows/plan-phase.md
+++ b/get-shit-done/workflows/plan-phase.md
@@ -237,7 +237,7 @@ grep -l "## Validation Architecture" "${PHASE_DIR}"/*-RESEARCH.md 2>/dev/null
 test -f "${PHASE_DIR}/${PADDED_PHASE}-VALIDATION.md" && echo "VALIDATION_CREATED=true" || echo "VALIDATION_CREATED=false"
 ```
 5. If `VALIDATION_CREATED=false`: STOP — do not proceed to Step 6
-6. If `commit_docs`: `commit-docs "docs(phase-${PHASE}): add validation strategy"`
+6. If `commit_docs`: `commit "docs(phase-${PHASE}): add validation strategy"`
 
 **If not found:** Warn and continue — plans may fail Dimension 8.
 

--- a/get-shit-done/workflows/validate-phase.md
+++ b/get-shit-done/workflows/validate-phase.md
@@ -128,7 +128,7 @@ Handle return:
 git add {test_files}
 git commit -m "test(phase-${PHASE}): add Nyquist validation tests"
 
-node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" commit-docs "docs(phase-${PHASE}): add/update validation strategy"
+node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" commit "docs(phase-${PHASE}): add/update validation strategy"
 ```
 
 ## 8. Results + Routing


### PR DESCRIPTION
## Summary
- Replaced non-existent `commit-docs` gsd-tools command with valid `commit` command
- Fixed in validate-phase.md and plan-phase.md workflows

Closes #968

## Test plan
- [ ] Run `/gsd:plan-phase` through to the commit step — should succeed
- [ ] Run `/gsd:validate-phase` through to the commit step — should succeed
- [ ] Verify `node bin/gsd-tools.cjs commit --help` shows correct usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)