### PR TITLE
fix(researcher): verify package versions against registry before recommending

### DIFF
--- a/agents/gsd-phase-researcher.md
+++ b/agents/gsd-phase-researcher.md
@@ -238,6 +238,12 @@ Priority: Context7 > Official Docs > Official GitHub > Verified WebSearch > Unve
 npm install [packages]
 \`\`\`
 
+**Version verification:** Before writing the Standard Stack table, verify each recommended package version is current:
+\`\`\`bash
+npm view [package] version
+\`\`\`
+Document the verified version and publish date. Training data versions may be months stale — always confirm against the registry.
+
 ## Architecture Patterns
 
 ### Recommended Project Structure


### PR DESCRIPTION
## Summary

The researcher agent now includes a mandatory version verification step before writing the Standard Stack section.

## Problem

The researcher recommends package versions from training data, which can be months stale. This leads to plans that reference outdated or yanked versions (#899, patch 5).

## Fix

Add a version verification instruction to `gsd-phase-researcher.md`:

```bash
npm view [package] version
```

The researcher must verify each recommended package against the registry and document the verified version and publish date.

## Changes

- `agents/gsd-phase-researcher.md`: Add version verification protocol after the Standard Stack installation block

Addresses patch 5 from #899