### PR TITLE
fix(state): preserve frontmatter status when body Status field is missing

### DIFF
--- a/get-shit-done/bin/lib/state.cjs
+++ b/get-shit-done/bin/lib/state.cjs
@@ -733,9 +733,20 @@ function stripFrontmatter(content) {
 }
 
 function syncStateFrontmatter(content, cwd) {
+  // Read existing frontmatter BEFORE stripping — it may contain values
+  // that the body no longer has (e.g., Status field removed by an agent).
+  const existingFm = extractFrontmatter(content);
   const body = stripFrontmatter(content);
-  const fm = buildStateFrontmatter(body, cwd);
-  const yamlStr = reconstructFrontmatter(fm);
+  const derivedFm = buildStateFrontmatter(body, cwd);
+
+  // Preserve existing frontmatter status when body-derived status is 'unknown'.
+  // This prevents a missing Status: field in the body from overwriting a
+  // previously valid status (e.g., 'executing' → 'unknown').
+  if (derivedFm.status === 'unknown' && existingFm.status && existingFm.status !== 'unknown') {
+    derivedFm.status = existingFm.status;
+  }
+
+  const yamlStr = reconstructFrontmatter(derivedFm);
   return `---\n${yamlStr}\n---\n\n${body}`;
 }
 

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -475,6 +475,30 @@ describe('STATE.md frontmatter sync', () => {
     assert.ok(content.includes('status: paused'), 'frontmatter should reflect latest status');
   });
 
+  test('preserves frontmatter status when body Status field is missing', () => {
+    // Simulate: frontmatter has status: executing, but body lost Status: field
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      `---
+status: executing
+milestone: v1.0
+---
+
+# Project State
+
+**Current Phase:** 03
+**Current Plan:** 03-02
+`
+    );
+
+    // Any writeStateMd triggers syncStateFrontmatter — use state update on a field that exists
+    runGsdTools('state update "Current Plan" "03-03"', tmpDir);
+
+    const content = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    assert.ok(content.includes('status: executing'), 'should preserve existing status, not overwrite with unknown');
+    assert.ok(!content.includes('status: unknown'), 'should not contain unknown status');
+  });
+
   test('round-trip: write then read via state json', () => {
     fs.writeFileSync(
       path.join(tmpDir, '.planning', 'STATE.md'),


### PR DESCRIPTION
## What
Preserve existing frontmatter `status` when `syncStateFrontmatter()` would overwrite it with `unknown`.

## Why
`writeStateMd()` calls `syncStateFrontmatter()` on every write, which rebuilds YAML frontmatter from the body via `buildStateFrontmatter()`. If the body's `Status:` field is missing (removed by an agent, or never present in that format), `normalizedStatus` defaults to `'unknown'`, overwriting a previously valid status like `'executing'` or `'completed'`.

This affects any project where agents rewrite the STATE.md body without preserving all fields — the status silently degrades to `unknown` on the next write.

**Root cause:** `stateReplaceField()` can only replace existing fields, never add missing ones. If Status is lost from the body, no subsequent write can restore it — every `writeStateMd()` call stamps `status: unknown` into frontmatter.

**Fix:** Read existing frontmatter before stripping, and preserve its `status` value when the body-derived status would be `unknown`. Frontmatter becomes self-healing — once set, status persists even if the body loses the field.

## Testing
- [x] Tested on Linux
- [x] `npm test` passes (1035 tests)
- [x] New test: verifies status preservation when body lacks Status field

## Checklist
- [x] Follows GSD style (no enterprise patterns, no filler)
- [x] No unnecessary dependencies added

## Breaking Changes
None