### PR TITLE
fix(state): use Math.floor for progress bar filled blocks

### DIFF
--- a/get-shit-done/bin/lib/state.cjs
+++ b/get-shit-done/bin/lib/state.cjs
@@ -289,7 +289,7 @@ function cmdStateUpdateProgress(cwd, raw) {
 
   const percent = totalPlans > 0 ? Math.min(100, Math.round(totalSummaries / totalPlans * 100)) : 0;
   const barWidth = 10;
-  const filled = Math.round(percent / 100 * barWidth);
+  const filled = Math.floor(percent / 100 * barWidth);
   const bar = '\u2588'.repeat(filled) + '\u2591'.repeat(barWidth - filled);
   const progressStr = `[${bar}] ${percent}%`;
 


### PR DESCRIPTION
## What
Fix progress bar showing 100% full at 99% completion due to Math.round rounding up.

## Why
When progress is at 99%, `Math.round(99/100 * 10)` = `Math.round(9.9)` = `10`, which shows a completely full progress bar. Users expect a full bar only at exactly 100%.

Closes #N/A — found during code review.

## How
Changed `Math.round` to `Math.floor` for the filled blocks calculation. This ensures 99% shows 9/10 blocks and only 100% shows a completely full bar.

## Testing
- [x] macOS
- [ ] Windows
- [ ] Linux

**Runtimes tested:**
- [x] Claude Code

## Checklist
- [x] Follows GSD style — no filler
- [x] No unnecessary dependencies
- [x] Existing tests pass

## Breaking Changes
None — visual-only change to progress bar display.