### PR TITLE
feat(debug): add --diagnose flag for diagnosis-only mode

### DIFF
--- a/commands/gsd/debug.md
+++ b/commands/gsd/debug.md
@@ -1,7 +1,7 @@
 ---
 name: gsd:debug
 description: Systematic debugging with persistent state across context resets
-argument-hint: [issue description]
+argument-hint: [--diagnose] [issue description]
 allowed-tools:
   - Read
   - Bash
@@ -15,6 +15,9 @@ Debug issues using scientific method with subagent isolation.
 **Orchestrator role:** Gather symptoms, spawn gsd-debugger agent, handle checkpoints, spawn continuations.
 
 **Why subagent:** Investigation burns context fast (reading files, forming hypotheses, testing). Fresh 200k context per investigation. Main context stays lean for user interaction.
+
+**Flags:**
+- `--diagnose` — Diagnose only. Find root cause without applying a fix. Returns a structured Root Cause Report. Use when you want to validate the diagnosis before committing to a fix.
 </objective>
 
 <available_agent_types>
@@ -24,6 +27,10 @@ Valid GSD subagent types (use exact names — do not fall back to 'general-purpo
 
 <context>
 User's issue: $ARGUMENTS
+
+Parse flags from $ARGUMENTS:
+- If `--diagnose` is present, set `diagnose_only=true` and remove the flag from the issue description.
+- Otherwise, `diagnose_only=false`.
 
 Check for active sessions:
 ```bash
@@ -87,7 +94,7 @@ timeline: {timeline}
 
 <mode>
 symptoms_prefilled: true
-goal: find_and_fix
+goal: {if diagnose_only: "find_root_cause_only", else: "find_and_fix"}
 </mode>
 
 <debug_file>
@@ -106,12 +113,18 @@ Task(
 
 ## 4. Handle Agent Return
 
-**If `## ROOT CAUSE FOUND`:**
-- Display root cause and evidence summary
+**If `## ROOT CAUSE FOUND` (diagnose-only mode):**
+- Display root cause, confidence level, files involved, and suggested fix strategies
 - Offer options:
-  - "Fix now" - spawn fix subagent
-  - "Plan fix" - suggest /gsd:plan-phase --gaps
-  - "Manual fix" - done
+  - "Fix now" — spawn a continuation agent with `goal: find_and_fix` to apply the fix (see step 5)
+  - "Plan fix" — suggest `/gsd:plan-phase --gaps`
+  - "Manual fix" — done
+
+**If `## DEBUG COMPLETE` (find_and_fix mode):**
+- Display root cause and fix summary
+- Offer options:
+  - "Plan fix" — suggest `/gsd:plan-phase --gaps` if further work needed
+  - "Done" — mark resolved
 
 **If `## CHECKPOINT REACHED`:**
 - Present checkpoint details to user
@@ -128,9 +141,9 @@ Task(
   - "Manual investigation" - done
   - "Add more context" - gather more symptoms, spawn again
 
-## 5. Spawn Continuation Agent (After Checkpoint)
+## 5. Spawn Continuation Agent (After Checkpoint or "Fix now")
 
-When user responds to checkpoint, spawn fresh agent:
+When user responds to checkpoint OR selects "Fix now" from diagnose-only results, spawn fresh agent:
 
 ```markdown
 <objective>


### PR DESCRIPTION
## Summary

Fixes #1396 — adds `--diagnose` flag to `/gsd:debug` that stops after finding the root cause without applying a fix.

- Parses `--diagnose` from arguments, sets `goal: find_root_cause_only`
- Returns a structured Root Cause Report with confidence level, files involved, and fix strategies
- Offers "Fix now" (spawn continuation with `find_and_fix`), "Plan fix", or "Manual fix"
- Separates `## ROOT CAUSE FOUND` (diagnose-only) from `## DEBUG COMPLETE` (find_and_fix) return handling

**Replaces #1409** — recreated cleanly on current main. The original carried 140+ files of stale shared fixes that are now upstream. This PR touches only `commands/gsd/debug.md` (1 file, 22 insertions, 9 deletions).

## Test plan

- [ ] Run `/gsd:debug --diagnose "test issue"` — verify it stops at root cause without fixing
- [ ] Select "Fix now" — verify continuation agent spawns with `find_and_fix` goal
- [x] No executable code changes — workflow instruction only

🤖 Generated with [Claude Code](https://claude.com/claude-code)