### PR TITLE
fix(hooks): add version header to gsd-workflow-guard.js

### DIFF
--- a/hooks/gsd-workflow-guard.js
+++ b/hooks/gsd-workflow-guard.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+// gsd-hook-version: {{GSD_VERSION}}
 // GSD Workflow Guard — PreToolUse hook
 // Detects when Claude attempts file edits outside a GSD workflow context
 // (no active /gsd: command or Task subagent) and injects an advisory warning.


### PR DESCRIPTION
## Fixes #1249

**Problem:** Persistent `⚠ stale hooks — run /gsd:update` warning in the statusline, even when running the latest GSD version (v1.26.0).

**Root cause:** `gsd-workflow-guard.js` was missing the `// gsd-hook-version: {{GSD_VERSION}}` header. The stale hook detection in `gsd-check-update.js` scans all `gsd-*.js` files in the hooks directory and flags any without a version header as stale (`hookVersion: 'unknown'`). Since `gsd-workflow-guard.js` never had this header, every update check flagged it.

**Fix:** Added the `// gsd-hook-version: {{GSD_VERSION}}` header to `gsd-workflow-guard.js`. The install script already replaces `{{GSD_VERSION}}` with the actual version for all `.js` hook files. Users need to run `/gsd:update` once after this fix is released to get the stamped hook file.

**Changes:**
- `hooks/gsd-workflow-guard.js`: Added version header (1 line)

**Tests:** All existing tests pass.