### PR TITLE
docs: add missing build:hooks step to development installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,13 +150,16 @@ Use `--sdk` to also install the GSD SDK CLI (`gsd-sdk`) for headless autonomous 
 <details>
 <summary><strong>Development Installation</strong></summary>
 
-Clone the repository and run the installer locally:
+Clone the repository, build hooks, and run the installer locally:
 
 ```bash
 git clone https://github.com/gsd-build/get-shit-done.git
 cd get-shit-done
+npm run build:hooks
 node bin/install.js --claude --local
 ```
+
+The `build:hooks` step is required — it compiles hook sources into `hooks/dist/` which the installer copies from. Without it, hooks won't be installed and you'll get hook errors in Claude Code. (The npm release handles this automatically via `prepublishOnly`.)
 
 Installs to `./.claude/` for testing modifications before contributing.
 


### PR DESCRIPTION
## Summary
- The development installation instructions were missing the `npm run build:hooks` step
- Without it, `hooks/dist/` doesn't exist when installing from a git clone, so the installer silently skips hook copying but still registers them in `settings.json`
- This causes hook errors (SessionStart, PostToolUse, PreToolUse) at runtime

## Test plan
- [ ] Follow the updated development installation instructions from a fresh clone
- [ ] Verify no hook errors on session start

🤖 Generated with [Claude Code](https://claude.com/claude-code)