### PR TITLE
feat: GitOps versioning strategy with automated branching and release trains

### DIFF
--- a/.github/workflows/auto-branch.yml
+++ b/.github/workflows/auto-branch.yml
@@ -1,0 +1,101 @@
+name: Auto-Create Branch for Issues
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  create-branch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    # Only trigger on specific labels that map to branch types
+    if: >-
+      contains(fromJSON('["bug", "enhancement", "priority: critical", "type: chore", "area: docs"]'),
+      github.event.label.name)
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Determine branch type and create branch
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const label = context.payload.label.name;
+            const issue = context.payload.issue;
+            const number = issue.number;
+
+            // Generate slug from title (lowercase, alphanumeric + hyphens, max 40 chars)
+            const slug = issue.title
+              .toLowerCase()
+              .replace(/[^a-z0-9]+/g, '-')
+              .replace(/^-+|-+$/g, '')
+              .substring(0, 40)
+              .replace(/-+$/, '');
+
+            // Map label to branch prefix
+            const prefixMap = {
+              'bug': 'fix',
+              'enhancement': 'feat',
+              'priority: critical': 'hotfix',
+              'type: chore': 'chore',
+              'area: docs': 'docs',
+            };
+
+            const prefix = prefixMap[label];
+            if (!prefix) return;
+
+            const branchName = `${prefix}/${number}-${slug}`;
+
+            // Check if branch already exists
+            try {
+              await github.rest.git.getRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `heads/${branchName}`,
+              });
+              console.log(`Branch ${branchName} already exists — skipping`);
+              return;
+            } catch (e) {
+              if (e.status !== 404) throw e;
+              // 404 = branch doesn't exist, proceed to create
+            }
+
+            // Get main branch SHA
+            const { data: mainRef } = await github.rest.git.getRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'heads/main',
+            });
+
+            // Create branch
+            await github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `refs/heads/${branchName}`,
+              sha: mainRef.object.sha,
+            });
+
+            console.log(`✅ Created branch: ${branchName}`);
+
+            // Comment on issue with branch info
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+              body: [
+                `### 🌿 Branch created: \`${branchName}\``,
+                '',
+                'To start working on this issue:',
+                '```bash',
+                `git fetch origin ${branchName}`,
+                `git checkout ${branchName}`,
+                '```',
+                '',
+                `When ready, open a PR from \`${branchName}\` → \`main\`.`,
+                '',
+                `<sub>Auto-created from label: \`${label}\`</sub>`,
+              ].join('\n'),
+            });

--- a/.github/workflows/branch-naming.yml
+++ b/.github/workflows/branch-naming.yml
@@ -1,0 +1,36 @@
+name: Validate Branch Name
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  check-branch:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Validate branch naming convention
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = context.payload.pull_request.head.ref;
+
+            const validPrefixes = [
+              'feat/', 'fix/', 'hotfix/', 'docs/', 'chore/',
+              'refactor/', 'test/', 'release/', 'ci/', 'perf/', 'revert/',
+            ];
+
+            const alwaysValid = ['main', 'develop'];
+            if (alwaysValid.includes(branch)) return;
+            if (branch.startsWith('dependabot/') || branch.startsWith('renovate/')) return;
+
+            const isValid = validPrefixes.some(prefix => branch.startsWith(prefix));
+            if (!isValid) {
+              const prefixList = validPrefixes.map(p => `\`${p}\``).join(', ');
+              core.warning(
+                `Branch \`${branch}\` doesn't follow naming convention.\n` +
+                `Expected prefixes: ${prefixList}\n` +
+                `Example: \`feat/123-add-review-command\` or \`fix/456-hook-filter\`\n\n` +
+                `See VERSIONING.md for the full branching strategy.`
+              );
+            }

