### PR TITLE
feat: research-before-questions config option (#1186)

### DIFF
--- a/get-shit-done/workflows/discuss-phase.md
+++ b/get-shit-done/workflows/discuss-phase.md
@@ -445,6 +445,25 @@ Continue to discuss_areas with selected areas.
 <step name="discuss_areas">
 For each selected area, conduct a focused discussion loop.
 
+**Research-before-questions mode:** Check if `research_questions` is enabled in config (from init context or `.planning/config.json`). When enabled, before presenting questions for each area:
+1. Do a brief web search for best practices related to the area topic
+2. Summarize the top findings in 2-3 bullet points
+3. Present the research alongside the question so the user can make a more informed decision
+
+Example with research enabled:
+```
+Let's talk about [Authentication Strategy].
+
+📊 Best practices research:
+• OAuth 2.0 + PKCE is the current standard for SPAs (replaces implicit flow)
+• Session tokens with httpOnly cookies preferred over localStorage for XSS protection
+• Consider passkey/WebAuthn support — adoption is accelerating in 2025-2026
+
+With that context: How should users authenticate?
+```
+
+When disabled (default), skip the research and present questions directly as before.
+
 **Batch mode support:** Parse optional `--batch` from `$ARGUMENTS`.
 - Accept `--batch`, `--batch=N`, or `--batch N`
 

--- a/get-shit-done/workflows/new-project.md
+++ b/get-shit-done/workflows/new-project.md
@@ -222,6 +222,13 @@ Ask inline (freeform, NOT AskUserQuestion):
 
 Wait for their response. This gives you the context needed to ask intelligent follow-up questions.
 
+**Research-before-questions mode:** Check if `research_questions` is enabled in `.planning/config.json` (or the config from init context). When enabled, before asking follow-up questions about a topic area:
+1. Do a brief web search for best practices related to what the user described
+2. Mention key findings naturally as you ask questions (e.g., "Most projects like this use X — is that what you're thinking, or something different?")
+3. This makes questions more informed without changing the conversational flow
+
+When disabled (default), ask questions directly as before.
+
 **Follow the thread:**
 
 Based on what they said, ask follow-up questions that dig into their response. Use AskUserQuestion with options that probe what they mentioned — interpretations, clarifications, concrete examples.

--- a/get-shit-done/workflows/settings.md
+++ b/get-shit-done/workflows/settings.md
@@ -135,6 +135,15 @@ AskUserQuestion([
       { label: "Yes (Recommended)", description: "Warn when context usage exceeds 65%. Helps avoid losing work." },
       { label: "No", description: "Disable warnings. Allows Claude to reach auto-compact naturally. Good for long unattended runs." }
     ]
+  },
+  {
+    question: "Research best practices before asking questions? (web search during new-project and discuss-phase)",
+    header: "Research Qs",
+    multiSelect: false,
+    options: [
+      { label: "No (Recommended)", description: "Ask questions directly. Faster, uses fewer tokens." },
+      { label: "Yes", description: "Search web for best practices before each question group. More informed questions but uses more tokens." }
+    ]
   }
 ])
 ```
@@ -161,7 +170,8 @@ Merge new settings into existing config.json:
   },
   "hooks": {
     "context_warnings": true/false,
-    "workflow_guard": true/false
+    "workflow_guard": true/false,
+    "research_questions": true/false
   }
 }
 ```


### PR DESCRIPTION
## Problem

During `/gsd:new-project` and `/gsd:discuss-phase`, GSD asks questions without first researching best practices. Users may not know the optimal approach for a domain, leading to suboptimal decisions.

From #1186: _"It would be great if it had an option: 'For each question I ask you, should I first search the web for best practices'."_

## Solution

New `workflow.research_questions` config toggle (default: `false`):

```json
{ "workflow": { "research_questions": true } }
```

When enabled:
- **discuss-phase**: Searches best practices for each gray area before presenting questions. Shows 2-3 bullet points of research alongside the question.
- **new-project**: Researches the user's domain before follow-up questions, weaving findings into the conversation naturally.

Configurable via `/gsd:settings` → "Research Qs" toggle.

**Default is off** since it adds token cost and latency — opt-in for users who want more informed questioning.

Closes #1186