### PR TITLE
fix: correct decimal phase number padding

### DIFF
--- a/get-shit-done/bin/lib/init.cjs
+++ b/get-shit-done/bin/lib/init.cjs
@@ -113,7 +113,7 @@ function cmdInitPlanPhase(cwd, phase, raw) {
     phase_number: phaseInfo?.phase_number || null,
     phase_name: phaseInfo?.phase_name || null,
     phase_slug: phaseInfo?.phase_slug || null,
-    padded_phase: phaseInfo?.phase_number?.padStart(2, '0') || null,
+    padded_phase: phaseInfo?.phase_number ? normalizePhaseName(phaseInfo.phase_number) : null,
     phase_req_ids,
 
     // Existing artifacts
@@ -397,7 +397,7 @@ function cmdInitPhaseOp(cwd, phase, raw) {
     phase_number: phaseInfo?.phase_number || null,
     phase_name: phaseInfo?.phase_name || null,
     phase_slug: phaseInfo?.phase_slug || null,
-    padded_phase: phaseInfo?.phase_number?.padStart(2, '0') || null,
+    padded_phase: phaseInfo?.phase_number ? normalizePhaseName(phaseInfo.phase_number) : null,
 
     // Existing artifacts
     has_research: phaseInfo?.has_research || false,


### PR DESCRIPTION
## Summary
- Replaced raw `.padStart(2, '0')` with `normalizePhaseName()` at both `padded_phase` assignments in `init.cjs` (lines 116 and 400)
- `normalizePhaseName()` already exists in `core.cjs` and correctly pads only the integer prefix before any decimal portion
- Decimal phase numbers like "8.1" now pad to "08.1" instead of staying "8.1"

Closes #915

## Test plan
- [x] Phase "8" pads to "08"
- [x] Phase "8.1" pads to "08.1"
- [x] Phase "12" stays "12"
- [x] Phase "12.3" stays "12.3"

🤖 Generated with [Claude Code](https://claude.com/claude-code)