### PR TITLE
fix: embed evolution rules in generated PROJECT.md so agents see them at runtime (#1039)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -358,7 +358,7 @@ Equivalent paths for other runtimes:
 
 ```
 .planning/
-├── PROJECT.md              # Project vision, constraints, decisions
+├── PROJECT.md              # Project vision, constraints, decisions, evolution rules
 ├── REQUIREMENTS.md         # Scoped requirements (v1/v2/out-of-scope)
 ├── ROADMAP.md              # Phase breakdown with status tracking
 ├── STATE.md                # Living memory: position, decisions, blockers, metrics

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -70,7 +70,7 @@
 **Produces:**
 | Artifact | Description |
 |----------|-------------|
-| `PROJECT.md` | Project vision, constraints, technical decisions |
+| `PROJECT.md` | Project vision, constraints, technical decisions, evolution rules |
 | `REQUIREMENTS.md` | Scoped requirements with unique IDs (REQ-XX) |
 | `ROADMAP.md` | Phase breakdown with status tracking and requirement mapping |
 | `STATE.md` | Initial project state with position, decisions, metrics |

--- a/get-shit-done/templates/project.md
+++ b/get-shit-done/templates/project.md
@@ -127,6 +127,8 @@ Common types: Tech stack, Timeline, Budget, Dependencies, Compatibility, Perform
 <evolution>
 
 PROJECT.md evolves throughout the project lifecycle.
+These rules are embedded in the generated PROJECT.md (## Evolution section)
+and implemented by workflows/transition.md and workflows/complete-milestone.md.
 
 **After each phase transition:**
 1. Requirements invalidated? → Move to Out of Scope with reason

--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -214,6 +214,7 @@ Execute each wave in sequence. Within a wave: parallel if `PARALLELIZATION=true`
        <files_to_read>
        Read these files at execution start using the Read tool:
        - {phase_dir}/{plan_file} (Plan)
+       - .planning/PROJECT.md (Project context — core value, requirements, evolution rules)
        - .planning/STATE.md (State)
        - .planning/config.json (Config, if exists)
        - ./CLAUDE.md (Project instructions, if exists — follow project-specific guidelines and coding conventions)

--- a/get-shit-done/workflows/new-milestone.md
+++ b/get-shit-done/workflows/new-milestone.md
@@ -54,6 +54,27 @@ Add/update:
 
 Update Active requirements section and "Last updated" footer.
 
+Ensure the `## Evolution` section exists in PROJECT.md. If missing (projects created before this feature), add it before the footer:
+
+```markdown
+## Evolution
+
+This document evolves at phase transitions and milestone boundaries.
+
+**After each phase transition** (via `/gsd:transition`):
+1. Requirements invalidated? → Move to Out of Scope with reason
+2. Requirements validated? → Move to Validated with phase reference
+3. New requirements emerged? → Add to Active
+4. Decisions to log? → Add to Key Decisions
+5. "What This Is" still accurate? → Update if drifted
+
+**After each milestone** (via `/gsd:complete-milestone`):
+1. Full review of all sections
+2. Core Value check — still the right priority?
+3. Audit Out of Scope — reasons still valid?
+4. Update Context with current state
+```
+
 ## 5. Update STATE.md
 
 ```markdown

--- a/get-shit-done/workflows/new-project.md
+++ b/get-shit-done/workflows/new-project.md
@@ -335,6 +335,27 @@ Initialize with any decisions made during questioning:
 *Last updated: [date] after initialization*
 ```
 
+**Evolution section** (include at the end of PROJECT.md, before the footer):
+
+```markdown
+## Evolution
+
+This document evolves at phase transitions and milestone boundaries.
+
+**After each phase transition** (via `/gsd:transition`):
+1. Requirements invalidated? → Move to Out of Scope with reason
+2. Requirements validated? → Move to Validated with phase reference
+3. New requirements emerged? → Add to Active
+4. Decisions to log? → Add to Key Decisions
+5. "What This Is" still accurate? → Update if drifted
+
+**After each milestone** (via `/gsd:complete-milestone`):
+1. Full review of all sections
+2. Core Value check — still the right priority?
+3. Audit Out of Scope — reasons still valid?
+4. Update Context with current state
+```
+
 Do not compress. Capture everything gathered.
 
 **Commit PROJECT.md:**


### PR DESCRIPTION
## Summary

Fixes #1039 — The `<evolution>` block in `templates/project.md` defined requirement lifecycle rules but these instructions never made it into the generated `PROJECT.md` that agents read at runtime.

## Problem

The template's `<evolution>` block specified what should happen at phase transitions (validate/invalidate requirements, log decisions, check drift). But:
1. The generated `PROJECT.md` didn't include these rules
2. Phase workflows (`execute-phase`, `execute-plan`) didn't read `PROJECT.md` at all
3. Only `transition.md` and `complete-milestone.md` implemented the rules — but if users skipped `/gsd:transition`, the evolution review never happened

## Changes

| File | Change |
|------|--------|
| `workflows/new-project.md` | Add `## Evolution` section to generated PROJECT.md with phase transition and milestone review checklists |
| `workflows/new-milestone.md` | Ensure `## Evolution` section exists in PROJECT.md (backfills for older projects) |
| `workflows/execute-phase.md` | Add `.planning/PROJECT.md` to executor `<files_to_read>` — executors now have project context |
| `templates/project.md` | Add comment noting `<evolution>` block is implemented by transition.md and complete-milestone.md |
| `docs/ARCHITECTURE.md` | Note evolution rules in PROJECT.md directory listing |
| `docs/FEATURES.md` | Update PROJECT.md artifact description |
| `CHANGELOG.md` | Document Evolution section and executor context additions |

## How It Works Now

1. `/gsd:new-project` generates PROJECT.md **with** a `## Evolution` section containing the checklist
2. `/gsd:new-milestone` backfills the section if missing (older projects)
3. Executor agents read PROJECT.md at execution start — they can see core value, requirements, and evolution rules
4. `/gsd:transition` and `/gsd:complete-milestone` continue to implement the full evolution logic

## Testing

755/755 tests pass ✅