### PR TITLE
feat(quick): --full flag automatically enables --discuss and --research

### DIFF
--- a/get-shit-done/workflows/quick.md
+++ b/get-shit-done/workflows/quick.md
@@ -7,7 +7,7 @@ With `--full` flag: enables plan-checking (max 2 iterations) and post-execution 
 
 With `--research` flag: spawns a focused research agent before planning. Investigates implementation approaches, library options, and pitfalls. Use when you're unsure how to approach a task.
 
-Flags are composable: `--discuss --research --full` gives discussion + research + plan-checking + verification.
+Flags are composable: `--full` implies `--discuss` and `--research` (the full quality pipeline). Equivalently, `--discuss --research --full` is the same as just `--full`.
 </purpose>
 
 <required_reading>
@@ -31,6 +31,8 @@ Parse `$ARGUMENTS` for:
 - `--discuss` flag → store as `$DISCUSS_MODE` (true/false)
 - `--research` flag → store as `$RESEARCH_MODE` (true/false)
 - Remaining text → use as `$DESCRIPTION` if non-empty
+
+**`--full` implies `--discuss` and `--research`:** When `$FULL_MODE` is true, also set `$DISCUSS_MODE` and `$RESEARCH_MODE` to true (unless the user wants the full quality pipeline, it makes sense to include discussion and research by default — the whole point of `--full` is maximum quality). Users who explicitly only want plan-checking + verification without discuss/research can use `--full --no-discuss --no-research` if needed in the future.
 
 If `$DESCRIPTION` is empty after parsing, prompt user interactively:
 
@@ -743,6 +745,7 @@ Ready for next task: /gsd:quick ${GSD_WS}
 - [ ] ROADMAP.md validation passes
 - [ ] User provides task description
 - [ ] `--full`, `--discuss`, and `--research` flags parsed from arguments when present
+- [ ] `--full` automatically enables `--discuss` and `--research` (full quality pipeline)
 - [ ] Slug generated (lowercase, hyphens, max 40 chars)
 - [ ] Quick ID generated (YYMMDD-xxx format, 2s Base36 precision)
 - [ ] Directory created at `.planning/quick/YYMMDD-xxx-slug/`

--- a/tests/quick-full-flag.test.cjs
+++ b/tests/quick-full-flag.test.cjs
@@ -1,0 +1,60 @@
+/**
+ * GSD Tools Tests - quick --full flag implies --discuss and --research
+ *
+ * Validates that the quick workflow's --full flag automatically enables
+ * --discuss and --research for the complete quality pipeline.
+ *
+ * Closes: #1498
+ */
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+
+describe('quick --full implies --discuss and --research (#1498)', () => {
+  const workflowPath = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'quick.md');
+
+  test('workflow documents --full implies --discuss and --research', () => {
+    const content = fs.readFileSync(workflowPath, 'utf8');
+    assert.ok(
+      content.includes('--full') && content.includes('implies') &&
+      content.includes('--discuss') && content.includes('--research'),
+      'workflow should document that --full implies --discuss and --research'
+    );
+  });
+
+  test('purpose section describes --full as the complete pipeline', () => {
+    const content = fs.readFileSync(workflowPath, 'utf8');
+    const purposeMatch = content.match(/<purpose>([\s\S]*?)<\/purpose>/);
+    const purpose = purposeMatch ? purposeMatch[1] : '';
+    assert.ok(
+      purpose.includes('--full') && purpose.includes('implies'),
+      'purpose should describe --full as implying discuss+research'
+    );
+  });
+
+  test('flag parsing step sets DISCUSS_MODE and RESEARCH_MODE when FULL_MODE is true', () => {
+    const content = fs.readFileSync(workflowPath, 'utf8');
+    // The workflow should have logic that sets discuss/research when full is set
+    assert.ok(
+      content.includes('FULL_MODE') && content.includes('DISCUSS_MODE') && content.includes('RESEARCH_MODE'),
+      'workflow should reference all three mode variables'
+    );
+    // Should describe the implication
+    assert.ok(
+      content.includes('$FULL_MODE') && content.includes('$DISCUSS_MODE') && content.includes('$RESEARCH_MODE'),
+      'workflow should set DISCUSS_MODE and RESEARCH_MODE when FULL_MODE is true'
+    );
+  });
+
+  test('success criteria include --full auto-enable requirement', () => {
+    const content = fs.readFileSync(workflowPath, 'utf8');
+    const criteriaMatch = content.match(/<success_criteria>([\s\S]*?)<\/success_criteria>/);
+    const criteria = criteriaMatch ? criteriaMatch[1] : '';
+    assert.ok(
+      criteria.includes('--full') && criteria.includes('--discuss') && criteria.includes('--research'),
+      'success criteria should include --full auto-enable requirement'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

When using `/gsd:quick`, getting the complete quality pipeline previously required stacking all three flags: `--discuss --research --full`. Since `--full` represents "maximum quality," it should naturally include discussion and research — these are prerequisites for quality, not independent features.

Now `/gsd:quick --full` is equivalent to `/gsd:quick --discuss --research --full`.

### Changes
- `quick.md` flag parsing: when `$FULL_MODE` is true, also set `$DISCUSS_MODE` and `$RESEARCH_MODE` to true
- Purpose section updated to document the implication
- Success criteria updated

## Test plan
- [x] 4 new tests in `tests/quick-full-flag.test.cjs`
- [x] Full test suite passes

Closes #1498

🤖 Generated with [Claude Code](https://claude.com/claude-code)