### PR TITLE
feat(hooks): add config option to disable context window warnings

### DIFF
--- a/get-shit-done/templates/config.json
+++ b/get-shit-done/templates/config.json
@@ -33,5 +33,8 @@
   "safety": {
     "always_confirm_destructive": true,
     "always_confirm_external_services": true
+  },
+  "hooks": {
+    "context_warnings": true
   }
 }

--- a/get-shit-done/workflows/settings.md
+++ b/get-shit-done/workflows/settings.md
@@ -126,6 +126,15 @@ AskUserQuestion([
       { label: "Per Phase", description: "Create branch for each phase (gsd/phase-{N}-{name})" },
       { label: "Per Milestone", description: "Create branch for entire milestone (gsd/{version}-{name})" }
     ]
+  },
+  {
+    question: "Enable context window warnings? (injects advisory messages when context is getting full)",
+    header: "Ctx Warnings",
+    multiSelect: false,
+    options: [
+      { label: "Yes (Recommended)", description: "Warn when context usage exceeds 65%. Helps avoid losing work." },
+      { label: "No", description: "Disable warnings. Allows Claude to reach auto-compact naturally. Good for long unattended runs." }
+    ]
   }
 ])
 ```
@@ -149,6 +158,9 @@ Merge new settings into existing config.json:
   },
   "git": {
     "branching_strategy": "none" | "phase" | "milestone"
+  },
+  "hooks": {
+    "context_warnings": true/false
   }
 }
 ```
@@ -220,6 +232,7 @@ Display:
 | UI Phase             | {On/Off} |
 | UI Safety Gate       | {On/Off} |
 | Git Branching        | {None/Per Phase/Per Milestone} |
+| Context Warnings     | {On/Off} |
 | Saved as Defaults    | {Yes/No} |
 
 These settings apply to future /gsd:plan-phase and /gsd:execute-phase runs.

--- a/hooks/gsd-context-monitor.js
+++ b/hooks/gsd-context-monitor.js
@@ -43,6 +43,20 @@ process.stdin.on('end', () => {
       process.exit(0);
     }
 
+    // Check if context warnings are disabled via config
+    const cwd = data.cwd || process.cwd();
+    const configPath = path.join(cwd, '.planning', 'config.json');
+    if (fs.existsSync(configPath)) {
+      try {
+        const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+        if (config.hooks?.context_warnings === false) {
+          process.exit(0);
+        }
+      } catch (e) {
+        // Ignore config parse errors
+      }
+    }
+
     const tmpDir = os.tmpdir();
     const metricsPath = path.join(tmpDir, `claude-ctx-${sessionId}.json`);
 


### PR DESCRIPTION
## Summary

Adds a `hooks.context_warnings` config option (default: `true`) that allows users to disable the context monitor hook's advisory messages. When set to `false`, the hook exits silently, allowing Claude Code to reach auto-compact naturally.

## Problem

Users running long unattended sessions report that the context warning injection prevents Claude from reaching auto-compact mode, requiring manual `/clear` babysitting (#976).

## Solution

- Read `.planning/config.json` in the context monitor hook
- If `hooks.context_warnings` is `false`, exit without injecting any message
- Default remains `true` (existing behavior preserved)
- Exposed in `/gsd:settings` UI for easy toggling

## Usage

```bash
# Via settings UI
/gsd:settings

# Or via CLI
node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-set hooks.context_warnings false
```

## Changes

- `hooks/gsd-context-monitor.js`: Check config before emitting warnings
- `get-shit-done/templates/config.json`: Add `hooks.context_warnings` default
- `get-shit-done/workflows/settings.md`: Add setting to UI + config schema + summary table

Fixes #976