### PR TITLE
fix: use BeforeTool hook event for Gemini CLI prompt guard

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -3214,24 +3214,26 @@ function uninstall(isGlobal, runtime = 'claude') {
       }
     }
 
-    // Remove GSD hooks from PreToolUse (prompt injection guard)
-    if (settings.hooks && settings.hooks.PreToolUse) {
-      const before = settings.hooks.PreToolUse.length;
-      settings.hooks.PreToolUse = settings.hooks.PreToolUse.filter(entry => {
-        if (entry.hooks && Array.isArray(entry.hooks)) {
-          const hasGsdHook = entry.hooks.some(h =>
-            h.command && h.command.includes('gsd-prompt-guard')
-          );
-          return !hasGsdHook;
+    // Remove GSD hooks from PreToolUse and BeforeTool (Gemini uses BeforeTool)
+    for (const eventName of ['PreToolUse', 'BeforeTool']) {
+      if (settings.hooks && settings.hooks[eventName]) {
+        const before = settings.hooks[eventName].length;
+        settings.hooks[eventName] = settings.hooks[eventName].filter(entry => {
+          if (entry.hooks && Array.isArray(entry.hooks)) {
+            const hasGsdHook = entry.hooks.some(h =>
+              h.command && h.command.includes('gsd-prompt-guard')
+            );
+            return !hasGsdHook;
+          }
+          return true;
+        });
+        if (settings.hooks[eventName].length < before) {
+          settingsModified = true;
+          console.log(`  ${green}✓${reset} Removed prompt injection guard hook from settings`);
         }
-        return true;
-      });
-      if (settings.hooks.PreToolUse.length < before) {
-        settingsModified = true;
-        console.log(`  ${green}✓${reset} Removed prompt injection guard hook from settings`);
-      }
-      if (settings.hooks.PreToolUse.length === 0) {
-        delete settings.hooks.PreToolUse;
+        if (settings.hooks[eventName].length === 0) {
+          delete settings.hooks[eventName];
+        }
       }
     }
 
@@ -4117,7 +4119,8 @@ function install(isGlobal, runtime = 'claude') {
     }
 
     // Configure PreToolUse hook for prompt injection detection
-    const preToolEvent = 'PreToolUse';
+    // Gemini and Antigravity use BeforeTool instead of PreToolUse for pre-tool hooks
+    const preToolEvent = (runtime === 'gemini' || runtime === 'antigravity') ? 'BeforeTool' : 'PreToolUse';
     if (!settings.hooks[preToolEvent]) {
       settings.hooks[preToolEvent] = [];
     }


### PR DESCRIPTION
## Summary

- Gemini CLI uses `BeforeTool` instead of `PreToolUse` for pre-tool hooks. The prompt injection guard hook was hardcoded to `PreToolUse`, causing Gemini CLI to log `Invalid hook event name: "PreToolUse" from project config. Skipping.` on every startup.
- Applied the same runtime-conditional mapping already used for post-tool hooks (`AfterTool` vs `PostToolUse` on line 4024), so Gemini and Antigravity runtimes now get `BeforeTool` while Claude Code and others continue to get `PreToolUse`.
- Updated the uninstall/cleanup path to iterate both `PreToolUse` and `BeforeTool` when removing GSD hooks, matching the existing pattern for `PostToolUse`/`AfterTool` cleanup.

Fixes #1295

## Test plan

- [x] Full test suite passes (1166/1166, 0 failures)
- [ ] Install GSD with Gemini CLI runtime and verify no "Invalid hook event name" error on startup
- [ ] Verify prompt injection guard hook appears under `BeforeTool` in Gemini settings.json
- [ ] Verify Claude Code runtime still uses `PreToolUse` as before
- [ ] Uninstall and verify both `BeforeTool` and `PreToolUse` entries are cleaned up