### PR TITLE
fix: use fs.writeSync to prevent stdout truncation when piped

### DIFF
--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -147,8 +147,9 @@ function reapStaleTempFiles(prefix = 'gsd-', { maxAgeMs = 5 * 60 * 1000, dirsOnl
 }
 
 function output(result, raw, rawValue) {
+  let data;
   if (raw && rawValue !== undefined) {
-    process.stdout.write(String(rawValue));
+    data = String(rawValue);
   } else {
     const json = JSON.stringify(result, null, 2);
     // Large payloads exceed Claude Code's Bash tool buffer (~50KB).
@@ -157,16 +158,20 @@ function output(result, raw, rawValue) {
       reapStaleTempFiles();
       const tmpPath = path.join(require('os').tmpdir(), `gsd-${Date.now()}.json`);
       fs.writeFileSync(tmpPath, json, 'utf-8');
-      process.stdout.write('@file:' + tmpPath);
+      data = '@file:' + tmpPath;
     } else {
-      process.stdout.write(json);
+      data = json;
     }
   }
-  process.exit(0);
+  // process.stdout.write() is async when stdout is a pipe — process.exit()
+  // can tear down the process before the reader consumes the buffer.
+  // fs.writeSync(1, ...) blocks until the kernel accepts the bytes, and
+  // skipping process.exit() lets the event loop drain naturally.
+  fs.writeSync(1, data);
 }
 
 function error(message) {
-  process.stderr.write('Error: ' + message + '\n');
+  fs.writeSync(2, 'Error: ' + message + '\n');
   process.exit(1);
 }
 


### PR DESCRIPTION
## summary

fixes #1275

`output()` in `core.cjs` calls `process.stdout.write(json)` then `process.exit(0)`. when stdout is a pipe (`| jq`, `| python3`), the write is async — `process.exit()` tears down the process before the reader consumes the buffer, truncating the JSON.

related to #493 which fixed the >50KB case via tmpfile routing. this fixes the same race for all payloads under 50KB.

## fix

swap `process.stdout.write()` for `fs.writeSync(1, data)` — synchronous write to fd 1. drop `process.exit(0)` on the success path so the event loop drains naturally. same treatment for `error()` with fd 2.

## tested

- existing test suite: 114/114 pass
- `roadmap get-phase` piped to `jq`: 5/5 pass (was 0/5)
- `roadmap get-phase` piped to `python3 -c "json.load(sys.stdin)"`: 5/5 pass (was 0/5)
- `--raw` flag: works
- `error()` path: stderr output + exit code 1 preserved
- redirect to file: still works (no regression)