### PR TITLE
fix(autonomous): clarify phase count display to prevent misleading N/T banner

### DIFF
--- a/get-shit-done/workflows/autonomous.md
+++ b/get-shit-done/workflows/autonomous.md
@@ -136,7 +136,9 @@ For the current phase, display the progress banner:
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
-Where N = current phase number (from the ROADMAP, e.g., 6), T = total milestone phases (from `phase_count` parsed in initialize step, e.g., 8), P = percentage of all milestone phases completed so far. Calculate P as: (number of phases with `disk_status` "complete" from the latest `roadmap analyze` / T × 100). Use █ for filled and ░ for empty segments in the progress bar (8 characters wide).
+Where N = current phase number (from the ROADMAP, e.g., 63), T = total milestone phases (from `phase_count` parsed in initialize step, e.g., 67). **Important:** T must be `phase_count` (the total number of phases in this milestone), NOT the count of remaining/incomplete phases. When phases are numbered 61-67, T=7 and the banner should read `Phase 63/7` (phase 63, 7 total in milestone), not `Phase 63/3` (which would confuse 3 remaining with 3 total). P = percentage of all milestone phases completed so far. Calculate P as: (number of phases with `disk_status` "complete" from the latest `roadmap analyze` / T × 100). Use █ for filled and ░ for empty segments in the progress bar (8 characters wide).
+
+**Alternative display when phase numbers exceed total** (e.g., multi-milestone projects where phases are numbered globally): If N > T (phase number exceeds milestone phase count), use the format `Phase {N} ({position}/{T})` where `position` is the 1-based index of this phase among incomplete phases being processed. This prevents confusing displays like "Phase 63/5".
 
 **3a. Smart Discuss**
 
@@ -919,7 +921,7 @@ When any phase operation fails or a blocker is detected, present 3 options via A
 - [ ] Complete-milestone invoked via Skill() with ${milestone_version} arg
 - [ ] Cleanup invoked via Skill() — internal confirmation is acceptable (CTRL-01)
 - [ ] Final completion banner displayed after lifecycle
-- [ ] Progress bar uses phase number / total milestone phases (not position among incomplete)
+- [ ] Progress bar uses phase number / total milestone phases (not position among incomplete), with fallback display when phase numbers exceed total
 - [ ] Smart discuss documents relationship to discuss-phase with CTRL-03 note
 - [ ] Frontend phases get UI-SPEC generated before planning (step 3a.5) if not already present
 - [ ] Frontend phases get UI review audit after successful execution (step 3d.5) if UI-SPEC exists


### PR DESCRIPTION
## Summary

Fixes #1516 — the autonomous progress banner showed `Phase 63/5` where `5` was the count of remaining incomplete phases, easily mistaken for "63 out of 5 total." The phase *number* (63) comes from the ROADMAP while the *total* (5) was being sourced from the incomplete phase count rather than `phase_count`.

- Clarifies that `T` in `Phase {N}/{T}` must be `phase_count` (total milestone phases), not remaining count
- Adds **fallback display format** for multi-milestone projects where phase numbers exceed the total: `Phase {N} ({position}/{T})` prevents confusing displays like "Phase 63/5"
- Updates success criteria to reflect the fallback behavior

### Root cause

In multi-milestone projects, phases are often numbered globally (milestone 1: phases 1-20, milestone 2: phases 21-40, etc.). The `phase_count` from `init milestone-op` correctly returns the count of phase directories in the *current* milestone, but when the LLM computes the banner, it sometimes uses the filtered incomplete-phases array length instead of `phase_count`, producing the misleading display.

## Test plan

- [ ] Run `/gsd:autonomous` on a project with globally-numbered phases spanning multiple milestones
- [ ] Verify banner shows `Phase 63 (3/7)` instead of `Phase 63/5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)