### PR TITLE
fix(install): add matcher and timeout to context-monitor hook

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -4055,14 +4055,36 @@ function install(isGlobal, runtime = 'claude') {
 
     if (!hasContextMonitorHook) {
       settings.hooks[postToolEvent].push({
+        matcher: 'Bash|Edit|Write|MultiEdit|Agent|Task',
         hooks: [
           {
             type: 'command',
-            command: contextMonitorCommand
+            command: contextMonitorCommand,
+            timeout: 10
           }
         ]
       });
       console.log(`  ${green}✓${reset} Configured context window monitor hook`);
+    } else {
+      // Migrate existing context monitor hooks: add matcher and timeout if missing
+      for (const entry of settings.hooks[postToolEvent]) {
+        if (entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-context-monitor'))) {
+          let migrated = false;
+          if (!entry.matcher) {
+            entry.matcher = 'Bash|Edit|Write|MultiEdit|Agent|Task';
+            migrated = true;
+          }
+          for (const h of entry.hooks) {
+            if (h.command && h.command.includes('gsd-context-monitor') && !h.timeout) {
+              h.timeout = 10;
+              migrated = true;
+            }
+          }
+          if (migrated) {
+            console.log(`  ${green}✓${reset} Updated context monitor hook (added matcher + timeout)`);
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Fixes #1246

**Problem:** The `gsd-context-monitor` PostToolUse hook was registered without a `matcher` or `timeout` in settings.json. This caused it to fire on every tool use including `Read`, `Glob`, and `Grep`. When multiple `Read` calls happen in parallel, some hook processes failed with errors.

**Fix:**
- Added `matcher: 'Bash|Edit|Write|MultiEdit|Agent|Task'` to limit the hook to tools that modify context
- Added `timeout: 10` to prevent hangs
- Added migration logic so existing installations get the matcher and timeout on next `/gsd:update`

**Changes:**
- `bin/install.js`: Updated context monitor hook configuration and added migration path

**Tests:** 248 related tests pass.