### PR TITLE
fix: expand brownfield detection for Android, Kotlin, Gradle, and more

### DIFF
--- a/get-shit-done/bin/lib/init.cjs
+++ b/get-shit-done/bin/lib/init.cjs
@@ -252,7 +252,23 @@ function cmdInitNewProject(cwd, raw) {
   let hasCode = false;
   let hasPackageFile = false;
   try {
-    const codeExtensions = new Set(['.ts', '.js', '.py', '.go', '.rs', '.swift', '.java']);
+    const codeExtensions = new Set([
+      '.ts', '.js', '.py', '.go', '.rs', '.swift', '.java',
+      '.kt', '.kts',           // Kotlin (Android, server-side)
+      '.c', '.cpp', '.h',      // C/C++
+      '.cs',                   // C#
+      '.rb',                   // Ruby
+      '.php',                  // PHP
+      '.dart',                 // Dart (Flutter)
+      '.m', '.mm',             // Objective-C / Objective-C++
+      '.scala',                // Scala
+      '.groovy',               // Groovy (Gradle build scripts)
+      '.lua',                  // Lua
+      '.r', '.R',              // R
+      '.zig',                  // Zig
+      '.ex', '.exs',           // Elixir
+      '.clj',                  // Clojure
+    ]);
     const skipDirs = new Set(['node_modules', '.git', '.planning', '.claude', '__pycache__', 'target', 'dist', 'build']);
     function findCodeFiles(dir, depth) {
       if (depth > 3) return false;
@@ -273,7 +289,18 @@ function cmdInitNewProject(cwd, raw) {
                    pathExistsInternal(cwd, 'requirements.txt') ||
                    pathExistsInternal(cwd, 'Cargo.toml') ||
                    pathExistsInternal(cwd, 'go.mod') ||
-                   pathExistsInternal(cwd, 'Package.swift');
+                   pathExistsInternal(cwd, 'Package.swift') ||
+                   pathExistsInternal(cwd, 'build.gradle') ||
+                   pathExistsInternal(cwd, 'build.gradle.kts') ||
+                   pathExistsInternal(cwd, 'pom.xml') ||
+                   pathExistsInternal(cwd, 'Gemfile') ||
+                   pathExistsInternal(cwd, 'composer.json') ||
+                   pathExistsInternal(cwd, 'pubspec.yaml') ||
+                   pathExistsInternal(cwd, 'CMakeLists.txt') ||
+                   pathExistsInternal(cwd, 'Makefile') ||
+                   pathExistsInternal(cwd, 'build.zig') ||
+                   pathExistsInternal(cwd, 'mix.exs') ||
+                   pathExistsInternal(cwd, 'project.clj');
 
   const result = {
     // Models

--- a/tests/init.test.cjs
+++ b/tests/init.test.cjs
@@ -1022,6 +1022,88 @@ describe('cmdInitNewProject', () => {
     const output = JSON.parse(result.output);
     assert.strictEqual(output.planning_exists, true);
   });
+
+  test('brownfield with Kotlin files detected (Android project)', () => {
+    const srcDir = path.join(tmpDir, 'app', 'src', 'main');
+    fs.mkdirSync(srcDir, { recursive: true });
+    fs.writeFileSync(path.join(srcDir, 'MainActivity.kt'), 'class MainActivity');
+
+    const result = runGsdTools('init new-project', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.has_existing_code, true);
+    assert.strictEqual(output.is_brownfield, true);
+  });
+
+  test('brownfield with build.gradle detected (Android/Gradle project)', () => {
+    fs.writeFileSync(path.join(tmpDir, 'build.gradle'), 'apply plugin: "com.android.application"');
+
+    const result = runGsdTools('init new-project', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.has_package_file, true);
+    assert.strictEqual(output.is_brownfield, true);
+    assert.strictEqual(output.needs_codebase_map, true);
+  });
+
+  test('brownfield with build.gradle.kts detected (Kotlin DSL)', () => {
+    fs.writeFileSync(path.join(tmpDir, 'build.gradle.kts'), 'plugins { id("com.android.application") }');
+
+    const result = runGsdTools('init new-project', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.has_package_file, true);
+    assert.strictEqual(output.is_brownfield, true);
+  });
+
+  test('brownfield with pom.xml detected (Maven project)', () => {
+    fs.writeFileSync(path.join(tmpDir, 'pom.xml'), '<project></project>');
+
+    const result = runGsdTools('init new-project', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.has_package_file, true);
+    assert.strictEqual(output.is_brownfield, true);
+  });
+
+  test('brownfield with pubspec.yaml detected (Flutter/Dart project)', () => {
+    fs.writeFileSync(path.join(tmpDir, 'pubspec.yaml'), 'name: my_app');
+
+    const result = runGsdTools('init new-project', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.has_package_file, true);
+    assert.strictEqual(output.is_brownfield, true);
+  });
+
+  test('brownfield with Dart files detected', () => {
+    const libDir = path.join(tmpDir, 'lib');
+    fs.mkdirSync(libDir, { recursive: true });
+    fs.writeFileSync(path.join(libDir, 'main.dart'), 'void main() {}');
+
+    const result = runGsdTools('init new-project', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.has_existing_code, true);
+    assert.strictEqual(output.is_brownfield, true);
+  });
+
+  test('brownfield with C++ files detected', () => {
+    fs.writeFileSync(path.join(tmpDir, 'main.cpp'), 'int main() { return 0; }');
+
+    const result = runGsdTools('init new-project', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.has_existing_code, true);
+    assert.strictEqual(output.is_brownfield, true);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## TL;DR

**What**: Expanded brownfield project detection in `cmdInitNewProject` to recognize Android, Kotlin, Gradle, Flutter, C/C++, and 15+ additional ecosystems.
**Why**: Detection only covered 7 file extensions and 5 package files, causing Android and many other project types to be misidentified as greenfield -- skipping codebase mapping.
**How**: Added 18 code extensions and 11 package/build files to the detection lists.

## What

`cmdInitNewProject` uses two detection mechanisms to identify brownfield projects:

1. **Code file scan** (`codeExtensions`): walks the directory tree looking for source files
2. **Package file check** (`hasPackageFile`): checks for build/dependency manifest files at the project root

Both lists were incomplete. The code extension set only included `.ts`, `.js`, `.py`, `.go`, `.rs`, `.swift`, `.java`. The package file check only covered `package.json`, `requirements.txt`, `Cargo.toml`, `go.mod`, `Package.swift`.

This PR adds:

**Code extensions** (18 new): `.kt`, `.kts` (Kotlin), `.c`, `.cpp`, `.h` (C/C++), `.cs` (C#), `.rb` (Ruby), `.php`, `.dart` (Flutter), `.m`, `.mm` (Objective-C), `.scala`, `.groovy`, `.lua`, `.r`, `.R`, `.zig`, `.ex`, `.exs` (Elixir), `.clj` (Clojure)

**Package files** (11 new): `build.gradle`, `build.gradle.kts` (Android/Gradle), `pom.xml` (Maven), `Gemfile` (Ruby), `composer.json` (PHP), `pubspec.yaml` (Flutter), `CMakeLists.txt`, `Makefile`, `build.zig`, `mix.exs` (Elixir), `project.clj` (Clojure)

## Why

Reported in #1325: running `/gsd:new-project` in an Android project failed to detect existing code, treating it as greenfield and skipping the codebase mapping step. The root cause is that Kotlin (`.kt`/`.kts`) and Gradle (`build.gradle`/`build.gradle.kts`) were not in the detection lists.

## How

- Extended the `codeExtensions` Set in `cmdInitNewProject` with 18 additional extensions
- Extended the `hasPackageFile` check with 11 additional build/dependency files
- Added 7 regression tests covering Kotlin, build.gradle, build.gradle.kts, pom.xml, pubspec.yaml, Dart, and C++ detection

Fixes #1325