### PR TITLE
feat: --analyze flag for discuss-phase trade-off analysis (#833)

### DIFF
--- a/commands/gsd/discuss-phase.md
+++ b/commands/gsd/discuss-phase.md
@@ -1,7 +1,7 @@
 ---
 name: gsd:discuss-phase
 description: Gather phase context through adaptive questioning before planning. Use --auto to skip interactive questions (Claude picks recommended defaults).
-argument-hint: "<phase> [--auto]"
+argument-hint: "<phase> [--auto] [--batch] [--analyze]"
 allowed-tools:
   - Read
   - Write

--- a/get-shit-done/workflows/discuss-phase.md
+++ b/get-shit-done/workflows/discuss-phase.md
@@ -406,6 +406,30 @@ For each selected area, conduct a focused discussion loop.
 
 **Batch mode support:** Parse optional `--batch` from `$ARGUMENTS`.
 - Accept `--batch`, `--batch=N`, or `--batch N`
+
+**Analyze mode support:** Parse optional `--analyze` from `$ARGUMENTS`.
+When `--analyze` is active, before presenting each question (or question group in batch mode), provide a brief **trade-off analysis** for the decision:
+- 2-3 options with pros/cons based on codebase context and common patterns
+- A recommended approach with reasoning
+- Known pitfalls or constraints from prior phases
+
+Example with `--analyze`:
+```
+**Trade-off analysis: Authentication strategy**
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| Session cookies | Simple, httpOnly prevents XSS | Requires CSRF protection, sticky sessions |
+| JWT (stateless) | Scalable, no server state | Token size, revocation complexity |
+| OAuth 2.0 + PKCE | Industry standard for SPAs | More setup, redirect flow UX |
+
+💡 Recommended: OAuth 2.0 + PKCE — your app has social login in requirements (REQ-04) and this aligns with the existing NextAuth setup in `src/lib/auth.ts`.
+
+How should users authenticate?
+```
+
+This gives the user context to make informed decisions without extra prompting. When `--analyze` is absent, present questions directly as before.
+- Accept `--batch`, `--batch=N`, or `--batch N`
 - Default to 4 questions per batch when no number is provided
 - Clamp explicit sizes to 2-5 so a batch stays answerable
 - If `--batch` is absent, keep the existing one-question-at-a-time flow


### PR DESCRIPTION
## Problem

During discuss-phase, questions are asked without context on the trade-offs involved. Users who don't know the domain well enough have to research separately before answering.

From #833: _"To optionally provide you with a dialogue / debate / trade-off analysis for questions just ahead of asking them."_

## Solution

New `--analyze` flag for `/gsd:discuss-phase`:

```bash
/gsd:discuss-phase 3 --analyze
/gsd:discuss-phase --batch --analyze  # composable with batch mode
```

Before each question, presents a trade-off table:
```
**Trade-off analysis: Authentication strategy**

| Approach | Pros | Cons |
|----------|------|------|
| Session cookies | Simple, httpOnly | Requires CSRF |
| JWT (stateless) | Scalable | Revocation complexity |
| OAuth 2.0 + PKCE | Industry standard | More setup |

💡 Recommended: OAuth 2.0 + PKCE — aligns with existing NextAuth setup.

How should users authenticate?
```

Closes #833