### PR TITLE
Add more safeguards when commit docs is false, support 2 level identation in frontmatter, .md files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Frontmatter `must_haves` parsing now handles template-style 2-space indentation for `key_links`, covering issue #1356-style plans in verification.
+
 ## [1.28.0] - 2026-03-22
 
 ### Added

--- a/agents/gsd-executor.md
+++ b/agents/gsd-executor.md
@@ -314,11 +314,17 @@ After each task completes (verification passed, done criteria met), commit immed
 
 **1. Check modified files:** `git status --short`
 
-**2. Stage task-related files individually** (NEVER `git add .` or `git add -A`):
+**2. Stage task-related application/runtime files individually** (NEVER `git add .`, `git add -A`, or raw-stage `.planning/` paths):
 ```bash
 git add src/api/auth.ts
 git add src/types/user.ts
 ```
+
+If a task also changes `.planning/` artifacts, do NOT stage them with raw git commands. Route planning docs through the CLI guard instead:
+```bash
+node ~/.claude/get-shit-done/bin/gsd-tools.cjs commit "docs({phase}): {description}" --files .planning/STATE.md .planning/ROADMAP.md
+```
+The CLI is the source of truth for whether planning docs are committed or skipped.
 
 **3. Commit type:**
 
@@ -351,7 +357,10 @@ git commit -m "{type}({phase}-{plan}): {concise task description}
 - **Single-repo:** `TASK_COMMIT=$(git rev-parse --short HEAD)` — track for SUMMARY.
 - **Multi-repo (sub_repos):** Extract hashes from `commit-to-subrepo` JSON output (`repos.{name}.hash`). Record all hashes for SUMMARY (e.g., `backend@abc1234, frontend@def5678`).
 
-**6. Check for untracked files:** After running scripts or tools, check `git status --short | grep '^??'`. For any new untracked files: commit if intentional, add to `.gitignore` if generated/runtime output. Never leave generated files untracked.
+**6. Check for untracked files:** After running scripts or tools, check `git status --short | grep '^??'`.
+- Application/source files created intentionally for the task: stage them individually and commit normally.
+- Generated/runtime output: add to `.gitignore` or remove it. Never leave generated files untracked.
+- `.planning/` artifacts: NEVER `git add`, `git add -A`, or `git add -f` them. If they should be committed, use `node ~/.claude/get-shit-done/bin/gsd-tools.cjs commit ... --files ...`; otherwise leave them for the planning workflow to skip. Do not force-add `.planning/` files.
 </task_commit_protocol>
 
 <summary_creation>

--- a/get-shit-done/bin/lib/frontmatter.cjs
+++ b/get-shit-done/bin/lib/frontmatter.cjs
@@ -160,97 +160,123 @@ function spliceFrontmatter(content, newObj) {
   return `---\n${yamlStr}\n---\n\n` + content;
 }
 
