### PR TITLE
enhancement(workflow): add decision IDs for discuss-to-plan traceability

### DIFF
--- a/agents/gsd-plan-checker.md
+++ b/agents/gsd-plan-checker.md
@@ -277,9 +277,11 @@ issue:
 
 **Process:**
 1. Parse CONTEXT.md sections: Decisions, Claude's Discretion, Deferred Ideas
-2. For each locked Decision, find implementing task(s)
-3. Verify no tasks implement Deferred Ideas (scope creep)
-4. Verify Discretion areas are handled (planner's choice is valid)
+2. Extract all numbered decisions (D-01, D-02, etc.) from the `<decisions>` section
+3. For each locked Decision, find implementing task(s) — check task actions for D-XX references
+4. Verify 100% decision coverage: every D-XX must appear in at least one task's action or rationale
+5. Verify no tasks implement Deferred Ideas (scope creep)
+6. Verify Discretion areas are handled (planner's choice is valid)
 
 **Red flags:**
 - Locked decision has no implementing task

--- a/agents/gsd-planner.md
+++ b/agents/gsd-planner.md
@@ -60,6 +60,7 @@ The orchestrator provides user decisions in `<user_decisions>` tags from `/gsd:d
    - If user said "use library X" → task MUST use library X, not an alternative
    - If user said "card layout" → task MUST implement cards, not tables
    - If user said "no animations" → task MUST NOT include animations
+   - Reference the decision ID (D-01, D-02, etc.) in task actions for traceability
 
 2. **Deferred Ideas (from `## Deferred Ideas`)** — MUST NOT appear in plans
    - If user deferred "search functionality" → NO search tasks allowed
@@ -69,7 +70,8 @@ The orchestrator provides user decisions in `<user_decisions>` tags from `/gsd:d
    - Make reasonable choices and document in task actions
 
 **Self-check before returning:** For each plan, verify:
-- [ ] Every locked decision has a task implementing it
+- [ ] Every locked decision (D-01, D-02, etc.) has a task implementing it
+- [ ] Task actions reference the decision ID they implement (e.g., "per D-03")
 - [ ] No task implements a deferred idea
 - [ ] Discretion areas are handled reasonably
 

--- a/get-shit-done/templates/context.md
+++ b/get-shit-done/templates/context.md
@@ -31,14 +31,14 @@ Template for `.planning/phases/XX-name/{phase_num}-CONTEXT.md` - captures implem
 ## Implementation Decisions
 
 ### [Area 1 that was discussed]
-- [Specific decision made]
-- [Another decision if applicable]
+- **D-01:** [Specific decision made]
+- **D-02:** [Another decision if applicable]
 
 ### [Area 2 that was discussed]
-- [Specific decision made]
+- **D-03:** [Specific decision made]
 
 ### [Area 3 that was discussed]
-- [Specific decision made]
+- **D-04:** [Specific decision made]
 
 ### Claude's Discretion
 [Areas where user explicitly said "you decide" — Claude has flexibility here during planning/implementation]

--- a/get-shit-done/workflows/discuss-phase.md
+++ b/get-shit-done/workflows/discuss-phase.md
@@ -650,11 +650,11 @@ mkdir -p ".planning/phases/${padded_phase}-${phase_slug}"
 ## Implementation Decisions
 
 ### [Category 1 that was discussed]
-- [Decision or preference captured]
-- [Another decision if applicable]
+- **D-01:** [Decision or preference captured]
+- **D-02:** [Another decision if applicable]
 
 ### [Category 2 that was discussed]
-- [Decision or preference captured]
+- **D-03:** [Decision or preference captured]
 
 ### Claude's Discretion
 [Areas where user said "you decide" — note that Claude has flexibility here]


### PR DESCRIPTION
## Fixes #1243

**Problem:** Decisions captured in CONTEXT.md during discuss-phase had no formal IDs. The planner consumed them as prose, and there was no mechanism to verify that every decision was covered by at least one plan task. In a real project, 6 out of 61 decisions were missed.

**Fix:** Added decision IDs (D-01, D-02, etc.) throughout the discuss → plan → check pipeline:

### Changes:
- **`templates/context.md`**: Decision items now use `**D-XX:**` prefix format
- **`workflows/discuss-phase.md`**: `write_context` step numbers decisions sequentially
- **`agents/gsd-planner.md`**: Planner references decision IDs in task actions; self-check verifies every D-XX is covered
- **`agents/gsd-plan-checker.md`**: Dimension 7 (Context Compliance) extracts D-XX IDs and verifies 100% coverage — uncovered decisions are flagged as blockers

**Backward compatible:** Existing CONTEXT.md files without numbered decisions still work — the plan-checker's decision coverage check only activates when D-XX patterns are found.

**Tests:** 172 related tests pass.