### PR TITLE
docs: document inherit profile for non-Anthropic model providers (#1036)

### DIFF
--- a/get-shit-done/references/model-profiles.md
+++ b/get-shit-done/references/model-profiles.md
@@ -40,7 +40,25 @@ Model profiles control which Claude model each GSD agent uses. This allows balan
 **inherit** - Follow the current session model
 - All agents resolve to `inherit`
 - Best when you switch models interactively (for example OpenCode `/model`)
+- **Required when using non-Anthropic providers** (OpenRouter, local models, etc.) — otherwise GSD may call Anthropic models directly, incurring unexpected costs
 - Use when: you want GSD to follow your currently selected runtime model
+
+## Using Non-Anthropic Models (OpenRouter, Local, etc.)
+
+If you're using Claude Code with OpenRouter, a local model, or any non-Anthropic provider, set the `inherit` profile to prevent GSD from calling Anthropic models for subagents:
+
+```bash
+# Via settings command
+/gsd:settings
+# → Select "Inherit" for model profile
+
+# Or manually in .planning/config.json
+{
+  "model_profile": "inherit"
+}
+```
+
+Without `inherit`, GSD's default `balanced` profile spawns specific Anthropic models (`opus`, `sonnet`, `haiku`) for each agent type, which can result in additional API costs through your non-Anthropic provider.
 
 ## Resolution Logic
 

--- a/get-shit-done/workflows/settings.md
+++ b/get-shit-done/workflows/settings.md
@@ -49,7 +49,7 @@ AskUserQuestion([
       { label: "Quality", description: "Opus everywhere except verification (highest cost)" },
       { label: "Balanced (Recommended)", description: "Opus for planning, Sonnet for research/execution/verification" },
       { label: "Budget", description: "Sonnet for writing, Haiku for research/verification (lowest cost)" },
-      { label: "Inherit", description: "Use current session model for all agents (best for OpenCode /model)" }
+      { label: "Inherit", description: "Use current session model for all agents (best for OpenRouter, local models, or runtime model switching)" }
     ]
   },
   {


### PR DESCRIPTION
## Problem

Users on OpenRouter or local models get unexpected API costs because GSD's default `balanced` profile spawns specific Anthropic models (`opus`, `sonnet`, `haiku`) for subagents. The `inherit` profile exists but wasn't well-documented for this use case.

From #1036: _"I used an openrouter model in claude code. In GSD it keeps calling anthropic models to do the tasks and I ended up paying an additional cost to openrouter because it keeps calling these models."_

## Changes

- **model-profiles.md**: Add "Using Non-Anthropic Models" section explaining when and how to use `inherit` profile
- **model-profiles.md**: Update `inherit` description to note it's **required** for non-Anthropic providers
- **settings.md**: Update Inherit option description to mention OpenRouter and local models (was only mentioning OpenCode `/model`)

## Before/After

**Before:** Inherit described as _"best for OpenCode /model"_
**After:** Inherit described as _"best for OpenRouter, local models, or runtime model switching"_ with explicit documentation section

Closes #1036