### PR TITLE
fix(workstream): require name arg for set, add --clear flag

### DIFF
--- a/get-shit-done/bin/lib/workstream.cjs
+++ b/get-shit-done/bin/lib/workstream.cjs
@@ -339,9 +339,13 @@ function cmdWorkstreamComplete(cwd, name, options, raw) {
 // ─── Active Workstream Commands ──────────────────────────────────────────────
 
 function cmdWorkstreamSet(cwd, name, raw) {
-  if (!name) {
+  if (!name || name === '--clear') {
+    if (name !== '--clear') {
+      error('Workstream name required. Usage: workstream set <name> (or workstream set --clear to unset)');
+    }
+    const previous = getActiveWorkstream(cwd);
     setActiveWorkstream(cwd, null);
-    output({ active: null, cleared: true }, raw);
+    output({ active: null, cleared: true, previous: previous || null }, raw);
     return;
   }
 

--- a/tests/workstream.test.cjs
+++ b/tests/workstream.test.cjs
@@ -268,6 +268,24 @@ describe('workstream set/get', () => {
     assert.ok(result.success);
     assert.strictEqual(result.output, 'ws-a');
   });
+
+  test('errors when set called with no name (#1527)', () => {
+    const result = runGsdTools(['workstream', 'set', '--raw'], tmpDir);
+    assert.ok(!result.success, 'should fail when no name provided');
+    assert.ok(result.error.includes('name required'), 'error should mention name required');
+  });
+
+  test('--clear explicitly unsets active workstream', () => {
+    // First set one
+    runGsdTools(['workstream', 'set', 'ws-b', '--raw'], tmpDir);
+    // Then clear
+    const result = runGsdTools(['workstream', 'set', '--clear', '--raw'], tmpDir);
+    assert.ok(result.success);
+    const data = JSON.parse(result.output);
+    assert.strictEqual(data.active, null);
+    assert.strictEqual(data.cleared, true);
+    assert.strictEqual(data.previous, 'ws-b');
+  });
 });
 
 // ─── Collision Detection ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #1527 — `workstream set` with no argument silently cleared the active workstream. Users who forgot to type the name lost their active selection with no confirmation and no way to know what it was.

- **`workstream set`** (no args) now errors: `"Workstream name required. Usage: workstream set <name> (or workstream set --clear to unset)"`
- **`workstream set --clear`** explicitly clears, and reports the `previous` workstream in the output so the user knows what was unset
- Aligns with the reporter's preferred approach (option 1+2 from the issue)

### Breaking change note

This is technically a breaking change for scripts that relied on `workstream set` (no args) to clear the active workstream. Those scripts should be updated to use `workstream set --clear`. The change is intentional — the silent-clear behavior was a footgun.

## Test plan

- [x] New test: errors when set called with no name
- [x] New test: --clear explicitly unsets and reports previous
- [x] Existing workstream tests: 63 pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)