### PR TITLE
feat(discuss): add --chain flag for interactive discuss with auto plan+execute

### DIFF
--- a/commands/gsd/discuss-phase.md
+++ b/commands/gsd/discuss-phase.md
@@ -1,7 +1,7 @@
 ---
 name: gsd:discuss-phase
-description: Gather phase context through adaptive questioning before planning. Use --auto to skip interactive questions (Claude picks recommended defaults).
-argument-hint: "<phase> [--auto] [--batch] [--analyze] [--text]"
+description: Gather phase context through adaptive questioning before planning. Use --auto to skip interactive questions (Claude picks recommended defaults). Use --chain for interactive discuss followed by automatic plan+execute.
+argument-hint: "<phase> [--auto] [--chain] [--batch] [--analyze] [--text]"
 allowed-tools:
   - Read
   - Write

--- a/get-shit-done/workflows/discuss-phase.md
+++ b/get-shit-done/workflows/discuss-phase.md
@@ -155,6 +155,11 @@ Exit workflow.
 - In `discuss_areas`: for each discussion question, choose the recommended option (first option, or the one marked "recommended") without using AskUserQuestion
 - Log each auto-selected choice inline so the user can review decisions in the context file
 - After discussion completes, auto-advance to plan-phase (existing behavior)
+
+**Chain mode** — If `--chain` is present in ARGUMENTS:
+- Discussion is fully interactive (questions, gray area selection — same as default mode)
+- After discussion completes, auto-advance to plan-phase → execute-phase (same as `--auto`)
+- This is the middle ground: user controls the discuss decisions, then plan+execute run autonomously
 </step>
 
 <step name="check_existing">
@@ -938,6 +943,7 @@ Created: .planning/phases/${PADDED_PHASE}-${SLUG}/${PADDED_PHASE}-CONTEXT.md
 ---
 
 **Also available:**
+- `/gsd:discuss-phase ${PHASE} --chain ${GSD_WS}` — re-run with auto plan+execute after
 - `/gsd:plan-phase ${PHASE} --skip-research ${GSD_WS}` — plan without research
 - `/gsd:ui-phase ${PHASE} ${GSD_WS}` — generate UI design contract before planning (if phase has frontend work)
 - Review/edit CONTEXT.md before continuing
@@ -1025,10 +1031,10 @@ node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" commit "docs(state): record
 <step name="auto_advance">
 Check for auto-advance trigger:
 
