### PR TITLE
fix: prevent nested Skill calls that break AskUserQuestion (#1009)

### DIFF
--- a/get-shit-done/workflows/plan-phase.md
+++ b/get-shit-done/workflows/plan-phase.md
@@ -170,7 +170,16 @@ Use AskUserQuestion:
   - "Run discuss-phase first" — Capture design decisions before planning
 
 If "Continue without context": Proceed to step 5.
-If "Run discuss-phase first": Display `/gsd:discuss-phase {X}` and exit workflow.
+If "Run discuss-phase first":
+  **IMPORTANT:** Do NOT invoke discuss-phase as a nested Skill/Task call — AskUserQuestion
+  does not work correctly in nested subcontexts (#1009). Instead, display the command
+  and exit so the user runs it as a top-level command:
+  ```
+  Run this command first, then re-run /gsd:plan-phase {X}:
+
+  /gsd:discuss-phase {X}
+  ```
+  **Exit the plan-phase workflow. Do not continue.**
 
 ## 5. Handle Research
 


### PR DESCRIPTION
## Problem

When `plan-phase` detects missing CONTEXT.md and the user selects 'Run discuss-phase first', if the workflow invokes discuss-phase as a nested Skill call, all AskUserQuestion calls auto-resolve with empty answers. User never sees any questions.

## Root cause
Claude Code's Skill/Task tool runs nested commands in a subcontext where AskUserQuestion doesn't propagate back to the top-level TUI.

## Fix
Made the 'Run discuss-phase first' path in plan-phase.md explicitly:
1. Display the command for the user to run as a top-level command
2. Add explicit warning: "Do NOT invoke discuss-phase as a nested Skill/Task call"
3. Exit the plan-phase workflow immediately

The user runs `/gsd:discuss-phase N` separately (which works correctly), then re-runs `/gsd:plan-phase N`.

Fixes #1009