### PR TITLE
fix(verifier): always load ROADMAP SCs regardless of PLAN must_haves

### DIFF
--- a/agents/gsd-verifier.md
+++ b/agents/gsd-verifier.md
@@ -88,13 +88,21 @@ Extract phase goal from ROADMAP.md — this is the outcome to verify, not the ta
 
 In re-verification mode, must-haves come from Step 0.
 
-**Option A: Must-haves in PLAN frontmatter**
+**Step 2a: Always load ROADMAP Success Criteria**
+
+```bash
+PHASE_DATA=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" roadmap get-phase "$PHASE_NUM" --raw)
+```
+
+Parse the `success_criteria` array from the JSON output. These are the **roadmap contract** — they must always be verified regardless of what PLAN frontmatter says. Store them as `roadmap_truths`.
+
+**Step 2b: Load PLAN frontmatter must-haves (if present)**
 
 ```bash
 grep -l "must_haves:" "$PHASE_DIR"/*-PLAN.md 2>/dev/null
 ```
 
-If found, extract and use:
+If found, extract:
 
 ```yaml
 must_haves:
@@ -110,25 +118,20 @@ must_haves:
       via: "fetch in useEffect"
 ```
 
-**Option B: Use Success Criteria from ROADMAP.md**
+**Step 2c: Merge must-haves**
 
-If no must_haves in frontmatter, check for Success Criteria:
+Combine all sources into a single must-haves list:
 
-```bash
-PHASE_DATA=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" roadmap get-phase "$PHASE_NUM" --raw)
-```
+1. **Start with `roadmap_truths`** from Step 2a (these are non-negotiable)
+2. **Merge PLAN frontmatter truths** from Step 2b (these add plan-specific detail)
+3. **Deduplicate:** If a PLAN truth clearly restates a roadmap SC, keep the roadmap SC wording (it's the contract)
+4. **If neither 2a nor 2b produced any truths**, fall back to Option C below
 
-Parse the `success_criteria` array from the JSON output. If non-empty:
-1. **Use each Success Criterion directly as a truth** (they are already observable, testable behaviors)
-2. **Derive artifacts:** For each truth, "What must EXIST?" — map to concrete file paths
-3. **Derive key links:** For each artifact, "What must be CONNECTED?" — this is where stubs hide
-4. **Document must-haves** before proceeding
-
-Success Criteria from ROADMAP.md are the contract — they take priority over Goal-derived truths.
+**CRITICAL:** PLAN frontmatter must-haves must NOT reduce scope. If ROADMAP.md defines 5 Success Criteria but the plan only lists 3 in must_haves, all 5 must still be verified. The plan can ADD must-haves but never subtract roadmap SCs.
 
 **Option C: Derive from phase goal (fallback)**
 
-If no must_haves in frontmatter AND no Success Criteria in ROADMAP:
+If no Success Criteria in ROADMAP AND no must_haves in frontmatter:
 
 1. **State the goal** from ROADMAP.md
 2. **Derive truths:** "What must be TRUE?" — list 3-7 observable, testable behaviors


### PR DESCRIPTION
## Summary

- Verifier Step 2 now **always** loads ROADMAP.md Success Criteria first (Step 2a)
- PLAN frontmatter must_haves are merged on top (Step 2b), not used exclusively
- PLAN must_haves can add verification criteria but never subtract from the roadmap contract

## Problem

Per #1418 Gap 2: the verifier's Step 2 had a priority chain (A → B → C) where Option A (PLAN frontmatter must_haves) bypassed Option B (ROADMAP SCs) entirely. A planner could define 3 of 5 roadmap SCs in must_haves, and the verifier would only check those 3 — silently skipping 2 roadmap requirements.

This enabled silent scope reduction: phases marked COMPLETE while original roadmap Success Criteria remained unfulfilled.

## Fix

Restructured Step 2 into:
- **2a:** Always load ROADMAP SCs as `roadmap_truths` (non-negotiable baseline)
- **2b:** Load PLAN frontmatter must_haves if present (additive detail)
- **2c:** Merge — roadmap SCs + plan must_haves, deduplicated, roadmap wording takes precedence
- **Option C** remains as fallback when neither source has truths

## Test plan

- [x] Full suite: **1504 tests, 0 failures**
- [x] Manual: define 5 SCs in ROADMAP, put only 3 in PLAN must_haves, verify all 5 are checked

Addresses #1418

🤖 Generated with [Claude Code](https://claude.com/claude-code)