### PR TITLE
fix(todos): rename todos/done to todos/completed in workflows and docs

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -736,7 +736,7 @@
 **Requirements:**
 - REQ-TODO-01: System MUST capture todo from current conversation context
 - REQ-TODO-02: Todos MUST be stored in `.planning/todos/pending/`
-- REQ-TODO-03: Completed todos MUST move to `.planning/todos/done/`
+- REQ-TODO-03: Completed todos MUST move to `.planning/todos/completed/`
 - REQ-TODO-04: Check-todos MUST list all pending items with selection to work on one
 
 ---

--- a/docs/ja-JP/FEATURES.md
+++ b/docs/ja-JP/FEATURES.md
@@ -736,7 +736,7 @@
 **要件:**
 - REQ-TODO-01: システムは現在の会話コンテキストから Todo をキャプチャしなければならない
 - REQ-TODO-02: Todo は `.planning/todos/pending/` に保存されなければならない
-- REQ-TODO-03: 完了した Todo は `.planning/todos/done/` に移動されなければならない
+- REQ-TODO-03: 完了した Todo は `.planning/todos/completed/` に移動されなければならない
 - REQ-TODO-04: check-todos は保留中のすべてのアイテムを一覧表示し、作業するアイテムを選択できなければならない
 
 ---

--- a/docs/ko-KR/FEATURES.md
+++ b/docs/ko-KR/FEATURES.md
@@ -736,7 +736,7 @@
 **요구사항.**
 - REQ-TODO-01: 현재 대화 컨텍스트에서 할 일을 캡처해야 합니다.
 - REQ-TODO-02: 할 일은 `.planning/todos/pending/`에 저장되어야 합니다.
-- REQ-TODO-03: 완료된 할 일은 `.planning/todos/done/`으로 이동해야 합니다.
+- REQ-TODO-03: 완료된 할 일은 `.planning/todos/completed/`으로 이동해야 합니다.
 - REQ-TODO-04: check-todos는 모든 보류 항목을 나열하고 하나를 선택하여 작업할 수 있어야 합니다.
 
 ---

--- a/get-shit-done/workflows/add-todo.md
+++ b/get-shit-done/workflows/add-todo.md
@@ -20,7 +20,7 @@ Extract from init JSON: `commit_docs`, `date`, `timestamp`, `todo_count`, `todos
 
 Ensure directories exist:
 ```bash
-mkdir -p .planning/todos/pending .planning/todos/done
+mkdir -p .planning/todos/pending .planning/todos/completed
 ```
 
 Note existing areas from the todos array for consistency in infer_area step.

--- a/get-shit-done/workflows/check-todos.md
+++ b/get-shit-done/workflows/check-todos.md
@@ -126,7 +126,7 @@ Use AskUserQuestion:
 <step name="execute_action">
 **Work on it now:**
 ```bash
-mv ".planning/todos/pending/[filename]" ".planning/todos/done/"
+mv ".planning/todos/pending/[filename]" ".planning/todos/completed/"
 ```
 Update STATE.md todo count. Present problem/solution context. Begin work or ask how to proceed.
 
@@ -155,7 +155,7 @@ If todo was moved to done/, commit the change:
 
 ```bash
 git rm --cached .planning/todos/pending/[filename] 2>/dev/null || true
-node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" commit "docs: start work on todo - [title]" --files .planning/todos/done/[filename] .planning/STATE.md
+node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" commit "docs: start work on todo - [title]" --files .planning/todos/completed/[filename] .planning/STATE.md
 ```
 
 Tool respects `commit_docs` config and gitignore automatically.

--- a/get-shit-done/workflows/note.md
+++ b/get-shit-done/workflows/note.md
@@ -101,7 +101,7 @@ If a scope has no directory or no entries, show: `(no notes)`
 3. If N is invalid or refers to an already-promoted note, tell the user and stop
 4. **Requires `.planning/` directory** — if it doesn't exist, warn: "Todos require a GSD project. Run `/gsd:new-project` to initialize one."
 5. Ensure `.planning/todos/pending/` directory exists
-6. Generate todo ID: `{NNN}-{slug}` where NNN is the next sequential number (scan both `.planning/todos/pending/` and `.planning/todos/done/` for the highest existing number, increment by 1, zero-pad to 3 digits) and slug is the first ~4 meaningful words of the note text
+6. Generate todo ID: `{NNN}-{slug}` where NNN is the next sequential number (scan both `.planning/todos/pending/` and `.planning/todos/completed/` for the highest existing number, increment by 1, zero-pad to 3 digits) and slug is the first ~4 meaningful words of the note text
 7. Extract the note text from the source file (body after frontmatter)
 8. Create `.planning/todos/pending/{id}.md`:
 


### PR DESCRIPTION
## Summary

- Replace all `todos/done/` references with `todos/completed/` to match the CLI implementation
- 6 files changed across 3 workflows and 3 FEATURES.md docs (EN, JA, KO)

## Problem

Per #1438: the CLI (`commands.cjs`, `init.cjs`) creates and uses `todos/completed/`, but workflow docs reference `todos/done/`. When Claude follows workflow instructions literally, it creates the wrong directory — completed todos end up in `todos/done/` while `gsd-tools todo complete` puts them in `todos/completed/`.

## Files Changed

| File | Occurrences |
|------|------------|
| `workflows/check-todos.md` | 2 (lines 129, 158) |
| `workflows/add-todo.md` | 1 (line 23) |
| `workflows/note.md` | 1 (line 104) |
| `docs/FEATURES.md` | 1 (REQ-TODO-03) |
| `docs/ja-JP/FEATURES.md` | 1 (REQ-TODO-03) |
| `docs/ko-KR/FEATURES.md` | 1 (REQ-TODO-03) |

## Verification

```bash
grep -r "todos/done" .  # returns 0 results after fix
```

## Test plan

- [x] Zero `todos/done` references remaining in codebase
- [x] Full suite: **1504 tests, 0 failures**

Closes #1438

🤖 Generated with [Claude Code](https://claude.com/claude-code)