### PR TITLE
fix(executor): add untracked files check after task commits

### DIFF
--- a/agents/gsd-executor.md
+++ b/agents/gsd-executor.md
@@ -337,6 +337,8 @@ git commit -m "{type}({phase}-{plan}): {concise task description}
 ```
 
 **5. Record hash:** `TASK_COMMIT=$(git rev-parse --short HEAD)` — track for SUMMARY.
+
+**6. Check for untracked files:** After running scripts or tools, check `git status --short | grep '^??'`. For any new untracked files: commit if intentional, add to `.gitignore` if generated/runtime output. Never leave generated files untracked.
 </task_commit_protocol>
 
 <summary_creation>

--- a/get-shit-done/workflows/execute-plan.md
+++ b/get-shit-done/workflows/execute-plan.md
@@ -279,6 +279,15 @@ TASK_COMMIT=$(git rev-parse --short HEAD)
 TASK_COMMITS+=("Task ${TASK_NUM}: ${TASK_COMMIT}")
 ```
 
+**6. Check for untracked generated files:**
+```bash
+git status --short | grep '^??'
+```
+If new untracked files appeared after running scripts or tools, decide for each:
+- **Commit it** — if it's a source file, config, or intentional artifact
+- **Add to .gitignore** — if it's a generated/runtime output (build artifacts, `.env` files, cache files, compiled output)
+- Do NOT leave generated files untracked
+
 </task_commit>
 
 <step name="checkpoint_protocol">


### PR DESCRIPTION
## Summary

After committing task changes, the executor now checks for untracked files and handles them appropriately — commit if intentional, add to `.gitignore` if generated/runtime output.

## Problem

When a plan creates a script that produces output files at runtime (e.g., a dotenv artifact, a generated config), the executor runs the script to verify it works — which drops the generated file into the working tree. Neither the planner, executor, nor verifier catches this, leaving untracked files behind (#957).

## Fix

Add step 6 to the task commit protocol in both:
- `get-shit-done/workflows/execute-plan.md`
- `agents/gsd-executor.md`

After committing, run `git status --short | grep '^??'` and for each new untracked file, either commit it or add it to `.gitignore`.

Fixes #957