### PR TITLE
fix: handle EPERM/EACCES in scanForLeakedPaths on Windows

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -2434,13 +2434,29 @@ function install(isGlobal, runtime = 'claude') {
     const leakedPaths = [];
     function scanForLeakedPaths(dir) {
       if (!fs.existsSync(dir)) return;
-      const entries = fs.readdirSync(dir, { withFileTypes: true });
+      let entries;
+      try {
+        entries = fs.readdirSync(dir, { withFileTypes: true });
+      } catch (err) {
+        if (err.code === 'EPERM' || err.code === 'EACCES') {
+          return; // skip inaccessible directories
+        }
+        throw err;
+      }
       for (const entry of entries) {
         const fullPath = path.join(dir, entry.name);
         if (entry.isDirectory()) {
           scanForLeakedPaths(fullPath);
         } else if ((entry.name.endsWith('.md') || entry.name.endsWith('.toml')) && entry.name !== 'CHANGELOG.md') {
-          const content = fs.readFileSync(fullPath, 'utf8');
+          let content;
+          try {
+            content = fs.readFileSync(fullPath, 'utf8');
+          } catch (err) {
+            if (err.code === 'EPERM' || err.code === 'EACCES') {
+              continue; // skip inaccessible files
+            }
+            throw err;
+          }
           const matches = content.match(/(?:~|\$HOME)\/\.claude\b/g);
           if (matches) {
             leakedPaths.push({ file: fullPath.replace(targetDir + '/', ''), count: matches.length });


### PR DESCRIPTION
## Summary
- Wraps `fs.readdirSync` in `scanForLeakedPaths` with a try/catch that silently skips directories throwing `EPERM` or `EACCES`
- Wraps `fs.readFileSync` with the same guard for files that are listed by dirent but deny read access
- Prevents installer crash on Windows when scanning directories with restricted ACLs (e.g. Chrome/Gemini certificate stores)

Closes #964

## Test plan
- [ ] Run installer on Windows against a directory tree containing restricted-ACL folders
- [ ] Verify installer completes without EPERM crash
- [ ] Verify leaked-path detection still works for accessible files

🤖 Generated with [Claude Code](https://claude.com/claude-code)