### PR TITLE
fix(workflows): add explicit TaskOutput instructions to map-codebase

### DIFF
--- a/get-shit-done/workflows/map-codebase.md
+++ b/get-shit-done/workflows/map-codebase.md
@@ -172,9 +172,19 @@ Continue to collect_confirmations.
 </step>
 
 <step name="collect_confirmations">
-Wait for all 4 agents to complete.
+Wait for all 4 agents to complete using TaskOutput tool.
 
-Read each agent's output file to collect confirmations.
+**For each agent task_id returned by the Agent tool calls above:**
+```
+TaskOutput tool:
+  task_id: "{task_id from Agent result}"
+  block: true
+  timeout: 300000
+```
+
+Call TaskOutput for all 4 agents in parallel (single message with 4 TaskOutput calls).
+
+Once all TaskOutput calls return, read each agent's output file to collect confirmations.
 
 **Expected confirmation format from each agent:**
 ```


### PR DESCRIPTION
## Summary

- `/gsd:map-codebase` now explicitly instructs Claude to use `TaskOutput` tool to wait for background agents
- Prevents indefinite "Waiting for agents to complete..." state

Rebased version of #434 (old fork token expired).

## Test plan

- [ ] Run `/gsd:map-codebase` and verify orchestrator collects all 4 agent outputs without hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)