### PR TITLE
feat: /gsd:fast command for trivial inline tasks (#609)

### DIFF
--- a/commands/gsd/fast.md
+++ b/commands/gsd/fast.md
@@ -1,0 +1,30 @@
+---
+name: gsd:fast
+description: Execute a trivial task inline — no subagents, no planning overhead
+argument-hint: "[task description]"
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Grep
+  - Glob
+---
+
+<objective>
+Execute a trivial task directly in the current context without spawning subagents
+or generating PLAN.md files. For tasks too small to justify planning overhead:
+typo fixes, config changes, small refactors, forgotten commits, simple additions.
+
+This is NOT a replacement for /gsd:quick — use /gsd:quick for anything that
+needs research, multi-step planning, or verification. /gsd:fast is for tasks
+you could describe in one sentence and execute in under 2 minutes.
+</objective>
+
+<execution_context>
+@~/.claude/get-shit-done/workflows/fast.md
+</execution_context>
+
+<process>
+Execute the fast workflow from @~/.claude/get-shit-done/workflows/fast.md end-to-end.
+</process>

--- a/get-shit-done/workflows/fast.md
+++ b/get-shit-done/workflows/fast.md
@@ -1,0 +1,105 @@
+<purpose>
+Execute a trivial task inline without subagent overhead. No PLAN.md, no Task spawning,
+no research, no plan checking. Just: understand → do → commit → log.
+
+For tasks like: fix a typo, update a config value, add a missing import, rename a
+variable, commit uncommitted work, add a .gitignore entry, bump a version number.
+
+Use /gsd:quick for anything that needs multi-step planning or research.
+</purpose>
+
+<process>
+
+<step name="parse_task">
+Parse `$ARGUMENTS` for the task description.
+
+If empty, ask:
+```
+What's the quick fix? (one sentence)
+```
+
+Store as `$TASK`.
+</step>
+
+<step name="scope_check">
+**Before doing anything, verify this is actually trivial.**
+
+A task is trivial if it can be completed in:
+- ≤ 3 file edits
+- ≤ 1 minute of work
+- No new dependencies or architecture changes
+- No research needed
+
+If the task seems non-trivial (multi-file refactor, new feature, needs research),
+say:
+
+```
+This looks like it needs planning. Use /gsd:quick instead:
+  /gsd:quick "{task description}"
+```
+
+And stop.
+</step>
+
+<step name="execute_inline">
+Do the work directly:
+
+1. Read the relevant file(s)
+2. Make the change(s)
+3. Verify the change works (run existing tests if applicable, or do a quick sanity check)
+
+**No PLAN.md.** Just do it.
+</step>
+
+<step name="commit">
+Commit the change atomically:
+
+```bash
+git add -A
+git commit -m "fix: {concise description of what changed}"
+```
+
+Use conventional commit format: `fix:`, `feat:`, `docs:`, `chore:`, `refactor:` as appropriate.
+</step>
+
+<step name="log_to_state">
+If `.planning/STATE.md` exists, append to the "Quick Tasks Completed" table.
+If the table doesn't exist, skip this step silently.
+
+```bash
+# Check if STATE.md has quick tasks table
+if grep -q "Quick Tasks Completed" .planning/STATE.md 2>/dev/null; then
+  # Append entry — workflow handles the format
+  echo "| $(date +%Y-%m-%d) | fast | $TASK | ✅ |" >> .planning/STATE.md
+fi
+```
+</step>
+
+<step name="done">
+Report completion:
+
+```
+✅ Done: {what was changed}
+   Commit: {short hash}
+   Files: {list of changed files}
+```
+
+No next-step suggestions. No workflow routing. Just done.
+</step>
+
+</process>
+
+<guardrails>
+- NEVER spawn a Task/subagent — this runs inline
+- NEVER create PLAN.md or SUMMARY.md files
+- NEVER run research or plan-checking
+- If the task takes more than 3 file edits, STOP and redirect to /gsd:quick
+- If you're unsure how to implement it, STOP and redirect to /gsd:quick
+</guardrails>
+
+<success_criteria>
+- [ ] Task completed in current context (no subagents)
+- [ ] Atomic git commit with conventional message
+- [ ] STATE.md updated if it exists
+- [ ] Total operation under 2 minutes wall time
+</success_criteria>

--- a/get-shit-done/workflows/help.md
+++ b/get-shit-done/workflows/help.md
@@ -151,6 +151,21 @@ Usage: `/gsd:quick`
 Usage: `/gsd:quick --research --full`
 Result: Creates `.planning/quick/NNN-slug/PLAN.md`, `.planning/quick/NNN-slug/SUMMARY.md`
 
+---
+
+**`/gsd:fast [description]`**
+Execute a trivial task inline — no subagents, no planning files, no overhead.
+
+For tasks too small to justify planning: typo fixes, config changes, forgotten commits, simple additions. Runs in the current context, makes the change, commits, and logs to STATE.md.
+
+- No PLAN.md or SUMMARY.md created
+- No subagent spawned (runs inline)
+- ≤ 3 file edits — redirects to `/gsd:quick` if task is non-trivial
+- Atomic commit with conventional message
+
+Usage: `/gsd:fast "fix the typo in README"`
+Usage: `/gsd:fast "add .env to gitignore"`
+
 ### Roadmap Management
 
 **`/gsd:add-phase <description>`**

--- a/tests/copilot-install.test.cjs
+++ b/tests/copilot-install.test.cjs
@@ -625,7 +625,7 @@ describe('copyCommandsAsCopilotSkills', () => {
       // Count gsd-* directories — should be 31
       const dirs = fs.readdirSync(tempDir, { withFileTypes: true })
         .filter(e => e.isDirectory() && e.name.startsWith('gsd-'));
-      assert.strictEqual(dirs.length, 42, `expected 42 skill folders, got ${dirs.length}`);
+      assert.strictEqual(dirs.length, 43, `expected 43 skill folders, got ${dirs.length}`);
     } finally {
       fs.rmSync(tempDir, { recursive: true });
     }
@@ -1119,7 +1119,7 @@ const { execFileSync } = require('child_process');
 const crypto = require('crypto');
 
 const INSTALL_PATH = path.join(__dirname, '..', 'bin', 'install.js');
-const EXPECTED_SKILLS = 42;
+const EXPECTED_SKILLS = 43;
 const EXPECTED_AGENTS = 16;
 
 function runCopilotInstall(cwd) {


### PR DESCRIPTION
## Problem

`/gsd:quick` spawns an Opus planner + Sonnet executor subagent even for trivial tasks like fixing a typo or adding a .gitignore entry. The planning overhead (PLAN.md, SUMMARY.md, subagent context) can exceed the actual work.

From #609: _"it starts a whole planning exercise (using Opus), for something that's pretty trivial... It ends up taking time and using a lot more tokens than feels necessary."_

## Solution

New `/gsd:fast` command that runs **inline** — no subagents, no planning files:

| | `/gsd:fast` | `/gsd:quick` |
|---|---|---|
| Subagents | None (inline) | Planner + Executor |
| PLAN.md | No | Yes |
| SUMMARY.md | No | Yes |
| Research | No | Optional (`--research`) |
| Verification | No | Optional (`--full`) |
| Best for | Typos, configs, simple fixes | Multi-step ad-hoc tasks |

### Scope guard
If the task needs >3 file edits or seems non-trivial, `/gsd:fast` redirects to `/gsd:quick` instead of attempting it.

### Files
- `commands/gsd/fast.md` — Command definition
- `get-shit-done/workflows/fast.md` — Inline execution workflow
- `get-shit-done/workflows/help.md` — Added to help output

### Usage
```
/gsd:fast "fix the typo in README"
/gsd:fast "add .env to gitignore"
/gsd:fast "bump version to 1.2.3"
```

Closes #609