### PR TITLE
fix settings.json getting overwritten when contains comments (jsonc)

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -369,7 +369,8 @@ function resolveOpencodeConfigPath(configDir) {
 function readSettings(settingsPath) {
   if (fs.existsSync(settingsPath)) {
     try {
-      return JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+      const content = fs.readFileSync(settingsPath, 'utf8');
+      return parseJsonc(content);
     } catch (e) {
       return {};
     }


### PR DESCRIPTION
When a settings.json contains a comment (e.g. `// some comment`) GSD's installer failed to parse it and silently overwrote the entire file with an empty object to which it would add the triggers, causing loss of the original configuration.

Fixes #1461