### PR TITLE
feat: detect and prevent silent scope reduction in planner

### DIFF
--- a/agents/gsd-plan-checker.md
+++ b/agents/gsd-plan-checker.md
@@ -314,6 +314,49 @@ issue:
   fix_hint: "Remove search task - belongs in future phase per user decision"
 ```
 
+## Dimension 7b: Scope Reduction Detection
+
+**Question:** Did the planner silently simplify user decisions instead of delivering them fully?
+
+**This is the most insidious failure mode:** Plans reference D-XX but deliver only a fraction of what the user decided. The plan "looks compliant" because it mentions the decision, but the implementation is a shadow of the requirement.
+
+**Process:**
+1. For each task action in all plans, scan for scope reduction language:
+   - `"v1"`, `"v2"`, `"simplified"`, `"static for now"`, `"hardcoded"`
+   - `"future enhancement"`, `"placeholder"`, `"basic version"`, `"minimal"`
+   - `"will be wired later"`, `"dynamic in future"`, `"skip for now"`
+   - `"not wired to"`, `"not connected to"`, `"stub"`
+2. For each match, cross-reference with the CONTEXT.md decision it claims to implement
+3. Compare: does the task deliver what D-XX actually says, or a reduced version?
+4. If reduced: BLOCKER — the planner must either deliver fully or propose phase split
+
+**Red flags (from real incident):**
+- CONTEXT.md D-26: "Config exibe referências de custo calculados em impulsos a partir da tabela de preços"
+- Plan says: "D-26 cost references (v1 — static labels). NOT wired to billingPrecosOriginaisModel — dynamic pricing display is a future enhancement"
+- This is a BLOCKER: the planner invented "v1/v2" versioning that doesn't exist in the user's decision
+
+**Severity:** ALWAYS BLOCKER. Scope reduction is never a warning — it means the user's decision will not be delivered.
+
+**Example:**
+```yaml
+issue:
+  dimension: scope_reduction
+  severity: blocker
+  description: "Plan reduces D-26 from 'calculated costs in impulses' to 'static hardcoded labels'"
+  plan: "03"
+  task: 1
+  decision: "D-26: Config exibe referências de custo calculados em impulsos"
+  plan_action: "static labels v1 — NOT wired to billing"
+  fix_hint: "Either implement D-26 fully (fetch from billingPrecosOriginaisModel) or return PHASE SPLIT RECOMMENDED"
+```
+
+**Fix path:** When scope reduction is detected, the checker returns ISSUES FOUND with recommendation:
+```
+Plans reduce {N} user decisions. Options:
+1. Revise plans to deliver decisions fully (may increase plan count)
+2. Split phase: [suggested grouping of D-XX into sub-phases]
+```
+
 ## Dimension 8: Nyquist Compliance
 
 Skip if: `workflow.nyquist_validation` is explicitly set to `false` in config.json (absent key = enabled), phase has no RESEARCH.md, or RESEARCH.md has no "Validation Architecture" section. Output: "Dimension 8: SKIPPED (nyquist_validation disabled or not applicable)"

--- a/agents/gsd-planner.md
+++ b/agents/gsd-planner.md
@@ -81,6 +81,45 @@ The orchestrator provides user decisions in `<user_decisions>` tags from `/gsd:d
 - Note in task action: "Using X per user decision (research suggested Y)"
 </context_fidelity>
 
+<scope_reduction_prohibition>
+## CRITICAL: Never Simplify User Decisions — Split Instead
+
+**PROHIBITED language/patterns in task actions:**
+- "v1", "v2", "simplified version", "static for now", "hardcoded for now"
+- "future enhancement", "placeholder", "basic version", "minimal implementation"
+- "will be wired later", "dynamic in future phase", "skip for now"
+- Any language that reduces a CONTEXT.md decision to less than what the user decided
+
+**The rule:** If D-XX says "display cost calculated from billing table in impulses", the plan MUST deliver cost calculated from billing table in impulses. NOT "static label /min" as a "v1".
+
+**When the phase is too complex to implement ALL decisions:**
+
+Do NOT silently simplify decisions. Instead:
+
+1. **Create a decision coverage matrix** mapping every D-XX to a plan/task
+2. **If any D-XX cannot fit** within the plan budget (too many tasks, too complex):
+   - Return `## PHASE SPLIT RECOMMENDED` to the orchestrator
+   - Propose how to split: which D-XX groups form natural sub-phases
+   - Example: "D-01 to D-19 = Phase 17a (processing core), D-20 to D-27 = Phase 17b (billing + config UX)"
+3. The orchestrator will present the split to the user for approval
+4. After approval, plan each sub-phase within budget
+
+**Why this matters:** The user spent time making decisions. Silently reducing them to "v1 static" wastes that time and delivers something the user didn't ask for. Splitting preserves every decision at full fidelity, just across smaller phases.
+
+**Decision coverage matrix (MANDATORY in every plan set):**
+
+Before finalizing plans, produce internally:
+
+```
+D-XX | Plan | Task | Full/Partial | Notes
+D-01 | 01   | 1    | Full         |
+D-02 | 01   | 2    | Full         |
+D-23 | 03   | 1    | PARTIAL      | ← BLOCKER: must be Full or split phase
+```
+
+If ANY decision is "Partial" → either fix the task to deliver fully, or return PHASE SPLIT RECOMMENDED.
+</scope_reduction_prohibition>
+
 <philosophy>
 
 ## Solo Developer + Claude Workflow

