### PR TITLE
fix(core): return 'opus' directly instead of mapping to 'inherit'

### DIFF
--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -374,7 +374,7 @@ function resolveModelInternal(cwd, agentType) {
   // Check per-agent override first
   const override = config.model_overrides?.[agentType];
   if (override) {
-    return override === 'opus' ? 'inherit' : override;
+    return override;
   }
 
   // Fall back to profile lookup
@@ -382,8 +382,7 @@ function resolveModelInternal(cwd, agentType) {
   const agentModels = MODEL_PROFILES[agentType];
   if (!agentModels) return 'sonnet';
   if (profile === 'inherit') return 'inherit';
-  const resolved = agentModels[profile] || agentModels['balanced'] || 'sonnet';
-  return resolved === 'opus' ? 'inherit' : resolved;
+  return agentModels[profile] || agentModels['balanced'] || 'sonnet';
 }
 
 // ─── Misc utilities ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Removes the `opus → inherit` conversion in `resolveModelInternal()` so quality profile subagents actually get Opus.

## Problem

`resolveModelInternal()` mapped `'opus'` to `'inherit'`, assuming the parent process runs on Opus. But Claude Code defaults to Sonnet, so `'inherit'` resolves to Sonnet — silently downgrading quality profile subagents (#695).

## Fix

Return the resolved model name directly without conversion. Claude Code's Task tool now supports model aliases like `'opus'`, `'sonnet'`, `'haiku'` directly.

Before:
```javascript
return resolved === 'opus' ? 'inherit' : resolved;
```

After:
```javascript
return agentModels[profile] || agentModels['balanced'] || 'sonnet';
```

## Changes

- `get-shit-done/bin/lib/core.cjs`: Remove opus→inherit mapping in both override and profile resolution paths

Fixes #695