### PR TITLE
feat: add block-no-verify PreToolUse hook for Claude Code contributors

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx --yes block-no-verify@1.1.2"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Closes #1231. Add .claude/settings.json with a block-no-verify PreToolUse hook. When contributors develop GSD using Claude Code, the agent can bypass pre-commit hooks with hook-bypass flags. This adds a Bash PreToolUse hook running npx --yes block-no-verify@1.1.2 to intercept and block such commands. See https://github.com/tupe12334/block-no-verify. Disclosure: I am the author and maintainer of block-no-verify.