### PR TITLE
fix: validate hook schemas to prevent silent settings.json rejection

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -2895,6 +2895,50 @@ function cleanupOrphanedHooks(settings) {
     console.log(`  ${green}✓${reset} Removed orphaned hook registrations`);
   }
 
+  // Validate hook schemas to prevent settings.json from failing Zod validation.
+  // Claude Code validates the entire settings file with a strict Zod schema.
+  // If ANY hook has an invalid schema (e.g., type: "agent" missing "prompt"),
+  // the ENTIRE settings.json is silently discarded — disabling all plugins,
+  // env vars, and other configuration. This defensive check removes invalid
+  // hook entries and cleans up empty event arrays to prevent this.
+  if (settings.hooks) {
+    let fixedHooks = false;
+    for (const eventType of Object.keys(settings.hooks)) {
+      const hookEntries = settings.hooks[eventType];
+      if (Array.isArray(hookEntries)) {
+        const validated = hookEntries.filter(entry => {
+          if (!entry.hooks || !Array.isArray(entry.hooks)) return true;
+          const validHooks = entry.hooks.filter(h => {
+            // Agent hooks require a "prompt" field per Claude Code's schema
+            if (h.type === 'agent' && !h.prompt) {
+              fixedHooks = true;
+              return false;
+            }
+            // Command hooks require a "command" field
+            if (h.type === 'command' && !h.command) {
+              fixedHooks = true;
+              return false;
+            }
+            return true;
+          });
+          if (validHooks.length === 0) return false;
+          entry.hooks = validHooks;
+          return true;
+        });
+        settings.hooks[eventType] = validated;
+      }
+
+      // Remove empty hook event arrays
+      if (Array.isArray(settings.hooks[eventType]) && settings.hooks[eventType].length === 0) {
+        delete settings.hooks[eventType];
+        fixedHooks = true;
+      }
+    }
+    if (fixedHooks) {
+      console.log(`  ${green}✓${reset} Fixed invalid hook entries (prevents settings.json schema rejection)`);
+    }
+  }
+
   // Fix #330: Update statusLine if it points to old GSD statusline.js path
   // Only match the specific old GSD path pattern (hooks/statusline.js),
   // not third-party statusline scripts that happen to contain 'statusline.js'


### PR DESCRIPTION
## Problem

Claude Code validates `settings.json` with a strict Zod schema — if **any** field fails validation, the **entire** file is silently discarded (`settings: null`). This means a single malformed hook entry can disable all plugins, env vars, marketplace configs, and every other setting, with zero user-facing error.

GSD's existing `cleanupOrphanedHooks()` only matches hooks by `command` name pattern (`gsd-` prefix). It does not catch hooks that are structurally invalid per Claude Code's schema — for example, a `type: "agent"` hook missing the required `prompt` field.

### Real-world impact

A user had 10 installed plugins silently fail to load. Reinstalling Claude Code did not help. Root cause: a leftover Stop hook with `type: "agent"` but no `prompt` field (orphaned after GSD removed the intel-prune Stop hook in v1.9.2) caused Zod to reject the entire `settings.json`.

## Fix

After the existing orphan cleanup pass, add a schema validation step that:

1. Removes `type: "agent"` hooks missing the required `prompt` field
2. Removes `type: "command"` hooks missing the required `command` field
3. Cleans up empty hook event arrays (e.g., `Stop: []`) left after filtering
4. Logs when invalid hooks are fixed

This is purely defensive — it only removes entries that would cause Claude Code to silently discard the entire settings file.

## Test plan

- [ ] Install GSD on a settings.json containing a `type: "agent"` hook without `prompt` → verify the invalid hook is removed and plugins load normally
- [ ] Install GSD on a clean settings.json → verify no changes are made
- [ ] Install GSD on a settings.json with valid hooks → verify hooks are preserved