### PR TITLE
Modify codex command in review.md

### DIFF
--- a/get-shit-done/workflows/review.md
+++ b/get-shit-done/workflows/review.md
@@ -128,7 +128,7 @@ claude -p "$(cat /tmp/gsd-review-prompt-{phase}.md)" --no-input 2>/dev/null > /t
 
 **Codex:**
 ```bash
-codex -p "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-review-codex-{phase}.md
+codex exec --skip-git-repo-check "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-review-codex-{phase}.md
 ```
 
 If a CLI fails, log the error and continue with remaining CLIs.


### PR DESCRIPTION
Updated the codex command to include 'exec' and skip git repo check.

## What

Fix Codex CLI invocation syntax in the review workflow — change `codex -p` to `codex exec --skip-git-repo-check`.

## Why

The current `codex -p "..."` syntax is incorrect: `-p` is parsed as `--config-profile` (config profile selector) in Codex CLI, not as a prompt input. This causes every Codex review invocation to fail silently with `config profile not found`. Additionally, Codex requires `--skip-git-repo-check` when run outside a trusted git directory, otherwise it exits immediately with `Not inside a trusted directory`.

Closes #<!-- issue number -->

## How

- Changed `codex -p "$(cat ...)"` to `codex exec --skip-git-repo-check "$(cat ...)"` in the review workflow
- `codex exec` is the correct non-interactive execution subcommand (equivalent to `claude -p` / `gemini -p`)
- `--skip-git-repo-check` prevents the trust directory check that blocks execution in review contexts where the CWD may not be a trusted repo

## Testing

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Codex
- [ ] Copilot
- [ ] N/A (not runtime-specific)

### Test details

Verified all three CLI invocations end-to-end with a real code review prompt (267 lines, reviewing a Python script):

| CLI | Command | Result | Time |
|-----|---------|--------|------|
| Claude | `claude -p "..." --no-input` | ✅ 71-line review | 28s |
| Gemini | `gemini -p "..."` | ✅ 41-line review | 38s |
| Codex (before fix) | `codex -p "..."` | ❌ `config profile not found` | 0.08s |
| Codex (after fix) | `codex exec --skip-git-repo-check "..."` | ✅ 42-line review | 88s |

## Checklist

- [x] Follows GSD style (no enterprise patterns, no filler)
- [ ] Updates CHANGELOG.md for user-facing changes
- [x] No unnecessary dependencies added
- [ ] Works on Windows (backslash paths tested)
- [x] Templates/references updated if behavior changed
- [x] Existing tests pass (`npm test`)

## Breaking Changes

None

## Screenshots / recordings

N/A
