### PR TITLE
feat: cross-reference pending todos during discuss-phase (#1111)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   - Pre-wave dependency check in `execute-phase`: verifies key-links from prior wave artifacts before spawning next wave
   - Cross-Plan Data Contracts (Dimension 9) in plan-checker: detects incompatible transformations between plans sharing data pipelines
   - Export-level spot check in `verify-phase`: catches dead stores that exist in wired files but are never called
+- **Todo cross-reference in discuss-phase** — New `cross_reference_todos` step checks pending todos for relevance to the current phase, lets users fold them into scope or mark as reviewed. Prevents silent scope gaps where earlier phases captured work that gets missed (#1111)
 
 ### Fixed
 - **Requirements `mark-complete` is now idempotent** — Re-marking already-completed requirements returns `already_complete` instead of `not_found` (#948)

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -111,6 +111,7 @@
 - REQ-DISC-05: System MUST support `--auto` flag to auto-select recommended defaults
 - REQ-DISC-06: System MUST support `--batch` flag for grouped question intake
 - REQ-DISC-07: System MUST scout relevant source files before identifying gray areas (code-aware discussion)
+- REQ-DISC-08: System MUST cross-reference pending todos for phase relevance and let users fold them into scope
 
 **Produces:** `{padded_phase}-CONTEXT.md` — User preferences that feed into research and planning
 

--- a/get-shit-done/workflows/discuss-phase.md
+++ b/get-shit-done/workflows/discuss-phase.md
@@ -284,6 +284,41 @@ From the scan, identify:
 Store as internal `<codebase_context>` for use in analyze_phase and present_gray_areas. This is NOT written to a file — it's used within this session only.
 </step>
 
+<step name="cross_reference_todos">
+Check if any pending todos are relevant to this phase's scope. Prevents silent scope gaps where earlier phases captured work that belongs in this phase.
+
+```bash
+TODO_INIT=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" init todos)
+if [[ "$TODO_INIT" == @file:* ]]; then TODO_INIT=$(cat "${TODO_INIT#@file:}"); fi
+```
+
+Parse `todo_count` from JSON. **If 0: skip this step entirely** (no workflow slowdown).
+
+**If todos exist:** Extract phase goal keywords from ROADMAP.md. For each pending todo, check relevance via:
+- **Area match** — todo `area` field overlaps with phase domain
+- **File match** — todo `files` reference paths this phase will touch
+- **Keyword match** — todo title/description contains phase goal terms
+
+**If relevant todos found:**
+
+```
+AskUserQuestion:
+  question: "Found {N} pending todo(s) that may be relevant to Phase {X}. Fold any into this phase's scope?"
+  allowMultiple: true
+  options:
+    - label: "{todo_title_1}"
+      description: "From: {todo_file} — {todo_description_preview}"
+    - label: "{todo_title_2}"
+      description: "From: {todo_file} — {todo_description_preview}"
+    ...
+```
+
+**Selected todos** → store as `folded_todos` for inclusion in CONTEXT.md `<decisions>` section.
+**Unselected todos** → store as `reviewed_todos` for inclusion in CONTEXT.md `<deferred>` section.
+
+**If no relevant todos:** Skip silently.
+</step>
+
 <step name="analyze_phase">
 Analyze the phase to identify gray areas worth discussing. **Use both `prior_decisions` and `codebase_context` to ground the analysis.**
 
@@ -544,7 +579,23 @@ mkdir -p ".planning/phases/${padded_phase}-${phase_slug}"
 ### Claude's Discretion
 [Areas where user said "you decide" — note that Claude has flexibility here]
 
+### Folded Todos
+[Only include if `folded_todos` is non-empty from cross_reference_todos step]
+- **{todo_title}**: {todo_description} — Folded from backlog into this phase's scope
+
 </decisions>
+
+<deferred>
+## Deferred Items
+
+### Reviewed Todos (not folded)
+[Only include if `reviewed_todos` is non-empty from cross_reference_todos step]
+- **{todo_title}**: {todo_description} — Reviewed, deemed out of scope for this phase
+
+### Deferred Ideas
+[Ideas that surfaced during discussion but belong in a future phase]
+
+</deferred>
 
 <canonical_refs>
 ## Canonical References


### PR DESCRIPTION
## Summary

Fixes #1111 — Todos created during earlier phases can be missed because `discuss-phase` doesn't check the todo backlog.

## Changes

Adds a `cross_reference_todos` step to `discuss-phase.md` between `scout_codebase` and `analyze_phase`:

1. Loads pending todos via `gsd-tools init todos`
2. Checks each todo for relevance using area match, file match, and keyword match against phase goal
3. If matches found, presents via `AskUserQuestion` (multiSelect) for user to fold into scope
4. **Folded todos** → recorded in CONTEXT.md `<decisions>` section
5. **Reviewed but not folded** → recorded in CONTEXT.md `<deferred>` section
6. **No matching todos or zero todos** → step is invisible (no workflow slowdown)

Also adds `<deferred>` section to CONTEXT.md template for tracking deferred ideas and reviewed todos.