### PR TITLE
fix(phase): skip 999.x backlog phases in phase-add numbering

### DIFF
--- a/get-shit-done/bin/lib/phase.cjs
+++ b/get-shit-done/bin/lib/phase.cjs
@@ -346,11 +346,13 @@ function cmdPhaseAdd(cwd, description, raw, customId) {
     dirName = `${prefix}${newPhaseId}-${slug}`;
   } else {
     // Sequential mode: find highest integer phase number (in current milestone only)
+    // Skip 999.x backlog phases — they live outside the active sequence
     const phasePattern = /#{2,4}\s*Phase\s+(\d+)[A-Z]?(?:\.\d+)*:/gi;
     let maxPhase = 0;
     let m;
     while ((m = phasePattern.exec(content)) !== null) {
       const num = parseInt(m[1], 10);
+      if (num >= 999) continue; // backlog phases use 999.x numbering
       if (num > maxPhase) maxPhase = num;
     }
 

--- a/tests/phase.test.cjs
+++ b/tests/phase.test.cjs
@@ -655,6 +655,43 @@ describe('phase add command', () => {
     const roadmap = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
     assert.ok(roadmap.includes('**Requirements**: TBD'), 'new phase entry should include Requirements TBD');
   });
+
+  test('skips 999.x backlog phases when calculating next phase number', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      `# Roadmap v1.0
+
+### Phase 1: Foundation
+**Goal:** Setup
+
+### Phase 2: API
+**Goal:** Build API
+
+### Phase 3: UI
+**Goal:** Build UI
+
+### Phase 999.1: Future Idea A
+**Goal:** Backlog item
+
+### Phase 999.2: Future Idea B
+**Goal:** Backlog item
+
+---
+`
+    );
+
+    const result = runGsdTools('phase add Dashboard', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.phase_number, 4, 'should be phase 4, not 1000');
+    assert.strictEqual(output.slug, 'dashboard');
+
+    assert.ok(
+      fs.existsSync(path.join(tmpDir, '.planning', 'phases', '04-dashboard')),
+      'directory should be 04-dashboard, not 1000-dashboard'
+    );
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #1946

## Summary

- `cmdPhaseAdd` included backlog phases (999.x) in `maxPhase` calculation, causing next phase number to be 1000 instead of the correct sequential value
- Added `if (num >= 999) continue;` to skip backlog phases when determining the next phase ID
- All 1527 existing tests pass; no regressions

## Reproduction

1. Have a ROADMAP.md with backlog entries using 999.x numbering (e.g., `Phase 999.1:`, `Phase 999.2:`)
2. Run `gsd-tools phase add "New Phase"`
3. **Before fix:** creates Phase 1000
4. **After fix:** creates correct sequential phase (e.g., Phase 4 if phases 1-3 exist)

## Test plan

- [x] Unit tests pass (1527/1528, 1 pre-existing unrelated failure)
- [x] Manual test: project with phases 1-3 + backlog 999.1/999.2 → `phase add` correctly produces phase 4, then 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
