### PR TITLE
fix: sanitize backlog phase slugs to prevent newlines in directory names

### DIFF
--- a/commands/gsd/add-backlog.md
+++ b/commands/gsd/add-backlog.md
@@ -29,7 +29,7 @@ the normal phase sequence and accumulate context over time.
 
 3. **Create the phase directory:**
    ```bash
-   SLUG=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" generate-slug "$ARGUMENTS")
+   SLUG=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" generate-slug "$ARGUMENTS" --raw)
    mkdir -p ".planning/phases/${NEXT}-${SLUG}"
    touch ".planning/phases/${NEXT}-${SLUG}/.gitkeep"
    ```

--- a/commands/gsd/thread.md
+++ b/commands/gsd/thread.md
@@ -62,7 +62,7 @@ Create a new thread:
 
 1. Generate slug from description:
    ```bash
-   SLUG=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" generate-slug "$ARGUMENTS")
+   SLUG=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" generate-slug "$ARGUMENTS" --raw)
    ```
 
 2. Create the threads directory if needed:

--- a/tests/commands.test.cjs
+++ b/tests/commands.test.cjs
@@ -836,6 +836,44 @@ describe('generate-slug command', () => {
     assert.ok(!result.success, 'should fail without text');
     assert.ok(result.error.includes('text required'), 'error should mention text required');
   });
+
+  test('--raw output contains no newlines or JSON fragments (issue #1391)', () => {
+    const result = runGsdTools('generate-slug "execution flow graph view" --raw', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+    assert.strictEqual(result.output, 'execution-flow-graph-view');
+    assert.ok(!result.output.includes('\n'), 'slug must not contain newlines');
+    assert.ok(!result.output.includes('{'), 'slug must not contain JSON braces');
+    assert.ok(!result.output.includes('"'), 'slug must not contain quotes');
+  });
+
+  test('--raw output is safe for use in directory names', () => {
+    const result = runGsdTools('generate-slug "milestone plan editor with launch" --raw', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+    assert.match(result.output, /^[a-z0-9-]+$/, 'slug must only contain lowercase alphanumeric and hyphens');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// add-backlog template regression (issue #1391)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('add-backlog template slug safety (issue #1391)', () => {
+  test('add-backlog.md uses --raw flag for generate-slug', () => {
+    const templatePath = path.join(__dirname, '..', 'commands', 'gsd', 'add-backlog.md');
+    const template = fs.readFileSync(templatePath, 'utf-8');
+
+    // The generate-slug call must include --raw to avoid JSON in directory names
+    assert.match(template, /generate-slug.*--raw/,
+      'add-backlog.md must use --raw flag with generate-slug to prevent JSON in directory names');
+  });
+
+  test('thread.md uses --raw flag for generate-slug', () => {
+    const templatePath = path.join(__dirname, '..', 'commands', 'gsd', 'thread.md');
+    const template = fs.readFileSync(templatePath, 'utf-8');
+
+    assert.match(template, /generate-slug.*--raw/,
+      'thread.md must use --raw flag with generate-slug to prevent JSON in file names');
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Added `--raw` flag to `generate-slug` calls in `add-backlog.md` and `thread.md` command templates
- Without `--raw`, the CLI outputs JSON (`{"slug": "..."}`) which gets embedded in directory/file names, producing paths like `999.1-{\n  "slug": "execution-flow-graph-view"\n}`
- Also fixed the same missing flag in `thread.md` which had the identical bug

## Root Cause

The `generate-slug` command outputs structured JSON by default (for programmatic consumption) and a plain string when `--raw` is passed. The `add-backlog.md` template captured the JSON output into a shell variable and used it directly in `mkdir -p`, embedding newlines and JSON syntax into directory names.

## Test Plan

- [x] Added regression test verifying `add-backlog.md` uses `--raw` flag with `generate-slug`
- [x] Added regression test verifying `thread.md` uses `--raw` flag with `generate-slug`
- [x] Added tests verifying `--raw` output contains no newlines, braces, or quotes
- [x] Added test verifying `--raw` output matches `^[a-z0-9-]+$` pattern (safe for directory names)
- [x] Full test suite passes (1472 tests, 0 failures)

Closes #1391