### PR TITLE
feat: add execution hardening (pre-wave check, cross-plan contracts, export spot-check)

### DIFF
--- a/agents/gsd-plan-checker.md
+++ b/agents/gsd-plan-checker.md
@@ -370,6 +370,25 @@ Overall: ✅ PASS / ❌ FAIL
 
 If FAIL: return to planner with specific fixes. Same revision loop as other dimensions (max 3 loops).
 
+## Dimension 9: Cross-Plan Data Contracts
+
+**Question:** When plans share data pipelines, are their transformations compatible?
+
+**Process:**
+1. Identify data entities in multiple plans' `key_links` or `<action>` elements
+2. For each shared data path, check if one plan's transformation conflicts with another's:
+   - Plan A strips/sanitizes data that Plan B needs in original form
+   - Plan A's output format doesn't match Plan B's expected input
+   - Two plans consume the same stream with incompatible assumptions
+3. Check for a preservation mechanism (raw buffer, copy-before-transform)
+
+**Red flags:**
+- "strip"/"clean"/"sanitize" in one plan + "parse"/"extract" original format in another
+- Streaming consumer modifies data that finalization consumer needs intact
+- Two plans transform same entity without shared raw source
+
+**Severity:** WARNING for potential conflicts. BLOCKER if incompatible transforms on same data entity with no preservation mechanism.
+
 </verification_dimensions>
 
 <verification_process>
@@ -700,6 +719,7 @@ Plan verification complete when:
   - [ ] No tasks contradict locked decisions
   - [ ] Deferred ideas not included in plans
 - [ ] Overall status determined (passed | issues_found)
+- [ ] Cross-plan data contracts checked (no conflicting transforms on shared data)
 - [ ] Structured issues returned (if any found)
 - [ ] Result returned to orchestrator
 

--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -178,6 +178,27 @@ Execute each wave in sequence. Within a wave: parallel if `PARALLELIZATION=true`
 
    For real failures: report which plan failed → ask "Continue?" or "Stop?" → if continue, dependent plans may also fail. If stop, partial completion report.
 
+5b. **Pre-wave dependency check (waves 2+ only):**
+
+    Before spawning wave N+1, for each plan in the upcoming wave:
+    ```bash
+    node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" verify key-links {phase_dir}/{plan}-PLAN.md
+    ```
+
+    If any key-link from a PRIOR wave's artifact fails verification:
+
+    ## Cross-Plan Wiring Gap
+
+    | Plan | Link | From | Expected Pattern | Status |
+    |------|------|------|-----------------|--------|
+    | {plan} | {via} | {from} | {pattern} | NOT FOUND |
+
+    Wave {N} artifacts may not be properly wired. Options:
+    1. Investigate and fix before continuing
+    2. Continue (may cause cascading failures in wave {N+1})
+
+    Key-links referencing files in the CURRENT (upcoming) wave are skipped.
+
 6. **Execute checkpoint plans between waves** — see `<checkpoint_handling>`.
 
 7. **Proceed to next wave.**

--- a/get-shit-done/workflows/verify-phase.md
+++ b/get-shit-done/workflows/verify-phase.md
@@ -126,6 +126,17 @@ WIRED = imported AND used. ORPHANED = exists but not imported/used.
 | ✓ | ✓ | ✗ | ⚠️ ORPHANED |
 | ✓ | ✗ | - | ✗ STUB |
 | ✗ | - | - | ✗ MISSING |
+
+**Export-level spot check (WARNING severity):**
+
+For artifacts that pass Level 3, spot-check individual exports:
+- Extract key exported symbols (functions, constants, classes — skip types/interfaces)
+- For each, grep for usage outside the defining file
+- Flag exports with zero external call sites as "exported but unused"
+
+This catches dead stores like `setPlan()` that exist in a wired file but are
+never actually called. Report as WARNING — may indicate incomplete cross-plan
+wiring or leftover code from plan revisions.
 </step>
 
 <step name="verify_wiring">


### PR DESCRIPTION
## Summary

Three additive quality improvements to the execution pipeline — pure .md changes, no JS.

- **Pre-wave dependency check** (execute-phase): Before spawning wave N+1, verify key-links from prior wave artifacts using `gsd-tools.cjs verify key-links`. Catches cross-plan wiring gaps before they cascade into downstream failures.

- **Cross-Plan Data Contracts** (plan-checker, new Dimension 9): Checks that plans sharing data pipelines have compatible transformations. Flags when one plan strips/sanitizes data another plan needs in original form.

- **Export-level spot check** (verify-phase): After Level 3 wiring verification passes, spot-check individual exported symbols for actual usage outside the defining file. Catches dead stores that exist in wired files but are never called.

## Motivation

These arose from real execution failures in multi-wave phases where:
1. Wave 1 produced artifacts that Wave 2 plans referenced, but key-links weren't verified between waves
2. Two plans transformed the same data entity with incompatible assumptions (one sanitized, the other needed raw)
3. Exported functions passed wiring checks (file was imported) but were never actually called

## Changes

| File | Change | Type |
|------|--------|------|
| `get-shit-done/workflows/execute-phase.md` | Added step 5b (pre-wave key-link check) | Additive |
| `agents/gsd-plan-checker.md` | Added Dimension 9 + success criteria entry | Additive |
| `get-shit-done/workflows/verify-phase.md` | Added export spot-check after Level 3 | Additive |

## Test plan

- [ ] Verify pre-wave check triggers on wave 2+ (not wave 1)
- [ ] Verify Dimension 9 flags incompatible transforms in test plans
- [ ] Verify export spot-check runs after Level 3 wiring passes
- [ ] Confirm no regressions in existing verification flow