### PR TITLE
feat: add Cursor CLI runtime support

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -766,11 +766,9 @@ function convertCursorToolName(claudeTool) {
 }
 
 function convertSlashCommandsToCursorSkillMentions(content) {
-  let converted = content.replace(/\/gsd:([a-z0-9-]+)/gi, (_, commandName) => {
-    return `gsd-${String(commandName).toLowerCase()}`;
-  });
-  converted = converted.replace(/\/gsd-help\b/g, 'gsd-help');
-  return converted;
+  // Keep leading "/" for slash commands; only normalize gsd: -> gsd-.
+  // This preserves rendered "next step" commands like "/gsd-execute-phase 17".
+  return content.replace(/gsd:/gi, 'gsd-');
 }
 
 function convertClaudeToCursorMarkdown(content) {
@@ -1831,7 +1829,7 @@ function copyWithPathReplacement(srcDir, destDir, pathPrefix, runtime, isCommand
     } else if (isCursor && (entry.name.endsWith('.cjs') || entry.name.endsWith('.js'))) {
       // For Cursor, also convert Claude references in JS/CJS utility scripts
       let jsContent = fs.readFileSync(srcPath, 'utf8');
-      jsContent = jsContent.replace(/\/gsd:([a-z0-9-]+)/gi, (_, cmd) => `gsd-${cmd.toLowerCase()}`);
+      jsContent = jsContent.replace(/gsd:/gi, 'gsd-');
       jsContent = jsContent.replace(/\.claude\/skills\//g, '.cursor/skills/');
       jsContent = jsContent.replace(/CLAUDE\.md/g, '.cursor/rules/');
       jsContent = jsContent.replace(/\bClaude Code\b/g, 'Cursor');

--- a/tests/cursor-conversion.test.cjs
+++ b/tests/cursor-conversion.test.cjs
@@ -35,6 +35,26 @@ Test body
     assert.equal(nameMatch[1], 'gsd-quick', 'skill name is plain scalar');
     assert.ok(!result.includes('name: "gsd-quick"'), 'quoted skill name is not emitted');
   });
+
+  test('preserves slash for slash commands in markdown body', () => {
+    const input = `---
+name: gsd:plan-phase
+description: Plan a phase
+---
+
+Next:
+/gsd:execute-phase 17
+/gsd-help
+gsd:progress
+`;
+
+    const result = convertClaudeCommandToCursorSkill(input, 'gsd-plan-phase');
+
+    assert.ok(result.includes('/gsd-execute-phase 17'), 'slash command remains slash-prefixed');
+    assert.ok(result.includes('/gsd-help'), 'existing slash command is preserved');
+    assert.ok(result.includes('gsd-progress'), 'non-slash gsd: references still normalize');
+    assert.ok(!result.includes('/gsd:execute-phase'), 'legacy colon command form is removed');
+  });
 });
 
 describe('convertClaudeAgentToCursorAgent', () => {


### PR DESCRIPTION
## Summary

- Adds Cursor as a supported runtime alongside Claude Code, OpenCode, Gemini, Codex, Copilot, and Antigravity
- Cursor installs skills to `~/.cursor/skills/gsd-*/SKILL.md` (same directory layout as Codex skills)
- Includes full Claude-to-Cursor content adaptation: tool name mappings (`Bash`→`Shell`, `Edit`→`StrReplace`), subagent type conversion (`general-purpose`→`generalPurpose`), project convention rewrites (`CLAUDE.md`→`.cursor/rules/`, `.claude/skills/`→`.cursor/skills/`), and brand reference updates

## What's included

- `--cursor` flag for install/uninstall
- `--all` now includes `cursor`
- Interactive runtime prompt includes Cursor as option 7
- Help text updated with `--cursor` examples
- `getGlobalDir`, `getDirName`, `getConfigDirFromHome` all handle `cursor` runtime
- `copyCommandsAsCursorSkills` writes skills with a `<cursor_skill_adapter>` header section covering invocation, user prompting, tool usage, and subagent spawning
- `convertClaudeAgentToCursorAgent` adapts agent markdown for Cursor
- Manifest tracking, uninstall, and `finishInstall` all support `cursor`
- No `settings.json`, hooks, or statusline (Cursor manages its own session lifecycle)

## Credit

This implementation was originally authored by [@PabloVallejo](https://github.com/PabloVallejo) in [PabloVallejo/get-shit-done](https://github.com/PabloVallejo/get-shit-done/tree/feat/cursor-cli-support) and rebased onto the current upstream `main` by [@mitchelladam](https://github.com/mitchelladam) to resolve conflicts with the Copilot and Antigravity runtime additions.

## Test plan

- [x] `npm test` passes (755 tests, 0 failures)
- [x] `npx get-shit-done-cc --cursor --global` installs 39 skills to `~/.cursor/skills/`
- [x] `npx get-shit-done-cc --cursor --global --uninstall` removes all 39 GSD cursor skills
- [x] `npx get-shit-done-cc --all --global` installs for all 7 runtimes including cursor
- [x] Interactive prompt shows Cursor as option 7

Made with [Cursor](https://cursor.com)