### PR TITLE
fix: use realpathSync.native for session projectId hash on Windows

### DIFF
--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -695,9 +695,20 @@ function getSessionScopedWorkstreamFile(cwd) {
   const sessionKey = getWorkstreamSessionKey();
   if (!sessionKey) return null;
 
+  // Use realpathSync.native so the hash is derived from the canonical filesystem
+  // path. On Windows, path.resolve returns whatever case the caller supplied,
+  // while realpathSync.native returns the case the OS recorded — they differ on
+  // case-insensitive NTFS, producing different hashes and different tmpdir slots.
+  // Fall back to path.resolve when the directory does not yet exist.
+  let planningAbs;
+  try {
+    planningAbs = fs.realpathSync.native(planningRoot(cwd));
+  } catch {
+    planningAbs = path.resolve(planningRoot(cwd));
+  }
   const projectId = crypto
     .createHash('sha1')
-    .update(path.resolve(planningRoot(cwd)))
+    .update(planningAbs)
     .digest('hex')
     .slice(0, 16);
 


### PR DESCRIPTION
Closes #1593

## What
Use `fs.realpathSync.native` (with a `path.resolve` fallback) instead of `path.resolve` when computing the session-scoped workstream project ID.

## Why
On Windows, `path.resolve` returns whatever case the caller supplied; `fs.realpathSync.native` returns the OS-canonical case. These produce different SHA-1 hashes → different `gsd-workstream-sessions/<id>/` tmpdir slots. The test helper used `realpathSync.native`; the implementation used `path.resolve` — they were looking at different directories, so pointer lifecycle assertions always failed on Windows despite the underlying logic being correct.

## How
Wrap the path derivation in a try/catch: attempt `realpathSync.native` (handles symlinks and case normalisation), fall back to `path.resolve` when the `.planning` directory doesn't exist yet (e.g. during `new-project`).

## Testing
- [ ] macOS
- [x] Windows (root cause is Windows-specific path canonicalisation)
- [ ] Linux

- [x] N/A (not runtime-specific)

All three `pointer lifecycle hardening` tests pass locally. These have been failing on every Windows CI run since #1560 was merged.

## Checklist
- [x] Issue linked (`Closes #1593`)
- [x] Follows GSD style
- [x] Existing tests pass

## Breaking Changes
None