### PR TITLE
fix: remove model:inherit from OpenCode agent conversion (#1156)

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -1228,6 +1228,13 @@ function convertClaudeToOpencodeFrontmatter(content, { isAgent = false } = {}) {
       continue;
     }
 
+    // Strip model: field — OpenCode doesn't support Claude Code model aliases
+    // like 'haiku', 'sonnet', 'opus', or 'inherit'. Omitting lets OpenCode use
+    // its configured default model. See #1156.
+    if (trimmed.startsWith('model:')) {
+      continue;
+    }
+
     // Convert color names to hex for opencode (commands only; agents strip color above)
     if (trimmed.startsWith('color:')) {
       const colorValue = trimmed.substring(6).trim().toLowerCase();
@@ -1264,8 +1271,10 @@ function convertClaudeToOpencodeFrontmatter(content, { isAgent = false } = {}) {
   }
 
   // For agents: add required OpenCode agent fields
+  // Note: Do NOT add 'model: inherit' — OpenCode does not recognize the 'inherit'
+  // keyword and throws ProviderModelNotFoundError. Omitting model: lets OpenCode
+  // use its default model for subagents. See #1156.
   if (isAgent) {
-    newLines.push('model: inherit');
     newLines.push('mode: subagent');
   }
 

--- a/tests/runtime-converters.test.cjs
+++ b/tests/runtime-converters.test.cjs
@@ -5,6 +5,8 @@
  * Larger runtime test suites (Copilot, Codex, Antigravity) have their own files.
  *
  * OpenCode: convertClaudeToOpencodeFrontmatter (agent + command modes)
+ *   model: inherit is NOT added (OpenCode doesn't support it — see #1156)
+ *   but mode: subagent IS added (required by OpenCode agents).
  * Gemini: convertClaudeToGeminiAgent (frontmatter + tool mapping + body escaping)
  */
 
@@ -56,10 +58,10 @@ describe('OpenCode agent conversion (isAgent: true)', () => {
     assert.ok(frontmatter.includes('name: gsd-executor'), 'name: should be preserved for agents');
   });
 
-  test('adds model: inherit', () => {
+  test('does not add model: inherit (OpenCode does not support it)', () => {
     const result = convertClaudeToOpencodeFrontmatter(SAMPLE_AGENT, { isAgent: true });
     const frontmatter = result.split('---')[1];
-    assert.ok(frontmatter.includes('model: inherit'), 'model: inherit should be added');
+    assert.ok(!frontmatter.includes('model: inherit'), 'model: inherit should NOT be added — OpenCode throws ProviderModelNotFoundError');
   });
 
   test('adds mode: subagent', () => {


### PR DESCRIPTION
## Problem

All 15 GSD agent definitions installed for OpenCode contain `model: inherit` in their YAML frontmatter. OpenCode does not recognize `inherit` as a valid model identifier and throws `ProviderModelNotFoundError` when spawning any GSD subagent.

Additionally, the `gsd-set-profile` command has `model: haiku` which is also a Claude Code-specific alias that OpenCode cannot resolve.

Root cause analysis by @rtenggario in #1156.

## Fix

- Removed `model: inherit` injection for OpenCode agents in `convertClaudeToOpencodeFrontmatter()`
- Added stripping of `model:` field entirely during OpenCode frontmatter conversion — OpenCode uses its configured default model when no model field is specified
- Updated test to verify `model: inherit` is NOT added

## Affected files
- `bin/install.js` — OpenCode frontmatter converter
- `tests/opencode-agent-conversion.test.cjs` — updated test expectations

All 755 tests pass.

Fixes #1156