### PR TITLE
fix: add environment-based runtime detection for /gsd-review

### DIFF
--- a/get-shit-done/workflows/review.md
+++ b/get-shit-done/workflows/review.md
@@ -38,8 +38,28 @@ Then run /gsd:review again.
 ```
 Exit.
 
-If only one CLI is the current runtime (e.g. running inside Claude), skip it for the review
-to ensure independence. At least one DIFFERENT CLI must be available.
+Determine which CLI to skip based on the current runtime environment:
+
+```bash
+# Environment-based runtime detection (priority order)
+if [ "$ANTIGRAVITY_AGENT" = "1" ]; then
+  # Antigravity is a separate client — all CLIs are external, skip none
+  SELF_CLI="none"
+elif [ -n "$CLAUDE_CODE_ENTRYPOINT" ]; then
+  # Running inside Claude Code CLI — skip claude for independence
+  SELF_CLI="claude"
+else
+  # Other environments (Gemini CLI, Codex CLI, etc.)
+  # Fall back to AI self-identification to decide which CLI to skip
+  SELF_CLI="auto"
+fi
+```
+
+Rules:
+- If `SELF_CLI="none"` → invoke ALL available CLIs (no skip)
+- If `SELF_CLI="claude"` → skip claude, use gemini/codex
+- If `SELF_CLI="auto"` → the executing AI identifies itself and skips its own CLI
+- At least one DIFFERENT CLI must be available for the review to proceed.
 </step>
 
 <step name="gather_context">


### PR DESCRIPTION
## Problem

The `/gsd-review` workflow determines which CLI to skip by relying on AI self-identification (line 41-42). This fails in environments where the backend model does not match the client — e.g., running a Gemini model inside [Antigravity](https://github.com/nicepkg/aide) (a Claude Code fork). The AI may incorrectly skip a CLI.

## Solution

Replace the 2-line heuristic with environment variable-based detection:

```bash
if [ "$ANTIGRAVITY_AGENT" = "1" ]; then
  SELF_CLI="none"      # All CLIs are external
elif [ -n "$CLAUDE_CODE_ENTRYPOINT" ]; then
  SELF_CLI="claude"    # Skip claude for independence
else
  SELF_CLI="auto"      # Fallback to AI self-identification
fi
```

| Environment | Detection | Skip Strategy |
|---|---|---|
| Antigravity | `ANTIGRAVITY_AGENT=1` | Skip none — all CLIs are external |
| Claude Code CLI | `CLAUDE_CODE_ENTRYPOINT` | Skip claude |
| Other (Gemini/Codex) | Fallback | AI self-identification |

## Scope

Only lines 41-42 of `get-shit-done/workflows/review.md` are changed.