### PR TITLE
fix: use arrays for RUNTIME_DIRS to fix zsh word-splitting (#1173)

### DIFF
--- a/get-shit-done/workflows/update.md
+++ b/get-shit-done/workflows/update.md
@@ -20,8 +20,11 @@ First, derive `PREFERRED_RUNTIME` from the invoking prompt's `execution_context`
 Use `PREFERRED_RUNTIME` as the first runtime checked so `/gsd:update` targets the runtime that invoked it.
 
 ```bash
-# Runtime candidates: "<runtime>:<config-dir>"
-RUNTIME_DIRS="claude:.claude opencode:.config/opencode opencode:.opencode gemini:.gemini codex:.codex"
+# Runtime candidates: "<runtime>:<config-dir>" stored as an array.
+# Using an array instead of a space-separated string ensures correct
+# iteration in both bash and zsh (zsh does not word-split unquoted
+# variables by default). Fixes #1173.
+RUNTIME_DIRS=( "claude:.claude" "opencode:.config/opencode" "opencode:.opencode" "gemini:.gemini" "codex:.codex" )
 
 # PREFERRED_RUNTIME should be set from execution_context before running this block.
 # If not set, infer from runtime env vars; fallback to claude.
@@ -40,23 +43,23 @@ if [ -z "$PREFERRED_RUNTIME" ]; then
 fi
 
 # Reorder entries so preferred runtime is checked first.
-ORDERED_RUNTIME_DIRS=""
-for entry in $RUNTIME_DIRS; do
+ORDERED_RUNTIME_DIRS=()
+for entry in "${RUNTIME_DIRS[@]}"; do
   runtime="${entry%%:*}"
   if [ "$runtime" = "$PREFERRED_RUNTIME" ]; then
-    ORDERED_RUNTIME_DIRS="$ORDERED_RUNTIME_DIRS $entry"
+    ORDERED_RUNTIME_DIRS+=( "$entry" )
   fi
 done
-for entry in $RUNTIME_DIRS; do
+for entry in "${RUNTIME_DIRS[@]}"; do
   runtime="${entry%%:*}"
   if [ "$runtime" != "$PREFERRED_RUNTIME" ]; then
-    ORDERED_RUNTIME_DIRS="$ORDERED_RUNTIME_DIRS $entry"
+    ORDERED_RUNTIME_DIRS+=( "$entry" )
   fi
 done
 
 # Check local first (takes priority only if valid and distinct from global)
 LOCAL_VERSION_FILE="" LOCAL_MARKER_FILE="" LOCAL_DIR="" LOCAL_RUNTIME=""
-for entry in $ORDERED_RUNTIME_DIRS; do
+for entry in "${ORDERED_RUNTIME_DIRS[@]}"; do
   runtime="${entry%%:*}"
   dir="${entry#*:}"
   if [ -f "./$dir/get-shit-done/VERSION" ] || [ -f "./$dir/get-shit-done/workflows/update.md" ]; then
@@ -69,7 +72,7 @@ for entry in $ORDERED_RUNTIME_DIRS; do
 done
 
 GLOBAL_VERSION_FILE="" GLOBAL_MARKER_FILE="" GLOBAL_DIR="" GLOBAL_RUNTIME=""
-for entry in $ORDERED_RUNTIME_DIRS; do
+for entry in "${ORDERED_RUNTIME_DIRS[@]}"; do
   runtime="${entry%%:*}"
   dir="${entry#*:}"
   if [ -f "$HOME/$dir/get-shit-done/VERSION" ] || [ -f "$HOME/$dir/get-shit-done/workflows/update.md" ]; then


### PR DESCRIPTION
## Problem

The version detection script in `update.md` uses a space-separated string for `RUNTIME_DIRS` and iterates with `for entry in $RUNTIME_DIRS`. This relies on word-splitting which works in bash but **fails in zsh** — zsh does not word-split unquoted variables by default, so the entire string is treated as one entry and detection always falls through to `UNKNOWN` scope.

## Fix

Convert `RUNTIME_DIRS` and `ORDERED_RUNTIME_DIRS` from space-separated strings to proper bash/zsh arrays:

- `RUNTIME_DIRS="a b c"` → `RUNTIME_DIRS=( "a" "b" "c" )`
- `for entry in $RUNTIME_DIRS` → `for entry in "${RUNTIME_DIRS[@]}"`
- `ORDERED_RUNTIME_DIRS="$ORDERED_RUNTIME_DIRS $entry"` → `ORDERED_RUNTIME_DIRS+=( "$entry" )`

This works correctly in both bash and zsh.

## Testing

Verified the array syntax is valid in both shells:
```bash
# bash
RUNTIME_DIRS=( "claude:.claude" "opencode:.opencode" )
for entry in "${RUNTIME_DIRS[@]}"; do echo "$entry"; done
# claude:.claude
# opencode:.opencode

# zsh (same output)
```

Closes #1173