+function stripYamlQuotes(value) {
+  if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+function parseMustHavesScalar(value) {
+  const normalized = stripYamlQuotes(value.trim());
+  return /^\d+$/.test(normalized) ? parseInt(normalized, 10) : normalized;
+}
+
 function parseMustHavesBlock(content, blockName) {
-  // Extract a specific block from must_haves in raw frontmatter YAML
-  // Handles 3-level nesting: must_haves > artifacts/key_links > [{path, provides, ...}]
   const fmMatch = content.match(/^---\r?\n([\s\S]+?)\r?\n---/);
   if (!fmMatch) return [];
+  const lines = fmMatch[1].split(/\r?\n/);
+  const mustHavesIndex = lines.findIndex(line => /^\s*must_haves:\s*$/.test(line));
+  if (mustHavesIndex === -1) return [];
 
-  const yaml = fmMatch[1];
+  const mustHavesIndent = lines[mustHavesIndex].match(/^(\s*)/)[1].length;
+  let blockIndent = -1;
+  let blockStartIndex = -1;
 
-  // Find must_haves: first to detect its indentation level
-  const mustHavesMatch = yaml.match(/^(\s*)must_haves:\s*$/m);
-  if (!mustHavesMatch) return [];
-  const mustHavesIndent = mustHavesMatch[1].length;
+  for (let index = mustHavesIndex + 1; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (line.trim() === '') continue;
 
-  // Find the block (e.g., "truths:", "artifacts:", "key_links:") under must_haves
-  // It must be indented more than must_haves but we detect the actual indent dynamically
-  const blockPattern = new RegExp(`^(\\s+)${blockName}:\\s*$`, 'm');
-  const blockMatch = yaml.match(blockPattern);
-  if (!blockMatch) return [];
+    const indent = line.match(/^(\s*)/)[1].length;
+    if (indent <= mustHavesIndent) break;
 
-  const blockIndent = blockMatch[1].length;
-  // The block must be nested under must_haves (more indented)
-  if (blockIndent <= mustHavesIndent) return [];
+    const keyMatch = line.match(/^\s*([a-zA-Z0-9_-]+):\s*$/);
+    if (keyMatch && keyMatch[1] === blockName) {
+      blockIndent = indent;
+      blockStartIndex = index + 1;
+      break;
+    }
+  }
 
-  // Find where the block starts in the yaml string
-  const blockStart = yaml.indexOf(blockMatch[0]);
-  if (blockStart === -1) return [];
-
-  const afterBlock = yaml.slice(blockStart);
-  const blockLines = afterBlock.split(/\r?\n/).slice(1); // skip the header line
+  if (blockStartIndex === -1) return [];
 
   // List items are indented one level deeper than blockIndent
   // Continuation KVs are indented one level deeper than list items
   const items = [];
   let current = null;
-  let listItemIndent = -1; // detected from first "- " line
+  let itemIndent = -1;
+  let currentArrayKey = null;
+  let currentArrayIndent = -1;
 
-  for (const line of blockLines) {
-    // Skip empty lines
+  const pushCurrent = () => {
+    if (current !== null) items.push(current);
+  };
+
+  for (let index = blockStartIndex; index < lines.length; index += 1) {
+    const line = lines[index];
     if (line.trim() === '') continue;
     const indent = line.match(/^(\s*)/)[1].length;
-    // Stop at same or lower indent level than the block header
-    if (indent <= blockIndent && line.trim() !== '') break;
+    if (indent <= blockIndent) break;
 
     const trimmed = line.trim();
-
     if (trimmed.startsWith('- ')) {
-      // Detect list item indent from the first occurrence
-      if (listItemIndent === -1) listItemIndent = indent;
+      if (itemIndent === -1 || indent === itemIndent) {
+        pushCurrent();
+        itemIndent = indent;
+        currentArrayKey = null;
+        currentArrayIndent = -1;
 
-      // Only treat as a top-level list item if at the expected indent
-      if (indent === listItemIndent) {
-        if (current) items.push(current);
-        current = {};
-        const afterDash = trimmed.slice(2);
-        // Check if it's a simple string item (no colon means not a key-value)
-        if (!afterDash.includes(':')) {
-          current = afterDash.replace(/^["']|["']$/g, '');
-        } else {
-          // Key-value on same line as dash: "- path: value"
-          const kvMatch = afterDash.match(/^(\w+):\s*"?([^"]*)"?\s*$/);
+        const itemValue = trimmed.slice(2).trim();
+        if (itemValue === '') {
+          current = {};
+          continue;
+        }
+
+        if (!/^["']/.test(itemValue)) {
+          const kvMatch = itemValue.match(/^([a-zA-Z0-9_-]+):\s*(.*)$/);
           if (kvMatch) {
             current = {};
-            current[kvMatch[1]] = kvMatch[2];
+            if (kvMatch[2].trim() === '') {
+              current[kvMatch[1]] = [];
+              currentArrayKey = kvMatch[1];
+              currentArrayIndent = indent;
+            } else {
+              current[kvMatch[1]] = parseMustHavesScalar(kvMatch[2]);
+            }
+            continue;
           }
         }
+
+        current = parseMustHavesScalar(itemValue);
         continue;
       }
+
+      if (current && typeof current === 'object' && currentArrayKey && indent > currentArrayIndent) {
+        if (!Array.isArray(current[currentArrayKey])) {
+          current[currentArrayKey] = current[currentArrayKey] ? [current[currentArrayKey]] : [];
+        }
+        current[currentArrayKey].push(parseMustHavesScalar(trimmed.slice(2)));
+      }
+      continue;
     }
 
-    if (current && typeof current === 'object' && indent > listItemIndent) {
-      // Continuation key-value or nested array item
-      if (trimmed.startsWith('- ')) {
-        // Array item under a key
-        const arrVal = trimmed.slice(2).replace(/^["']|["']$/g, '');
-        const keys = Object.keys(current);
-        const lastKey = keys[keys.length - 1];
-        if (lastKey && !Array.isArray(current[lastKey])) {
-          current[lastKey] = current[lastKey] ? [current[lastKey]] : [];
-        }
-        if (lastKey) current[lastKey].push(arrVal);
-      } else {
-        const kvMatch = trimmed.match(/^(\w+):\s*"?([^"]*)"?\s*$/);
-        if (kvMatch) {
-          const val = kvMatch[2];
-          // Try to parse as number
-          current[kvMatch[1]] = /^\d+$/.test(val) ? parseInt(val, 10) : val;
+    if (current && typeof current === 'object') {
+      const kvMatch = trimmed.match(/^([a-zA-Z0-9_-]+):\s*(.*)$/);
+      if (kvMatch) {
+        if (kvMatch[2].trim() === '') {
+          current[kvMatch[1]] = [];
+          currentArrayKey = kvMatch[1];
+          currentArrayIndent = indent;
+        } else {
+          current[kvMatch[1]] = parseMustHavesScalar(kvMatch[2]);
+          currentArrayKey = null;
+          currentArrayIndent = -1;
         }
       }
     }
   }
-  if (current) items.push(current);
+
+  pushCurrent();
 
   return items;
 }

--- a/get-shit-done/references/git-planning-commit.md
+++ b/get-shit-done/references/git-planning-commit.md
@@ -2,6 +2,8 @@
 
 Commit planning artifacts using the gsd-tools CLI, which automatically checks `commit_docs` config and gitignore status.
 
+Never stage `.planning/` files with raw git commands such as `git add .planning/...`, `git add .`, `git add -A`, or `git add -f`. Planning artifacts must go through `gsd-tools.cjs commit` so the CLI can commit or skip them safely.
+
 ## Commit via CLI
 
 Always use `gsd-tools.cjs commit` for `.planning/` files — it handles `commit_docs` and gitignore checks automatically:
@@ -11,6 +13,8 @@ node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" commit "docs({scope}): {des
 ```
 
 The CLI will return `skipped` (with reason) if `commit_docs` is `false` or `.planning/` is gitignored. No manual conditional checks needed.
+
+If you are making a code commit in the same task, stage only the non-`.planning/` files with raw git and run a separate `gsd-tools.cjs commit` for planning artifacts when appropriate.
 
 ## Amend previous commit
 

--- a/get-shit-done/references/planning-config.md
+++ b/get-shit-done/references/planning-config.md
@@ -29,12 +29,13 @@ Configuration options for `.planning/` directory behavior.
 <commit_docs_behavior>
 
 **When `commit_docs: true` (default):**
-- Planning files committed normally
+- Planning files are committed via `gsd-tools.cjs commit`, never raw `git add` for `.planning/`
 - SUMMARY.md, STATE.md, ROADMAP.md tracked in git
 - Full history of planning decisions preserved
 
 **When `commit_docs: false`:**
-- Skip all `git add`/`git commit` for `.planning/` files
+- `gsd-tools.cjs commit` skips `.planning/` commits
+- Do not stage or force-add `.planning/` files with raw git commands
 - User must add `.planning/` to `.gitignore`
 - Useful for: OSS contributions, client projects, keeping planning private
 
@@ -64,6 +65,8 @@ node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" commit "docs: update state"
 ```
 
 The CLI checks `commit_docs` config and gitignore status internally — no manual conditionals needed.
+
+Raw staging is intentionally unsupported for planning docs: never use `git add .planning/...`, `git add .`, `git add -A`, or `git add -f` to sweep `.planning/` into a normal code commit.
 
 </commit_docs_behavior>
 

--- a/get-shit-done/workflows/fast.md
+++ b/get-shit-done/workflows/fast.md
@@ -55,9 +55,14 @@ Do the work directly:
 Commit the change atomically:
 
 ```bash
-git add -A
+git status --short
+git add path/to/file
 git commit -m "fix: {concise description of what changed}"
 ```
+
+Stage only the intended non-`.planning/` files for the quick task. Never use `git add -A`, `git add .`, or raw `git add .planning/...` here.
+
+If the task touched `.planning/` artifacts, do not stage them with raw git. Use `node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" commit ... --files ...` so planning commits are routed through the CLI guard or skipped.
 
 Use conventional commit format: `fix:`, `feat:`, `docs:`, `chore:`, `refactor:` as appropriate.
 </step>

--- a/tests/frontmatter.test.cjs
+++ b/tests/frontmatter.test.cjs
@@ -312,6 +312,29 @@ must_haves:
     assert.strictEqual(result[0].pattern, 'import.*auth');
   });
 
+  test('extracts key_links from template-style 2-space indentation', () => {
+    const content = `---
+phase: 01
+must_haves:
+  truths:
+    - "Plan still includes observable truths"
+  key_links:
+    - from: "tests/auth.test.ts"
+      to: "src/auth.ts"
+      via: "import statement"
+      pattern: "import.*auth"
+status: draft
+---
+`;
+    const result = parseMustHavesBlock(content, 'key_links');
+    assert.deepStrictEqual(result, [{
+      from: 'tests/auth.test.ts',
+      to: 'src/auth.ts',
+      via: 'import statement',
+      pattern: 'import.*auth',
+    }]);
+  });
+
   test('returns empty array when block not found', () => {
     const content = `---
 phase: 01
@@ -395,6 +418,19 @@ must_haves:
     assert.strictEqual(result[1], 'Coverage exceeds 80%');
   });
 
+  test('preserves mismatched quotes in scalar list items', () => {
+    const content = `---
+phase: 01
+must_haves:
+  truths:
+    - "leading-only
+    - trailing-only"
+---
+`;
+    const result = parseMustHavesBlock(content, 'truths');
+    assert.deepStrictEqual(result, ['"leading-only', 'trailing-only"']);
+  });
+
   test('parses artifacts with 2-space indentation — issue #1356', () => {
     const content = `---
 phase: 01
@@ -431,6 +467,26 @@ must_haves:
     assert.strictEqual(result[0].path, 'src/api.ts');
     // The nested array should be captured
     assert.ok(result[0].exports !== undefined, 'should have exports field');
+  });
+
+  test('handles nested arrays within artifact objects using 2-space indentation', () => {
+    const content = `---
+phase: 01
+must_haves:
+  artifacts:
+    - path: "src/api.ts"
+      provides: "REST endpoints"
+      exports:
+        - "GET"
+        - "POST"
+---
+`;
+    const result = parseMustHavesBlock(content, 'artifacts');
+    assert.deepStrictEqual(result, [{
+      path: 'src/api.ts',
+      provides: 'REST endpoints',
+      exports: ['GET', 'POST'],
+    }]);
   });
 });
 

--- a/tests/verify.test.cjs
+++ b/tests/verify.test.cjs
@@ -858,8 +858,9 @@ describe('verify key-links command', () => {
     cleanup(tmpDir);
   });
 
-  function writePlanWithKeyLinks(tmpDir, keyLinksYaml) {
-    // parseMustHavesBlock expects 4-space indent for block name, 6-space for items, 8-space for keys
+  function writePlanWithKeyLinks(tmpDir, keyLinksYaml, { indentation = 4 } = {}) {
+    const blockIndent = ' '.repeat(indentation);
+    const itemIndent = ' '.repeat(indentation + 2);
     const content = [
       '---',
       'phase: 01-test',
@@ -870,8 +871,8 @@ describe('verify key-links command', () => {
       'files_modified: [src/a.js]',
       'autonomous: true',
       'must_haves:',
-      '    key_links:',
-      ...keyLinksYaml.map(line => `      ${line}`),
+      `${blockIndent}key_links:`,
+      ...keyLinksYaml.map(line => `${itemIndent}${line}`),
       '---',
       '',
       '<tasks>',
@@ -888,12 +889,28 @@ describe('verify key-links command', () => {
     fs.writeFileSync(planPath, content);
   }
 
-  test('verifies link when pattern found in source', () => {
+  test('verifies key_links with 4-space indentation when pattern found in source', () => {
     writePlanWithKeyLinks(tmpDir, [
       '- from: "src/a.js"',
       '  to: "src/b.js"',
       '  pattern: "import.*b"',
     ]);
+    fs.writeFileSync(path.join(tmpDir, 'src', 'a.js'), "import { x } from './b';\n");
+    fs.writeFileSync(path.join(tmpDir, 'src', 'b.js'), 'exports.x = 1;\n');
+
+    const result = runGsdTools('verify key-links .planning/phases/01-test/01-01-PLAN.md', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.all_verified, true, `Expected all_verified true: ${JSON.stringify(output)}`);
+  });
+
+  test('verifies key_links with template-style 2-space indentation when pattern found in source', () => {
+    writePlanWithKeyLinks(tmpDir, [
+      '- from: "src/a.js"',
+      '  to: "src/b.js"',
+      '  pattern: "import.*b"',
+    ], { indentation: 2 });
     fs.writeFileSync(path.join(tmpDir, 'src', 'a.js'), "import { x } from './b';\n");
     fs.writeFileSync(path.join(tmpDir, 'src', 'b.js'), 'exports.x = 1;\n');
 


### PR DESCRIPTION
## What

Fixes planning doc commit guardrails and makes `verify key-links` correctly read `must_haves.key_links` from valid plan frontmatter.

## Why

Agents were still being guided toward staging `.planning/` files outside the CLI guard, and key-links verification was failing on real plan files because the parser assumed one rigid YAML indentation shape.

Closes #1356 

## How

Updated the executor/workflow/reference guidance so `.planning/` artifacts are never staged with raw git and must go through `gsd-tools.cjs commit`, which preserves the existing `commit_docs` and gitignore checks. Hardened `parseMustHavesBlock` to parse `must_haves` blocks relative to actual indentation instead of fixed spacing, and added regressions covering template-style 2-space YAML plus end-to-end `verify key-links` behavior.

## Testing

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Codex
- [ ] Copilot
- [x] N/A (not runtime-specific)

### Test details

Automated tests

## Checklist

- [x] Follows GSD style (no enterprise patterns, no filler)
- [x] Updates CHANGELOG.md for user-facing changes
- [x] No unnecessary dependencies added
- [ ] Works on Windows (backslash paths tested)
- [x] Templates/references updated if behavior changed
- [x] Existing tests pass (`npm test`)

## Breaking Changes

None