### PR TITLE
fix(workstreams): replace GSD_TOOLS env var with resolved binary path

### DIFF
--- a/commands/gsd/workstreams.md
+++ b/commands/gsd/workstreams.md
@@ -35,30 +35,30 @@ If no subcommand given, default to `list`.
 ## Step 2: Execute Operation
 
 ### list
-Run: `node "$GSD_TOOLS" workstream list --raw --cwd "$CWD"`
+Run: `node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" workstream list --raw --cwd "$CWD"`
 Display the workstreams in a table format showing name, status, current phase, and progress.
 
 ### create
-Run: `node "$GSD_TOOLS" workstream create <name> --raw --cwd "$CWD"`
+Run: `node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" workstream create <name> --raw --cwd "$CWD"`
 After creation, display the new workstream path and suggest next steps:
 - `/gsd:new-milestone --ws <name>` to set up the milestone
 
 ### status
-Run: `node "$GSD_TOOLS" workstream status <name> --raw --cwd "$CWD"`
+Run: `node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" workstream status <name> --raw --cwd "$CWD"`
 Display detailed phase breakdown and state information.
 
 ### switch
-Run: `node "$GSD_TOOLS" workstream set <name> --raw --cwd "$CWD"`
+Run: `node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" workstream set <name> --raw --cwd "$CWD"`
 Also set `GSD_WORKSTREAM` for the current session when the runtime supports it.
 If the runtime exposes a session identifier, GSD also stores the active workstream
 session-locally so concurrent sessions do not overwrite each other.
 
 ### progress
-Run: `node "$GSD_TOOLS" workstream progress --raw --cwd "$CWD"`
+Run: `node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" workstream progress --raw --cwd "$CWD"`
 Display a progress overview across all workstreams.
 
 ### complete
-Run: `node "$GSD_TOOLS" workstream complete <name> --raw --cwd "$CWD"`
+Run: `node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" workstream complete <name> --raw --cwd "$CWD"`
 Archive the workstream to milestones/.
 
 ### resume


### PR DESCRIPTION
## Summary

- Replace `GSD_TOOLS` environment variable references with the resolved absolute path `$HOME/.claude/get-shit-done/bin/gsd-tools.cjs` in the workstreams command docs
- Ensures workstream commands work correctly in runtimes where `GSD_TOOLS` is not set

reference: https://github.com/gsd-build/get-shit-done/pull/1236

BTW: actually it's better to use the env var for cross platform deployment, but it seems that the env var comes from nowhere, so comply with other commands first