### PR TITLE
fix: prevent PROJECT.md drift and fix phase completion counters (#956)

### DIFF
--- a/get-shit-done/bin/lib/phase.cjs
+++ b/get-shit-done/bin/lib/phase.cjs
@@ -880,6 +880,34 @@ function cmdPhaseComplete(cwd, phaseNum, raw) {
       `$1Phase ${phaseNum} complete${nextPhaseNum ? `, transitioned to Phase ${nextPhaseNum}` : ''}`
     );
 
+    // Increment Completed Phases counter (#956)
+    const completedMatch = stateContent.match(/\*\*Completed Phases:\*\*\s*(\d+)/);
+    if (completedMatch) {
+      const newCompleted = parseInt(completedMatch[1], 10) + 1;
+      stateContent = stateContent.replace(
+        /(\*\*Completed Phases:\*\*\s*)\d+/,
+        `$1${newCompleted}`
+      );
+
+      // Recalculate percent based on completed / total (#956)
+      const totalMatch = stateContent.match(/\*\*Total Phases:\*\*\s*(\d+)/);
+      if (totalMatch) {
+        const totalPhases = parseInt(totalMatch[1], 10);
+        if (totalPhases > 0) {
+          const newPercent = Math.round((newCompleted / totalPhases) * 100);
+          stateContent = stateContent.replace(
+            /(\*\*Progress:\*\*\s*)\d+%/,
+            `$1${newPercent}%`
+          );
+          // Also update percent field if it exists separately
+          stateContent = stateContent.replace(
+            /(percent:\s*)\d+/,
+            `$1${newPercent}`
+          );
+        }
+      }
+    }
+
     writeStateMd(statePath, stateContent, cwd);
   }
 

--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -412,6 +412,28 @@ node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" commit "docs(phase-{X}): co
 ```
 </step>
 
+<step name="update_project_md">
+**Evolve PROJECT.md to reflect phase completion (prevents planning document drift — #956):**
+
+PROJECT.md tracks validated requirements, decisions, and current state. Without this step,
+PROJECT.md falls behind silently over multiple phases.
+
+1. Read `.planning/PROJECT.md`
+2. If the file exists and has a `## Validated Requirements` or `## Requirements` section:
+   - Move any requirements validated by this phase from Active → Validated
+   - Add a brief note: `Validated in Phase {X}: {Name}`
+3. If the file has a `## Current State` or similar section:
+   - Update it to reflect this phase's completion (e.g., "Phase {X} complete — {one-liner}")
+4. Update the `Last updated:` footer to today's date
+5. Commit the change:
+
+```bash
+node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" commit "docs(phase-{X}): evolve PROJECT.md after phase completion" --files .planning/PROJECT.md
+```
+
+**Skip this step if** `.planning/PROJECT.md` does not exist.
+</step>
+
 <step name="offer_next">
 
 **Exception:** If `gaps_found`, the `verify_phase_goal` step already presents the gap-closure path (`/gsd:plan-phase {X} --gaps`). No additional routing needed — skip auto-advance.


### PR DESCRIPTION
## Problem

After 18+ phases, planning documents drift silently (#956). Two root causes:

### 1. PROJECT.md never updated in standard workflow cycle
The standard path is `discuss → plan → execute → verify`. None of these update PROJECT.md.
Only `transition.md` (optional) and `complete-milestone.md` evolve it — but `transition.md`
is not reliably invoked in practice.

**Result:** Features ship, requirements get validated, but PROJECT.md falls behind by 4+ phases.

### 2. `cmdPhaseComplete()` doesn't increment counters
`phase complete` advances `Current Phase` and updates `Status`, but:
- `Completed Phases` counter is never incremented
- `percent` / progress percentage is never recalculated

**Result:** STATE.md shows stale progress (e.g., 100% when actually 86% done).

## Fix

### execute-phase.md: New `update_project_md` step
Added between `update_roadmap` and `offer_next` steps:
1. Read PROJECT.md
2. Move phase requirements from Active → Validated
3. Update Current State section
4. Bump `Last updated` timestamp
5. Commit PROJECT.md
6. Skip if PROJECT.md doesn't exist

### phase.cjs: Counter increment + percent recalculation
After updating Last Activity Description:
1. Parse `**Completed Phases:**` and increment by 1
2. Parse `**Total Phases:**` and recalculate `percent = round(completed/total * 100)`
3. Update both the `**Progress:**` field and `percent:` frontmatter field

## Files Changed
- `get-shit-done/workflows/execute-phase.md` — new update_project_md step
- `get-shit-done/bin/lib/phase.cjs` — counter increment + percent recalculation

Fixes #956