### PR TITLE
fix: add sequential fallback for map-codebase on runtimes without Task tool (#1174)

### DIFF
--- a/get-shit-done/workflows/map-codebase.md
+++ b/get-shit-done/workflows/map-codebase.md
@@ -82,12 +82,25 @@ mkdir -p .planning/codebase
 Continue to spawn_agents.
 </step>
 
-<step name="spawn_agents">
+<step name="detect_runtime_capabilities">
+Before spawning agents, detect whether the current runtime supports the `Task` tool for subagent delegation.
+
+**Runtimes with Task tool:** Claude Code, Cursor (native subagent support)
+**Runtimes WITHOUT Task tool:** Antigravity, Gemini CLI, OpenCode, Codex, and others
+
+**How to detect:** Check if you have access to a `Task` tool. If you do NOT have a `Task` tool (or only have tools like `browser_subagent` which is for web browsing, NOT code analysis):
+
+→ **Skip `spawn_agents` and `collect_confirmations`** — go directly to `sequential_mapping` instead.
+
+**CRITICAL:** Never use `browser_subagent` or `Explore` as a substitute for `Task`. The `browser_subagent` tool is exclusively for web page interaction and will fail for codebase analysis. If `Task` is unavailable, perform the mapping sequentially in-context.
+</step>
+
+<step name="spawn_agents" condition="Task tool is available">
 Spawn 4 parallel gsd-codebase-mapper agents.
 
 Use Task tool with `subagent_type="gsd-codebase-mapper"`, `model="{mapper_model}"`, and `run_in_background=true` for parallel execution.
 
-**CRITICAL:** Use the dedicated `gsd-codebase-mapper` agent, NOT `Explore`. The mapper agent writes documents directly.
+**CRITICAL:** Use the dedicated `gsd-codebase-mapper` agent, NOT `Explore` or `browser_subagent`. The mapper agent writes documents directly.
 
 **Agent 1: Tech Focus**
 
@@ -191,6 +204,37 @@ Ready for orchestrator summary.
 **What you receive:** Just file paths and line counts. NOT document contents.
 
 If any agent failed, note the failure and continue with successful documents.
+
+Continue to verify_output.
+</step>
+
+<step name="sequential_mapping" condition="Task tool is NOT available (e.g. Antigravity, Gemini CLI, Codex)">
+When the `Task` tool is unavailable, perform codebase mapping sequentially in the current context. This replaces `spawn_agents` and `collect_confirmations`.
+
+**IMPORTANT:** Do NOT use `browser_subagent`, `Explore`, or any browser-based tool. Use only file system tools (Read, Bash, Write, Grep, Glob, list_dir, view_file, grep_search, or equivalent tools available in your runtime).
+
+Perform all 4 mapping passes sequentially:
+
+**Pass 1: Tech Focus**
+- Explore package.json/Cargo.toml/go.mod/requirements.txt, config files, dependency trees
+- Write `.planning/codebase/STACK.md` — Languages, runtime, frameworks, dependencies, configuration
+- Write `.planning/codebase/INTEGRATIONS.md` — External APIs, databases, auth providers, webhooks
+
+**Pass 2: Architecture Focus**
+- Explore directory structure, entry points, module boundaries, data flow
+- Write `.planning/codebase/ARCHITECTURE.md` — Pattern, layers, data flow, abstractions, entry points
+- Write `.planning/codebase/STRUCTURE.md` — Directory layout, key locations, naming conventions
+
+**Pass 3: Quality Focus**
+- Explore code style, error handling patterns, test files, CI config
+- Write `.planning/codebase/CONVENTIONS.md` — Code style, naming, patterns, error handling
+- Write `.planning/codebase/TESTING.md` — Framework, structure, mocking, coverage
+
+**Pass 4: Concerns Focus**
+- Explore TODOs, known issues, fragile areas, security patterns
+- Write `.planning/codebase/CONCERNS.md` — Tech debt, bugs, security, performance, fragile areas
+
+Use the same document templates as the `gsd-codebase-mapper` agent. Include actual file paths formatted with backticks.
 
 Continue to verify_output.
 </step>
@@ -307,10 +351,10 @@ End workflow.
 
 <success_criteria>
 - .planning/codebase/ directory created
-- 4 parallel gsd-codebase-mapper agents spawned with run_in_background=true
-- Agents write documents directly (orchestrator doesn't receive document contents)
-- Read agent output files to collect confirmations
+- If Task tool available: 4 parallel gsd-codebase-mapper agents spawned with run_in_background=true
+- If Task tool NOT available: 4 sequential mapping passes performed inline (never using browser_subagent)
 - All 7 codebase documents exist
+- No empty documents (each should have >20 lines)
 - Clear completion summary with line counts
 - User offered clear next steps in GSD style
 </success_criteria>


### PR DESCRIPTION
## Problem

Runtimes like Antigravity don't have a `Task` tool for spawning subagents. When the agent encounters `Task()` calls in the map-codebase workflow, it falls back to `browser_subagent` (the only delegation-like tool available), which is exclusively for web browsing — causing `/gsd:map-codebase` to open multiple browser windows that fail to analyze the codebase.

Reported in #1174: _"multiple browser_subagent instances are triggered to run. However, browser_subagent is a browser-based agent, which causes the gsd-map-codebase command to fail to execute correctly."_

## Fix

1. **`detect_runtime_capabilities` step** — Before spawning agents, checks whether the `Task` tool is available. If not, routes to sequential fallback.

2. **Explicit warning** — `CRITICAL: Never use browser_subagent or Explore as a substitute for Task.`

3. **`sequential_mapping` step** — When `Task` is unavailable, performs all 4 mapping passes (tech, arch, quality, concerns) sequentially using only file system tools (Read, Bash, Write, Grep, etc.). Produces the same 7 output documents.

## Affected Runtimes

- **Antigravity** — confirmed affected (has `browser_subagent` but no `Task`)
- **Gemini CLI** — likely affected (no `Task` tool)
- **Codex** — likely affected (no `Task` tool)
- **Claude Code / Cursor** — unaffected (have `Task` tool, continue using parallel agents)

Closes #1174