### PR TITLE
fix: list OpenCode as runtime with Task tool support in map-codebase

### DIFF
--- a/get-shit-done/workflows/map-codebase.md
+++ b/get-shit-done/workflows/map-codebase.md
@@ -85,10 +85,10 @@ Continue to spawn_agents.
 <step name="detect_runtime_capabilities">
 Before spawning agents, detect whether the current runtime supports the `Task` tool for subagent delegation.
 
-**Runtimes with Task tool:** Claude Code, Cursor (native subagent support)
-**Runtimes WITHOUT Task tool:** Antigravity, Gemini CLI, OpenCode, Codex, and others
+**Runtimes with Task tool:** Claude Code, Cursor, OpenCode (native subagent support via `Task` or `task`)
+**Runtimes WITHOUT Task tool:** Antigravity, Gemini CLI, Codex, and others
 
-**How to detect:** Check if you have access to a `Task` tool. If you do NOT have a `Task` tool (or only have tools like `browser_subagent` which is for web browsing, NOT code analysis):
+**How to detect:** Check if you have access to a `Task` or `task` tool (either casing counts). If you do NOT have a Task/task tool (or only have tools like `browser_subagent` which is for web browsing, NOT code analysis):
 
 → **Skip `spawn_agents` and `collect_confirmations`** — go directly to `sequential_mapping` instead.
 
@@ -218,7 +218,7 @@ If any agent failed, note the failure and continue with successful documents.
 Continue to verify_output.
 </step>
 
-<step name="sequential_mapping" condition="Task tool is NOT available (e.g. Antigravity, Gemini CLI, Codex)">
+<step name="sequential_mapping" condition="Task/task tool is NOT available (e.g. Antigravity, Gemini CLI, Codex)">
 When the `Task` tool is unavailable, perform codebase mapping sequentially in the current context. This replaces `spawn_agents` and `collect_confirmations`.
 
 **IMPORTANT:** Do NOT use `browser_subagent`, `Explore`, or any browser-based tool. Use only file system tools (Read, Bash, Write, Grep, Glob, list_dir, view_file, grep_search, or equivalent tools available in your runtime).

--- a/tests/init.test.cjs
+++ b/tests/init.test.cjs
@@ -950,6 +950,19 @@ describe('cmdInitMapCodebase', () => {
     assert.deepStrictEqual(output.existing_maps, []);
     assert.strictEqual(output.codebase_dir_exists, true);
   });
+
+  test('map-codebase workflow lists OpenCode as having Task tool support (#1316)', () => {
+    const workflow = fs.readFileSync(
+      path.join(__dirname, '..', 'get-shit-done', 'workflows', 'map-codebase.md'), 'utf8'
+    );
+    // OpenCode must appear in the "with Task tool" line, not the "WITHOUT" line
+    const withLine = workflow.split('\n').find(l => l.includes('Runtimes with Task tool'));
+    const withoutLine = workflow.split('\n').find(l => l.includes('WITHOUT Task tool'));
+    assert.ok(withLine, 'workflow should have a "Runtimes with Task tool" line');
+    assert.ok(withoutLine, 'workflow should have a "WITHOUT Task tool" line');
+    assert.ok(withLine.includes('OpenCode'), 'OpenCode must be listed under runtimes WITH Task tool');
+    assert.ok(!withoutLine.includes('OpenCode'), 'OpenCode must NOT be listed under runtimes WITHOUT Task tool');
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## TL;DR

**What:** Move OpenCode from the "WITHOUT Task tool" list to the "with Task tool" list in the map-codebase workflow.
**Why:** OpenCode has a `task` tool that supports subagent spawning, but the workflow incorrectly classified it as lacking one, forcing unnecessary sequential fallback.
**How:** Update the runtime capability lists in `detect_runtime_capabilities` step and add case-insensitive tool name guidance.

## What

- `get-shit-done/workflows/map-codebase.md`: Move OpenCode to the "Runtimes with Task tool" line. Clarify that either `Task` or `task` (either casing) qualifies for parallel agent spawning.
- `tests/init.test.cjs`: Add regression test verifying OpenCode is listed under runtimes WITH Task tool support and NOT under the WITHOUT list.

## Why

When running `/gsd:map-codebase` in OpenCode, the agent reads the static runtime list and concludes it lacks a Task tool. It then falls back to sequential mapping. The agent eventually self-corrects by discovering its own `task` tool, but this wastes tokens and causes confusion (as reported in the issue).

## How

The `detect_runtime_capabilities` step already instructs the agent to "check if you have access to a Task tool." The static list was the only source of the misclassification. The fix updates the list and adds guidance that either `Task` or `task` casing counts.

Fixes #1316