### PR TITLE
fix(quick): use lighter planner defaults for trivial quick tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ Then `/gsd:new-milestone` starts the next version — same flow as `new-project`
 
 Quick mode gives you GSD guarantees (atomic commits, state tracking) with a faster path:
 
-- **Same agents** — Planner + executor, same quality
+- **Lighter default planner** — Standard `/gsd:quick` uses the quick-planner profile to keep trivial tasks moving
 - **Skips optional steps** — No research, no plan checker, no verifier by default
 - **Separate tracking** — Lives in `.planning/quick/`, not phases
 
@@ -384,7 +384,7 @@ Quick mode gives you GSD guarantees (atomic commits, state tracking) with a fast
 
 **`--research` flag:** Spawns a focused researcher before planning. Investigates implementation approaches, library options, and pitfalls. Use when you're unsure how to approach a task.
 
-**`--full` flag:** Enables plan-checking (max 2 iterations) and post-execution verification.
+**`--full` flag:** Enables plan-checking (max 2 iterations) and post-execution verification, and keeps the standard planner profile for stricter plans.
 
 Flags are composable: `--discuss --research --full` gives discussion + research + plan-checking + verification.
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -322,6 +322,8 @@ Execute ad-hoc task with GSD guarantees.
 | `--discuss` | Lightweight pre-planning discussion |
 | `--research` | Spawn focused researcher before planning |
 
+Default quick runs use the lighter quick-planner profile; `--full` keeps the standard planner profile for stricter plans.
+
 Flags are composable.
 
 ```bash

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -410,6 +410,7 @@ Disable these to speed up phases in familiar domains or when conserving tokens.
 | Agent | `quality` | `balanced` | `budget` | `inherit` |
 |-------|-----------|------------|----------|-----------|
 | gsd-planner | Opus | Opus | Sonnet | Inherit |
+| gsd-quick-planner | Opus | Sonnet | Sonnet | Inherit |
 | gsd-roadmapper | Opus | Sonnet | Sonnet | Inherit |
 | gsd-executor | Opus | Sonnet | Sonnet | Inherit |
 | gsd-phase-researcher | Opus | Sonnet | Haiku | Inherit |

--- a/get-shit-done/bin/lib/init.cjs
+++ b/get-shit-done/bin/lib/init.cjs
@@ -270,7 +270,8 @@ function cmdInitQuick(cwd, description, raw) {
 
   const result = {
     // Models
-    planner_model: resolveModelInternal(cwd, 'gsd-planner'),
+    planner_model: resolveModelInternal(cwd, 'gsd-quick-planner'),
+    full_planner_model: resolveModelInternal(cwd, 'gsd-planner'),
     executor_model: resolveModelInternal(cwd, 'gsd-executor'),
     checker_model: resolveModelInternal(cwd, 'gsd-plan-checker'),
     verifier_model: resolveModelInternal(cwd, 'gsd-verifier'),

--- a/get-shit-done/bin/lib/model-profiles.cjs
+++ b/get-shit-done/bin/lib/model-profiles.cjs
@@ -8,6 +8,7 @@
  */
 const MODEL_PROFILES = {
   'gsd-planner': { quality: 'opus', balanced: 'opus', budget: 'sonnet' },
+  'gsd-quick-planner': { quality: 'opus', balanced: 'sonnet', budget: 'sonnet' },
   'gsd-roadmapper': { quality: 'opus', balanced: 'sonnet', budget: 'sonnet' },
   'gsd-executor': { quality: 'opus', balanced: 'sonnet', budget: 'sonnet' },
   'gsd-phase-researcher': { quality: 'opus', balanced: 'sonnet', budget: 'haiku' },

--- a/get-shit-done/references/model-profiles.md
+++ b/get-shit-done/references/model-profiles.md
@@ -7,6 +7,7 @@ Model profiles control which Claude model each GSD agent uses. This allows balan
 | Agent | `quality` | `balanced` | `budget` | `inherit` |
 |-------|-----------|------------|----------|-----------|
 | gsd-planner | opus | opus | sonnet | inherit |
+| gsd-quick-planner | opus | sonnet | sonnet | inherit |
 | gsd-roadmapper | opus | sonnet | sonnet | inherit |
 | gsd-executor | opus | sonnet | sonnet | inherit |
 | gsd-phase-researcher | opus | sonnet | haiku | inherit |
@@ -84,6 +85,9 @@ Per-project default: Set in `.planning/config.json`:
 
 **Why Opus for gsd-planner?**
 Planning involves architecture decisions, goal decomposition, and task design. This is where model quality has the highest impact.
+
+**Why Sonnet for gsd-quick-planner in balanced?**
+Quick tasks still need planning, but they are explicitly constrained to 1-3 atomic tasks. Sonnet is fast enough for that narrower scope and saves Opus for milestone-scale planning or `--full` quick runs.
 
 **Why Sonnet for gsd-executor?**
 Executors follow explicit PLAN.md instructions. The plan already contains the reasoning; execution is implementation.

--- a/get-shit-done/workflows/quick.md
+++ b/get-shit-done/workflows/quick.md
@@ -111,7 +111,7 @@ INIT=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" init quick "$DESCRIP
 if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 ```
 