-1. Parse `--auto` flag from $ARGUMENTS
-2. **Sync chain flag with intent** — if user invoked manually (no `--auto`), clear the ephemeral chain flag from any previous interrupted `--auto` chain. This does NOT touch `workflow.auto_advance` (the user's persistent settings preference):
+1. Parse `--auto` and `--chain` flags from $ARGUMENTS
+2. **Sync chain flag with intent** — if user invoked manually (no `--auto` and no `--chain`), clear the ephemeral chain flag from any previous interrupted `--auto` chain. This does NOT touch `workflow.auto_advance` (the user's persistent settings preference):
    ```bash
-   if [[ ! "$ARGUMENTS" =~ --auto ]]; then
+   if [[ ! "$ARGUMENTS" =~ --auto ]] && [[ ! "$ARGUMENTS" =~ --chain ]]; then
      node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-set workflow._auto_chain_active false 2>/dev/null
    fi
    ```
@@ -1038,12 +1044,12 @@ Check for auto-advance trigger:
    AUTO_CFG=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-get workflow.auto_advance 2>/dev/null || echo "false")
    ```
 
-**If `--auto` flag present AND `AUTO_CHAIN` is not true:** Persist chain flag to config (handles direct `--auto` usage without new-project):
+**If `--auto` or `--chain` flag present AND `AUTO_CHAIN` is not true:** Persist chain flag to config (handles direct usage without new-project):
 ```bash
 node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-set workflow._auto_chain_active true
 ```
 
-**If `--auto` flag present OR `AUTO_CHAIN` is true OR `AUTO_CFG` is true:**
+**If `--auto` flag present OR `--chain` flag present OR `AUTO_CHAIN` is true OR `AUTO_CFG` is true:**
 
 Display banner:
 ```
@@ -1070,7 +1076,7 @@ This keeps the auto-advance chain flat — discuss, plan, and execute all run at
 
   Auto-advance pipeline finished: discuss → plan → execute
 
-  Next: /gsd:discuss-phase ${NEXT_PHASE} --auto ${GSD_WS}
+  Next: /gsd:discuss-phase ${NEXT_PHASE} ${WAS_CHAIN ? "--chain" : "--auto"} ${GSD_WS}
   <sub>/clear first → fresh context window</sub>
   ```
 - **PLANNING COMPLETE** → Planning done, execution didn't complete:
@@ -1089,7 +1095,7 @@ This keeps the auto-advance chain flat — discuss, plan, and execute all run at
   Continue: /gsd:plan-phase ${PHASE} --gaps ${GSD_WS}
   ```
 
-**If neither `--auto` nor config enabled:**
+**If none of `--auto`, `--chain`, nor config enabled:**
 Route to `confirm_creation` step (existing behavior — show manual next steps).
 </step>
 
@@ -1113,4 +1119,6 @@ Route to `confirm_creation` step (existing behavior — show manual next steps).
 - Checkpoint file written after each area completes (incremental save)
 - Interrupted sessions can be resumed from checkpoint (no re-answering completed areas)
 - Checkpoint file cleaned up after successful CONTEXT.md write
+- `--chain` triggers interactive discuss followed by auto plan+execute (no auto-answering)
+- `--chain` and `--auto` both persist chain flag and auto-advance to plan-phase
 </success_criteria>


### PR DESCRIPTION
## Summary

Adds `--chain` flag to `/gsd:discuss-phase` that provides the middle ground between fully manual and fully automatic workflows:

```bash
/gsd:discuss-phase 5 --chain
```

- **Discussion is fully interactive** — user answers questions, selects gray areas, provides input
- **After context is captured, auto-advances** to plan → execute (same pipeline as `--auto`)
- **No auto-answering** — unlike `--auto`, the user controls every discuss decision

This addresses the community request from #1327 for per-phase automation where users want to control discuss decisions but skip the manual advancement between plan and execute steps.

## Context

The community discussion in #1327 revealed two preferences:

1. **Full milestone batch** (`/gsd:discuss-milestone`) — discuss all phases upfront, then autonomous (original proposal)
2. **Per-phase chain** (`/gsd:discuss-phase --chain`) — discuss one phase interactively, then auto plan+execute (community-preferred, 5+ thumbs up from @thijstijsma's comment)

This PR implements the per-phase variant, which is lower-risk and more broadly useful. The full-milestone variant can coexist as a future addition.

## Workflow comparison

| Flag | Discuss | Plan | Execute |
|------|---------|------|---------|
| *(none)* | Interactive | Manual `/gsd:plan-phase` | Manual `/gsd:execute-phase` |
| `--chain` | **Interactive** | **Auto** | **Auto** |
| `--auto` | Auto-answers | Auto | Auto |

## What changed

| File | Change |
|------|--------|
| `get-shit-done/workflows/discuss-phase.md` | Parse `--chain` flag; include in auto_advance trigger conditions; sync chain flag with ephemeral config; preserve `--chain` vs `--auto` in next-phase suggestions |
| `commands/gsd/discuss-phase.md` | Updated argument-hint and description to document `--chain` |

## Design decisions

- **`--chain` does NOT affect auto-answering**: Only `--auto` triggers auto-select behavior in `check_existing`, `present_gray_areas`, and `discuss_areas` steps. `--chain` leaves all of these interactive.
- **Ephemeral chain flag**: Both `--auto` and `--chain` persist `workflow._auto_chain_active=true` so the plan-phase auto-advance chain continues. Cleared when invoked without either flag.
- **Next-phase suggestion preserves mode**: If the user used `--chain`, the "Next:" suggestion uses `--chain` (not `--auto`) to maintain the interactive discuss preference.

## Test plan

- [ ] `--chain` triggers auto-advance after discuss completes
- [ ] `--chain` does NOT auto-select gray areas (interactive selection)
- [ ] `--chain` does NOT auto-answer questions (interactive discussion)
- [ ] `--chain` persists ephemeral chain flag for plan-phase continuation
- [ ] `--auto` behavior unchanged (regression check)
- [ ] No flag behavior unchanged (regression check)
- [ ] Next-phase suggestion preserves `--chain` when used

Closes #1327

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>