### PR TITLE
fix(hooks): remove duplicate const cwd in context-monitor

### DIFF
--- a/hooks/gsd-context-monitor.js
+++ b/hooks/gsd-context-monitor.js
@@ -115,7 +115,6 @@ process.stdin.on('end', () => {
     fs.writeFileSync(warnPath, JSON.stringify(warnData));
 
     // Detect if GSD is active (has .planning/STATE.md in working directory)
-    const cwd = data.cwd || process.cwd();
     const isGsdActive = fs.existsSync(path.join(cwd, '.planning', 'STATE.md'));
 
     // Build advisory warning message (never use imperative commands that


### PR DESCRIPTION
## Summary

- `gsd-context-monitor.js` declares `const cwd` at line 47 and again at line 118 in the same scope
- Node.js throws `SyntaxError: Identifier 'cwd' has already been declared` — the hook crashes on every PostToolUse invocation
- Fix: remove the redundant second declaration (cwd is already in scope)

## Test plan

- [ ] `echo '{}' | node hooks/gsd-context-monitor.js` exits cleanly (no SyntaxError)
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)