### PR TITLE
fix(plan-phase): preserve chain flag across discuss→plan→execute

### DIFF
--- a/get-shit-done/workflows/plan-phase.md
+++ b/get-shit-done/workflows/plan-phase.md
@@ -855,10 +855,10 @@ Route to `<offer_next>` OR `auto_advance` depending on flags/config.
 
 Check for auto-advance trigger:
 
-1. Parse `--auto` flag from $ARGUMENTS
-2. **Sync chain flag with intent** — if user invoked manually (no `--auto`), clear the ephemeral chain flag from any previous interrupted `--auto` chain. This does NOT touch `workflow.auto_advance` (the user's persistent settings preference):
+1. Parse `--auto` and `--chain` flags from $ARGUMENTS
+2. **Sync chain flag with intent** — if user invoked manually (no `--auto` and no `--chain`), clear the ephemeral chain flag from any previous interrupted `--auto` chain. This does NOT touch `workflow.auto_advance` (the user's persistent settings preference):
    ```bash
-   if [[ ! "$ARGUMENTS" =~ --auto ]]; then
+   if [[ ! "$ARGUMENTS" =~ --auto ]] && [[ ! "$ARGUMENTS" =~ --chain ]]; then
      node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-set workflow._auto_chain_active false 2>/dev/null
    fi
    ```
@@ -868,7 +868,14 @@ Check for auto-advance trigger:
    AUTO_CFG=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-get workflow.auto_advance 2>/dev/null || echo "false")
    ```
 
-**If `--auto` flag present OR `AUTO_CHAIN` is true OR `AUTO_CFG` is true:**
+**If `--auto` or `--chain` flag present AND `AUTO_CHAIN` is not true:** Persist chain flag to config (handles direct invocation without prior discuss-phase):
+```bash
+if ([[ "$ARGUMENTS" =~ --auto ]] || [[ "$ARGUMENTS" =~ --chain ]]) && [[ "$AUTO_CHAIN" != "true" ]]; then
+  node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-set workflow._auto_chain_active true
+fi
+```
+
+**If `--auto` or `--chain` flag present OR `AUTO_CHAIN` is true OR `AUTO_CFG` is true:**
 
 Display banner:
 ```

--- a/tests/chain-flag-plan-phase.test.cjs
+++ b/tests/chain-flag-plan-phase.test.cjs
@@ -1,0 +1,70 @@
+/**
+ * GSD Tools Tests - chain flag preservation in plan-phase
+ *
+ * Validates that plan-phase.md correctly handles the --chain flag
+ * so that discuss→plan→execute auto-advance works without manual
+ * intervention.
+ *
+ * Closes: #1620
+ */
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+
+describe('plan-phase chain flag preservation (#1620)', () => {
+  const planPath = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'plan-phase.md');
+  const discussPath = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'discuss-phase.md');
+
+  test('plan-phase sync-flag guard checks both --auto AND --chain', () => {
+    const content = fs.readFileSync(planPath, 'utf8');
+    // The guard that clears _auto_chain_active must require BOTH flags to be absent
+    assert.ok(
+      content.includes('if [[ ! "$ARGUMENTS" =~ --auto ]] && [[ ! "$ARGUMENTS" =~ --chain ]]; then'),
+      'plan-phase should check for both --auto and --chain before clearing chain flag'
+    );
+  });
+
+  test('plan-phase persists chain flag to config before auto-advancing', () => {
+    const content = fs.readFileSync(planPath, 'utf8');
+    // Plan-phase must persist the chain flag (config-set workflow._auto_chain_active true)
+    assert.ok(
+      content.includes('config-set workflow._auto_chain_active true'),
+      'plan-phase should persist chain flag via config-set workflow._auto_chain_active true'
+    );
+  });
+
+  test('plan-phase and discuss-phase use the same guard pattern for clearing _auto_chain_active', () => {
+    const planContent = fs.readFileSync(planPath, 'utf8');
+    const discussContent = fs.readFileSync(discussPath, 'utf8');
+
+    const guardPattern = 'if [[ ! "$ARGUMENTS" =~ --auto ]] && [[ ! "$ARGUMENTS" =~ --chain ]]; then';
+
+    assert.ok(
+      planContent.includes(guardPattern),
+      'plan-phase should use the dual-flag guard pattern'
+    );
+    assert.ok(
+      discussContent.includes(guardPattern),
+      'discuss-phase should use the dual-flag guard pattern'
+    );
+  });
+
+  test('plan-phase auto-advance trigger includes --chain flag', () => {
+    const content = fs.readFileSync(planPath, 'utf8');
+    // The trigger condition should mention --chain alongside --auto
+    assert.ok(
+      content.includes('`--auto` or `--chain` flag present OR `AUTO_CHAIN` is true OR `AUTO_CFG` is true'),
+      'plan-phase auto-advance trigger should check for --chain flag'
+    );
+  });
+
+  test('plan-phase parses both --auto and --chain flags', () => {
+    const content = fs.readFileSync(planPath, 'utf8');
+    assert.ok(
+      content.includes('Parse `--auto` and `--chain` flags from $ARGUMENTS'),
+      'plan-phase step 15 should parse both --auto and --chain flags'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1620

`/gsd:discuss-phase N --chain` is supposed to auto-advance through discuss → plan → execute, but the chain would break at plan → execute. Two issues in `plan-phase.md` step 15:

### Bug 1: Sync-flag guard only checked `--auto`

The guard that clears the ephemeral `_auto_chain_active` flag only checked for `--auto`:
```bash
if [[ ! "$ARGUMENTS" =~ --auto ]]; then
  config-set workflow._auto_chain_active false
fi
```

`discuss-phase.md` already correctly checks for **both** flags. Updated `plan-phase.md` to match:
```bash
if [[ ! "$ARGUMENTS" =~ --auto ]] && [[ ! "$ARGUMENTS" =~ --chain ]]; then
  config-set workflow._auto_chain_active false
fi
```

### Bug 2: Missing chain flag persistence

`discuss-phase.md` persists the chain flag before auto-advancing (`config-set workflow._auto_chain_active true`), but `plan-phase.md` never did — so if the flag wasn't already set (config read failure, race condition), the chain would silently break.

Added the same persistence guard to `plan-phase.md` step 15, matching `discuss-phase.md`'s pattern.

## Test plan

- [x] New test `tests/chain-flag-plan-phase.test.cjs` (5 tests) verifies:
  - Sync-flag guard checks both `--auto` AND `--chain`
  - Plan-phase persists chain flag via `config-set workflow._auto_chain_active true`
  - Both discuss-phase.md and plan-phase.md use identical dual-flag guard patterns
  - Auto-advance trigger condition mentions `--chain`
  - Step 15 parses both flags
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>