### PR TITLE
fix: workspace project_root resolves to child repo, not parent

### DIFF
--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -58,6 +58,13 @@ function findProjectRoot(startDir) {
   const root = path.parse(resolved).root;
   const homedir = require('os').homedir();
 
+  // If startDir already contains .planning/, it IS the project root.
+  // Do not walk up to a parent workspace that also has .planning/ (#1362).
+  const ownPlanning = path.join(resolved, '.planning');
+  if (fs.existsSync(ownPlanning) && fs.statSync(ownPlanning).isDirectory()) {
+    return startDir;
+  }
+
   // Check if startDir or any of its ancestors (up to AND including the
   // candidate project root) contains a .git directory. This handles both
   // `backend/` (direct sub-repo) and `backend/src/modules/` (nested inside),

--- a/tests/core.test.cjs
+++ b/tests/core.test.cjs
@@ -1509,6 +1509,33 @@ describe('findProjectRoot', () => {
 
     assert.strictEqual(findProjectRoot(projectRoot), projectRoot);
   });
+
+  test('does not walk past child with own .planning/ to workspace parent (#1362)', () => {
+    // Workspace layout: parent has .planning/, child git repo also has .planning/
+    // findProjectRoot should return the child (startDir), not the parent
+    fs.mkdirSync(path.join(projectRoot, '.planning'), { recursive: true });
+
+    const childRepo = path.join(projectRoot, 'authenticator');
+    fs.mkdirSync(path.join(childRepo, '.planning'), { recursive: true });
+    fs.mkdirSync(path.join(childRepo, '.git'), { recursive: true });
+
+    assert.strictEqual(findProjectRoot(childRepo), childRepo);
+  });
+
+  test('does not walk past nested dir whose git root has .planning/ (#1362)', () => {
+    // Workspace layout: parent has .planning/, child git repo also has .planning/
+    // cwd is deep inside child — should resolve to child root, not workspace root
+    fs.mkdirSync(path.join(projectRoot, '.planning'), { recursive: true });
+
+    const childRepo = path.join(projectRoot, 'authenticator');
+    fs.mkdirSync(path.join(childRepo, '.planning'), { recursive: true });
+    fs.mkdirSync(path.join(childRepo, '.git'), { recursive: true });
+
+    const deepDir = path.join(childRepo, 'src', 'lib');
+    fs.mkdirSync(deepDir, { recursive: true });
+
+    assert.strictEqual(findProjectRoot(deepDir), childRepo);
+  });
 });
 
 // ─── reapStaleTempFiles ─────────────────────────────────────────────────────


### PR DESCRIPTION
## TL;DR

`findProjectRoot()` now returns `startDir` immediately when it already contains `.planning/`, preventing workspace parent directories from hijacking project root resolution.

## What changed

Added an early-return check at the top of `findProjectRoot()` in `core.cjs`: if `startDir` itself contains a `.planning/` directory, return it without walking up the directory tree.

## Why

In a GSD workspace layout where both the workspace root and a child git repo have `.planning/`:

```
~/gsd-workspaces/fix-reinvite-users/          <-- workspace root, has .planning/
  authenticator/                               <-- git repo, also has .planning/
```

`findProjectRoot(authenticator/)` walked up, found `.planning/` at the parent, confirmed the child was inside a git repo, and returned the parent. This caused all init commands (`phase complete`, `plan-phase`, etc.) to set `project_root` to the workspace root, making phase/roadmap lookups fail with "Phase not found" because the actual artifacts live in the child's `.planning/`.

## Tests

Two new tests in `core.test.cjs`:
- Direct workspace child with own `.planning/` resolves to itself (not parent)
- Deep path inside workspace child resolves to the child git root (not workspace root)

All 17 `findProjectRoot` tests pass. Full suite: 1410/1413 pass, 3 pre-existing config environment-sensitivity failures unrelated to this change.

Fixes #1362