### PR TITLE
fix(roadmap): fall back to full ROADMAP.md for backlog phases

### DIFF
--- a/get-shit-done/bin/lib/roadmap.cjs
+++ b/get-shit-done/bin/lib/roadmap.cjs
@@ -87,10 +87,14 @@ function cmdRoadmapGetPhase(cwd, phaseNum, raw) {
     // Escape special regex chars in phase number, handle decimal
     const escapedPhase = escapeRegex(phaseNum);
 
-    // Search the current milestone slice first, then fall back to full roadmap
+    // Search the current milestone slice first, then fall back to full roadmap.
+    // A malformed_roadmap result (checklist-only) from the milestone should not
+    // block finding a full header match in the wider roadmap content.
     const fullContent = stripShippedMilestones(rawContent);
-    const result = searchPhaseInContent(milestoneContent, escapedPhase, phaseNum)
-      || searchPhaseInContent(fullContent, escapedPhase, phaseNum);
+    const milestoneResult = searchPhaseInContent(milestoneContent, escapedPhase, phaseNum);
+    const result = (milestoneResult && !milestoneResult.error)
+      ? milestoneResult
+      : searchPhaseInContent(fullContent, escapedPhase, phaseNum) || milestoneResult;
 
     if (!result) {
       output({ found: false, phase_number: phaseNum }, raw, '');

--- a/tests/roadmap-phase-fallback.test.cjs
+++ b/tests/roadmap-phase-fallback.test.cjs
@@ -178,6 +178,35 @@ describe('roadmap get-phase fallback to full ROADMAP.md (#1634)', () => {
     assert.ok(output.message.includes('missing'), 'should explain the issue');
   });
 
+  test('checklist in milestone does not block full header match in wider roadmap', () => {
+    writeState(tmpDir, 'v1.0');
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      `# Roadmap
+
+## v1.0 Current Release
+
+### Phase 1: Foundation
+**Goal:** Set up project infrastructure
+
+- [ ] **Phase 50: Cleanup** - referenced in checklist
+
+## v2.0 Future Release
+
+### Phase 50: Cleanup
+**Goal:** Remove deprecated modules
+`
+    );
+
+    const result = runGsdTools('roadmap get-phase 50', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.equal(output.found, true, 'full header in v2.0 should win over checklist in v1.0');
+    assert.equal(output.phase_name, 'Cleanup');
+    assert.equal(output.goal, 'Remove deprecated modules');
+  });
+
   test('section extraction from fallback includes correct content boundaries', () => {
     writeState(tmpDir, 'v1.0');
     fs.writeFileSync(


### PR DESCRIPTION
## Summary
- Extracts `searchPhaseInContent` helper to search for a phase header within arbitrary content strings
- `cmdRoadmapGetPhase` now searches the current milestone slice first, then falls back to the full (non-shipped) roadmap content
- Fixes `roadmap get-phase` returning `found: false` for phases in future milestones or backlog sections
- Fixes precedence bug where a checklist-only reference in the current milestone would short-circuit the `||` fallback and prevent finding a full header match in the wider roadmap

Closes #1634

## Test plan
- [x] 7 tests covering: active milestone phase, backlog fallback, future milestone fallback, missing phase, malformed_roadmap via fallback, section boundaries, checklist-vs-header precedence
- [x] All 2023 tests pass
- [x] Adversarial review found and fixed the `||` short-circuit precedence bug

🤖 Generated with [Claude Code](https://claude.com/claude-code)