### PR TITLE
feat(plan-phase): ask user about research instead of silently deciding

### DIFF
--- a/get-shit-done/workflows/plan-phase.md
+++ b/get-shit-done/workflows/plan-phase.md
@@ -174,11 +174,32 @@ If "Run discuss-phase first": Display `/gsd:discuss-phase {X}` and exit workflow
 
 ## 5. Handle Research
 
-**Skip if:** `--gaps` flag, `--skip-research` flag, or `research_enabled` is false (from init) without `--research` override.
+**Skip if:** `--gaps` flag or `--skip-research` flag.
 
 **If `has_research` is true (from init) AND no `--research` flag:** Use existing, skip to step 6.
 
 **If RESEARCH.md missing OR `--research` flag:**
+
+**If no explicit flag (`--research` or `--skip-research`) and not `--auto`:**
+Ask the user whether to research, with a contextual recommendation based on the phase:
+
+```
+AskUserQuestion([
+  {
+    question: "Research before planning Phase {X}: {phase_name}?",
+    header: "Research",
+    multiSelect: false,
+    options: [
+      { label: "Research first (Recommended)", description: "Investigate domain, patterns, and dependencies before planning. Best for new features, unfamiliar integrations, or architectural changes." },
+      { label: "Skip research", description: "Plan directly from context and requirements. Best for bug fixes, simple refactors, or well-understood tasks." }
+    ]
+  }
+])
+```
+
+If user selects "Skip research": skip to step 6.
+
+**If `--auto` and `research_enabled` is false:** Skip research silently (preserves automated behavior).
 
 Display banner:
 ```


### PR DESCRIPTION
## Summary

Instead of silently skipping research based on the `research_enabled` config toggle, plan-phase now asks the user whether to research before planning.

## Problem

The plan-phase workflow silently decides whether to research based on a config toggle. Users aren't aware of why research sometimes runs and sometimes doesn't, leading to inconsistent behavior (#846).

## Fix

When no explicit flag (`--research` or `--skip-research`) is provided and not in `--auto` mode, prompt the user:

- **"Research first (Recommended)"** — for new features, unfamiliar integrations, architectural changes
- **"Skip research"** — for bug fixes, simple refactors, well-understood tasks

Existing behavior preserved:
- `--research` / `--skip-research` flags still work as silent overrides
- `--auto` mode respects the config toggle silently
- If RESEARCH.md already exists, it's reused without prompting

Fixes #846