### PR TITLE
feat: MCP tool awareness for GSD subagents (#973)

### DIFF
--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -140,6 +140,13 @@ Execute each wave in sequence. Within a wave: parallel if `PARALLELIZATION=true`
        - .claude/skills/ or .agents/skills/ (Project skills, if either exists — list skills, read SKILL.md for each, follow relevant rules during implementation)
        </files_to_read>
 
+       <mcp_tools>
+       If CLAUDE.md or project instructions reference MCP tools (e.g. jCodeMunch, context7,
+       or other MCP servers), prefer those tools over Grep/Glob for code navigation when available.
+       MCP tools often save significant tokens by providing structured code indexes.
+       Check tool availability first — if MCP tools are not accessible, fall back to Grep/Glob.
+       </mcp_tools>
+
        <success_criteria>
        - [ ] All tasks executed
        - [ ] Each task committed individually

--- a/get-shit-done/workflows/execute-plan.md
+++ b/get-shit-done/workflows/execute-plan.md
@@ -135,7 +135,8 @@ If previous SUMMARY has unresolved "Issues Encountered" or "Next Phase Readiness
 Deviations are normal — handle via rules below.
 
 1. Read @context files from prompt
-2. Per task:
+2. **MCP tools:** If CLAUDE.md or project instructions reference MCP tools (e.g. jCodeMunch for code navigation), prefer them over Grep/Glob when available. Fall back to Grep/Glob if MCP tools are not accessible.
+3. Per task:
    - **MANDATORY read_first gate:** If the task has a `<read_first>` field, you MUST read every listed file BEFORE making any edits. This is not optional. Do not skip files because you "already know" what's in them — read them. The read_first files establish ground truth for the task.
    - `type="auto"`: if `tdd="true"` → TDD execution. Implement with deviation rules + auth gates. Verify done criteria. Commit (see task_commit). Track hash for Summary.
    - `type="checkpoint:*"`: STOP → checkpoint_protocol → wait for user → continue only after confirmation.


### PR DESCRIPTION
## Problem

GSD executor agents ignore MCP tools like jCodeMunch even when CLAUDE.md says "ALL agents MUST use jCodeMunch for code navigation." Agents default to Grep/Glob because those are explicitly referenced in workflow patterns.

## Fix

Added MCP tool instructions to both workflow files:

### execute-phase.md
New `<mcp_tools>` section in the executor agent prompt:
- Tells agents to check if CLAUDE.md references MCP tools
- Prefer MCP tools over Grep/Glob for code navigation
- Fall back to Grep/Glob if MCP tools not accessible

### execute-plan.md
Added Step 2 in execute section with MCP tool guidance before task execution loop.

## Why this works
Agents already read CLAUDE.md at startup. The issue was that workflow instructions never told agents to **act** on MCP tool references in CLAUDE.md. This change creates a direct instruction path: CLAUDE.md says "use jCodeMunch" → workflow says "prefer MCP tools referenced in CLAUDE.md".

Fixes #973