### PR TITLE
fix: correct 'config get' to 'config-get' in workflow files

### DIFF
--- a/get-shit-done/workflows/audit-milestone.md
+++ b/get-shit-done/workflows/audit-milestone.md
@@ -133,7 +133,7 @@ For each REQ-ID, determine status using all three sources:
 Skip if `workflow.nyquist_validation` is explicitly `false` (absent = enabled).
 
 ```bash
-NYQUIST_CONFIG=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config get workflow.nyquist_validation --raw 2>/dev/null)
+NYQUIST_CONFIG=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-get workflow.nyquist_validation --raw 2>/dev/null)
 ```
 
 If `false`: skip entirely.

--- a/get-shit-done/workflows/validate-phase.md
+++ b/get-shit-done/workflows/validate-phase.md
@@ -19,7 +19,7 @@ Parse: `phase_dir`, `phase_number`, `phase_name`, `phase_slug`, `padded_phase`.
 
 ```bash
 AUDITOR_MODEL=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" resolve-model gsd-nyquist-auditor --raw)
-NYQUIST_CFG=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config get workflow.nyquist_validation --raw)
+NYQUIST_CFG=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-get workflow.nyquist_validation --raw)
 ```
 
 If `NYQUIST_CFG` is `false`: exit with "Nyquist validation is disabled. Enable via /gsd:settings."


### PR DESCRIPTION
## Summary
- Fixes `config get` (space-separated) to `config-get` (hyphenated) in `validate-phase.md` and `audit-milestone.md`
- The gsd-tools.cjs CLI expects hyphenated subcommands; the space form causes "Unknown command: config" errors

Closes #1301

## Test plan
- [x] All 1236 tests pass
- [x] Verified no other `config get` (space) instances remain in codebase
- [x] `grep -rn 'gsd-tools.cjs.*config get'` returns zero matches after fix

Generated with [Claude Code](https://claude.com/claude-code)