### PR TITLE
fix(build): add syntax validation to hook build script

### DIFF
--- a/scripts/build-hooks.js
+++ b/scripts/build-hooks.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 /**
  * Copy GSD hooks to dist for installation.
+ * Runs via prepublishOnly to ensure hooks/dist/ is always fresh before npm publish.
  */
 
 const fs = require('fs');
@@ -22,6 +23,8 @@ function build() {
     fs.mkdirSync(DIST_DIR, { recursive: true });
   }
 
+  let errors = 0;
+
   // Copy hooks to dist
   for (const hook of HOOKS_TO_COPY) {
     const src = path.join(HOOKS_DIR, hook);
@@ -35,6 +38,19 @@ function build() {
     console.log(`Copying ${hook}...`);
     fs.copyFileSync(src, dest);
     console.log(`  → ${dest}`);
+
+    // Validate: check for syntax errors using Node's --check flag
+    const { spawnSync } = require('child_process');
+    const check = spawnSync(process.execPath, ['--check', dest], { stdio: 'pipe', encoding: 'utf8' });
+    if (check.status !== 0) {
+      console.error(`  ✗ SYNTAX ERROR in ${hook}: ${(check.stderr || '').trim()}`);
+      errors++;
+    }
+  }
+
+  if (errors > 0) {
+    console.error(`\nBuild failed: ${errors} hook(s) have syntax errors.`);
+    process.exit(1);
   }
 
   console.log('\nBuild complete.');


### PR DESCRIPTION
## Summary

Fixes #1113 — v1.25.1 shipped `hooks/dist/` with the stale pre-fix `gsd-context-monitor.js` containing the duplicate `const cwd` declaration.

## Root Cause

The `prepublishOnly` script (`build-hooks.js`) copies hooks from `hooks/` to `hooks/dist/`, but had no validation. v1.25.1 was published before the `const cwd` fix landed on `main`, so the npm tarball contained the broken hook.

## Fix

Enhanced `scripts/build-hooks.js` to validate each hook with `node --check` after copying. If any hook has a syntax error, the build fails with exit code 1, **preventing `npm publish` from shipping broken hooks**.

Verified that `node --check` correctly catches the duplicate `const cwd` pattern:

```
SyntaxError: Identifier 'cwd' has already been declared
```

## What This Means for Release

The source `hooks/gsd-context-monitor.js` is already fixed on `main` (PR #1105). The next `npm publish` will run `prepublishOnly → build-hooks.js`, which will:
1. Copy the fixed source to `hooks/dist/`
2. Validate all hooks pass `node --check`
3. Only then allow publish to proceed

All 755 tests pass.