### PR TITLE
fix(hooks): remove duplicate const cwd in gsd-context-monitor.js

### DIFF
--- a/hooks/gsd-context-monitor.js
+++ b/hooks/gsd-context-monitor.js
@@ -115,7 +115,6 @@ process.stdin.on('end', () => {
     fs.writeFileSync(warnPath, JSON.stringify(warnData));
 
     // Detect if GSD is active (has .planning/STATE.md in working directory)
-    const cwd = data.cwd || process.cwd();
     const isGsdActive = fs.existsSync(path.join(cwd, '.planning', 'STATE.md'));
 
     // Build advisory warning message (never use imperative commands that


### PR DESCRIPTION
## Summary

- Remove duplicate `const cwd` declaration in `hooks/gsd-context-monitor.js` that causes a `SyntaxError` on every PostToolUse invocation

## Problem

`const cwd` is declared twice in the same `try` block scope (line 47 and line 118), causing:

```
SyntaxError: Identifier 'cwd' has already been declared
```

This means the context monitor hook **never runs** — every tool call triggers a "PostToolUse hook error" in the UI, and context usage warnings are completely non-functional.

## Fix

One-line deletion: remove the second `const cwd = data.cwd || process.cwd();` on line 118, since the variable from line 47 is already in scope at that point.

## Test

```bash
# Before fix:
echo '{}' | node hooks/gsd-context-monitor.js
# → SyntaxError: Identifier 'cwd' has already been declared

# After fix:
echo '{}' | node hooks/gsd-context-monitor.js
# → exits cleanly (code 0)
```

Fixes #1092

🤖 Generated with [Claude Code](https://claude.com/claude-code)