### PR TITLE
fix(agents): remove permissionMode that breaks Gemini CLI agent loading

### DIFF
--- a/agents/gsd-debugger.md
+++ b/agents/gsd-debugger.md
@@ -2,7 +2,6 @@
 name: gsd-debugger
 description: Investigates bugs using scientific method, manages debug sessions, handles checkpoints. Spawned by /gsd:debug orchestrator.
 tools: Read, Write, Edit, Bash, Grep, Glob, WebSearch
-permissionMode: acceptEdits
 color: orange
 # hooks:
 #   PostToolUse:

--- a/agents/gsd-executor.md
+++ b/agents/gsd-executor.md
@@ -2,7 +2,6 @@
 name: gsd-executor
 description: Executes GSD plans with atomic commits, deviation handling, checkpoint protocols, and state management. Spawned by execute-phase orchestrator or execute-plan command.
 tools: Read, Write, Edit, Bash, Grep, Glob
-permissionMode: acceptEdits
 color: yellow
 # hooks:
 #   PostToolUse:

--- a/tests/agent-frontmatter.test.cjs
+++ b/tests/agent-frontmatter.test.cjs
@@ -386,55 +386,23 @@ describe('DISCUSS: discussion log generation', () => {
   });
 });
 
-// ─── Worktree Permission Mode (#1334) ───────────────────────────────────────
+// ─── Cross-runtime agent compatibility (#1522) ──────────────────────────────
 
-describe('PERM: worktree agents have permissionMode: acceptEdits', () => {
-  // Agents spawned with isolation="worktree" need permissionMode: acceptEdits
-  // to avoid per-directory edit permission prompts in the worktree path.
-  // See: anthropics/claude-code#29110, anthropics/claude-code#28041
-  const WORKTREE_AGENTS = ['gsd-executor', 'gsd-debugger'];
+describe('COMPAT: agents must not use runtime-specific frontmatter keys', () => {
+  // permissionMode is Claude Code-specific and breaks Gemini CLI agent loading.
+  // It also has no effect on subagent Write permissions in Claude Code (blocked
+  // at runtime level regardless). See #1522, #1387.
+  const AGENTS_WITH_WRITE = ['gsd-executor', 'gsd-debugger'];
 
-  for (const agent of WORKTREE_AGENTS) {
-    test(`${agent} has permissionMode: acceptEdits`, () => {
+  for (const agent of AGENTS_WITH_WRITE) {
+    test(`${agent} does not have permissionMode (breaks Gemini CLI)`, () => {
       const content = fs.readFileSync(path.join(AGENTS_DIR, agent + '.md'), 'utf-8');
       const frontmatter = content.split('---')[1] || '';
       assert.ok(
-        frontmatter.includes('permissionMode: acceptEdits'),
-        `${agent} must have permissionMode: acceptEdits — worktree agents need this to avoid ` +
-        `per-directory edit permission prompts (see #1334)`
+        !frontmatter.includes('permissionMode'),
+        `${agent} must not have permissionMode — it breaks Gemini CLI agent loading (#1522) ` +
+        `and has no effect in Claude Code (#1387)`
       );
     });
   }
-
-  test('worktree-spawned agents are covered', () => {
-    // Verify that agents referenced with isolation="worktree" in workflows
-    // are included in the WORKTREE_AGENTS list above
-    const dirs = [WORKFLOWS_DIR, COMMANDS_DIR];
-    const worktreeAgentTypes = new Set();
-
-    for (const dir of dirs) {
-      if (!fs.existsSync(dir)) continue;
-      const files = fs.readdirSync(dir).filter(f => f.endsWith('.md'));
-      for (const file of files) {
-        const content = fs.readFileSync(path.join(dir, file), 'utf-8');
-        // Find patterns like: subagent_type="gsd-executor" ... isolation="worktree"
-        // These can span multiple lines in Task() calls
-        const taskBlocks = content.match(/Task\([^)]*isolation="worktree"[^)]*\)/gs) || [];
-        for (const block of taskBlocks) {
-          const typeMatch = block.match(/subagent_type="([^"]+)"/);
-          if (typeMatch) {
-            worktreeAgentTypes.add(typeMatch[1]);
-          }
-        }
-      }
-    }
-
-    for (const agentType of worktreeAgentTypes) {
-      assert.ok(
-        WORKTREE_AGENTS.includes(agentType),
-        `${agentType} is spawned with isolation="worktree" but not in WORKTREE_AGENTS list — ` +
-        `add permissionMode: acceptEdits to its frontmatter and update this test`
-      );
-    }
-  });
 });


### PR DESCRIPTION
## Summary

Fixes #1522 — `permissionMode: acceptEdits` in gsd-executor and gsd-debugger frontmatter is Claude Code-specific and causes Gemini CLI to hard-fail on agent load.

- Removes `permissionMode: acceptEdits` from `gsd-executor.md` and `gsd-debugger.md`
- Updates tests to enforce cross-runtime compatibility (verify the key is absent)
- The field had no effect in Claude Code anyway (#1387) — subagent Write permissions are controlled at runtime level

### Context

PR #1338 added `permissionMode: acceptEdits` to worktree agents to avoid per-directory edit permission prompts. However:
1. Gemini CLI validates frontmatter strictly and rejects unknown keys, making both agents completely unusable
2. Claude Code ignores `permissionMode` for background subagents — Write permissions are blocked at the runtime level regardless

The `bin/install.js` Gemini conversion already strips this key (line 2672), but agents loaded directly from disk still break.

## Test plan

- [x] Updated tests: verify `permissionMode` absent from executor and debugger (96 pass, 0 fail)
- [x] Full suite: no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)