### PR TITLE
docs: Adds uninstall local command for Gemini in all README languages

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -785,6 +785,7 @@ npx get-shit-done-cc --antigravity --global --uninstall
 # ローカルインストール（現在のプロジェクト）
 npx get-shit-done-cc --claude --local --uninstall
 npx get-shit-done-cc --opencode --local --uninstall
+npx get-shit-done-cc --gemini --local --uninstall
 npx get-shit-done-cc --codex --local --uninstall
 npx get-shit-done-cc --copilot --local --uninstall
 npx get-shit-done-cc --cursor --local --uninstall

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -774,6 +774,7 @@ npx get-shit-done-cc --antigravity --global --uninstall
 # 로컬 설치 (현재 프로젝트)
 npx get-shit-done-cc --claude --local --uninstall
 npx get-shit-done-cc --opencode --local --uninstall
+npx get-shit-done-cc --gemini --local --uninstall
 npx get-shit-done-cc --codex --local --uninstall
 npx get-shit-done-cc --copilot --local --uninstall
 npx get-shit-done-cc --cursor --local --uninstall

--- a/README.md
+++ b/README.md
@@ -780,6 +780,7 @@ npx get-shit-done-cc --antigravity --global --uninstall
 # Local installs (current project)
 npx get-shit-done-cc --claude --local --uninstall
 npx get-shit-done-cc --opencode --local --uninstall
+npx get-shit-done-cc --gemini --local --uninstall
 npx get-shit-done-cc --codex --local --uninstall
 npx get-shit-done-cc --copilot --local --uninstall
 npx get-shit-done-cc --cursor --local --uninstall

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -395,6 +395,7 @@ CLAUDE_CONFIG_DIR=/home/youruser/.claude npx get-shit-done-cc --global
 ### Desinstalar
 
 ```bash
+# Instalações globais
 npx get-shit-done-cc --claude --global --uninstall
 npx get-shit-done-cc --opencode --global --uninstall
 npx get-shit-done-cc --gemini --global --uninstall
@@ -402,6 +403,15 @@ npx get-shit-done-cc --codex --global --uninstall
 npx get-shit-done-cc --copilot --global --uninstall
 npx get-shit-done-cc --cursor --global --uninstall
 npx get-shit-done-cc --antigravity --global --uninstall
+
+# Instalações locais (projeto atual)
+npx get-shit-done-cc --claude --local --uninstall
+npx get-shit-done-cc --opencode --local --uninstall
+npx get-shit-done-cc --gemini --local --uninstall
+npx get-shit-done-cc --codex --local --uninstall
+npx get-shit-done-cc --copilot --local --uninstall
+npx get-shit-done-cc --cursor --local --uninstall
+npx get-shit-done-cc --antigravity --local --uninstall
 ```
 
 ---

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -751,6 +751,7 @@ npx get-shit-done-cc --antigravity --global --uninstall
 # 本地安装（当前项目）
 npx get-shit-done-cc --claude --local --uninstall
 npx get-shit-done-cc --opencode --local --uninstall
+npx get-shit-done-cc --gemini --local --uninstall
 npx get-shit-done-cc --codex --local --uninstall
 npx get-shit-done-cc --copilot --local --uninstall
 npx get-shit-done-cc --cursor --local --uninstall


### PR DESCRIPTION
## What

Add uninstall local command for Gemini in README.md for all languages.

## Why

To maintain the consistency of the project's documentation as it evolves.

## Testing

### Platforms tested

- [ ] macOS
- [ *] Windows (including backslash path handling)
- [* ] Linux

### Runtimes tested

- [ *] Gemini CLI

- I tested the command in a local Gemini installation and it works as expected.

## Checklist

- [ *] Follows GSD style (no enterprise patterns, no filler)
- [ ] Updates CHANGELOG.md for user-facing changes (don't now if it's necessary for this fix)
- [ *] No unnecessary dependencies added
- [ *] Works on Windows (backslash paths tested)
- [* ] Templates/references updated if behavior changed
- [* ] Existing tests pass (`npm test`)

## Breaking Changes

None
