### PR TITLE
fix(stats): replace undefined $GSD_TOOLS with standard gsd-tools path

### DIFF
--- a/get-shit-done/workflows/stats.md
+++ b/get-shit-done/workflows/stats.md
@@ -12,7 +12,7 @@ Read all files referenced by the invoking prompt's execution_context before star
 Gather project statistics:
 
 ```bash
-STATS=$(node "$GSD_TOOLS" stats json)
+STATS=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" stats json)
 if [[ "$STATS" == @file:* ]]; then STATS=$(cat "${STATS#@file:}"); fi
 ```
 


### PR DESCRIPTION
## Summary

- `stats.md` workflow used `$GSD_TOOLS` which is never defined anywhere in the codebase
- All other 60+ workflows use the hardcoded path `$HOME/.claude/get-shit-done/bin/gsd-tools.cjs`
- The undefined variable caused the LLM to improvise the path at runtime, producing `tools/gsd-tools.mjs` instead of `bin/gsd-tools.cjs`

## Error
```
Error: Cannot find module '/Users/.../.claude/get-shit-done/tools/gsd-tools.mjs'
```

## Fix
One-line change: replace `$GSD_TOOLS` with the standard path used by every other workflow.