### PR TITLE
feat: context window size awareness for 1M+ models (#1086)

### DIFF
--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -65,6 +65,7 @@ function loadConfig(cwd) {
     parallelization: true,
     brave_search: false,
     resolve_model_ids: false, // when true, resolve aliases (opus/sonnet/haiku) to full model IDs
+    context_window: 200000, // default 200k; set to 1000000 for Opus/Sonnet 4.6 1M models
   };
 
   try {
@@ -108,6 +109,7 @@ function loadConfig(cwd) {
       parallelization,
       brave_search: get('brave_search') ?? defaults.brave_search,
       resolve_model_ids: get('resolve_model_ids') ?? defaults.resolve_model_ids,
+      context_window: get('context_window') ?? defaults.context_window,
       model_overrides: parsed.model_overrides || null,
     };
   } catch {

--- a/get-shit-done/bin/lib/init.cjs
+++ b/get-shit-done/bin/lib/init.cjs
@@ -31,6 +31,7 @@ function cmdInitExecutePhase(cwd, phase, raw) {
     // Config flags
     commit_docs: config.commit_docs,
     parallelization: config.parallelization,
+    context_window: config.context_window,
     branching_strategy: config.branching_strategy,
     phase_branch_template: config.phase_branch_template,
     milestone_branch_template: config.milestone_branch_template,

--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -191,8 +191,9 @@ Execute each wave in sequence. Within a wave: parallel if `PARALLELIZATION=true`
 
 2. **Spawn executor agents:**
 
-   Pass paths only — executors read files themselves with their fresh 200k context.
-   This keeps orchestrator context lean (~10-15%).
+   Pass paths only — executors read files themselves with their fresh context window.
+   For 200k models, this keeps orchestrator context lean (~10-15%).
+   For 1M+ models (Opus 4.6, Sonnet 4.6), richer context can be passed directly.
 
    ```
    Task(
@@ -652,7 +653,13 @@ Only suggest the commands listed above. Do not invent or hallucinate command nam
 </process>
 
 <context_efficiency>
-Orchestrator: ~10-15% context. Subagents: fresh 200k each. No polling (Task blocks). No context bleed.
+Orchestrator: ~10-15% context for 200k windows, can use more for 1M+ windows.
+Subagents: fresh context each (200k-1M depending on model). No polling (Task blocks). No context bleed.
+
+For 1M+ context models, consider:
+- Passing richer context (code snippets, dependency outputs) directly to executors instead of just file paths
+- Running small phases (≤3 plans, no dependencies) inline without subagent spawning overhead
+- Relaxing /clear recommendations — context rot onset is much further out with 5x window
 </context_efficiency>
 
 <failure_handling>


### PR DESCRIPTION
## Context

Opus 4.6 and Sonnet 4.6 ship with 1M token context windows. GSD's architecture was designed around 200k — spawning fresh subagents to avoid context rot, passing only file paths to executors, keeping orchestrator at 10-15%.

With 5x more context, some of these constraints can be relaxed.

## Changes

### `core.cjs`: New `context_window` config option
- Default: `200000` (backward compatible)
- Users can set `"context_window": 1000000` in config.json for 1M models
- Exposed in `loadConfig()` return value

### `init.cjs`: Expose in init output
- `context_window` is now part of the init JSON so workflows can branch on it

### `execute-phase.md`: Context-size-aware guidance
- Updated executor context passing: 200k → paths only; 1M+ → richer context allowed
- Updated context_efficiency section with 1M-specific strategies:
  - Inline small phases (≤3 plans, no deps) without subagent overhead
  - Relax `/clear` recommendations
  - Pass code snippets and dependency outputs directly

### Context monitor: Already adaptive
The hook uses percentage-based thresholds (35% warning, 25% critical) — works correctly for any window size.

Addresses #1086