### PR TITLE
feat: interactive executor mode for pair-programming style execution (#963)

### DIFF
--- a/commands/gsd/execute-phase.md
+++ b/commands/gsd/execute-phase.md
@@ -1,7 +1,7 @@
 ---
 name: gsd:execute-phase
 description: Execute all plans in a phase with wave-based parallelization
-argument-hint: "<phase-number> [--gaps-only]"
+argument-hint: "<phase-number> [--gaps-only] [--interactive]"
 allowed-tools:
   - Read
   - Write
@@ -31,6 +31,7 @@ Phase: $ARGUMENTS
 
 **Flags:**
 - `--gaps-only` — Execute only gap closure plans (plans with `gap_closure: true` in frontmatter). Use after verify-work creates fix plans.
+- `--interactive` — Execute plans sequentially inline (no subagents) with user checkpoints between tasks. Lower token usage, pair-programming style. Best for small phases, bug fixes, and verification gaps.
 
 Context files are resolved inside the workflow via `gsd-tools init execute-phase` and per-subagent `<files_to_read>` blocks.
 </context>

--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -37,6 +37,54 @@ fi
 ```
 </step>
 
+<step name="check_interactive_mode">
+**Parse `--interactive` flag from $ARGUMENTS.**
+
+**If `--interactive` flag present:** Switch to interactive execution mode.
+
+Interactive mode executes plans sequentially **inline** (no subagent spawning) with user
+checkpoints between tasks. The user can review, modify, or redirect work at any point.
+
+**Interactive execution flow:**
+
+1. Load plan inventory as normal (discover_and_group_plans)
+2. For each plan (sequentially, ignoring wave grouping):
+
+   a. **Present the plan to the user:**
+      ```
+      ## Plan {plan_id}: {plan_name}
+
+      Objective: {from plan file}
+      Tasks: {task_count}
+
+      Options:
+      - Execute (proceed with all tasks)
+      - Review first (show task breakdown before starting)
+      - Skip (move to next plan)
+      - Stop (end execution, save progress)
+      ```
+
+   b. **If "Review first":** Read and display the full plan file. Ask again: Execute, Modify, Skip.
+
+   c. **If "Execute":** Read and follow `~/.claude/get-shit-done/workflows/execute-plan.md` **inline**
+      (do NOT spawn a subagent). Execute tasks one at a time.
+
+   d. **After each task:** Pause briefly. If the user intervenes (types anything), stop and address
+      their feedback before continuing. Otherwise proceed to next task.
+
+   e. **After plan complete:** Show results, commit, create SUMMARY.md, then present next plan.
+
+3. After all plans: proceed to verification (same as normal mode).
+
+**Benefits of interactive mode:**
+- No subagent overhead — dramatically lower token usage
+- User catches mistakes early — saves costly verification cycles
+- Maintains GSD's planning/tracking structure
+- Best for: small phases, bug fixes, verification gaps, learning GSD
+
+**Skip to handle_branching step** (interactive plans execute inline after grouping).
+</step>
+
 <step name="handle_branching">
 Check `branching_strategy` from init:
 


### PR DESCRIPTION
## Problem

GSD execution spawns autonomous subagents that run to completion. This works well for large phases but has downsides:
- High token usage from subagent overhead
- No way to intervene when Claude goes off track
- Overkill for small fixes or verification gaps
- Unreliable for fixing minor issues found in verification

## Solution: `--interactive` flag

`/gsd:execute-phase 5 --interactive`

### How it works

1. Plans are presented to the user one at a time (ignoring wave grouping)
2. For each plan, user chooses: **Execute**, **Review first**, **Skip**, or **Stop**
3. Plans execute **inline** in the orchestrator's context (no subagent spawning)
4. After each task, the agent pauses — user can intervene or let it continue
5. SUMMARY.md, commits, and STATE.md updates happen normally

### Benefits
- **Lower tokens**: No subagent context overhead
- **User control**: Catch mistakes before they compound
- **GSD structure**: Maintains planning, tracking, and verification
- **Pair programming**: Closer to working with Claude than delegating to it

### Changes
- `execute-phase.md`: New `check_interactive_mode` step with full interactive flow
- `execute-phase` command: Documented `--interactive` flag

### Best for
- Small phases (1-3 plans)
- Bug fixes and gap closure
- Verification issue remediation
- Learning GSD workflow

Fixes #963