### PR TITLE
feat: add Cline runtime support via .clinerules

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -1,0 +1,27 @@
+# GSD — Get Shit Done
+
+## What This Project Is
+GSD is a structured AI development workflow system. It coordinates AI agents through planning phases, not direct code edits.
+
+## Core Rule: Never Edit Outside a GSD Workflow
+Do not make direct repo edits. All changes must go through a GSD workflow:
+- `/gsd:plan-phase` → plan the work
+- `/gsd:execute-phase` → build it
+- `/gsd:verify-work` → verify results
+
+## Architecture
+- `get-shit-done/bin/lib/` — Core Node.js library (CommonJS .cjs, no external deps)
+- `get-shit-done/workflows/` — Workflow definition files (.md)
+- `agents/` — Agent definition files (.md)
+- `commands/gsd/` — Slash command definitions (.md)
+- `tests/` — Test files (.test.cjs, node:test + node:assert)
+
+## Coding Standards
+- **CommonJS only** — use `require()`, never `import`
+- **No external dependencies in core** — only Node.js built-ins
+- **Test framework** — `node:test` and `node:assert` ONLY, never Jest/Mocha/Chai
+- **File extensions** — `.cjs` for all test and lib files
+
+## Safety
+- Use `execFileSync` (array args) not `execSync` (string interpolation)
+- Validate user-provided paths with `validatePath()` from `get-shit-done/bin/lib/security.cjs`

--- a/tests/cline-support.test.cjs
+++ b/tests/cline-support.test.cjs
@@ -1,0 +1,33 @@
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+
+describe('Cline runtime support', () => {
+  test('.clinerules file exists at repo root', () => {
+    const p = path.join(__dirname, '..', '.clinerules');
+    assert.ok(fs.existsSync(p), '.clinerules should exist at repo root');
+  });
+
+  test('.clinerules references GSD workflow enforcement', () => {
+    const content = fs.readFileSync(path.join(__dirname, '..', '.clinerules'), 'utf-8');
+    assert.ok(
+      content.includes('gsd') || content.includes('GSD') || content.includes('workflow'),
+      '.clinerules should mention GSD workflows'
+    );
+  });
+
+  test('.clinerules includes coding standards', () => {
+    const content = fs.readFileSync(path.join(__dirname, '..', '.clinerules'), 'utf-8');
+    assert.ok(content.includes('CommonJS') || content.includes('require'),
+      '.clinerules should mention CommonJS standard');
+    assert.ok(content.includes('node:test') || content.includes('node:assert'),
+      '.clinerules should mention test framework');
+  });
+
+  test('.clinerules includes architecture overview', () => {
+    const content = fs.readFileSync(path.join(__dirname, '..', '.clinerules'), 'utf-8');
+    assert.ok(content.includes('bin/lib') || content.includes('workflows') || content.includes('agents'),
+      '.clinerules should describe project architecture');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `.clinerules` at the repo root for Cline (VS Code AI coding extension)
- Covers GSD workflow enforcement, architecture overview, coding standards (CommonJS, node:test), and safety guidelines
- Follows the same pattern as CLAUDE.md (Claude Code) and AGENTS.md (Codex)

## Test plan
- [ ] `node --test tests/cline-support.test.cjs` — all pass
- [ ] `node scripts/run-tests.cjs` — no regressions

Closes #1509