### PR TITLE
feat(researcher): Runtime State Inventory for rename/refactor phases

### DIFF
--- a/agents/gsd-phase-researcher.md
+++ b/agents/gsd-phase-researcher.md
@@ -194,6 +194,7 @@ Priority: Context7 > Official Docs > Official GitHub > Verified WebSearch > Unve
 - [ ] Publication dates checked (prefer recent/current)
 - [ ] Confidence levels assigned honestly
 - [ ] "What might I have missed?" review completed
+- [ ] **If rename/refactor phase:** Runtime State Inventory completed — all 5 categories answered explicitly (not left blank)
 
 </verification_protocol>
 
@@ -273,6 +274,20 @@ src/
 | [problem] | [what you'd build] | [library] | [edge cases, complexity] |
 
 **Key insight:** [why custom solutions are worse in this domain]
+
+## Runtime State Inventory
+
+> Include this section for rename/refactor/migration phases only. Omit entirely for greenfield phases.
+
+| Category | Items Found | Action Required |
+|----------|-------------|------------------|
+| Stored data | [e.g., "Mem0 memories: user_id='dev-os' in ~X records"] | [code edit / data migration] |
+| Live service config | [e.g., "25 n8n workflows in SQLite not exported to git"] | [API patch / manual] |
+| OS-registered state | [e.g., "Windows Task Scheduler: 3 tasks with 'dev-os' in description"] | [re-register tasks] |
+| Secrets/env vars | [e.g., "SOPS key 'webhook_auth_header' — code rename only, key unchanged"] | [none / update key] |
+| Build artifacts | [e.g., "scripts/devos-cli/devos_cli.egg-info/ — stale after pyproject.toml rename"] | [reinstall package] |
+
+**Nothing found in category:** State explicitly ("None — verified by X").
 
 ## Common Pitfalls
 
@@ -407,6 +422,26 @@ Based on phase description, identify what needs investigating:
 - **Pitfalls:** Common beginner mistakes, gotchas, rewrite-causing errors
 - **Don't Hand-Roll:** Existing solutions for deceptively complex problems
 
+## Step 2.5: Runtime State Inventory (rename / refactor / migration phases only)
+
+**Trigger:** Any phase involving rename, rebrand, refactor, string replacement, or migration.
+
+A grep audit finds files. It does NOT find runtime state. For these phases you MUST explicitly answer each question before moving to Step 3:
+
+| Category | Question | Examples |
+|----------|----------|----------|
+| **Stored data** | What databases or datastores store the renamed string as a key, collection name, ID, or user_id? | ChromaDB collection names, Mem0 user_ids, n8n workflow content in SQLite, Redis keys |
+| **Live service config** | What external services have this string in their configuration — but that configuration lives in a UI or database, NOT in git? | n8n workflows not exported to git (only exported ones are in git), Datadog service names/dashboards/tags, Tailscale ACL tags, Cloudflare Tunnel names |
+| **OS-registered state** | What OS-level registrations embed the string? | Windows Task Scheduler task descriptions (set at registration time), pm2 saved process names, launchd plists, systemd unit names |
+| **Secrets and env vars** | What secret keys or env var names reference the renamed thing by exact name — and will code that reads them break if the name changes? | SOPS key names, .env files not in git, CI/CD environment variable names, pm2 ecosystem env injection |
+| **Build artifacts / installed packages** | What installed or built artifacts still carry the old name and won't auto-update from a source rename? | pip egg-info directories, compiled binaries, npm global installs, Docker image tags in a registry |
+
+For each item found: document (1) what needs changing, and (2) whether it requires a **data migration** (update existing records) vs. a **code edit** (change how new records are written). These are different tasks and must both appear in the plan.
+
+**The canonical question:** *After every file in the repo is updated, what runtime systems still have the old string cached, stored, or registered?*
+
+If the answer for a category is "nothing" — say so explicitly. Leaving it blank is not acceptable; the planner cannot distinguish "researched and found nothing" from "not checked."
+
 ## Step 3: Execute Research Protocol
 
 For each domain: Context7 first → Official docs → WebSearch → Cross-verify. Document findings with confidence levels as you go.
@@ -460,7 +495,7 @@ List missing test files, framework config, or shared fixtures needed before impl
 ## Phase Requirements
 
 | ID | Description | Research Support |
-|----|-------------|-----------------|
+|----|-------------|------------------|
 | {REQ-ID} | {from REQUIREMENTS.md} | {which research findings enable implementation} |
 </phase_requirements>
 ```


### PR DESCRIPTION
## Problem

When planning a rename, rebrand, or refactor phase, `gsd-phase-researcher` audits files with grep. That finds source code. It does **not** find runtime state — and runtime state is exactly what breaks silently after "the rename is done":

- ChromaDB collection names stored as strings in a vector database
- Mem0 `user_id` values baked into memory records
- n8n workflows stored in SQLite (only git-exported ones are in the repo)
- Windows Task Scheduler task descriptions set at registration time
- pm2 process names, launchd plists, systemd unit names
- SOPS key names, `.env` files not in git, CI/CD env var names
- pip `egg-info/` directories, compiled binaries, npm global installs

These survive a complete file-level rename. The system is broken; the tests are green.

## Solution

Adds a **Runtime State Inventory** — a structured investigation step that fires specifically for rename/rebrand/refactor/migration phases. Three additions to `gsd-phase-researcher.md`:

### 1. Pre-Submission Checklist (verification_protocol)
Adds a gate item so the checklist catches skipped inventories before `RESEARCH.md` is committed:
```
- [ ] **If rename/refactor phase:** Runtime State Inventory completed — all 5 categories answered explicitly (not left blank)
```

### 2. output_format — RESEARCH.md template
Adds a `## Runtime State Inventory` table to the template so every rename/refactor phase's output includes it. Greenfield phases omit it per the note.

### 3. execution_flow — Step 2.5
A structured investigation protocol between Step 2 (identify domains) and Step 3 (execute research). Five categories with questions and concrete examples for each:

| Category | Example items |
|----------|---------------|
| Stored data | ChromaDB collection names, Mem0 user_ids, Redis keys |
| Live service config | n8n workflows in SQLite, Datadog dashboards, Tailscale ACL tags |
| OS-registered state | Task Scheduler descriptions, pm2 names, launchd plists |
| Secrets/env vars | SOPS key names, `.env` not in git, CI/CD env vars |
| Build artifacts | pip egg-info dirs, compiled binaries, npm global installs |

The section also enforces that blank entries are not acceptable — the researcher must state "None — verified by X" explicitly so the planner can distinguish "checked and found nothing" from "never looked."

**The canonical question the section frames:**
> *After every file in the repo is updated, what runtime systems still have the old string cached, stored, or registered?*

## Scope

- Only fires on rename/rebrand/refactor/migration phases (trigger condition documented)
- Zero impact on greenfield phases — the output_format section says "Omit entirely for greenfield phases"
- No changes to any other agent or workflow file