### PR TITLE
feat: add custom model profile with fallback support

### DIFF
--- a/get-shit-done/bin/lib/commands.cjs
+++ b/get-shit-done/bin/lib/commands.cjs
@@ -4,9 +4,9 @@
 const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
-const { safeReadFile, loadConfig, isGitIgnored, execGit, normalizePhaseName, comparePhaseNum, getArchivedPhaseDirs, generateSlugInternal, getMilestoneInfo, getMilestonePhaseFilter, resolveModelInternal, stripShippedMilestones, toPosixPath, output, error, findPhaseInternal } = require('./core.cjs');
+const { safeReadFile, loadConfig, loadCustomModels, isGitIgnored, execGit, normalizePhaseName, comparePhaseNum, getArchivedPhaseDirs, generateSlugInternal, getMilestoneInfo, getMilestonePhaseFilter, resolveModelInternal, stripShippedMilestones, toPosixPath, output, error, findPhaseInternal } = require('./core.cjs');
 const { extractFrontmatter } = require('./frontmatter.cjs');
-const { MODEL_PROFILES } = require('./model-profiles.cjs');
+const { MODEL_PROFILES, AGENT_TO_ROLE } = require('./model-profiles.cjs');
 
 function cmdGenerateSlug(text, raw) {
   if (!text) {
@@ -211,6 +211,18 @@ function cmdResolveModel(cwd, agentType, raw) {
   const result = agentModels
     ? { model, profile }
     : { model, profile, unknown_agent: true };
+
+  // Include fallbacks for custom profile with array configuration
+  if (profile === 'custom') {
+    const customModels = loadCustomModels(cwd);
+    if (customModels) {
+      const role = AGENT_TO_ROLE[agentType];
+      if (role && customModels[role] && Array.isArray(customModels[role]) && customModels[role].length > 1) {
+        result.fallbacks = customModels[role].slice(1);
+      }
+    }
+  }
+
   output(result, raw, model);
 }
 

--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -5,7 +5,7 @@
 const fs = require('fs');
 const path = require('path');
 const { execSync, spawnSync } = require('child_process');
-const { MODEL_PROFILES } = require('./model-profiles.cjs');
+const { MODEL_PROFILES, AGENT_TO_ROLE } = require('./model-profiles.cjs');
 
 // ─── Path helpers ────────────────────────────────────────────────────────────
 
@@ -111,6 +111,18 @@ function loadConfig(cwd) {
   } catch {
     return defaults;
   }
+}
+
+function loadCustomModels(cwd) {
+  const configPath = path.join(cwd, '.planning', 'config.json');
+  try {
+    const raw = fs.readFileSync(configPath, 'utf-8');
+    const parsed = JSON.parse(raw);
+    if (parsed.model_profile === 'custom' && parsed.models) {
+      return parsed.models;
+    }
+  } catch {}
+  return null;
 }
 
 // ─── Git utilities ────────────────────────────────────────────────────────────
@@ -377,8 +389,29 @@ function resolveModelInternal(cwd, agentType) {
     return override;
   }
 
-  // Fall back to profile lookup
+  // Check custom model configuration if profile is "custom"
   const profile = String(config.model_profile || 'balanced').toLowerCase();
+  if (profile === 'custom') {
+    const customModels = loadCustomModels(cwd);
+    if (customModels) {
+      const role = AGENT_TO_ROLE[agentType];
+      if (role && customModels[role]) {
+        const roleModels = customModels[role];
+        // Support both single string and array formats
+        if (Array.isArray(roleModels) && roleModels.length > 0) {
+          return roleModels[0]; // Return primary model (first in fallback array)
+        }
+        if (typeof roleModels === 'string') {
+          return roleModels;
+        }
+      }
+    }
+    // Fallback to balanced profile if custom config is invalid
+    const agentModels = MODEL_PROFILES[agentType];
+    return agentModels?.['balanced'] || 'sonnet';
+  }
+
+  // Fall back to profile lookup
   const agentModels = MODEL_PROFILES[agentType];
   if (!agentModels) return 'sonnet';
   if (profile === 'inherit') return 'inherit';
@@ -477,6 +510,7 @@ module.exports = {
   error,
   safeReadFile,
   loadConfig,
+  loadCustomModels,
   isGitIgnored,
   execGit,
   escapeRegex,

--- a/get-shit-done/bin/lib/model-profiles.cjs
+++ b/get-shit-done/bin/lib/model-profiles.cjs
@@ -25,6 +25,38 @@ const MODEL_PROFILES = {
 };
 const VALID_PROFILES = Object.keys(MODEL_PROFILES['gsd-planner']);
 
+// Maps agent types to roles for custom model configuration.
+// Configure in .planning/config.json under "models" key with fallback arrays:
+//
+// {
+//   "model_profile": "custom",
+//   "models": {
+//     "planning": ["google/antigravity-claude-opus-4-6-thinking", "openai/gpt-5.2"],
+//     "coding": ["openai/gpt-5.3-codex", "openai/gpt-5.2-codex"],
+//     "research": ["google/antigravity-gemini-3-pro", "zai-coding-plan/glm-4.7"],
+//     "verification": ["google/antigravity-claude-opus-4-5-thinking", "openai/gpt-5.2"]
+//   }
+// }
+//
+// Each role can be a single model string or an array (first = primary, rest = fallbacks).
+const AGENT_TO_ROLE = {
+  'gsd-planner': 'planning',
+  'gsd-roadmapper': 'planning',
+  'gsd-executor': 'coding',
+  'gsd-phase-researcher': 'research',
+  'gsd-project-researcher': 'research',
+  'gsd-research-synthesizer': 'research',
+  'gsd-debugger': 'coding',
+  'gsd-codebase-mapper': 'research',
+  'gsd-verifier': 'verification',
+  'gsd-plan-checker': 'verification',
+  'gsd-integration-checker': 'verification',
+  'gsd-nyquist-auditor': 'verification',
+  'gsd-ui-researcher': 'research',
+  'gsd-ui-checker': 'verification',
+  'gsd-ui-auditor': 'verification',
+};
+
 /**
  * Formats the agent-to-model mapping as a human-readable table (in string format).
  *
@@ -63,6 +95,7 @@ function getAgentToModelMapForProfile(normalizedProfile) {
 module.exports = {
   MODEL_PROFILES,
   VALID_PROFILES,
+  AGENT_TO_ROLE,
   formatAgentToModelMapAsTable,
   getAgentToModelMapForProfile,
 };

--- a/get-shit-done/references/model-profiles.md
+++ b/get-shit-done/references/model-profiles.md
@@ -42,6 +42,11 @@ Model profiles control which Claude model each GSD agent uses. This allows balan
 - Best when you switch models interactively (for example OpenCode `/model`)
 - Use when: you want GSD to follow your currently selected runtime model
 
+**custom** - Manual model assignment with fallback support
+- Map specific models to each role (planning, coding, research, verification)
+- Define fallback arrays for each role - if primary fails, try fallbacks in order
+- Use when: using non-Anthropic models, or need specific model control per task type
+
 ## Resolution Logic
 
 Orchestrators resolve model before spawning:
@@ -49,8 +54,63 @@ Orchestrators resolve model before spawning:
 ```
 1. Read .planning/config.json
 2. Check model_overrides for agent-specific override
-3. If no override, look up agent in profile table
-4. Pass model parameter to Task call
+3. If profile is "custom", look up agent's role in custom models config
+4. If no override/custom, look up agent in profile table
+5. Pass model parameter to Task call
+```
+
+## Role Mapping
+
+When using the `custom` profile, agents are mapped to roles:
+
+| Role | Agents |
+|------|--------|
+| planning | gsd-planner, gsd-roadmapper |
+| coding | gsd-executor, gsd-debugger |
+| research | gsd-phase-researcher, gsd-project-researcher, gsd-research-synthesizer, gsd-codebase-mapper |
+| verification | gsd-verifier, gsd-plan-checker, gsd-integration-checker, gsd-nyquist-auditor |
+
+## Custom Model Configuration
+
+Use the `custom` profile to assign specific models to each role:
+
+```json
+{
+  "model_profile": "custom",
+  "models": {
+    "planning": "google/antigravity-claude-opus-4-6-thinking",
+    "coding": "openai/gpt-5.3-codex",
+    "research": "google/antigravity-gemini-3-pro",
+    "verification": "google/antigravity-claude-opus-4-5-thinking"
+  }
+}
+```
+
+### Fallback Support
+
+Each role can be an array of models. If the primary fails, orchestrators try fallbacks in order:
+
+```json
+{
+  "model_profile": "custom",
+  "models": {
+    "planning": [
+      "google/antigravity-claude-opus-4-6-thinking",
+      "openai/gpt-5.2",
+      "anthropic/claude-opus-4"
+    ],
+    "coding": ["openai/gpt-5.3-codex", "openai/gpt-5.2-codex"],
+    "research": ["google/antigravity-gemini-3-pro", "zai-coding-plan/glm-4.7"],
+    "verification": ["google/antigravity-claude-opus-4-5-thinking", "openai/gpt-5.2"]
+  }
+}
+```
+
+The `resolve-model` command returns fallbacks when configured:
+
+```bash
+gsd-tools resolve-model gsd-planner
+# Output: {"model": "google/antigravity-claude-opus-4-6-thinking", "profile": "custom", "fallbacks": ["openai/gpt-5.2", "anthropic/claude-opus-4"]}
 ```
 
 ## Per-Agent Overrides


### PR DESCRIPTION
**Summary**

Adds a `custom` model profile that allows mapping specific models to planning, coding, research, and verification roles. Supports fallback arrays so orchestrators can try alternate models if the primary fails.

**Changes**

- `AGENT_TO_ROLE` mapping for custom profile resolution
- `loadCustomModels()` to read models from `.planning/config.json`
- Updated `resolveModelInternal()` to check custom models before profile lookup
- Updated `cmdResolveModel()` to include fallbacks in output
- Documentation for custom profile configuration

**Usage**

```json
{
  "model_profile": "custom",
  "models": {
    "planning": ["google/antigravity-claude-opus-4-6-thinking", "openai/gpt-5.2"],
    "coding": ["openai/gpt-5.3-codex", "openai/gpt-5.2-codex"],
    "research": ["google/antigravity-gemini-3-pro", "zai-coding-plan/glm-4.7"],
    "verification": ["google/antigravity-claude-opus-4-5-thinking"]
  }
}
```

**Resolves**

Rebases the original PR #990 onto current main with the new modular code structure.