### PR TITLE
fix(workstreams): remove unnecessary Write from allowed-tools

### DIFF
--- a/commands/gsd/workstreams.md
+++ b/commands/gsd/workstreams.md
@@ -3,7 +3,6 @@ name: gsd:workstreams
 description: Manage parallel workstreams — list, create, switch, status, progress, complete, and resume
 allowed-tools:
   - Read
-  - Write
   - Bash
 ---
 


### PR DESCRIPTION
## Summary

Closes #1637

The `workstreams.md` command only delegates to `node "$GSD_TOOLS"` via Bash and formats JSON output. No `Write` calls appear anywhere in the command body, so `Write` in `allowed-tools` is unnecessary and overly permissive.

- Removed `Write` from the frontmatter `allowed-tools` list
- Keeps `Read` and `Bash` which are actually used

## Test plan

- [x] Verified `Write` only appears in frontmatter, never in command body
- [x] Command functionality unchanged — only tool permissions tightened

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>