### PR TITLE
fix(build): add syntax validation to hook build script (#1107)

### DIFF
--- a/scripts/build-hooks.js
+++ b/scripts/build-hooks.js
@@ -1,10 +1,14 @@
 #!/usr/bin/env node
 /**
  * Copy GSD hooks to dist for installation.
+ * Validates JavaScript syntax before copying to prevent shipping broken hooks.
+ * See #1107, #1109, #1125, #1161 — a duplicate const declaration shipped
+ * in dist and caused PostToolUse hook errors for all users.
  */
 
 const fs = require('fs');
 const path = require('path');
+const vm = require('vm');
 
 const HOOKS_DIR = path.join(__dirname, '..', 'hooks');
 const DIST_DIR = path.join(HOOKS_DIR, 'dist');
@@ -16,13 +20,34 @@ const HOOKS_TO_COPY = [
   'gsd-statusline.js'
 ];
 
+/**
+ * Validate JavaScript syntax without executing the file.
+ * Catches SyntaxError (duplicate const, missing brackets, etc.)
+ * before the hook gets shipped to users.
+ */
+function validateSyntax(filePath) {
+  const content = fs.readFileSync(filePath, 'utf8');
+  try {
+    // Use vm.compileFunction to check syntax without executing
+    new vm.Script(content, { filename: path.basename(filePath) });
+    return null; // No error
+  } catch (e) {
+    if (e instanceof SyntaxError) {
+      return e.message;
+    }
+    throw e;
+  }
+}
+
 function build() {
   // Ensure dist directory exists
   if (!fs.existsSync(DIST_DIR)) {
     fs.mkdirSync(DIST_DIR, { recursive: true });
   }
 
-  // Copy hooks to dist
+  let hasErrors = false;
+
+  // Copy hooks to dist with syntax validation
   for (const hook of HOOKS_TO_COPY) {
     const src = path.join(HOOKS_DIR, hook);
     const dest = path.join(DIST_DIR, hook);
@@ -32,9 +57,21 @@ function build() {
       continue;
     }
 
-    console.log(`Copying ${hook}...`);
+    // Validate syntax before copying
+    const syntaxError = validateSyntax(src);
+    if (syntaxError) {
+      console.error(`\x1b[31m✗ ${hook}: SyntaxError — ${syntaxError}\x1b[0m`);
+      hasErrors = true;
+      continue;
+    }
+
+    console.log(`\x1b[32m✓\x1b[0m Copying ${hook}...`);
     fs.copyFileSync(src, dest);
-    console.log(`  → ${dest}`);
+  }
+
+  if (hasErrors) {
+    console.error('\n\x1b[31mBuild failed: fix syntax errors above before publishing.\x1b[0m');
+    process.exit(1);
   }
 
   console.log('\nBuild complete.');


### PR DESCRIPTION
## Problem

The v1.25.1 npm package shipped with a broken `gsd-context-monitor.js` in `hooks/dist/` that had a duplicate `const cwd` declaration. This caused `PostToolUse:Read hook error` (and similar) on every tool call for all users. Even reinstalling v1.25.1 didn't fix it because the npm package itself contained the broken dist file.

## Fix

Added JavaScript syntax validation to `scripts/build-hooks.js` (runs during `prepublishOnly`):

- Each hook file is checked via `vm.Script` before copying to `dist/`
- If any hook has a `SyntaxError`, the build fails with a clear error and exits non-zero
- This blocks `npm publish` from shipping broken hooks

## Testing

```bash
npm run build:hooks  # validates and copies
npm test             # 755 tests pass
```

Refs #1107, #1109, #1125, #1161