### PR TITLE
fix: universal agent name replacement for non-Claude runtimes (#766)

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -552,7 +552,7 @@ function convertClaudeToCopilotContent(content, isGlobal = false) {
   // CONV-07: Command name conversion (all gsd: references → gsd-)
   c = c.replace(/gsd:/g, 'gsd-');
   // Runtime-neutral agent name replacement (#766)
-  c = neutralizeAgentReferences(c, 'COPILOT.md');
+  c = neutralizeAgentReferences(c, 'copilot-instructions.md');
   return c;
 }
 

--- a/tests/runtime-converters.test.cjs
+++ b/tests/runtime-converters.test.cjs
@@ -218,7 +218,7 @@ describe('neutralizeAgentReferences', () => {
   test('uses different instruction file per runtime', () => {
     const input = 'Read CLAUDE.md for instructions.';
     assert.ok(neutralizeAgentReferences(input, 'GEMINI.md').includes('GEMINI.md'));
-    assert.ok(neutralizeAgentReferences(input, 'COPILOT.md').includes('COPILOT.md'));
+    assert.ok(neutralizeAgentReferences(input, 'copilot-instructions.md').includes('copilot-instructions.md'));
     assert.ok(neutralizeAgentReferences(input, 'AGENTS.md').includes('AGENTS.md'));
   });
 


### PR DESCRIPTION
## Problem

Non-Claude runtimes (OpenCode, Gemini, Codex, Copilot, Antigravity) see `Claude` agent references and `CLAUDE.md` instructions that don't apply. OpenCode uses `AGENTS.md`, and telling agents 'Do NOT load full AGENTS.md' actively blocks correct behavior.

From #766: _"the CLAUDE.md specific instructions are still present when using an AGENTS.md framework like OpenCode. These instructions are actively harmful for non-Claude harnesses."_

## Solution

New shared `neutralizeAgentReferences(content, instructionFile)` function called by **all 5 non-Claude converters**:

| Replacement | Before | After |
|---|---|---|
| Agent name | `Claude handles...` | `the agent handles...` |
| Instruction file | `CLAUDE.md` | `AGENTS.md` / `GEMINI.md` / `COPILOT.md` |
| Blocking rule | `Do NOT load full AGENTS.md` | *(removed)* |

**Preserved** (not replaced):
- `Claude Code` (product name)
- `Claude Opus` / `Claude Sonnet` / `Claude Haiku` (model names)
- `claude-` prefixes (package names, CSS classes)

### Integration points
- OpenCode → `AGENTS.md`
- Gemini → `GEMINI.md`
- Copilot → `COPILOT.md`
- Antigravity → `GEMINI.md`
- Codex → `AGENTS.md`
- Claude Code → *unchanged* (references are correct)

### Tests
7 new tests covering all replacement rules (794/794 pass).

Closes #766