### PR TITLE
fix(plan-phase): update STATE.md after planning completes

### DIFF
--- a/get-shit-done/workflows/plan-phase.md
+++ b/get-shit-done/workflows/plan-phase.md
@@ -871,6 +871,19 @@ If `TEXT_MODE` is true, present as a plain-text numbered list (options already s
 
 ## 14. Present Final Status
 
+**Update STATE.md for plan completion:**
+```bash
+PLAN_COUNT=$(ls -1 ${PHASE_DIR}/*-PLAN.md 2>/dev/null | wc -l | tr -d ' ')
+node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" state update "Status" "Phase ${PHASE} planned — ready to execute"
+node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" state update "Last Activity" "$(date +%Y-%m-%d)"
+node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" state update "Last Activity Description" "Phase ${PHASE} planning complete (${PLAN_COUNT} plans)"
+```
+
+Commit the state update:
+```bash
+node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" commit "docs(state): record phase ${PHASE} planning complete" --files .planning/STATE.md
+```
+
 Route to `<offer_next>` OR `auto_advance` depending on flags/config.
 
 ## 15. Auto-Advance Check

--- a/tests/plan-phase-state-update.test.cjs
+++ b/tests/plan-phase-state-update.test.cjs
@@ -1,0 +1,75 @@
+/**
+ * plan-phase STATE.md update tests (#1626)
+ *
+ * Verifies that plan-phase.md updates STATE.md after planning completes,
+ * so downstream workflows (and users) can see the phase is ready to execute.
+ */
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+
+const WORKFLOW_PATH = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'plan-phase.md');
+
+describe('plan-phase STATE.md update (#1626)', () => {
+  let content;
+
+  test('plan-phase.md exists', () => {
+    assert.ok(fs.existsSync(WORKFLOW_PATH), 'get-shit-done/workflows/plan-phase.md should exist');
+    content = fs.readFileSync(WORKFLOW_PATH, 'utf-8');
+  });
+
+  test('plan-phase contains a state update call', () => {
+    content = content || fs.readFileSync(WORKFLOW_PATH, 'utf-8');
+    assert.ok(
+      content.includes('state update') || content.includes('state patch'),
+      'plan-phase.md should call gsd-tools state update or state patch'
+    );
+  });
+
+  test('state update sets status to planned / ready to execute', () => {
+    content = content || fs.readFileSync(WORKFLOW_PATH, 'utf-8');
+    assert.ok(
+      content.includes('planned') && content.includes('ready to execute'),
+      'status message should include "planned" and "ready to execute"'
+    );
+  });
+
+  test('state update happens in step 14 (Present Final Status)', () => {
+    content = content || fs.readFileSync(WORKFLOW_PATH, 'utf-8');
+    // Find the positions of step 14 header, the state update, and step 15 header
+    const step14Pos = content.indexOf('## 14. Present Final Status');
+    const step15Pos = content.indexOf('## 15. Auto-Advance Check');
+    const stateUpdatePos = content.indexOf('state update', step14Pos);
+
+    assert.ok(step14Pos !== -1, 'step 14 header should exist');
+    assert.ok(step15Pos !== -1, 'step 15 header should exist');
+    assert.ok(stateUpdatePos !== -1, 'state update call should exist after step 14');
+    assert.ok(
+      stateUpdatePos > step14Pos && stateUpdatePos < step15Pos,
+      'state update should appear between step 14 and step 15 (before auto-advance check)'
+    );
+  });
+
+  test('state update includes Last Activity field', () => {
+    content = content || fs.readFileSync(WORKFLOW_PATH, 'utf-8');
+    assert.ok(
+      content.includes('state update "Last Activity"'),
+      'plan-phase should update the Last Activity field in STATE.md'
+    );
+  });
+
+  test('state update commits the change', () => {
+    content = content || fs.readFileSync(WORKFLOW_PATH, 'utf-8');
+    // The commit should reference STATE.md
+    const step14Pos = content.indexOf('## 14. Present Final Status');
+    const step15Pos = content.indexOf('## 15. Auto-Advance Check');
+    const section14 = content.slice(step14Pos, step15Pos);
+
+    assert.ok(
+      section14.includes('commit') && section14.includes('STATE.md'),
+      'step 14 should commit the STATE.md update'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1626

After `/gsd:plan-phase` completes, STATE.md was never updated — it continued showing the previous phase state. The `execute-phase` workflow calls `state begin-phase` but `plan-phase` had no state update at all.

- Added STATE.md update to step 14 ("Present Final Status") in `plan-phase.md`
- Uses `state update` to set Status ("Phase N planned — ready to execute"), Last Activity (today's date), and Last Activity Description
- Commits the state change before routing to auto-advance or Next Up block
- Chose `state update` over `state patch` because STATE.md uses space-separated field names (`Last Activity`) that don't match `state patch`'s hyphenated key parsing

## Test plan

- [x] New test `tests/plan-phase-state-update.test.cjs` (6 tests) verifies:
  - `plan-phase.md` contains state update calls
  - Status message includes "planned" and "ready to execute"
  - State update is positioned before auto-advance (step 15)
  - Last Activity field is updated
  - State change is committed
- [x] All 2022 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>