### PR TITLE
fix: harden verify-work checkpoint rendering (supersedes #1337)

### DIFF
--- a/get-shit-done/bin/lib/security.cjs
+++ b/get-shit-done/bin/lib/security.cjs
@@ -237,7 +237,6 @@ function sanitizeForDisplay(text) {
 
   const protocolLeakPatterns = [
     /^\s*(?:assistant|user|system)\s+to=[^:\s]+:[^\n]+$/i,
-    /^\s*(?:assistant|user|system)\s+to=all:[^\n]+$/i,
     /^\s*<\|(?:assistant|user|system)[^|]*\|>\s*$/i,
   ];
 

--- a/get-shit-done/bin/lib/uat.cjs
+++ b/get-shit-done/bin/lib/uat.cjs
@@ -135,7 +135,8 @@ function parseCurrentTest(content) {
 
   const numberMatch = section.match(/^number:\s*(\d+)\s*$/m);
   const nameMatch = section.match(/^name:\s*(.+)\s*$/m);
-  const expectedBlockMatch = section.match(/^expected:\s*\|\n([\s\S]*?)(?=^\w[\w-]*:\s|\Z)/m);
+  const expectedBlockMatch = section.match(/^expected:\s*\|\n([\s\S]*?)(?=^\w[\w-]*:\s)/m)
+    || section.match(/^expected:\s*\|\n([\s\S]+)/m);
   const expectedInlineMatch = section.match(/^expected:\s*(.+)\s*$/m);
 
   if (!numberMatch || !nameMatch || (!expectedBlockMatch && !expectedInlineMatch)) {

--- a/tests/uat.test.cjs
+++ b/tests/uat.test.cjs
@@ -390,6 +390,51 @@ awaiting: user response
     assert.ok(result.output.includes('Chinese strings render correctly.'));
   });
 
+  test('does not truncate expected text containing the letter Z', () => {
+    fs.writeFileSync(uatPath, `---
+status: testing
+phase: 01-test-phase
+---
+
+## Current Test
+
+number: 3
+name: Timezone display
+expected: |
+  Timezone abbreviation shows CET.
+  Zero-offset zones display correctly.
+awaiting: user response
+`);
+
+    const result = runGsdTools(['uat', 'render-checkpoint', '--file', '.planning/phases/01-test-phase/01-UAT.md', '--raw'], tmpDir);
+    assert.strictEqual(result.success, true, `render-checkpoint failed: ${result.error}`);
+    assert.ok(result.output.includes('Timezone abbreviation shows CET.'),
+      'Expected text before Z-containing word should be present');
+    assert.ok(result.output.includes('Zero-offset zones display correctly.'),
+      'Expected text starting with Z should not be truncated by \\Z regex bug');
+  });
+
+  test('parses expected block when it is the last field in the section', () => {
+    fs.writeFileSync(uatPath, `---
+status: testing
+phase: 01-test-phase
+---
+
+## Current Test
+
+number: 4
+name: Final field test
+expected: |
+  This block has no trailing YAML key.
+  It ends at the section boundary.
+`);
+
+    const result = runGsdTools(['uat', 'render-checkpoint', '--file', '.planning/phases/01-test-phase/01-UAT.md', '--raw'], tmpDir);
+    assert.strictEqual(result.success, true, `render-checkpoint failed: ${result.error}`);
+    assert.ok(result.output.includes('This block has no trailing YAML key.'));
+    assert.ok(result.output.includes('It ends at the section boundary.'));
+  });
+
   test('fails when testing is already complete', () => {
     fs.writeFileSync(uatPath, `---
 status: complete


### PR DESCRIPTION
## Summary

- Harden verify-work checkpoint rendering with deterministic output and protocol leak sanitization
- Fix `\Z` regex bug that silently truncated expected text containing the letter Z
- Remove redundant regex pattern in `sanitizeForDisplay()`

Based on #1337 by @3metaJun. All original changes are preserved; this PR adds two targeted fixes for issues identified in code review.

## What changed

**From #1337 (cherry-picked):**
- `get-shit-done/bin/lib/uat.cjs` — add `cmdRenderCheckpoint()` / `parseCurrentTest()` / `buildCheckpoint()`
- `get-shit-done/bin/lib/security.cjs` — add `sanitizeForDisplay()` for protocol-style leak stripping
- `get-shit-done/bin/gsd-tools.cjs` — route `uat render-checkpoint`
- `get-shit-done/workflows/verify-work.md` — call `gsd-tools uat render-checkpoint --raw` instead of freehand composition
- `tests/` — dispatcher, security, and UAT render-checkpoint coverage

**Fixes applied on top:**
1. **`\Z` regex bug** (`uat.cjs` line 138): `\Z` is a Perl/Python/Ruby regex anchor, not valid in JavaScript. JS interprets `\Z` as a literal match for the character 'Z', which silently truncates expected text (e.g., "Zero-offset zones display correctly." gets cut). Replaced with a two-pass approach: try next-YAML-key lookahead first, fall back to greedy match to end-of-string.
2. **Redundant regex pattern** (`security.cjs`): The `to=all:` pattern was a subset of the existing `to=[^:\s]+:` pattern. Removed the dead pattern.

## Test plan

- [x] Added regression test proving the `\Z` bug (text containing Z was truncated — test fails before fix, passes after)
- [x] Added test for expected block as last field in section (no trailing YAML key)
- [x] All 14 UAT tests pass
- [x] All 64 security tests pass
- [x] Full suite: 1344 pass, 3 fail (all 3 pre-existing in `config.test.cjs` on main)


🤖 Generated with [Claude Code](https://claude.com/claude-code)