### PR TITLE
fix: replace nonexistent /gsd:transition with real commands in execute-phase

### DIFF
--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -463,7 +463,8 @@ Read and follow `~/.claude/get-shit-done/workflows/transition.md`, passing throu
 ## ✓ Phase {X}: {Name} Complete
 
 /gsd:progress — see updated roadmap
-/gsd:transition — plan next phase transition
+/gsd:discuss-phase {next} — discuss next phase before planning
+/gsd:plan-phase {next} — plan next phase
 /gsd:execute-phase {next} — execute next phase
 ```
 </step>


### PR DESCRIPTION
## What

Replace nonexistent `/gsd:transition` command with real `/gsd:discuss-phase` and `/gsd:plan-phase` commands in execute-phase completion output.

## Why

Users see `/gsd:transition` suggested after phase execution completes (with auto-advance disabled), but the command doesn't exist as a registered skill. `transition.md` is an internal workflow only invoked inline during auto-advance chains.

## How

Single text change in `get-shit-done/workflows/execute-phase.md` line 466 — replaced the display string in the non-auto-advance path (Path C). The internal auto-advance path (line 456) that reads `transition.md` by file path is completely untouched.

```diff
 /gsd:progress — see updated roadmap
-/gsd:transition — plan next phase transition
+/gsd:discuss-phase {next} — discuss next phase before planning
+/gsd:plan-phase {next} — plan next phase
 /gsd:execute-phase {next} — execute next phase
```

## Testing

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Codex
- [ ] Copilot
- [x] N/A (not runtime-specific)

### Test details

1. Ran `/gsd:execute-phase` with auto-advance OFF → confirmed `/gsd:transition` was suggested and command not found
2. Verified `/gsd:transition` is absent from `help.md`, README, and CHANGELOG
3. Verified `/gsd:discuss-phase` and `/gsd:plan-phase` are real registered commands listed in help docs
4. Confirmed auto-advance path (line 456) reads `transition.md` by file path, not as slash command — unaffected by this change

## Checklist

- [x] Follows GSD style (no enterprise patterns, no filler)
- [ ] Updates CHANGELOG.md for user-facing changes *(happy to add if maintainers want one — minor text fix)*
- [x] No unnecessary dependencies added
- [x] Works on Windows (backslash paths tested) — text-only change, no paths involved
- [x] Templates/references updated if behavior changed
- [x] Existing tests pass (`npm test`)

## Breaking Changes

None


