### PR TITLE
fix: only remove session tmp dir when last pointer file is cleared (#1593)

### DIFF
--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -714,8 +714,15 @@ function clearActiveWorkstreamPointer(filePath, cleanupDirPath) {
 
   // Session-scoped pointers for a repo share one tmp directory. Only remove it
   // when it is empty so clearing or self-healing one session never deletes siblings.
+  // Explicitly check remaining entries rather than relying on rmdirSync throwing
+  // ENOTEMPTY — that error is not raised reliably on Windows.
   if (cleanupDirPath) {
-    try { fs.rmdirSync(cleanupDirPath); } catch {}
+    try {
+      const remaining = fs.readdirSync(cleanupDirPath);
+      if (remaining.length === 0) {
+        fs.rmdirSync(cleanupDirPath);
+      }
+    } catch {}
   }
 }
 


### PR DESCRIPTION
Closes #1593

## What
`clearActiveWorkstreamPointer` now explicitly checks that the session tmp directory is empty before removing it, instead of calling `rmdirSync` and silently catching `ENOTEMPTY`.

## Why
On Windows, `rmdirSync` does not reliably raise `ENOTEMPTY` when a directory contains files. This caused the session tmp directory to be deleted while sibling pointer files for other active sessions still remained, breaking workstream routing for those sessions.

## How
Replaced `try { fs.rmdirSync(cleanupDirPath); } catch {}` with an explicit `fs.readdirSync()` emptiness check before calling `rmdirSync`. The invariant ("only delete when empty") is now enforced by the code, not assumed from OS error behavior.

## Testing
- [ ] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux

- [x] N/A (not runtime-specific)

All three `pointer lifecycle hardening` tests pass locally. These are the exact tests that were failing on Windows CI in `main` since #1560 was merged.

## Checklist
- [x] Issue linked above (`Closes #1593`)
- [x] Follows GSD style (no enterprise patterns, no filler)
- [x] Existing tests pass (`npm test`)
- [ ] Updates CHANGELOG.md for user-facing changes

## Breaking Changes
None