--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -1,0 +1,243 @@
+name: Release Train
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Action to perform'
+        required: true
+        type: choice
+        options:
+          - create-release-branch
+          - create-hotfix-branch
+          - promote-rc
+          - finalize-release
+      version:
+        description: 'Version (e.g., 1.27.0)'
+        required: true
+        type: string
+      base:
+        description: 'Base branch (default: main)'
+        required: false
+        type: string
+        default: main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  NODE_VERSION: 24
+
+jobs:
+  # ─── Create Release Branch ──────────────────────────────────────────────────
+  create-release:
+    runs-on: ubuntu-latest
+    if: inputs.action == 'create-release-branch'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.base }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Create release branch
+        run: |
+          VERSION="${{ inputs.version }}"
+          BRANCH="release/${VERSION}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git checkout -b "$BRANCH"
+
+          # Bump version in package.json
+          node -e "
+            const pkg = require('./package.json');
+            pkg.version = '${VERSION}';
+            require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+
+          # Update package-lock.json
+          npm install --package-lock-only
+
+          git add package.json package-lock.json
+          git commit -m "chore: bump version to ${VERSION}"
+          git push origin "$BRANCH"
+
+          echo "✅ Created release branch: $BRANCH"
+          echo "Next: merge feature PRs into $BRANCH, then run 'promote-rc'"
+
+      - name: Create tracking PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const version = '${{ inputs.version }}';
+            const branch = `release/${version}`;
+
+            const { data: pr } = await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Release v${version}`,
+              head: branch,
+              base: 'main',
+              body: [
+                `## Release v${version}`,
+                '',
+                '### Checklist',
+                '- [ ] All planned features merged',
+                '- [ ] RC published and tested (`npm install get-shit-done-cc@next`)',
+                '- [ ] CHANGELOG.md updated',
+                '- [ ] No critical bugs reported',
+                '- [ ] Ready for final release',
+                '',
+                '### Release candidates',
+                '_None yet — run "promote-rc" workflow to publish an RC._',
+                '',
+                `<sub>Created by release-train workflow</sub>`,
+              ].join('\n'),
+              draft: true,
+            });
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              labels: ['type: chore'],
+            });
+
+  # ─── Create Hotfix Branch ──────────────────────────────────────────────────
+  create-hotfix:
+    runs-on: ubuntu-latest
+    if: inputs.action == 'create-hotfix-branch'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Create hotfix branch
+        run: |
+          VERSION="${{ inputs.version }}"
+          BRANCH="hotfix/${VERSION}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git checkout -b "$BRANCH"
+
+          # Bump to patch version
+          node -e "
+            const pkg = require('./package.json');
+            pkg.version = '${VERSION}';
+            require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+          npm install --package-lock-only
+
+          git add package.json package-lock.json
+          git commit -m "chore: bump version to ${VERSION} (hotfix)"
+          git push origin "$BRANCH"
+
+          echo "✅ Created hotfix branch: $BRANCH"
+          echo "Cherry-pick or commit fixes, then run 'finalize-release'"
+
+  # ─── Promote to Release Candidate ──────────────────────────────────────────
+  promote-rc:
+    runs-on: ubuntu-latest
+    if: inputs.action == 'promote-rc'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: release/${{ inputs.version }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: 'https://registry.npmjs.org'
+          cache: npm
+
+      - run: npm ci
+
+      - name: Determine RC number
+        id: rc
+        run: |
+          VERSION="${{ inputs.version }}"
+          # Find existing RC tags
+          RC_COUNT=$(git tag -l "v${VERSION}-rc.*" | wc -l | tr -d ' ')
+          NEXT_RC=$((RC_COUNT + 1))
+          RC_VERSION="${VERSION}-rc.${NEXT_RC}"
+          echo "rc_version=$RC_VERSION" >> "$GITHUB_OUTPUT"
+          echo "📦 RC version: $RC_VERSION"
+
+      - name: Tag and publish RC
+        run: |
+          RC_VERSION="${{ steps.rc.outputs.rc_version }}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Update package.json to RC version
+          node -e "
+            const pkg = require('./package.json');
+            pkg.version = '${RC_VERSION}';
+            require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+
+          npm run build:hooks
+          git add -A
+          git commit -m "chore: bump to ${RC_VERSION}" || true
+          git tag -a "v${RC_VERSION}" -m "Release candidate v${RC_VERSION}"
+          git push origin "release/${{ inputs.version }}" --tags
+
+          echo "✅ Tagged v${RC_VERSION}"
+          echo "Install for testing: npx get-shit-done-cc@next"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  # ─── Finalize Release ──────────────────────────────────────────────────────
+  finalize-release:
+    runs-on: ubuntu-latest
+    if: inputs.action == 'finalize-release'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.base == 'main' && format('release/{0}', inputs.version) || format('hotfix/{0}', inputs.version) }}
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - run: npm ci
+
+      - name: Run full test suite
+        run: npm run test:coverage
+
+      - name: Finalize version
+        run: |
+          VERSION="${{ inputs.version }}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Ensure package.json has final version (not RC)
+          node -e "
+            const pkg = require('./package.json');
+            pkg.version = '${VERSION}';
+            require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+
+          npm run build:hooks
+          git add -A
+          git commit -m "chore: finalize v${VERSION}" || true
+          git tag -a "v${VERSION}" -m "Release v${VERSION}"
+          git push origin HEAD --tags
+
+          echo "✅ Finalized v${VERSION}"
+          echo "The release workflow will now trigger from the tag push."
+          echo "Merge the release/hotfix branch PR to complete."

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,253 @@
+# Versioning & Branching Strategy
+
+> GitOps-driven versioning with automated branch management for GSD.
+
+## Semantic Versioning
+
+GSD follows [Semantic Versioning 2.0.0](https://semver.org/):
+
+```
+MAJOR.MINOR.PATCH[-prerelease]
+
+1.27.0        — next feature release
+1.26.1        — patch fix on current release
+2.0.0         — breaking change (runtime API, config format, CLI flags)
+1.27.0-beta.1 — pre-release for testing
+```
+
+| Increment | When | Examples |
+|-----------|------|----------|
+| **PATCH** (1.26.x) | Bug fixes, typos, doc corrections, test additions | Hook filter fix, config.toml corruption fix |
+| **MINOR** (1.x.0) | New features, new commands, non-breaking enhancements | `/gsd:review`, `/gsd:plant-seed`, new runtime support |
+| **MAJOR** (x.0.0) | Breaking changes to config format, CLI flags, or runtime API | Removing a command, changing config schema, dropping Node version |
+
+## Branch Structure
+
+```
+main                          ← production, always deployable
+  │
+  ├── release/1.27.0          ← release candidate branch (created automatically)
+  │     ├── fix/1200-stale-hooks
+  │     └── feat/review-command
+  │
+  ├── release/1.26.1          ← hotfix release branch
+  │     └── fix/1202-codex-toml
+  │
+  ├── develop                 ← integration branch for next minor (optional)
+  │
+  ├── fix/*                   ← bug fix branches
+  │     ├── fix/1200-stale-hooks-filter
+  │     └── fix/1202-codex-config-toml
+  │
+  └── feat/*                  ← feature branches
+        ├── feat/review-command
+        ├── feat/plant-seed
+        └── feat/cicd-pipeline
+```
+
+### Branch Types
+
+| Prefix | Purpose | Base | Merges Into | Auto-created |
+|--------|---------|------|-------------|-------------|
+| `main` | Production | — | — | — |
+| `develop` | Next minor integration | `main` | `release/*` | No |
+| `release/X.Y.Z` | Release candidate | `main` or `develop` | `main` | Yes (on milestone) |
+| `fix/*` | Bug fixes | `main` | `release/X.Y.Z` or `main` | Yes (on issue label) |
+| `feat/*` | Features | `main` or `develop` | `release/X.Y.Z` or `develop` | Yes (on issue label) |
+| `hotfix/*` | Critical production fixes | `main` | `main` + `develop` | Yes (on `priority: critical` label) |
+| `chore/*` | Maintenance, refactoring | `main` | `main` | No |
+| `docs/*` | Documentation only | `main` | `main` | No |
+
+## Automated Branch Creation
+
+When an issue is labeled, a branch is automatically created:
+
+| Issue Label | Branch Created | Base Branch |
+|-------------|---------------|-------------|
+| `bug` | `fix/{number}-{slug}` | `main` |
+| `enhancement` | `feat/{number}-{slug}` | `main` |
+| `priority: critical` | `hotfix/{number}-{slug}` | `main` |
+| `type: chore` | `chore/{number}-{slug}` | `main` |
+| `area: docs` | `docs/{number}-{slug}` | `main` |
+
+### How it works
+
+1. Contributor opens issue → maintainer adds label (`bug`, `enhancement`, etc.)
+2. GitHub Action auto-creates a branch with the correct prefix and naming
+3. Contributor checks out the branch and works
+4. PR is opened against the appropriate target (main or release branch)
+5. CI runs, reviews happen, merge when ready
+
+## Release Train
+
+### Minor Release (1.27.0)
+
+```
+1. Features and fixes accumulate on main (or develop)
+2. When ready, create release branch:
+   → release/1.27.0 is auto-created via workflow dispatch
+3. Only bug fixes go into release/1.27.0
+4. Release candidate testing:
+   → v1.27.0-rc.1 tag → npm publish --tag next
+5. When stable:
+   → Merge release/1.27.0 → main
+   → Tag v1.27.0 → npm publish --tag latest
+   → Delete release branch
+```
+
+### Patch Release (1.26.1)
+
+```
+1. Critical fix needed on current production
+2. Create hotfix branch from main:
+   → hotfix/1202-codex-config-toml
+3. Fix, test, PR against main
+4. Merge → tag v1.26.1 → npm publish
+5. If develop exists, cherry-pick fix into develop
+```
+
+### Pre-release (1.27.0-beta.1)
+
+```
+1. Experimental features ready for testing
+2. Tag from release branch or main:
+   → v1.27.0-beta.1
+3. Publish to npm with --tag next:
+   → npm install get-shit-done-cc@next
+4. Gather feedback → iterate → promote to stable
+```
+
+## Commit Convention
+
+All commits follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <description>
+
+feat(review): add cross-AI peer review command
+fix(hooks): filter stale check to gsd-prefixed files only
+docs(readme): update command table for v1.27
+chore(ci): update Node matrix to 20, 22, 24
+refactor(core): adopt planningPaths() across modules
+test(integration): add E2E lifecycle harness
+```
+
+| Type | Version Bump | Description |
+|------|-------------|-------------|
+| `feat` | MINOR | New feature |
+| `fix` | PATCH | Bug fix |
+| `docs` | — | Documentation only |
+| `chore` | — | Maintenance, deps |
+| `refactor` | — | Code restructure |
+| `test` | — | Test additions |
+| `perf` | PATCH | Performance improvement |
+| `ci` | — | CI/CD changes |
+
+### Breaking Changes
+
+Append `!` or add `BREAKING CHANGE:` footer:
+
+```
+feat(config)!: rename depth to granularity
+
+BREAKING CHANGE: config.depth is now config.granularity.
+Existing configs are auto-migrated.
+```
+
+## Version Lifecycle
+
+```
+v1.26.0 (current stable)
+  │
+  ├── v1.26.1 (hotfix if needed)
+  │
+  ├── v1.27.0-rc.1 (release candidate)
+  ├── v1.27.0-rc.2 (fixes from RC testing)
+  ├── v1.27.0 (stable release)
+  │
+  ├── v1.28.0-beta.1 (experimental features)
+  ├── v1.28.0 (next minor)
+  │
+  └── v2.0.0 (if breaking changes needed)
+```
+
+## npm Distribution Tags
+
+| Tag | Purpose | Install Command |
+|-----|---------|----------------|
+| `latest` | Stable release | `npx get-shit-done-cc@latest` |
+| `next` | Pre-release/RC | `npx get-shit-done-cc@next` |
+| `beta` | Experimental | `npx get-shit-done-cc@beta` |
+
+## For Contributors
+
+1. **Check the issue** — Is there already a branch? Check the issue comments for an auto-created branch link.
+2. **Use the right prefix** — `fix/` for bugs, `feat/` for features, `docs/` for documentation.
+3. **Follow commit convention** — `type(scope): description` format.
+4. **Target the right branch** — PRs go to `main` unless there's an active `release/*` branch.
+5. **One concern per PR** — Don't mix features and bug fixes in the same PR.
+
+## For Maintainers
+
+1. **Label issues promptly** — Branch auto-creation triggers on label.
+2. **Create release branches** — Use the workflow dispatch when features are ready.
+3. **Tag releases** — Push `v*` tag to trigger the release pipeline.
+4. **Review before publish** — The `npm-publish` environment requires human approval.
+
+---
+
+## Pipeline Integration
+
+This versioning strategy is designed to work with the CI/CD/Release pipeline (PR #1208).
+Together they form the complete development lifecycle:
+
+### How the pieces fit
+
+```
+Issue filed
+  │
+  ├── Label added (bug/enhancement/critical)
+  │     └── auto-branch.yml creates fix/123-slug or feat/123-slug
+  │
+  ├── Contributor works on branch
+  │     └── branch-naming.yml validates prefix on PR open
+  │
+  ├── PR opened against main
+  │     ├── ci.yml: lint → test (9-matrix) → security → install-smoke
+  │     ├── pr-gate.yml: size analysis, command-workflow validation
+  │     └── Integration test harness runs (E2E lifecycle, git ops, installs)
+  │
+  ├── PR merged to main
+  │     └── cd.yml: detects version bump in package.json → auto-tags → triggers release
+  │
+  ├── Release train (manual or auto)
+  │     ├── release-train.yml: create-release-branch → promote-rc → finalize
+  │     └── release.yml: validate → ⏸️ HUMAN APPROVAL → npm publish → GitHub Release → verify
+  │
+  └── Post-release
+        ├── verify-release: npm propagation check + install smoke test
+        └── stale.yml: weekly cleanup of inactive PRs/issues
+```
+
+### Workflow files
+
+| File | Purpose | From |
+|------|---------|------|
+| `ci.yml` | Test matrix, lint, security, smoke tests | PR #1208 |
+| `release.yml` | Validate, publish npm, GitHub Release, verify | PR #1208 |
+| `cd.yml` | Auto-tag on version bump → trigger release | PR #1208 |
+| `pr-gate.yml` | PR size analysis, command/agent validation | PR #1208 |
+| `stale.yml` | Weekly cleanup of stale PRs/issues | PR #1208 |
+| `auto-branch.yml` | Create branch on issue label | This PR |
+| `release-train.yml` | Release branch management (create, RC, finalize) | This PR |
+| `branch-naming.yml` | Validate branch prefix convention | This PR |
+| `auto-label-issues.yml` | Add needs-triage to new issues | Existing |
+| `test.yml` | Legacy test runner (superseded by ci.yml) | Existing |
+
+### Required setup
+
+1. **GitHub Environments**: Create `npm-publish` with required reviewers (human approval gate)
+2. **Secrets**: Add `NPM_TOKEN` to the `npm-publish` environment
+3. **Branch protection**: Require `ci / lint`, `ci / test`, `pr-gate / pr-review` checks
+4. **Dependabot**: Already configured via `.github/dependabot.yml` (PR #1208)
+


### PR DESCRIPTION
## 🧪 EXPERIMENTAL — Looking for Feedback

This is an **experimental** proposal for a GitOps-driven versioning and branching strategy. Not production-ready — looking for feedback on the approach before finalizing.

**Designed to integrate with the CI/CD/Release pipeline in PR #1208.** Together they form the complete development lifecycle.

---

## What this adds

### 1. `VERSIONING.md` — Strategy document

Defines the entire versioning and branching approach:
- **Semantic versioning** rules (when to bump MAJOR/MINOR/PATCH)
- **Branch types**: `fix/*`, `feat/*`, `hotfix/*`, `release/*`, `chore/*`, `docs/*`
- **Conventional commits** convention with automatic version bump mapping
- **Release train** lifecycle: create branch → RC → test → finalize
- **npm distribution tags**: `latest`, `next`, `beta`
- **Pipeline integration** diagram showing how all workflows connect with PR #1208

### 2. `auto-branch.yml` — Automated branch creation

When an issue is labeled:
| Label | Branch created | Example |
|-------|---------------|---------|
| `bug` | `fix/{number}-{slug}` | `fix/1200-stale-hooks-filter` |
| `enhancement` | `feat/{number}-{slug}` | `feat/925-cross-ai-review` |
| `priority: critical` | `hotfix/{number}-{slug}` | `hotfix/1202-codex-config` |
| `type: chore` | `chore/{number}-{slug}` | `chore/1206-node-24-ci` |
| `area: docs` | `docs/{number}-{slug}` | `docs/1187-v126-release` |

Comments on the issue with checkout instructions.

### 3. `release-train.yml` — Release lifecycle management

Workflow dispatch with 4 actions:

```
create-release-branch → promote-rc → finalize-release
create-hotfix-branch  → finalize-release
```

- **create-release-branch**: Creates `release/X.Y.Z`, bumps package.json, opens draft PR
- **create-hotfix-branch**: Creates `hotfix/X.Y.Z` from main for urgent fixes
- **promote-rc**: Tags `vX.Y.Z-rc.N`, publishes to npm `@next` for testing
- **finalize-release**: Runs full test suite, tags final version, triggers release pipeline

### 4. `branch-naming.yml` — Convention validation

Warns (doesn't block) when PR branch names don't match the convention. Allows dependabot/renovate.

---

## Complete lifecycle (with PR #1208)

```
Issue → Label → Auto-branch → Work → PR → CI (lint/test/security)
  → PR gate (size/validation) → Merge → CD (auto-tag on version bump)
  → Release train (RC → test → finalize)
  → Release (validate → ⏸️ HUMAN APPROVAL → npm publish → verify)
  → Stale cleanup (weekly)
```

## Feedback wanted

- Is the branch naming convention reasonable? Should it be stricter (block) or advisory (warn)?
- Is the release train workflow (create → RC → finalize) the right level of ceremony?
- Should `develop` be a required integration branch, or is trunk-based (`main`-only) better for this project?
- Are the auto-branch label mappings correct?
- Any concerns about the automated branch creation from issue labels?