### PR TITLE
fix: add explicit agent type listings to prevent fallback after /clear (#949)

### DIFF
--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -10,6 +10,24 @@ Orchestrator coordinates, not executes. Each subagent loads the full execute-pla
 Read STATE.md before any operation to load project context.
 </required_reading>
 
+<available_agent_types>
+These are the valid GSD subagent types registered in .claude/agents/ (or equivalent for your runtime).
+Always use the exact name from this list — do not fall back to 'general-purpose' or other built-in types:
+
+- gsd-executor — Executes plan tasks, commits, creates SUMMARY.md
+- gsd-verifier — Verifies phase completion, checks quality gates
+- gsd-planner — Creates detailed plans from phase scope
+- gsd-phase-researcher — Researches technical approaches for a phase
+- gsd-plan-checker — Reviews plan quality before execution
+- gsd-debugger — Diagnoses and fixes issues
+- gsd-codebase-mapper — Maps project structure and dependencies
+- gsd-integration-checker — Checks cross-phase integration
+- gsd-nyquist-auditor — Validates verification coverage
+- gsd-ui-researcher — Researches UI/UX approaches
+- gsd-ui-checker — Reviews UI implementation quality
+- gsd-ui-auditor — Audits UI against design requirements
+</available_agent_types>
+
 <process>
 
 <step name="initialize" priority="first">

--- a/get-shit-done/workflows/plan-phase.md
+++ b/get-shit-done/workflows/plan-phase.md
@@ -8,6 +8,13 @@ Read all files referenced by the invoking prompt's execution_context before star
 @~/.claude/get-shit-done/references/ui-brand.md
 </required_reading>
 
+<available_agent_types>
+Valid GSD subagent types (use exact names — do not fall back to 'general-purpose'):
+- gsd-phase-researcher — Researches technical approaches for a phase
+- gsd-planner — Creates detailed plans from phase scope
+- gsd-plan-checker — Reviews plan quality before execution
+</available_agent_types>
+
 <process>
 
 ## 1. Initialize


### PR DESCRIPTION
## Problem

After `/clear`, Claude Code loses awareness of custom GSD agent types and falls back to `general-purpose`. Agent files exist in `.claude/agents/` but the model doesn't re-read them.

## Fix

Added `<available_agent_types>` sections with explicit agent type listings to:
- `execute-phase.md` — all 12 GSD agent types with descriptions
- `plan-phase.md` — 3 agent types used during planning

The listing is in the workflow instructions (which ARE re-read after `/clear`) so the model always has an unambiguous reference to valid types.

Fixes #949