### PR TITLE
fix: add runtime compatibility fallback for Copilot executor stuck issue (#1128)

### DIFF
--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -6,6 +6,20 @@ Execute all plans in a phase using wave-based parallel execution. Orchestrator s
 Orchestrator coordinates, not executes. Each subagent loads the full execute-plan context. Orchestrator: discover plans → analyze deps → group waves → spawn agents → handle checkpoints → collect results.
 </core_principle>
 
+<runtime_compatibility>
+**Subagent spawning is runtime-specific:**
+- **Claude Code:** Uses `Task(subagent_type="gsd-executor", ...)` — blocks until complete, returns result
+- **Copilot:** Uses `@gsd-executor` agent reference — if subagent spawning hangs or fails to return,
+  fall back to **sequential inline execution**: read and follow execute-plan.md directly for each plan
+  instead of spawning parallel agents. This is slower but reliable.
+- **Other runtimes (Gemini, Codex, OpenCode):** If Task/subagent API is unavailable, use sequential
+  inline execution as the fallback.
+
+**Fallback rule:** If a spawned agent completes its work (commits visible, SUMMARY.md exists) but
+the orchestrator never receives the completion signal, treat it as successful based on spot-checks
+and continue to the next wave/plan.
+</runtime_compatibility>
+
 <required_reading>
 Read STATE.md before any operation to load project context.
 </required_reading>


### PR DESCRIPTION
## Problem

In Copilot runtime, the `gsd-executor` orchestrator gets stuck waiting for sub-agents to return (#1128). Sub-agents finish their work (commits visible, SUMMARY.md created), but the orchestrator never receives the completion signal. This is 100% reproducible and makes parallel execution unusable on Copilot.

## Root Cause

The `Task(subagent_type="gsd-executor", ...)` syntax is Claude Code's subagent API. Copilot may not implement the same blocking/return semantics, causing the orchestrator to hang indefinitely waiting for a signal that never arrives.

## Fix

Added a `<runtime_compatibility>` section to `execute-phase.md`:

1. **Runtime-specific guidance:** Documents that Task() is Claude Code-specific, Copilot should use `@gsd-executor` agent references
2. **Fallback mechanism:** If subagent spawning hangs, fall back to sequential inline execution (read and follow execute-plan.md directly)
3. **Spot-check recovery rule:** If a spawned agent completes work but the orchestrator doesn't get the signal, treat as successful based on spot-checks (SUMMARY.md exists, git commits present) and continue

## Files Changed
- `get-shit-done/workflows/execute-phase.md` — runtime_compatibility section

Fixes #1128