### PR TITLE
fix(commit): stage file deletions when passed non-existent paths

### DIFF
--- a/get-shit-done/bin/lib/commands.cjs
+++ b/get-shit-done/bin/lib/commands.cjs
@@ -238,7 +238,13 @@ function cmdCommit(cwd, message, files, raw, amend, noVerify) {
   // Stage files
   const filesToStage = files && files.length > 0 ? files : ['.planning/'];
   for (const file of filesToStage) {
-    execGit(cwd, ['add', file]);
+    const fullPath = path.join(cwd, file);
+    if (!fs.existsSync(fullPath)) {
+      // File was deleted/moved — stage the deletion
+      execGit(cwd, ['rm', '--cached', '--ignore-unmatch', file]);
+    } else {
+      execGit(cwd, ['add', file]);
+    }
   }
 
   // Commit (--no-verify skips pre-commit hooks, used by parallel executor agents)


### PR DESCRIPTION
## What
Teach `cmdCommit` to detect and stage deleted files passed via `--files`.

## Why
When `check-todos` moves a file from `pending/` to `done/`, the commit only stages the new destination file. The deletion of the source is never staged because `git add` on a non-existent path is a no-op. This leaves orphaned entries in the pending directory.

Closes #1228

## How
Before running `git add`, check if the file exists on disk. If it doesn't (was deleted/moved), use `git rm --cached --ignore-unmatch` to stage the deletion instead.

## Testing
- [x] macOS
- [ ] Windows
- [ ] Linux

**Runtimes tested:**
- [x] Claude Code

## Checklist
- [x] Follows GSD style — no filler
- [x] No unnecessary dependencies
- [x] Windows-compatible (uses path.join)
- [x] Existing tests pass

## Breaking Changes
None — only changes behavior when a non-existent file path is passed to commit.