-Parse JSON for: `planner_model`, `executor_model`, `checker_model`, `verifier_model`, `commit_docs`, `quick_id`, `slug`, `date`, `timestamp`, `quick_dir`, `task_dir`, `roadmap_exists`, `planning_exists`.
+Parse JSON for: `planner_model`, `full_planner_model`, `executor_model`, `checker_model`, `verifier_model`, `commit_docs`, `quick_id`, `slug`, `date`, `timestamp`, `quick_dir`, `task_dir`, `roadmap_exists`, `planning_exists`.
 
 **If `roadmap_exists` is false:** Error — Quick mode requires an active project with ROADMAP.md. Run `/gsd:new-project` first.
 
@@ -377,7 +377,7 @@ Return: ## PLANNING COMPLETE with plan path
 </output>
 ",
   subagent_type="gsd-planner",
-  model="{planner_model}",
+  model="{FULL_MODE ? full_planner_model : planner_model}",
   description="Quick plan: ${DESCRIPTION}"
 )
 ```

--- a/tests/core.test.cjs
+++ b/tests/core.test.cjs
@@ -146,7 +146,7 @@ describe('resolveModelInternal', () => {
 
   describe('model profile structural validation', () => {
     test('all known agents resolve to a valid string for each profile', () => {
-      const knownAgents = ['gsd-planner', 'gsd-executor', 'gsd-phase-researcher', 'gsd-codebase-mapper'];
+      const knownAgents = ['gsd-planner', 'gsd-quick-planner', 'gsd-executor', 'gsd-phase-researcher', 'gsd-codebase-mapper'];
       const profiles = ['quality', 'balanced', 'budget', 'inherit'];
       const validValues = ['inherit', 'sonnet', 'haiku', 'opus'];
 
@@ -163,7 +163,7 @@ describe('resolveModelInternal', () => {
     });
 
     test('inherit profile forces all known agents to inherit model', () => {
-      const knownAgents = ['gsd-planner', 'gsd-executor', 'gsd-phase-researcher', 'gsd-codebase-mapper'];
+      const knownAgents = ['gsd-planner', 'gsd-quick-planner', 'gsd-executor', 'gsd-phase-researcher', 'gsd-codebase-mapper'];
       writeConfig({ model_profile: 'inherit' });
       for (const agent of knownAgents) {
         assert.strictEqual(resolveModelInternal(tmpDir, agent), 'inherit');
@@ -195,6 +195,15 @@ describe('resolveModelInternal', () => {
       // gsd-planner not overridden, should use quality profile -> opus
       assert.strictEqual(resolveModelInternal(tmpDir, 'gsd-planner'), 'opus');
     });
+
+    test('quick planner override can differ from standard planner', () => {
+      writeConfig({
+        model_profile: 'balanced',
+        model_overrides: { 'gsd-quick-planner': 'haiku' },
+      });
+      assert.strictEqual(resolveModelInternal(tmpDir, 'gsd-quick-planner'), 'haiku');
+      assert.strictEqual(resolveModelInternal(tmpDir, 'gsd-planner'), 'opus');
+    });
   });
 
   describe('edge cases', () => {
@@ -212,6 +221,7 @@ describe('resolveModelInternal', () => {
       writeConfig({});
       // balanced profile, gsd-planner -> opus
       assert.strictEqual(resolveModelInternal(tmpDir, 'gsd-planner'), 'opus');
+      assert.strictEqual(resolveModelInternal(tmpDir, 'gsd-quick-planner'), 'sonnet');
     });
   });
 });

--- a/tests/init.test.cjs
+++ b/tests/init.test.cjs
@@ -694,6 +694,9 @@ describe('cmdInitQuick', () => {
     assert.ok(/^\.planning\/quick\/\d{6}-[0-9a-z]{3}-fix-login-bug$/.test(output.task_dir),
       `task_dir format wrong: "${output.task_dir}"`);
 
+    assert.strictEqual(output.planner_model, 'sonnet');
+    assert.strictEqual(output.full_planner_model, 'opus');
+
     // next_num must NOT be present
     assert.ok(!('next_num' in output), 'next_num should not be in output');
   });
@@ -735,6 +738,20 @@ describe('cmdInitQuick', () => {
 
     const output = JSON.parse(result.output);
     assert.ok(output.slug.length <= 40, `Slug should be <= 40 chars, got ${output.slug.length}: "${output.slug}"`);
+  });
+
+  test('quality profile keeps quick and full planners on opus', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ model_profile: 'quality', commit_docs: true }, null, 2)
+    );
+
+    const result = runGsdTools('init quick "Fix login bug"', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.planner_model, 'opus');
+    assert.strictEqual(output.full_planner_model, 'opus');
   });
 });
 


### PR DESCRIPTION
Closes #609

## Summary
- add a dedicated `gsd-quick-planner` profile so standard `/gsd:quick` runs use a lighter planner default
- keep `--full` on the existing `gsd-planner` profile so stricter quick runs still get heavyweight planning
- document the split in quick command docs and model-profile references
- add tests for quick planner resolution, overrides, and init quick output

## Why
Issue #609 called out that trivial quick tasks still paid the full planning cost in balanced mode because `/gsd:quick` always resolved the standard planner profile, which defaults to Opus. This keeps milestone-scale planning untouched while making the default quick path cheaper and faster.

## Testing
- `npm test -- --test-name-pattern="resolveModelInternal|cmdInitQuick"`