### PR TITLE
fix(install): add .claude path replacement for Codex runtime

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -1006,6 +1006,10 @@ function convertSlashCommandsToCodexSkillMentions(content) {
 function convertClaudeToCodexMarkdown(content) {
   let converted = convertSlashCommandsToCodexSkillMentions(content);
   converted = converted.replace(/\$ARGUMENTS\b/g, '{{GSD_ARGS}}');
+  // Path replacement: .claude → .codex (#1430)
+  converted = converted.replace(/\$HOME\/\.claude\//g, '$HOME/.codex/');
+  converted = converted.replace(/~\/\.claude\//g, '~/.codex/');
+  converted = converted.replace(/\.\/\.claude\//g, './.codex/');
   // Runtime-neutral agent name replacement (#766)
   converted = neutralizeAgentReferences(converted, 'AGENTS.md');
   return converted;

--- a/tests/codex-config.test.cjs
+++ b/tests/codex-config.test.cjs
@@ -169,6 +169,21 @@ Run /gsd:execute-phase to proceed.`;
     const result = convertClaudeAgentToCodexAgent(input);
     assert.strictEqual(result, input, 'returns input unchanged');
   });
+
+  test('replaces .claude paths with .codex paths (#1430)', () => {
+    const input = `---
+name: gsd-debugger
+description: Debugs issues
+tools: Read, Bash
+---
+
+INIT=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" state load)
+node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" commit "docs: resolve"`;
+
+    const result = convertClaudeAgentToCodexAgent(input);
+    assert.ok(result.includes('$HOME/.codex/get-shit-done/bin/gsd-tools.cjs'), 'replaces $HOME/.claude/ with $HOME/.codex/');
+    assert.ok(!result.includes('$HOME/.claude/'), 'no .claude paths remain');
+  });
 });
 
 // ─── generateCodexAgentToml ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add `$HOME/.claude/` → `$HOME/.codex/` path replacement to `convertClaudeToCodexMarkdown()`
- Matches the pattern already used by Copilot, Gemini, Antigravity, Cursor, and Windsurf converters

## Problem

Per #1430: the installer's Codex converter only handled slash commands, `$ARGUMENTS`, and agent name neutralization — but not `.claude` path references. This left hardcoded `$HOME/.claude/get-shit-done/bin/gsd-tools.cjs` paths in agent files (e.g. `gsd-debugger.md:1125`), causing ENOENT on Codex installations where GSD lives at `~/.codex/`.

## Test plan

- [x] New test: `replaces .claude paths with .codex paths` via `convertClaudeAgentToCodexAgent`
- [x] Full suite: **1505 tests, 0 failures**

Closes #1430

🤖 Generated with [Claude Code](https://claude.com/claude-code)