### PR TITLE
feat(discuss): show remaining areas when asking to continue or move on

### DIFF
--- a/commands/gsd/discuss-phase.md
+++ b/commands/gsd/discuss-phase.md
@@ -68,7 +68,8 @@ Generate 3-4 **phase-specific** gray areas, not generic categories.
 
 **Probing depth:**
 - Ask 4 questions per area before checking
-- "More questions about [area], or move to next?"
+- "More questions about [area], or move to next? (Remaining: [list unvisited areas])"
+- Show remaining unvisited areas so user knows what's still ahead
 - If more → ask 4 more, check again
 - After all areas → "Ready to create context?"
 

--- a/get-shit-done/workflows/discuss-phase.md
+++ b/get-shit-done/workflows/discuss-phase.md
@@ -456,8 +456,10 @@ After all areas are auto-resolved, skip the "Explore more gray areas" prompt and
 
 3. **After the current set of questions, check:**
    - header: "[Area]" (max 12 chars)
-   - question: "More questions about [area], or move to next?"
+   - question: "More questions about [area], or move to next? (Remaining: [list other unvisited areas])"
    - options: "More questions" / "Next area"
+
+   When building the question text, list the remaining unvisited areas so the user knows what's ahead. For example: "More questions about Layout, or move to next? (Remaining: Loading behavior, Content ordering)"
 
    If "More questions" → ask another 4 single questions, or another 2-5 question batch when `--batch` is active, then check again
    If "Next area" → proceed to next selected area


### PR DESCRIPTION
## Summary

When the discuss-phase workflow asks the user "More questions about [area], or move to next?", it now also lists the remaining unvisited areas so the user can see what's ahead and make an informed decision.

## Example

Before:
> More questions about Layout, or move to next?

After:
> More questions about Layout, or move to next? (Remaining: Loading behavior, Content ordering)

## Changes

- `get-shit-done/workflows/discuss-phase.md`: Updated step 3 prompt to include remaining areas list
- `commands/gsd/discuss-phase.md`: Updated probing depth instructions to match

Fixes #992