### PR TITLE
Remove duplicate variable declaration

### DIFF
--- a/hooks/gsd-context-monitor.js
+++ b/hooks/gsd-context-monitor.js
@@ -115,7 +115,6 @@ process.stdin.on('end', () => {
     fs.writeFileSync(warnPath, JSON.stringify(warnData));
 
     // Detect if GSD is active (has .planning/STATE.md in working directory)
-    const cwd = data.cwd || process.cwd();
     const isGsdActive = fs.existsSync(path.join(cwd, '.planning', 'STATE.md'));
 
     // Build advisory warning message (never use imperative commands that


### PR DESCRIPTION
## What

This removes a duplicate declaration of the variable `cwd`.

## Why

I noticed `PostToolUse` popping up constantly and dug into the logs a bit, there's a duplicate variable declaration that was causing it.

Fixes #1094 

## Testing

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Codex
- [ ] Copilot
- [ ] N/A (not runtime-specific)

### Test details

I don't think there's really anything to test.

## Checklist

- [x] Follows GSD style (no enterprise patterns, no filler)
- [x] Updates CHANGELOG.md for user-facing changes
- [x] No unnecessary dependencies added
- [ ] Works on Windows (backslash paths tested)
- [ ] Templates/references updated if behavior changed
- [ ] Existing tests pass (`npm test`)

## Breaking Changes

None
