### PR TITLE
fix: semver 3+ segment parsing and CRLF frontmatter corruption recovery

### DIFF
--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -512,7 +512,8 @@ function getMilestoneInfo(cwd) {
 
     // First: check for list-format roadmaps using 🚧 (in-progress) marker
     // e.g. "- 🚧 **v2.1 Belgium** — Phases 24-28 (in progress)"
-    const inProgressMatch = roadmap.match(/🚧\s*\*\*v(\d+\.\d+)\s+([^*]+)\*\*/);
+    // e.g. "- 🚧 **v1.2.1 Tech Debt** — Phases 1-8 (in progress)"
+    const inProgressMatch = roadmap.match(/🚧\s*\*\*v(\d+(?:\.\d+)+)\s+([^*]+)\*\*/);
     if (inProgressMatch) {
       return {
         version: 'v' + inProgressMatch[1],
@@ -523,15 +524,16 @@ function getMilestoneInfo(cwd) {
     // Second: heading-format roadmaps — strip shipped milestones in <details> blocks
     const cleaned = stripShippedMilestones(roadmap);
     // Extract version and name from the same ## heading for consistency
-    const headingMatch = cleaned.match(/## .*v(\d+\.\d+)[:\s]+([^\n(]+)/);
+    // Supports 2+ segment versions: v1.2, v1.2.1, v2.0.1, etc.
+    const headingMatch = cleaned.match(/## .*v(\d+(?:\.\d+)+)[:\s]+([^\n(]+)/);
     if (headingMatch) {
       return {
         version: 'v' + headingMatch[1],
         name: headingMatch[2].trim(),
       };
     }
-    // Fallback: try bare version match
-    const versionMatch = cleaned.match(/v(\d+\.\d+)/);
+    // Fallback: try bare version match (greedy — capture longest version string)
+    const versionMatch = cleaned.match(/v(\d+(?:\.\d+)+)/);
     return {
       version: versionMatch ? versionMatch[0] : 'v1.0',
       name: 'milestone',

--- a/get-shit-done/bin/lib/frontmatter.cjs
+++ b/get-shit-done/bin/lib/frontmatter.cjs
@@ -10,7 +10,11 @@ const { safeReadFile, normalizeMd, output, error } = require('./core.cjs');
 
 function extractFrontmatter(content) {
   const frontmatter = {};
-  const match = content.match(/^---\r?\n([\s\S]+?)\r?\n---/);
+  // Find ALL frontmatter blocks at the start of the file.
+  // If multiple blocks exist (corruption from CRLF mismatch), use the LAST one
+  // since it represents the most recent state sync.
+  const allBlocks = [...content.matchAll(/(?:^|\n)\s*---\r?\n([\s\S]+?)\r?\n---/g)];
+  const match = allBlocks.length > 0 ? allBlocks[allBlocks.length - 1] : null;
   if (!match) return frontmatter;
 
   const yaml = match[1];

--- a/get-shit-done/bin/lib/roadmap.cjs
+++ b/get-shit-done/bin/lib/roadmap.cjs
@@ -181,7 +181,7 @@ function cmdRoadmapAnalyze(cwd, raw) {
 
   // Extract milestone info
   const milestones = [];
-  const milestonePattern = /##\s*(.*v(\d+\.\d+)[^(\n]*)/gi;
+  const milestonePattern = /##\s*(.*v(\d+(?:\.\d+)+)[^(\n]*)/gi;
   let mMatch;
   while ((mMatch = milestonePattern.exec(content)) !== null) {
     milestones.push({

--- a/get-shit-done/bin/lib/state.cjs
+++ b/get-shit-done/bin/lib/state.cjs
@@ -664,7 +664,17 @@ function buildStateFrontmatter(bodyContent, cwd) {
 }
 
 function stripFrontmatter(content) {
-  return content.replace(/^---\n[\s\S]*?\n---\n*/, '');
+  // Strip ALL frontmatter blocks at the start of the file.
+  // Handles CRLF line endings and multiple stacked blocks (corruption recovery).
+  // Greedy: keeps stripping ---...--- blocks separated by optional whitespace.
+  let result = content;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const stripped = result.replace(/^\s*---\r?\n[\s\S]*?\r?\n---\s*/, '');
+    if (stripped === result) break;
+    result = stripped;
+  }
+  return result;
 }
 
 function syncStateFrontmatter(content, cwd) {


### PR DESCRIPTION
## Problem

Two independent bugs cause `getMilestoneInfo()`, `state json`, `init progress`, and `roadmap analyze` to return wrong milestone data on projects using 3-segment semver versions (e.g. `v1.2.1`).

### Bug 1: Version regex only matches 2-segment versions

Every version regex in `getMilestoneInfo()` and `cmdRoadmapAnalyze()` uses `\d+\.\d+`, which matches `v1.2` but **not** `v1.2.1`, `v2.0.1`, etc.

**Concrete example:** A project at milestone `v1.2.1 Tech Debt & Hardening` with this ROADMAP heading:
```
- 🚧 **v1.2.1 Tech Debt & Hardening** -- Phases 1-8 (in progress)
```

`getMilestoneInfo()` returns `{ version: "v1.0", name: "milestone" }` because:
1. The 🚧 regex `v(\d+\.\d+)` captures `1.2` (drops `.1`), and the name regex `\s+([^*]+)` then fails to match because `.1` is still in the string
2. The heading regex also fails for the same reason
3. Falls through to the catch-all `{ version: 'v1.0', name: 'milestone' }`

This cascades into `state json`, `init progress`, `init execute-phase`, `init new-milestone`, and every workflow that calls `getMilestoneInfo()`.

### Bug 2: `state.cjs stripFrontmatter()` doesn't handle CRLF

PR #1105 fixed CRLF handling in `frontmatter.cjs` (`extractFrontmatter`, `spliceFrontmatter`, `parseMustHavesBlock`), but missed `state.cjs:stripFrontmatter()` which uses `^---\n` (LF-only).

When `syncStateFrontmatter()` runs on a STATE.md that already has a CRLF frontmatter block:
1. `stripFrontmatter()` fails to strip the CRLF block (regex doesn't match)
2. The CRLF block survives as "body" content
3. `buildStateFrontmatter()` generates new frontmatter from body fields + `getMilestoneInfo()` (which returns wrong data per Bug 1)
4. A new wrong frontmatter block is prepended → STATE.md now has **two** frontmatter blocks

Once corrupted, `extractFrontmatter()` always reads the **first** (stale) block, so `state json` returns the wrong milestone permanently.

## Solution

### Fix 1: Support 3+ segment semver versions

Changed `\d+\.\d+` → `\d+(?:\.\d+)+` in all 4 version regex locations:

| File | Location |
|------|----------|
| `core.cjs` | `getMilestoneInfo()` — 🚧 list-format match (line 515) |
| `core.cjs` | `getMilestoneInfo()` — heading-format match (line 528) |
| `core.cjs` | `getMilestoneInfo()` — bare version fallback (line 536) |
| `roadmap.cjs` | `cmdRoadmapAnalyze()` — milestone extraction (line 184) |

### Fix 2: CRLF-safe `stripFrontmatter()` with corruption recovery

Replaced the single-pass `^---\n` regex with a loop that:
- Uses `\r?\n` to handle both LF and CRLF
- Strips **all** stacked frontmatter blocks (recovers from corruption)
- Stops when no more blocks are found at the start of the file

### Fix 3: Defensive `extractFrontmatter()` for dual-block files

When multiple `---` blocks exist, `extractFrontmatter()` now uses the **last** block (most recent sync) instead of the first (stale). This is a read-path safety net — Fix 2 prevents new corruption, but existing corrupted STATE.md files need correct reads until the next write repairs them.

### Files changed

| File | What changed |
|------|-------------|
| `core.cjs` | `getMilestoneInfo()` — 3 version regexes updated to `\d+(?:\.\d+)+` |
| `roadmap.cjs` | `cmdRoadmapAnalyze()` — 1 milestone version regex updated |
| `state.cjs` | `stripFrontmatter()` — CRLF support + multi-block stripping loop |
| `frontmatter.cjs` | `extractFrontmatter()` — use last block when multiple exist |

## Before / After

**`getMilestoneInfo()` on a `v1.2.1` project:**

| Field | Before (broken) | After (fixed) |
|-------|-----------------|---------------|
| `version` | `"v1.0"` | `"v1.2.1"` |
| `name` | `"milestone"` | `"Tech Debt & Hardening"` |

**`state json` on a corrupted dual-frontmatter STATE.md:**

| Field | Before (broken) | After (fixed) |
|-------|-----------------|---------------|
| `milestone` | `"v1.0"` (from stale first block) | `"v1.2.1"` (from last block) |

**`init progress`:**

| Field | Before | After |
|-------|--------|-------|
| `milestone_version` | `"v1.0"` | `"v1.2.1"` |
| `milestone_name` | `"milestone"` | `"Tech Debt & Hardening"` |

## Test Results

All 755 existing tests pass. Additionally verified with manual tests:

- [x] `getMilestoneInfo()` — 🚧 list format with `v1.2.1`: returns `v1.2.1` ✓
- [x] `getMilestoneInfo()` — heading format with `v1.2.1`: returns `v1.2.1` ✓
- [x] `getMilestoneInfo()` — 2-segment `v2.0` backward compat: returns `v2.0` ✓
- [x] `getMilestoneInfo()` — 4-segment `v1.2.1.3`: returns `v1.2.1.3` ✓
- [x] `extractFrontmatter()` — dual blocks: returns last block's milestone ✓
- [x] `extractFrontmatter()` — single block: unchanged behavior ✓
- [x] `extractFrontmatter()` — no blocks: returns empty object ✓
- [x] `stripFrontmatter()` — dual LF blocks: strips both ✓
- [x] `stripFrontmatter()` — dual CRLF blocks: strips both ✓
- [x] `stripFrontmatter()` — single block: strips correctly ✓
- [x] `stripFrontmatter()` — no blocks: returns content unchanged ✓

Relates to #1085 (CRLF fix was incomplete for `state.cjs`)