### PR TITLE
feat: add Codex hooks support for SessionStart (#1020)

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -2689,6 +2689,36 @@ function install(isGlobal, runtime = 'claude') {
     const agentCount = installCodexConfig(targetDir, agentsSrc);
     console.log(`  ${green}✓${reset} Generated config.toml with ${agentCount} agent roles`);
     console.log(`  ${green}✓${reset} Generated ${agentCount} agent .toml config files`);
+
+    // Add Codex hooks (SessionStart for update checking) — requires codex_hooks feature flag
+    const configPath = path.join(targetDir, 'config.toml');
+    try {
+      let configContent = fs.existsSync(configPath) ? fs.readFileSync(configPath, 'utf-8') : '';
+
+      // Enable hooks feature flag if not present
+      if (!configContent.includes('codex_hooks')) {
+        const featuresSection = '[features]\ncodex_hooks = true\n';
+        if (configContent.includes('[features]')) {
+          configContent = configContent.replace(/\[features\]\n/, featuresSection);
+        } else {
+          configContent = featuresSection + '\n' + configContent;
+        }
+      }
+
+      // Add SessionStart hook for update checking
+      const updateCheckScript = path.resolve(targetDir, 'get-shit-done', 'hooks', 'gsd-update-check.js').replace(/\\/g, '/');
+      const hookBlock = `\n# GSD Hooks\n[[hooks]]\nevent = "SessionStart"\ncommand = "node ${updateCheckScript}"\n`;
+
+      if (!configContent.includes('gsd-update-check')) {
+        configContent += hookBlock;
+      }
+
+      fs.writeFileSync(configPath, configContent, 'utf-8');
+      console.log(`  ${green}✓${reset} Configured Codex hooks (SessionStart)`);
+    } catch (e) {
+      console.warn(`  ${yellow}⚠${reset}  Could not configure Codex hooks: ${e.message}`);
+    }
+
     return { settingsPath: null, settings: null, statuslineCommand: null, runtime };
   }
 


### PR DESCRIPTION
## Problem

Codex v0.114.0 added experimental hooks (`SessionStart` and `Stop`). GSD's Codex installer skipped hooks entirely — returned early before reaching the hooks configuration section.

## Fix

Updated the Codex install block in `install.js` to:

1. **Enable hooks feature flag:** Adds `codex_hooks = true` to `[features]` section
2. **Add SessionStart hook:** Registers `gsd-update-check.js` for version checking on session start
3. **Graceful fallback:** If config.toml write fails, warns but doesn't crash

### Hook format
```toml
[features]
codex_hooks = true

# GSD Hooks
[[hooks]]
event = "SessionStart"
command = "node /path/to/gsd-update-check.js"
```

### Not yet added
- `PostToolUse` hooks (context monitor) — waiting for Codex to add that event type
- `Stop` hooks — no GSD use case currently

Fixes #1020