### PR TITLE
fix: remove unnecessary Write from workstreams allowed-tools

### DIFF
--- a/commands/gsd/workstreams.md
+++ b/commands/gsd/workstreams.md
@@ -3,7 +3,6 @@ name: gsd:workstreams
 description: Manage parallel workstreams — list, create, switch, status, progress, complete, and resume
 allowed-tools:
   - Read
-  - Write
   - Bash
 ---
 


### PR DESCRIPTION
## Summary

- Remove `Write` from `commands/gsd/workstreams.md` allowed-tools list
- The command only delegates to `node "$GSD_TOOLS"` via Bash and formats JSON output — it never writes files
- Tightens tool surface from `[Read, Write, Bash]` to `[Read, Bash]`

Closes #1637

## Context

Noted by maintainer in [PR #1576 review](https://github.com/gsd-build/get-shit-done/pull/1576):

> The locally-merged version in `08f59fa` added `Write` unnecessarily — the proposed set here [`Read, Bash`] is actually tighter and more accurate.

## Test plan

- [ ] Verify `workstreams.md` frontmatter has only `Read` and `Bash` in allowed-tools
- [ ] Confirm no `Write`/`Edit` tool calls exist in the command body
- [ ] Run `/gsd:workstreams list` to verify command still works