### PR TITLE
chore: update CI to Node 20, 22, 24 — drop EOL Node 18

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [18, 20, 22]
+        node-version: [20, 22, 24]
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -37,13 +37,5 @@ jobs:
         run: npm ci
 
       - name: Run tests with coverage
-        # c8 v11 requires Node 20+ (engines: ^20.0.0 || >=22.0.0). Node 18 EOL April 2025.
-        # Use bash on all platforms so shell glob expansion works on Windows.
-        if: matrix.node-version != 18
         shell: bash
         run: npm run test:coverage
-
-      - name: Run tests (Node 18, coverage not supported)
-        if: matrix.node-version == 18
-        shell: bash
-        run: npm test

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/glittercowboy/get-shit-done/issues"
   },
   "engines": {
-    "node": ">=16.7.0"
+    "node": ">=20.0.0"
   },
   "devDependencies": {
     "c8": "^11.0.0",


### PR DESCRIPTION
## Changes

- **CI matrix**: `[18, 20, 22]` → `[20, 22, 24]`
- **engines**: `>=16.7.0` → `>=20.0.0`
- Removed Node 18 conditional — all versions now run `test:coverage`

## Rationale

- Node 18 EOL: April 2025 (11 months ago)
- Node 24 is the current release; Node 22 is active LTS
- `c8` coverage tool requires Node 20+ (`engines: ^20.0.0 || >=22.0.0`)
- All 797 tests pass on Node 24

## Impact

Users on Node 18 will see an engines warning on `npm install`. The code itself still works on 18 but is no longer tested.