### PR TITLE
fix(settings): clarify balanced profile uses Sonnet for research

### DIFF
--- a/get-shit-done/workflows/settings.md
+++ b/get-shit-done/workflows/settings.md
@@ -47,7 +47,7 @@ AskUserQuestion([
     multiSelect: false,
     options: [
       { label: "Quality", description: "Opus everywhere except verification (highest cost)" },
-      { label: "Balanced (Recommended)", description: "Opus for planning, Sonnet for execution/verification" },
+      { label: "Balanced (Recommended)", description: "Opus for planning, Sonnet for research/execution/verification" },
       { label: "Budget", description: "Sonnet for writing, Haiku for research/verification (lowest cost)" },
       { label: "Inherit", description: "Use current session model for all agents (best for OpenCode /model)" }
     ]


### PR DESCRIPTION
## Summary

The settings UI description for the balanced profile omitted that research uses Sonnet, leading users to believe 'planning' included research and expecting Opus for the researcher agent.

## Problem

Settings UI said: `Opus for planning, Sonnet for execution/verification`
Users assumed `planning` = research + planning → expected Opus for researcher.
Actual behavior: `gsd-phase-researcher` uses Sonnet in balanced profile.

## Fix

Updated description to: `Opus for planning, Sonnet for research/execution/verification`

This matches `model-profiles.md` and `MODEL_PROFILES` in `model-profiles.cjs`.

Fixes #680