### PR TITLE
fix(verifier): enforce human_needed status when human verification items exist

### DIFF
--- a/agents/gsd-verifier.md
+++ b/agents/gsd-verifier.md
@@ -442,15 +442,25 @@ npm test -- --grep "$PHASE_TEST_PATTERN" 2>&1 | grep -q "passing"
 
 ## Step 9: Determine Overall Status
 
-**Status: passed** — All truths VERIFIED, all artifacts pass levels 1-3, all key links WIRED, no blocker anti-patterns.
+Classify status using this decision tree IN ORDER (most restrictive first):
 
-**Status: gaps_found** — One or more truths FAILED, artifacts MISSING/STUB, key links NOT_WIRED, or blocker anti-patterns found.
+1. IF any truth FAILED, artifact MISSING/STUB, key link NOT_WIRED, or blocker anti-pattern found:
+   → **status: gaps_found**
 
-**Status: human_needed** — All automated checks pass but items flagged for human verification.
+2. IF Step 8 produced ANY human verification items (section is non-empty):
+   → **status: human_needed**
+   (Even if all truths are VERIFIED and score is N/N — human items take priority)
+
+3. IF all truths VERIFIED, all artifacts pass, all links WIRED, no blockers, AND no human verification items:
+   → **status: passed**
+
+**passed is ONLY valid when the human verification section is empty.** If you identified items requiring human testing in Step 8, status MUST be human_needed.
 
 **Score:** `verified_truths / total_truths`
 
 ## Step 10: Structure Gap Output (If Gaps Found)
+
+Before writing VERIFICATION.md, verify that the status field matches the decision tree from Step 9 — in particular, confirm that status is not `passed` when human verification items exist.
 
 Structure gaps in YAML frontmatter for `/gsd:plan-phase --gaps`:
 

--- a/get-shit-done/workflows/verify-phase.md
+++ b/get-shit-done/workflows/verify-phase.md
@@ -199,11 +199,18 @@ Format each as: Test Name → What to do → Expected result → Why can't verif
 </step>
 
 <step name="determine_status">
-**passed:** All truths VERIFIED, all artifacts pass levels 1-3, all key links WIRED, no blocker anti-patterns.
+Classify status using this decision tree IN ORDER (most restrictive first):
 
-**gaps_found:** Any truth FAILED, artifact MISSING/STUB, key link NOT_WIRED, or blocker found.
+1. IF any truth FAILED, artifact MISSING/STUB, key link NOT_WIRED, or blocker found:
+   → **gaps_found**
 
-**human_needed:** All automated checks pass but human verification items remain.
+2. IF the previous step produced ANY human verification items:
+   → **human_needed** (even if all truths VERIFIED and score is N/N)
+
+3. IF all checks pass AND no human verification items:
+   → **passed**
+
+**passed is ONLY valid when no human verification items exist.**
 
 **Score:** `verified_truths / total_truths`
 </step>


### PR DESCRIPTION
## Summary

- Replace advisory status descriptions in Step 9 with an ordered decision tree (most restrictive first): `gaps_found` → `human_needed` → `passed`
- Add explicit rule: `passed` is ONLY valid when zero human verification items exist
- Add self-check before writing VERIFICATION.md in Step 10
- Sync the same decision tree in the `verify-phase` workflow

## Problem

The verifier sets `status: passed` even when VERIFICATION.md contains a non-empty **Human Verification Required** section. This bypasses the `human_needed` → `HUMAN-UAT.md` → user approval gate in `execute-phase.md`, allowing phases to be marked complete without human testing.

**Root cause:** Step 9 describes three statuses as equal-weight options. When the verifier scores 6/6 truths verified, the strong numerical signal overrides the textual qualification about human items. The LLM treats `human_needed` as a softer alternative rather than a mandatory classification when human items exist.

## Real-world evidence

Observed in a project (dotmd, Phase 9 — speed benchmarks):

1. Phase goal: write benchmark scripts, execute them, collect empirical data on TEI concurrency and NER batching throughput
2. Executor correctly created benchmark scripts but did not execute them (they required live Docker services)
3. Verifier checked artifacts exist, syntax valid, code wired → scored **6/6 must-haves verified**
4. Verifier wrote `### Human Verification Required` with 2 items (TEI benchmark execution, GLiNER benchmark execution), each noting "Requires a running TEI/GLiNER service"
5. Verifier set `status: passed` instead of `status: human_needed`
6. Orchestrator read `passed` → skipped HUMAN-UAT creation → marked phase complete → updated REQUIREMENTS.md to `[x] Complete`

**Downstream impact:**
- `HUMAN-UAT.md` never created → items invisible to `/gsd:progress` and `/gsd:audit-uat`
- Requirements SPEED-01, SPEED-02 marked Complete without actual benchmark results
- Phase 10 (which depended on Phase 9 data) was planned and executed without benchmark numbers
- The phase goal — "Empirical data on whether TEI concurrency and NER batching improve throughput" — was never achieved
- The user discovered this only by accident

## Fix

The previous Step 9 listed three statuses as peer descriptions:

```
Status: passed — All truths VERIFIED...
Status: gaps_found — One or more truths FAILED...
Status: human_needed — All automated checks pass but items flagged...
```

The fix replaces this with an **ordered decision tree** evaluated top-to-bottom:

1. Any gaps → `gaps_found`
2. Any human verification items → `human_needed` (even if score is N/N)
3. Everything clean AND no human items → `passed`

Plus a self-check in Step 10: before writing VERIFICATION.md, confirm status matches the decision tree.

## Test plan

- [ ] Run verifier on a phase with human verification items → status should be `human_needed`
- [ ] Run verifier on a phase with no human items and all truths passed → status should be `passed`
- [ ] Run verifier on a phase with gaps → status should be `gaps_found`
- [ ] Verify orchestrator creates HUMAN-UAT.md when status is `human_needed`

## Note

The SDK path (`phase-runner.ts` `parseVerificationOutcome`) has a separate issue: it determines status from `result.success` rather than parsing the VERIFICATION.md file. The code comment acknowledges this as a TODO. That's a different scope — this PR addresses the prompt/agent layer only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)