### PR TITLE
feat(researcher): add claim provenance tagging and assumptions log

### DIFF
--- a/agents/gsd-phase-researcher.md
+++ b/agents/gsd-phase-researcher.md
@@ -25,6 +25,13 @@ If the prompt contains a `<files_to_read>` block, you MUST use the `Read` tool t
 - Document findings with confidence levels (HIGH/MEDIUM/LOW)
 - Write RESEARCH.md with sections the planner expects
 - Return structured result to orchestrator
+
+**Claim provenance (CRITICAL):** Every factual claim in RESEARCH.md must be tagged with its source:
+- `[VERIFIED: npm registry]` — confirmed via tool (npm view, web search, codebase grep)
+- `[CITED: docs.example.com/page]` — referenced from official documentation
+- `[ASSUMED]` — based on training knowledge, not verified in this session
+
+Claims tagged `[ASSUMED]` signal to the planner and discuss-phase that the information needs user confirmation before becoming a locked decision. Never present assumed knowledge as verified fact — especially for compliance requirements, retention policies, security standards, or performance targets where multiple valid approaches exist.
 </role>
 
 <project_context>
@@ -342,6 +349,17 @@ Verified patterns from official sources:
 
 **Deprecated/outdated:**
 - [Thing]: [why, what replaced it]
+
+## Assumptions Log
+
+> List all claims tagged `[ASSUMED]` in this research. The planner and discuss-phase use this
+> section to identify decisions that need user confirmation before execution.
+
+| # | Claim | Section | Risk if Wrong |
+|---|-------|---------|---------------|
+| A1 | [assumed claim] | [which section] | [impact] |
+
+**If this table is empty:** All claims in this research were verified or cited — no user confirmation needed.
 
 ## Open Questions
 


### PR DESCRIPTION
## Summary

- Research agents must now tag every factual claim with `[VERIFIED]`, `[CITED: url]`, or `[ASSUMED]`
- New `## Assumptions Log` section in RESEARCH.md template collects all `[ASSUMED]` claims in a table
- Downstream agents (planner, discuss-phase) can use this to surface unverified decisions for user confirmation

## Problem

Per #1431: research agents present assumptions as validated decisions without citing sources. This is dangerous because users rely on these agents for expert guidance — when an agent confidently states "audit logs should be permanent" or "industry standard is X", users may not challenge it. Assumptions then propagate unchallenged through research → planning → execution → verification.

## Changes

| File | Change |
|------|--------|
| `agents/gsd-phase-researcher.md` | Added claim provenance requirement to core responsibilities; added `## Assumptions Log` section to RESEARCH.md template |

## How It Works

Research agents tag claims inline:
- `[VERIFIED: npm registry]` — confirmed via tool during this session
- `[CITED: docs.example.com/page]` — referenced from official documentation  
- `[ASSUMED]` — based on training knowledge, not verified

The `## Assumptions Log` table at the end of RESEARCH.md collects all `[ASSUMED]` items with their section and risk-if-wrong assessment. Planners and discuss-phase can surface these for user review.

## Test plan

- [x] Full suite: **1504 tests, 0 failures**
- [x] Manual: run `/gsd:plan-phase` and verify RESEARCH.md includes provenance tags and assumptions log

Closes #1431

🤖 Generated with [Claude Code](https://claude.com/claude-code)