### PR TITLE
fix(next): remove reference to non-existent /gsd:complete-phase

### DIFF
--- a/get-shit-done/workflows/next.md
+++ b/get-shit-done/workflows/next.md
@@ -55,7 +55,7 @@ If plans exist but not all have matching summaries:
 
 **Route 5: All plans have summaries → verify and complete**
 If all plans in the current phase have summaries:
-→ Next action: `/gsd:verify-work` then `/gsd:complete-phase`
+→ Next action: `/gsd:verify-work`
 
 **Route 6: Phase complete, next phase exists → advance**
 If the current phase is complete and the next phase exists in ROADMAP:


### PR DESCRIPTION
## Summary

- Remove `/gsd:complete-phase` from `next.md` Route 5 — no such command exists
- After `/gsd:verify-work`, Route 6 handles advancing to the next phase automatically

## Problem

Per #1441: `/gsd:next` after verify-work routes to `/gsd:complete-phase` which doesn't exist, causing a skill-not-found error on Codex (and silent failures on other runtimes). Only `/gsd:complete-milestone` exists for completion.

## Test plan

- [x] Full suite: **1504 tests, 0 failures**
- [x] Grep confirms zero `complete-phase` references in workflow files

Closes #1441

🤖 Generated with [Claude Code](https://claude.com/claude-code)