### PR TITLE
feat: /gsd:next command for automatic workflow advancement (#927)

### DIFF
--- a/commands/gsd/next.md
+++ b/commands/gsd/next.md
@@ -1,0 +1,24 @@
+---
+name: gsd:next
+description: Automatically advance to the next logical step in the GSD workflow
+allowed-tools:
+  - Read
+  - Bash
+  - Grep
+  - Glob
+  - SlashCommand
+---
+<objective>
+Detect the current project state and automatically invoke the next logical GSD workflow step.
+No arguments needed — reads STATE.md, ROADMAP.md, and phase directories to determine what comes next.
+
+Designed for rapid multi-project workflows where remembering which phase/step you're on is overhead.
+</objective>
+
+<execution_context>
+@~/.claude/get-shit-done/workflows/next.md
+</execution_context>
+
+<process>
+Execute the next workflow from @~/.claude/get-shit-done/workflows/next.md end-to-end.
+</process>

--- a/get-shit-done/workflows/next.md
+++ b/get-shit-done/workflows/next.md
@@ -1,0 +1,97 @@
+<purpose>
+Detect current project state and automatically advance to the next logical GSD workflow step.
+Reads project state to determine: discuss → plan → execute → verify → complete progression.
+</purpose>
+
+<required_reading>
+Read all files referenced by the invoking prompt's execution_context before starting.
+</required_reading>
+
+<process>
+
+<step name="detect_state">
+Read project state to determine current position:
+
+```bash
+# Get state snapshot
+node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" state json 2>/dev/null || echo "{}"
+```
+
+Also read:
+- `.planning/STATE.md` — current phase, progress, plan counts
+- `.planning/ROADMAP.md` — milestone structure and phase list
+
+Extract:
+- `current_phase` — which phase is active
+- `plan_of` / `plans_total` — plan execution progress
+- `progress` — overall percentage
+- `status` — active, paused, etc.
+
+If no `.planning/` directory exists:
+```
+No GSD project detected. Run `/gsd:new-project` to get started.
+```
+Exit.
+</step>
+
+<step name="determine_next_action">
+Apply routing rules based on state:
+
+**Route 1: No phases exist yet → discuss**
+If ROADMAP has phases but no phase directories exist on disk:
+→ Next action: `/gsd:discuss-phase <first-phase>`
+
+**Route 2: Phase exists but has no CONTEXT.md or RESEARCH.md → discuss**
+If the current phase directory exists but has neither CONTEXT.md nor RESEARCH.md:
+→ Next action: `/gsd:discuss-phase <current-phase>`
+
+**Route 3: Phase has context but no plans → plan**
+If the current phase has CONTEXT.md (or RESEARCH.md) but no PLAN.md files:
+→ Next action: `/gsd:plan-phase <current-phase>`
+
+**Route 4: Phase has plans but incomplete summaries → execute**
+If plans exist but not all have matching summaries:
+→ Next action: `/gsd:execute-phase <current-phase>`
+
+**Route 5: All plans have summaries → verify and complete**
+If all plans in the current phase have summaries:
+→ Next action: `/gsd:verify-work` then `/gsd:complete-phase`
+
+**Route 6: Phase complete, next phase exists → advance**
+If the current phase is complete and the next phase exists in ROADMAP:
+→ Next action: `/gsd:discuss-phase <next-phase>`
+
+**Route 7: All phases complete → complete milestone**
+If all phases are complete:
+→ Next action: `/gsd:complete-milestone`
+
+**Route 8: Paused → resume**
+If STATE.md shows paused_at:
+→ Next action: `/gsd:resume-work`
+</step>
+
+<step name="show_and_execute">
+Display the determination:
+
+```
+## GSD Next
+
+**Current:** Phase [N] — [name] | [progress]%
+**Status:** [status description]
+
+▶ **Next step:** `/gsd:[command] [args]`
+  [One-line explanation of why this is the next step]
+```
+
+Then immediately invoke the determined command via SlashCommand.
+Do not ask for confirmation — the whole point of `/gsd:next` is zero-friction advancement.
+</step>
+
+</process>
+
+<success_criteria>
+- [ ] Project state correctly detected
+- [ ] Next action correctly determined from routing rules
+- [ ] Command invoked immediately without user confirmation
+- [ ] Clear status shown before invoking
+</success_criteria>

--- a/tests/copilot-install.test.cjs
+++ b/tests/copilot-install.test.cjs
@@ -625,7 +625,7 @@ describe('copyCommandsAsCopilotSkills', () => {
       // Count gsd-* directories — should be 31
       const dirs = fs.readdirSync(tempDir, { withFileTypes: true })
         .filter(e => e.isDirectory() && e.name.startsWith('gsd-'));
-      assert.strictEqual(dirs.length, 39, `expected 39 skill folders, got ${dirs.length}`);
+      assert.strictEqual(dirs.length, 40, `expected 40 skill folders, got ${dirs.length}`);
     } finally {
       fs.rmSync(tempDir, { recursive: true });
     }
@@ -1119,7 +1119,7 @@ const { execFileSync } = require('child_process');
 const crypto = require('crypto');
 
 const INSTALL_PATH = path.join(__dirname, '..', 'bin', 'install.js');
-const EXPECTED_SKILLS = 39;
+const EXPECTED_SKILLS = 40;
 const EXPECTED_AGENTS = 16;
 
 function runCopilotInstall(cwd) {


### PR DESCRIPTION
## Problem

Users managing multiple projects find it cumbersome to remember which phase/step they're on. They end up asking the agent for the next step before running the appropriate command.

Multiple users requested this (#927):
- @charlesangus: "95% of the time you want to move on to the obvious next thing"
- @overdrive-dev: "i run 4-6 projects simultaneously so next would be awesome"

## Solution

New `/gsd:next` command that:
1. Reads STATE.md, ROADMAP.md, and phase directories
2. Determines the next logical workflow step via routing rules
3. Shows a brief status line
4. Immediately invokes the next command (no confirmation needed)

### Routing rules:
| State | Next action |
|-------|-------------|
| No phases on disk | `/gsd:discuss-phase` |
| Phase has no context | `/gsd:discuss-phase` |
| Phase has context, no plans | `/gsd:plan-phase` |
| Plans exist, incomplete | `/gsd:execute-phase` |
| All plans done | `/gsd:verify-work` |
| Phase complete | `/gsd:discuss-phase <next>` |
| All phases complete | `/gsd:complete-milestone` |
| Paused | `/gsd:resume-work` |

## Files
- `commands/gsd/next.md` — command definition
- `get-shit-done/workflows/next.md` — workflow with routing logic

All 755 tests pass.

Closes #927