### PR TITLE
fix(execute-phase): add required description param to Task() calls

### DIFF
--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -236,6 +236,7 @@ Execute each selected wave in sequence. Within a wave: parallel if `PARALLELIZAT
    ```
    Task(
      subagent_type="gsd-executor",
+     description="Execute plan {plan_number} of phase {phase_number}",
      model="{executor_model}",
      isolation="worktree",
      prompt="
@@ -732,6 +733,7 @@ VERIFIER_SKILLS=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" agent-ski
 
 ```
 Task(
+  description="Verify phase {phase_number} goal achievement",
   prompt="Verify phase {phase_number} goal achievement.
 Phase directory: {phase_dir}
 Phase goal: {goal from ROADMAP.md}


### PR DESCRIPTION
Fixes #1556

## Summary

- The `gsd-executor` `Task()` call was missing the required `description` parameter
- The `gsd-verifier` `Task()` call was missing the required `description` parameter

Both omissions cause `InputValidationError: The required parameter 'description' is missing` when `/gsd:execute-phase` spawns agents in parallel.

## Root Cause

Claude Code's `Agent` tool requires `description` as a mandatory field. Neither `Task()` call in `execute-phase.md` included it, so every parallel execution attempt failed immediately on agent initialization.

## Fix

Added `description=` to both calls:

- `gsd-executor`: `description="Execute plan {plan_number} of phase {phase_number}"`
- `gsd-verifier`: `description="Verify phase {phase_number} goal achievement"`

## Test plan

- [x] All 1698 existing tests pass (`npm test`)
- [x] No other files modified