### PR TITLE
feat: integrate ui-phase and ui-review into autonomous workflow

### DIFF
--- a/get-shit-done/workflows/autonomous.md
+++ b/get-shit-done/workflows/autonomous.md
@@ -219,6 +219,51 @@ PHASE_STATE=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" init phase-op
 
 Check `has_context`. If false → go to handle_blocker: "Smart discuss for phase ${PHASE_NUM} did not produce CONTEXT.md."
 
+**3a.5. UI Design Contract (Frontend Phases)**
+
+Check if this phase has frontend indicators and whether a UI-SPEC already exists:
+
+```bash
+PHASE_SECTION=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" roadmap get-phase ${PHASE_NUM} 2>/dev/null)
+echo "$PHASE_SECTION" | grep -iE "UI|interface|frontend|component|layout|page|screen|view|form|dashboard|widget" > /dev/null 2>&1
+HAS_UI=$?
+UI_SPEC_FILE=$(ls "${PHASE_DIR}"/*-UI-SPEC.md 2>/dev/null | head -1)
+```
+
+Check if UI phase workflow is enabled:
+
+```bash
+UI_PHASE_CFG=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-get workflow.ui_phase 2>/dev/null || echo "true")
+```
+
+**If `HAS_UI` is 0 (frontend indicators found) AND `UI_SPEC_FILE` is empty (no UI-SPEC exists) AND `UI_PHASE_CFG` is not `false`:**
+
+Display:
+
+```
+Phase ${PHASE_NUM}: Frontend phase detected — generating UI design contract...
+```
+
+```
+Skill(skill="gsd:ui-phase", args="${PHASE_NUM}")
+```
+
+Verify UI-SPEC was created:
+
+```bash
+UI_SPEC_FILE=$(ls "${PHASE_DIR}"/*-UI-SPEC.md 2>/dev/null | head -1)
+```
+
+If still empty, display warning and continue: `Phase ${PHASE_NUM}: UI-SPEC generation did not produce output — continuing without design contract.`
+
+**If `UI_SPEC_FILE` is not empty (already exists):** Display:
+
+```
+Phase ${PHASE_NUM}: UI-SPEC exists — skipping ui-phase.
+```
+
+**If `HAS_UI` is 1 (no frontend indicators) OR `UI_PHASE_CFG` is `false`:** Skip silently.
+
 **3b. Plan**
 
 ```
@@ -260,7 +305,7 @@ Display:
 Phase ${PHASE_NUM} ✅ ${PHASE_NAME} — Verification passed
 ```
 
-Proceed to iterate step.
+Run UI review if this was a frontend phase (step 3d.5), then proceed to iterate step.
 
 **If `human_needed`:**
 
@@ -324,6 +369,38 @@ This limits gap closure to 1 automatic retry to prevent infinite loops.
 On **"Continue without fixing"**: Display `Phase ${PHASE_NUM} ⏭ Gaps deferred` and proceed to iterate step.
 
 On **"Stop autonomous mode"**: Go to handle_blocker with "User stopped — gaps remain in phase ${PHASE_NUM}".
+
+**3d.5. UI Review (Frontend Phases)**
+
+> Run after any successful execution routing (passed, human_needed accepted, or gaps deferred/accepted) — before proceeding to the iterate step.
+
+Check if this phase had a UI-SPEC (created in step 3a.5 or pre-existing):
+
+```bash
+UI_SPEC_FILE=$(ls "${PHASE_DIR}"/*-UI-SPEC.md 2>/dev/null | head -1)
+```
+
+Check if UI review is enabled:
+
+```bash
+UI_REVIEW_CFG=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-get workflow.ui_review 2>/dev/null || echo "true")
+```
+
+**If `UI_SPEC_FILE` is not empty AND `UI_REVIEW_CFG` is not `false`:**
+
+Display:
+
+```
+Phase ${PHASE_NUM}: Frontend phase with UI-SPEC — running UI review audit...
+```
+
+```
+Skill(skill="gsd:ui-review", args="${PHASE_NUM}")
+```
+
+Display the review result summary (score from UI-REVIEW.md if produced). Continue to iterate step regardless of score — UI review is advisory, not blocking.
+
+**If `UI_SPEC_FILE` is empty OR `UI_REVIEW_CFG` is `false`:** Skip silently, proceed to iterate step.
 
 </step>
 