--- a/get-shit-done/workflows/plan-phase.md
+++ b/get-shit-done/workflows/plan-phase.md
@@ -560,8 +560,41 @@ Task(
 ## 9. Handle Planner Return
 
 - **`## PLANNING COMPLETE`:** Display plan count. If `--skip-verify` or `plan_checker_enabled` is false (from init): skip to step 13. Otherwise: step 10.
+- **`## PHASE SPLIT RECOMMENDED`:** The planner determined the phase is too complex to implement all user decisions without simplifying them. Handle in step 9b.
 - **`## CHECKPOINT REACHED`:** Present to user, get response, spawn continuation (step 12)
 - **`## PLANNING INCONCLUSIVE`:** Show attempts, offer: Add context / Retry / Manual
+
+## 9b. Handle Phase Split Recommendation
+
+When the planner returns `## PHASE SPLIT RECOMMENDED`, it means the phase has too many decisions to implement at full fidelity within the plan budget. The planner proposes groupings.
+
+**Extract from planner return:**
+- Proposed sub-phases (e.g., "17a: processing core (D-01 to D-19)", "17b: billing + config UX (D-20 to D-27)")
+- Which D-XX decisions go in each sub-phase
+- Why the split is necessary (decision count, complexity estimate)
+
+**Present to user:**
+```
+## Phase {X} is too complex for full-fidelity implementation
+
+The planner found {N} decisions that cannot all be implemented without
+simplifying some. Instead of reducing your decisions, we recommend splitting:
+
+**Option 1: Split into sub-phases**
+- Phase {X}a: {name} — {D-XX to D-YY} ({N} decisions)
+- Phase {X}b: {name} — {D-XX to D-YY} ({M} decisions)
+
+**Option 2: Proceed anyway** (planner will attempt all, quality may degrade)
+
+**Option 3: Prioritize** — you choose which decisions to implement now,
+rest become a follow-up phase
+```
+
+Use AskUserQuestion with these 3 options.
+
+**If "Split":** Use `/gsd:insert-phase` to create the sub-phases, then replan each.
+**If "Proceed":** Return to planner with instruction to attempt all decisions at full fidelity, accepting more plans/tasks.
+**If "Prioritize":** Use AskUserQuestion (multiSelect) to let user pick which D-XX are "now" vs "later". Create CONTEXT.md for each sub-phase with the selected decisions.
 
 ## 10. Spawn gsd-plan-checker Agent
 


### PR DESCRIPTION
## Problem

When phases have many user decisions (from `/gsd:discuss-phase`), the planner sometimes silently simplifies them to fit within the plan budget. For example:

- **User decided (D-26):** "Config displays cost references calculated in impulses from the pricing table"
- **Planner delivered:** "D-26 cost references (v1 — static labels). NOT wired to billing. Dynamic pricing is a future enhancement."

The planner invented a "v1/v2" versioning that doesn't exist in the user's decision. The executor then faithfully implemented the simplified plan — building something the user never asked for.

This is the most insidious failure mode because:
- Plans reference D-XX (passes Dimension 7 context compliance check)
- Tasks mention the decision ID (looks traceable)
- But the implementation is a shadow of the actual requirement

## Root Cause

The planner's instinct when facing a complex phase is to **simplify individual decisions** ("make it static for v1"). The correct behavior should be to **split the phase** so every decision is implemented at full fidelity, just across smaller phases.

## Solution — Three coordinated changes

### 1. `agents/gsd-planner.md` — `<scope_reduction_prohibition>`

- Explicitly prohibits language like "v1", "static for now", "hardcoded", "future enhancement", "placeholder"
- Requires a **decision coverage matrix** mapping every D-XX to plan/task with Full/Partial status
- If any decision would be Partial: return `## PHASE SPLIT RECOMMENDED` instead of simplifying
- The user spent time making decisions in discuss-phase — silently reducing them wastes that time

### 2. `agents/gsd-plan-checker.md` — Dimension 7b: Scope Reduction Detection

- Scans all task actions for scope reduction language patterns
- Cross-references each match with the CONTEXT.md decision it claims to implement
- Compares: does the task deliver what D-XX **actually says**, or a reduced version?
- **Always BLOCKER severity** — scope reduction is never acceptable as a warning
- Includes a real-world example from the production incident that motivated this change

### 3. `get-shit-done/workflows/plan-phase.md` — Step 9b: Phase Split Handling

New orchestrator flow when planner returns `## PHASE SPLIT RECOMMENDED`:

- **Option 1: Split** — Create sub-phases via `/gsd:insert-phase`, each with a subset of D-XX decisions
- **Option 2: Proceed** — Attempt all decisions (accepting more plans/tasks, potential quality degradation)
- **Option 3: Prioritize** — User picks which D-XX are "now" vs "later"

## Real-world incident

Phase 17 (Media Processing) had 30 decisions including detailed billing requirements (D-20 to D-27). The planner:
1. Reduced D-26 ("calculated costs in impulses") to "static labels /min"
2. Reduced D-23 ("everything well explained for admin") to a single generic sentence
3. The executor then reimplemented an entire extraction service from scratch instead of reusing the existing one (D-03)

Result: 4 waves of execution building the wrong thing. The RESEARCH.md even had the correct pattern (dynamic costs from billing API) but the planner ignored it.

With these changes, the planner would have been blocked at plan creation, and the checker would have caught it even if the planner slipped through.

## Test plan

- [ ] Run `/gsd:plan-phase` on a phase with 15+ decisions — verify decision coverage matrix is produced
- [ ] Artificially add "v1 static" language to a plan — verify Dimension 7b flags BLOCKER
- [ ] Test PHASE SPLIT RECOMMENDED flow — verify 3 options presented to user
- [ ] Verify no regression on phases with few decisions (normal flow unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)