@@ -789,7 +866,7 @@ When any phase operation fails or a blocker is detected, present 3 options via A
 </process>
 
 <success_criteria>
-- [ ] All incomplete phases executed in order (smart discuss → plan → execute each)
+- [ ] All incomplete phases executed in order (smart discuss → ui-phase → plan → execute → ui-review each)
 - [ ] Smart discuss proposes grey area answers in tables, user accepts or overrides per area
 - [ ] Progress banners displayed between phases
 - [ ] Execute-phase invoked with --no-transition (autonomous manages transitions)
@@ -813,4 +890,8 @@ When any phase operation fails or a blocker is detected, present 3 options via A
 - [ ] Final completion banner displayed after lifecycle
 - [ ] Progress bar uses phase number / total milestone phases (not position among incomplete)
 - [ ] Smart discuss documents relationship to discuss-phase with CTRL-03 note
+- [ ] Frontend phases get UI-SPEC generated before planning (step 3a.5) if not already present
+- [ ] Frontend phases get UI review audit after successful execution (step 3d.5) if UI-SPEC exists
+- [ ] UI phase and UI review respect workflow.ui_phase and workflow.ui_review config toggles
+- [ ] UI review is advisory (non-blocking) — phase proceeds to iterate regardless of score
 </success_criteria>


### PR DESCRIPTION
## Summary

- `/gsd:autonomous` currently runs `discuss → plan → execute` per phase, but skips `/gsd:ui-phase` (UI design contract generation) and `/gsd:ui-review` (post-execution visual audit) for frontend phases
- This means users relying on autonomous mode miss the full UI-aware workflow that manual execution provides: `discuss → ui-phase → plan → execute → ui-review`
- This PR adds two conditional steps to the autonomous workflow to close that gap

## Changes

**Step 3a.5 — UI Design Contract (between discuss and plan):**
- Detects frontend phases via keyword matching on the ROADMAP phase description (same logic as `plan-phase.md` step 5.6)
- If frontend indicators found and no UI-SPEC.md exists, runs `/gsd:ui-phase` to generate the design contract before planning
- Skips silently for non-frontend phases or when UI-SPEC already exists
- Respects `workflow.ui_phase` config toggle

**Step 3d.5 — UI Review (after successful execution):**
- After any successful execution routing (passed, human_needed accepted, gaps deferred), checks if the phase had a UI-SPEC
- If UI-SPEC exists, runs `/gsd:ui-review` to audit the implementation against the design contract
- Advisory only — does not block phase progression regardless of score
- Respects `workflow.ui_review` config toggle

**Success criteria updated** to reflect the new full flow: `discuss → ui-phase → plan → execute → ui-review`

## Context

Discovered while using GSD v1.28.0 on a multi-tenant SaaS project (Next.js + Supabase) where every phase has frontend work. The project's CLAUDE.md specifies the full UI-aware flow as mandatory, but `/gsd:autonomous` bypasses it entirely.

## Test plan

- [ ] Run `/gsd:autonomous` on a milestone with a frontend phase (UI hint: yes in ROADMAP) — verify UI-SPEC is generated before planning
- [ ] Run `/gsd:autonomous` on a milestone with a non-frontend phase — verify UI steps are skipped silently
- [ ] Run `/gsd:autonomous` on a phase that already has a UI-SPEC — verify it skips ui-phase and shows "UI-SPEC exists" message
- [ ] Set `workflow.ui_phase: false` and verify UI-SPEC generation is skipped
- [ ] Set `workflow.ui_review: false` and verify UI review is skipped
- [ ] Verify UI review failure does not block phase progression

Generated with [Claude Code](https://claude.com/claude-code)