### PR TITLE
feat(commands): add explore, undo, import commands and enhance next with hard stops

### DIFF
--- a/commands/gsd/explore.md
+++ b/commands/gsd/explore.md
@@ -1,0 +1,32 @@
+---
+name: gsd:explore
+description: Socratic ideation and idea routing. Guide a conversation, then route outputs to the right GSD artifacts.
+argument-hint: "[topic or idea]"
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+  - Glob
+  - Grep
+  - Task
+  - AskUserQuestion
+---
+
+<objective>
+Socratic ideation -- guide a structured discovery conversation, then route outputs to the correct GSD artifacts (notes, todos, seeds, research questions, requirements, or new phases).
+</objective>
+
+<execution_context>
+@~/.claude/get-shit-done/workflows/explore.md
+@~/.claude/get-shit-done/references/ui-brand.md
+@~/.claude/get-shit-done/references/questioning.md
+@~/.claude/get-shit-done/references/domain-probes.md
+</execution_context>
+
+<context>
+$ARGUMENTS
+</context>
+
+<process>
+Execute the explore workflow from @~/.claude/get-shit-done/workflows/explore.md end-to-end.
+</process>

--- a/commands/gsd/import.md
+++ b/commands/gsd/import.md
@@ -1,0 +1,35 @@
+---
+name: gsd:import
+description: Ingest external plans or PRDs. Detects conflicts against project decisions before writing anything.
+argument-hint: "--from <filepath> | --prd <filepath>"
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+  - Glob
+  - Grep
+  - AskUserQuestion
+  - Task
+---
+
+<objective>
+Import external plans or PRDs into the GSD planning system with conflict detection and agent delegation.
+
+Two modes:
+- **--from**: Import an external plan file, detect conflicts, write as GSD PLAN.md, validate via gsd-plan-checker.
+- **--prd**: Extract a PRD into PROJECT.md + REQUIREMENTS.md, delegate ROADMAP.md generation to gsd-planner.
+</objective>
+
+<execution_context>
+@~/.claude/get-shit-done/workflows/import.md
+@~/.claude/get-shit-done/references/ui-brand.md
+@~/.claude/get-shit-done/references/gate-prompts.md
+</execution_context>
+
+<context>
+$ARGUMENTS
+</context>
+
+<process>
+Execute the import workflow end-to-end.
+</process>

--- a/commands/gsd/next.md
+++ b/commands/gsd/next.md
@@ -1,16 +1,22 @@
 ---
 name: gsd:next
-description: Automatically advance to the next logical step in the GSD workflow
+description: Automatically advance to the next logical step in the GSD workflow. Includes hard stops at milestone boundaries, error states, and verification gaps. Guards against runaway automation.
 allowed-tools:
   - Read
   - Bash
   - Grep
   - Glob
-  - SlashCommand
+  - Skill
+  - AskUserQuestion
 ---
 <objective>
 Detect the current project state and automatically invoke the next logical GSD workflow step.
 No arguments needed — reads STATE.md, ROADMAP.md, and phase directories to determine what comes next.
+
+Includes safety features from /gsd-continue (now merged):
+- Hard stops at milestone boundaries, error states, verification gaps, unresolved checkpoints
+- Consecutive-call budget guard (warns at 6+ consecutive invocations)
+- Skill() delegation instead of SlashCommand for reliable command routing
 
 Designed for rapid multi-project workflows where remembering which phase/step you're on is overhead.
 </objective>

--- a/commands/gsd/undo.md
+++ b/commands/gsd/undo.md
@@ -1,0 +1,35 @@
+---
+name: gsd:undo
+description: "Safe git revert. Roll back phase or plan commits using the phase manifest with dependency checks."
+argument-hint: "--last N | --phase NN | --plan NN-MM"
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+  - Glob
+  - Grep
+  - AskUserQuestion
+---
+
+<objective>
+Safe git revert — roll back GSD phase or plan commits using the phase manifest, with dependency checks and a confirmation gate before execution.
+
+Three modes:
+- **--last N**: Show recent GSD commits for interactive selection
+- **--phase NN**: Revert all commits for a phase (manifest + git log fallback)
+- **--plan NN-MM**: Revert all commits for a specific plan
+</objective>
+
+<execution_context>
+@~/.claude/get-shit-done/workflows/undo.md
+@~/.claude/get-shit-done/references/ui-brand.md
+@~/.claude/get-shit-done/references/gate-prompts.md
+</execution_context>
+
+<context>
+$ARGUMENTS
+</context>
+
+<process>
+Execute the undo workflow from @~/.claude/get-shit-done/workflows/undo.md end-to-end.
+</process>

--- a/get-shit-done/workflows/explore.md
+++ b/get-shit-done/workflows/explore.md
@@ -1,0 +1,394 @@
+<purpose>
+Socratic ideation workflow. Guide a structured discovery conversation using questioning.md
+principles and domain-probes.md for tech-specific follow-ups. At the end, route outputs to
+the correct GSD artifact locations (notes, todos, seeds, research questions, requirements,
+or new phases).
+
+Output: Up to 4 artifacts written to .planning/ paths and committed.
+</purpose>
+
+<required_reading>
+Read all files referenced by the invoking prompt's execution_context before starting:
+@~/.claude/get-shit-done/references/questioning.md
+@~/.claude/get-shit-done/references/domain-probes.md
+@~/.claude/get-shit-done/references/ui-brand.md
+</required_reading>
+
+<available_agent_types>
+Valid GSD subagent types (use exact names):
+- gsd-phase-researcher -- Deep-dive research on a topic
+</available_agent_types>
+
+<process>
+
+<step name="banner">
+Display the explore banner:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ GSD ► EXPLORING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+If `.planning/` exists, read STATE.md and ROADMAP.md inline for project context:
+
+```bash
+cat .planning/STATE.md 2>/dev/null
+cat .planning/ROADMAP.md 2>/dev/null
+```
+
+Display a brief context line if project state was found:
+```
+Project: {milestone_name} | Phase {N}: {phase_name} | Status: {status}
+```
+
+If no `.planning/` exists, display:
+```
+No active project. Exploring freely.
+```
+</step>
+
+<step name="socratic_conversation">
+Run a Socratic dialogue using questioning.md principles and domain-probes.md patterns.
+
+**Starting the conversation:**
+
+If `$ARGUMENTS` contains a topic or idea:
+- Acknowledge the topic and ask an open-ended question to explore it further
+- Example: "Interesting -- {topic}. What prompted this? What problem are you trying to solve?"
+
+If `$ARGUMENTS` is empty:
+- Ask what's on their mind:
+  ```
+  AskUserQuestion(
+    header: "Explore",
+    question: "What idea or question do you want to explore?",
+    options: []
+  )
+  ```
+
+**Conversation flow (5-8 exchanges max):**
+
+1. **Start open.** Let the user dump their mental model. Don't interrupt with structure.
+
+2. **Follow energy.** Whatever they emphasize, dig into that. What excited them? What problem sparked this?
+
+3. **Apply domain probes.** When the user mentions a technology area (auth, database, API, real-time, etc.), use 2-3 relevant probes from domain-probes.md to surface hidden assumptions and trade-offs. Don't run through them as a checklist -- pick the most relevant based on context.
+
+4. **Challenge vagueness.** Never accept fuzzy answers. "Good" means what? "Users" means who? "Simple" means how?
+
+5. **Make the abstract concrete.** "Walk me through using this." "What does that actually look like?"
+
+6. **Mid-conversation research offer.** After 2-3 exchanges, if the topic would benefit from deeper investigation, offer:
+   ```
+   AskUserQuestion(
+     header: "Research?",
+     question: "Want me to research this further before we continue?",
+     options: [
+       { label: "Yes", description: "Spawn a researcher to dig deeper" },
+       { label: "No", description: "Keep exploring together" }
+     ]
+   )
+   ```
+
+   If yes, spawn a research subagent:
+   ```
+   Task(
+     subagent_type="gsd-phase-researcher",
+     description="Research: {topic}",
+     prompt="Research the following topic in depth: {topic}
+
+   Context from conversation so far:
+   {summary of key points discussed}
+
+   Focus on:
+   - What approaches exist
+   - Trade-offs and pitfalls
+   - Recommendations for this specific context
+
+   Write findings to .planning/research/{topic-slug}.md"
+   )
+   ```
+
+   After research completes, summarize key findings and continue the conversation.
+
+7. **Know when to stop.** After 5-8 exchanges, or when the conversation reaches natural closure, move to output routing. Don't force more questions when clarity has been reached.
+
+**Anti-patterns (from questioning.md):**
+- Checklist walking -- going through domains regardless of what they said
+- Canned questions -- "What's your core value?" regardless of context
+- Interrogation -- firing questions without building on answers
+- Shallow acceptance -- taking vague answers without probing
+</step>
+
+<step name="output_routing">
+After the conversation, summarize the key insights discovered, then propose up to 4 concrete outputs from this list:
+
+**Available output types:**
+
+| Type | Description | Destination |
+|------|-------------|-------------|
+| Note | Captures a thought for later review | `.planning/notes/{YYYY-MM-DD}-{slug}.md` |
+| Todo | An actionable task to complete | `.planning/todos/pending/{NNN}-{slug}.md` |
+| Seed | A future capability idea with trigger conditions | `.planning/seeds/SEED-{NNN}-{slug}.md` |
+| Research question | A question needing deeper investigation | `.planning/research/questions.md` |
+| Requirement | A validated requirement for the project | `.planning/REQUIREMENTS.md` |
+| New phase | A new phase to add to the roadmap | `.planning/ROADMAP.md` |
+
+**Proposing outputs:**
+
+Present a numbered list of proposed outputs based on what emerged from the conversation:
+
+```
+Based on our conversation, here's what I'd suggest capturing:
+
+1. **Note** -- "{summary of the thought}"
+2. **Seed** -- "{future capability idea}"
+3. **Research question** -- "{question needing investigation}"
+4. **Todo** -- "{actionable next step}"
+```
+
+Then confirm with the user:
+
+```
+AskUserQuestion(
+  header: "Outputs?",
+  question: "Which outputs should I create? (list numbers, 'all', or 'none')",
+  options: [
+    { label: "All", description: "Create all proposed outputs" },
+    { label: "Let me pick", description: "I'll specify which ones" },
+    { label: "None", description: "Just wanted to think out loud" }
+  ]
+)
+```
+
+If "Let me pick" -- ask which numbers to create.
+If "None" -- skip to summary step.
+If "All" -- create all proposed outputs.
+</step>
+
+<step name="create_artifacts">
+For each confirmed output, create the artifact at the correct GSD path.
+
+**Slug generation** (used by all artifact types):
+```bash
+SLUG=$(echo "{title}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-\|-$//g')
+```
+
+---
+
+**Note:**
+
+Write `.planning/notes/{YYYY-MM-DD}-{slug}.md`:
+
+```bash
+mkdir -p .planning/notes
+```
+
+```markdown
+---
+date: "{YYYY-MM-DD HH:mm}"
+promoted: false
+---
+
+{Note content from conversation}
+```
+
+---
+
+**Todo:**
+
+Scan for highest existing number:
+```bash
+HIGHEST=$(ls .planning/todos/pending/*.md .planning/todos/completed/*.md 2>/dev/null | sed 's/.*\///' | grep -oE '^[0-9]+' | sort -n | tail -1)
+NEXT=$(printf "%03d" $(( ${HIGHEST:-0} + 1 )))
+```
+
+Write `.planning/todos/pending/{NEXT}-{slug}.md`:
+
+```bash
+mkdir -p .planning/todos/pending
+```
+
+```markdown
+---
+title: "{todo title}"
+status: pending
+priority: P2
+source: "/gsd-explore"
+created: {YYYY-MM-DD}
+theme: general
+---
+
+## Goal
+
+{Description of what needs to be done}
+
+## Context
+
+Captured during /gsd-explore session on {YYYY-MM-DD}.
+
+## Acceptance Criteria
+
+- [ ] {primary criterion}
+```
+
+---
+
+**Seed:**
+
+Scan for highest existing seed number:
+```bash
+HIGHEST=$(ls .planning/seeds/SEED-*.md 2>/dev/null | sed 's/.*SEED-//' | grep -oE '^[0-9]+' | sort -n | tail -1)
+NEXT=$(printf "%03d" $(( ${HIGHEST:-0} + 1 )))
+```
+
+Write `.planning/seeds/SEED-{NEXT}-{slug}.md`:
+
+```bash
+mkdir -p .planning/seeds
+```
+
+```markdown
+---
+id: SEED-{NEXT}
+status: dormant
+planted: {YYYY-MM-DD}
+trigger_when: "{trigger condition from conversation}"
+scope: "{Small|Medium|Large}"
+---
+
+# SEED-{NEXT}: {Idea title}
+
+## Why This Matters
+
+{Why this idea is worth capturing}
+
+## When to Surface
+
+**Trigger:** {trigger condition}
+
+This seed should be presented during `/gsd-new-milestone` when the milestone
+scope matches these conditions:
+- {condition 1}
+- {condition 2}
+
+## Scope Estimate
+
+**{scope}** -- {elaboration}
+
+## Notes
+
+Captured during /gsd-explore session on {YYYY-MM-DD}.
+```
+
+---
+
+**Research question:**
+
+Append to `.planning/research/questions.md` (create file if it does not exist):
+
+```bash
+mkdir -p .planning/research
+```
+
+If file does not exist, create it with a header first:
+```markdown
+# Research Questions
+
+Questions captured for future investigation.
+
+---
+```
+
+Append:
+```markdown
+- [ ] {Question text} -- Source: /gsd-explore ({YYYY-MM-DD})
+```
+
+---
+
+**Requirement:**
+
+Append to `.planning/REQUIREMENTS.md` with the next available requirement ID.
+
+Read the file first to find the highest existing ID pattern, then increment.
+
+Append the new requirement following the existing format in the file.
+
+---
+
+**New phase:**
+
+Append a new phase entry to `.planning/ROADMAP.md` following the existing phase format in the file.
+
+Read the file first to determine the next phase number and follow the established structure.
+</step>
+
+<step name="commit">
+Commit all created artifacts:
+
+```bash
+node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" commit "docs(explore): add {output-types} from /gsd-explore session" --files {list of created files}
+```
+
+Where `{output-types}` is a comma-separated list of what was created (e.g., "note, seed, todo").
+</step>
+
+<step name="summary">
+Display completion banner:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ GSD ► EXPLORE COMPLETE ✓
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+List artifacts created:
+```
+Created:
+  ✓ Note: .planning/notes/{filename}
+  ✓ Seed: .planning/seeds/{filename}
+  ✓ Research question: appended to .planning/research/questions.md
+```
+
+Display next steps in GSD style:
+
+```
+───────────────────────────────────────────────────────────────
+
+## ▶ Next Up
+
+**Explore more** -- continue ideating
+
+`/gsd-explore`
+
+<sub>`/clear` first → fresh context window</sub>
+
+───────────────────────────────────────────────────────────────
+
+**Also available:**
+- `/gsd-note` -- quick idea capture (no conversation)
+- `/gsd-plant-seed` -- plant a seed with full trigger details
+- `/gsd-plan-phase` -- plan next phase from captured ideas
+
+───────────────────────────────────────────────────────────────
+```
+
+End workflow.
+</step>
+
+</process>
+
+<success_criteria>
+- [ ] Socratic conversation uses questioning.md principles (open questions, follow energy, challenge vagueness)
+- [ ] Domain probes from domain-probes.md applied when tech topics emerge
+- [ ] Mid-conversation research option offered via gsd-phase-researcher Task()
+- [ ] Output routing covers all 6 types: notes, todos, seeds, research questions, requirements, new phases
+- [ ] User confirms which outputs to create before writing
+- [ ] Seeds use SEED-{NNN} sequential numbering
+- [ ] Todos use {NNN} sequential numbering from existing files
+- [ ] All artifacts written to correct .planning/ paths
+- [ ] Created artifacts committed via gsd-tools
+- [ ] GSD banner style used throughout (no PBR formatting)
+</success_criteria>

--- a/get-shit-done/workflows/import.md
+++ b/get-shit-done/workflows/import.md
@@ -1,0 +1,424 @@
+# Import Workflow
+
+External plan and PRD ingestion with conflict detection and agent delegation.
+
+Two execution paths:
+- **--from**: Import external plan → conflict detection → write PLAN.md → validate via gsd-plan-checker
+- **--prd**: Extract PRD → generate PROJECT.md + REQUIREMENTS.md → delegate ROADMAP.md to gsd-planner
+
+---
+
+<step name="banner">
+
+Display the stage banner:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ GSD ► IMPORT
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+</step>
+
+<step name="parse_arguments">
+
+Parse `$ARGUMENTS` to determine the execution mode:
+
+- If `--from` is present: extract FILEPATH (the next token after `--from`), set MODE=plan
+- If `--prd` is present: extract FILEPATH (the next token after `--prd`), set MODE=prd
+- If neither flag is found: display usage and exit:
+
+```
+Usage: /gsd-import --from <path> | --prd <path>
+
+  --from <path>   Import an external plan file into GSD format
+  --prd <path>    Extract a PRD into PROJECT.md, REQUIREMENTS.md, and ROADMAP.md
+```
+
+Validate that FILEPATH exists:
+
+```bash
+test -f "{FILEPATH}" || echo "FILE_NOT_FOUND"
+```
+
+If FILE_NOT_FOUND: display error and exit:
+
+```
+╔══════════════════════════════════════════════════════════════╗
+║  ERROR                                                       ║
+╚══════════════════════════════════════════════════════════════╝
+
+File not found: {FILEPATH}
+
+**To fix:** Verify the file path and try again.
+```
+
+</step>
+
+---
+
+## Path A: MODE=plan (--from)
+
+<step name="plan_load_context">
+
+Load project context for conflict detection:
+
+1. Read `.planning/ROADMAP.md` — extract phase structure, phase numbers, dependencies
+2. Read `.planning/PROJECT.md` — extract project constraints, tech stack, scope boundaries
+3. Glob for all CONTEXT.md files across phase directories:
+   ```bash
+   find .planning/phases/ -name "*-CONTEXT.md" -o -name "CONTEXT.md" 2>/dev/null
+   ```
+   Read each CONTEXT.md found — extract locked decisions (any decision in a `<decisions>` block)
+
+Store loaded context for conflict detection in the next step.
+
+</step>
+
+<step name="plan_read_input">
+
+Read the imported file at FILEPATH.
+
+Determine the format:
+- **GSD PLAN.md format**: Has YAML frontmatter with `phase:`, `plan:`, `type:` fields
+- **Freeform document**: Any other format (markdown spec, design doc, task list, etc.)
+
+Extract from the imported content:
+- **Phase target**: Which phase this plan belongs to (from frontmatter or inferred from content)
+- **Plan objectives**: What the plan aims to accomplish
+- **Tasks listed**: Individual work items described in the plan
+- **Files modified**: Any files mentioned as targets
+- **Dependencies**: Any referenced prerequisites
+
+</step>
+
+<step name="plan_conflict_detection">
+
+Run conflict checks against the loaded project context. Output as a plain-text conflict report using [BLOCKER], [WARNING], and [INFO] labels. Do NOT use markdown tables (no `|---|` format).
+
+### BLOCKER checks (any one prevents import):
+
+- Plan targets a phase number that does not exist in ROADMAP.md → [BLOCKER]
+- Plan specifies a tech stack that contradicts PROJECT.md constraints → [BLOCKER]
+- Plan contradicts a locked decision in any CONTEXT.md `<decisions>` block → [BLOCKER]
+- Plan uses PBR plan naming convention (PLAN-01.md, plan-01.md) → [BLOCKER] naming convention violation
+
+### WARNING checks (user confirmation required):
+
+- Plan has `depends_on` referencing plans that are not yet complete → [WARNING]
+- Plan modifies files that overlap with existing incomplete plans → [WARNING]
+- Plan phase number conflicts with existing phase numbering in ROADMAP.md → [WARNING]
+
+### INFO checks (informational, no action needed):
+
+- Plan uses a library not currently in the project tech stack → [INFO]
+- Plan adds a new phase to the ROADMAP.md structure → [INFO]
+
+Display the full Conflict Detection Report:
+
+```
+## Conflict Detection Report
+
+### BLOCKERS ({N})
+
+[BLOCKER] {Short title}
+  Found: {what the imported plan says}
+  Expected: {what project context requires}
+  → {Specific action to resolve}
+
+### WARNINGS ({N})
+
+[WARNING] {Short title}
+  Found: {what was detected}
+  Impact: {what could go wrong}
+  → {Suggested action}
+
+### INFO ({N})
+
+[INFO] {Short title}
+  Note: {relevant information}
+```
+
+**If any [BLOCKER] exists:**
+
+Display:
+```
+GSD > BLOCKED: {N} blockers must be resolved before import can proceed.
+```
+
+Exit WITHOUT writing any files. This is the safety gate — no PLAN.md is written when blockers exist.
+
+**If only WARNINGS and/or INFO (no blockers):**
+
+Ask via AskUserQuestion using the approve-revise-abort pattern:
+- question: "Review the warnings above. Proceed with import?"
+- header: "Approve?"
+- options: Approve | Abort
+
+If user selects "Abort": exit cleanly with message "Import cancelled."
+
+</step>
+
+<step name="plan_convert">
+
+Convert the imported content to GSD PLAN.md format.
+
+Ensure the PLAN.md has all required frontmatter fields:
+```yaml
+---
+phase: "{NN}-{slug}"
+plan: "{NN}-{MM}"
+type: "feature|refactor|config|test|docs"
+wave: 1
+depends_on: []
+files_modified: []
+autonomous: true
+must_haves:
+  truths: []
+  artifacts: []
+---
+```
+
+Apply GSD naming convention for the output filename:
+- Format: `{NN}-{MM}-PLAN.md` (e.g., `04-01-PLAN.md`)
+- NEVER use `PLAN-01.md`, `plan-01.md`, or any other format
+- NN = phase number (zero-padded), MM = plan number within the phase (zero-padded)
+
+Determine the target directory:
+```
+.planning/phases/{NN}-{slug}/
+```
+
+If the directory does not exist, create it:
+```bash
+mkdir -p ".planning/phases/{NN}-{slug}/"
+```
+
+Write the PLAN.md file to the target directory.
+
+</step>
+
+<step name="plan_validate">
+
+Delegate validation to gsd-plan-checker:
+
+```
+Task({
+  subagent_type: "gsd-plan-checker",
+  prompt: "Validate: .planning/phases/{phase}/{plan}-PLAN.md — check frontmatter completeness, task structure, and GSD conventions. Report any issues."
+})
+```
+
+If the checker returns errors:
+- Display the errors to the user
+- Ask the user to resolve issues before the plan is considered imported
+- Do not delete the written file — the user can fix and re-validate manually
+
+If the checker returns clean:
+- Display: "✓ Plan validation passed"
+
+</step>
+
+<step name="plan_finalize">
+
+Update `.planning/ROADMAP.md` to reflect the new plan:
+- Add the plan to the Plans list under the correct phase section
+- Include the plan name and description
+
+Update `.planning/STATE.md` if appropriate (e.g., increment total plan count).
+
+Commit the imported plan and updated files:
+```bash
+node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" commit "docs({phase}): import plan from {basename FILEPATH}" --files .planning/phases/{phase}/{plan}-PLAN.md .planning/ROADMAP.md
+```
+
+Display completion:
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ GSD ► IMPORT COMPLETE ✓
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+Show: plan filename written, phase directory, validation result, next steps.
+
+</step>
+
+---
+
+## Path B: MODE=prd (--prd)
+
+<step name="prd_read">
+
+Read the PRD file at FILEPATH.
+
+Identify and extract sections:
+- **Objectives**: What the project aims to achieve
+- **Requirements**: Functional and non-functional requirements
+- **Out-of-scope**: Explicitly excluded items
+- **Constraints**: Technical, timeline, or resource constraints
+- **Tech stack**: Languages, frameworks, databases, infrastructure
+
+</step>
+
+<step name="prd_gap_detection">
+
+Identify missing required information. Ask at most 3 AskUserQuestion prompts total — do not exceed this limit.
+
+Check for and ask about (only if missing from the PRD):
+
+1. **Missing project name** → ask: "What is the project name?"
+2. **Missing tech stack** → ask: "What tech stack will this use? (or 'TBD' to skip)"
+3. **Missing core objective** → ask: "What is the single core problem this solves?"
+
+If the information is already present in the PRD, skip that question. The goal is zero questions when the PRD is complete.
+
+</step>
+
+<step name="prd_generate_docs">
+
+Generate PROJECT.md content inline (no template file):
+
+```markdown
+# Project: {name}
+
+## What This Is
+
+{Description from PRD objectives}
+
+## Core Value
+
+{Core objective / problem statement}
+
+## Requirements
+
+### Active
+
+{Requirements extracted from PRD}
+
+### Out of Scope
+
+{Out-of-scope items from PRD}
+
+## Context
+
+{Constraints, tech stack, timeline from PRD}
+
+## Constraints
+
+{Technical and resource constraints}
+
+## Key Decisions
+
+| Decision | Rationale | Outcome |
+|----------|-----------|---------|
+| {decisions from PRD} | {rationale} | -- Pending |
+```
+
+Generate REQUIREMENTS.md content inline:
+
+```markdown
+# Requirements
+
+## Traceability
+
+| ID | Description | Status | Phase |
+|----|-------------|--------|-------|
+| PRD-01 | {requirement 1} | [ ] | TBD |
+| PRD-02 | {requirement 2} | [ ] | TBD |
+| ... | ... | ... | ... |
+
+## Details
+
+### PRD-01: {requirement title}
+
+{Requirement description from PRD}
+
+### PRD-02: {requirement title}
+
+{Requirement description from PRD}
+```
+
+Use PRD-{NN} format for requirement IDs extracted from the PRD.
+
+</step>
+
+<step name="prd_confirm">
+
+Display the generated PROJECT.md and REQUIREMENTS.md content to the user.
+
+Ask via AskUserQuestion using the approve-revise-abort pattern:
+- question: "Review the generated PROJECT.md and REQUIREMENTS.md above. Proceed?"
+- header: "Approve?"
+- options: Approve | Request changes | Abort
+
+If "Request changes": ask what to change, apply the revisions, and re-confirm (max 1 revision cycle).
+If "Abort": exit cleanly with message "Import cancelled."
+If "Approve": proceed to write files.
+
+</step>
+
+<step name="prd_write">
+
+Write the generated documents:
+
+```
+.planning/PROJECT.md
+.planning/REQUIREMENTS.md
+```
+
+Create the `.planning/` directory if it does not exist:
+```bash
+mkdir -p .planning
+```
+
+</step>
+
+<step name="prd_roadmap">
+
+Delegate ROADMAP.md generation to gsd-planner:
+
+```
+Task({
+  subagent_type: "gsd-planner",
+  prompt: "Generate a ROADMAP.md for this project:\n\nPROJECT.md content:\n{content}\n\nREQUIREMENTS.md content:\n{content}\n\nWrite .planning/ROADMAP.md following GSD roadmap format with phases, requirements coverage, and success criteria."
+})
+```
+
+Wait for the planner to complete. Verify that `.planning/ROADMAP.md` was written.
+
+</step>
+
+<step name="prd_finalize">
+
+Commit the generated planning documents:
+```bash
+node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" commit "docs(planning): import PRD from {basename FILEPATH}" --files .planning/PROJECT.md .planning/REQUIREMENTS.md .planning/ROADMAP.md
+```
+
+Display completion:
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ GSD ► IMPORT COMPLETE ✓
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+Show summary:
+- Artifacts written: PROJECT.md, REQUIREMENTS.md, ROADMAP.md
+- Requirement count: {N} requirements extracted
+- Phase count: {N} phases in ROADMAP.md
+- Next steps: `/gsd-discuss-phase 1` to begin detailed phase planning
+
+</step>
+
+---
+
+## Anti-Patterns
+
+Do NOT:
+- Use markdown tables (`|---|`) in the conflict detection report — use plain-text [BLOCKER]/[WARNING]/[INFO] labels
+- Write PLAN.md files as `PLAN-01.md` or `plan-01.md` — always use `{NN}-{MM}-PLAN.md`
+- Use `pbr:plan-checker` or `pbr:planner` — use `gsd-plan-checker` and `gsd-planner`
+- Write `.planning/.active-skill` — this is a PBR pattern with no GSD equivalent
+- Reference `pbr-tools`, `pbr:`, or `PLAN-BUILD-RUN` anywhere
+- Ask more than 3 AskUserQuestion prompts in the --prd gap detection step
+- Write any PLAN.md file when blockers exist — the safety gate must hold

--- a/get-shit-done/workflows/next.md
+++ b/get-shit-done/workflows/next.md
@@ -1,6 +1,8 @@
 <purpose>
 Detect current project state and automatically advance to the next logical GSD workflow step.
 Reads project state to determine: discuss → plan → execute → verify → complete progression.
+Includes hard-stop safety checks at milestone boundaries, error states, verification gaps,
+and unresolved checkpoints. Guards against runaway automation with a consecutive-call budget.
 </purpose>
 
 <required_reading>
@@ -9,29 +11,94 @@ Read all files referenced by the invoking prompt's execution_context before star
 
 <process>
 
+<step name="banner">
+Display the GSD stage banner:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ GSD ► NEXT
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+</step>
+
 <step name="detect_state">
 Read project state to determine current position:
 
 ```bash
 # Get state snapshot
-node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" state json 2>/dev/null || echo "{}"
+STATE=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" state json 2>/dev/null || echo "{}")
 ```
 
-Also read:
-- `.planning/STATE.md` — current phase, progress, plan counts
+Also read inline (not via Task):
+- `.planning/STATE.md` — current phase, progress, status, last_command
 - `.planning/ROADMAP.md` — milestone structure and phase list
 
 Extract:
 - `current_phase` — which phase is active
 - `plan_of` / `plans_total` — plan execution progress
 - `progress` — overall percentage
-- `status` — active, paused, etc.
+- `status` — planning, executing, verifying, complete, paused
+- `stopped_at` — phase/plan identifier or null
+- `last_command` — last command invoked (used by consecutive guard)
 
 If no `.planning/` directory exists:
 ```
 No GSD project detected. Run `/gsd-new-project` to get started.
 ```
 Exit.
+</step>
+
+<step name="consecutive_guard">
+Implement consecutive-call budget guard to prevent runaway automation.
+
+1. Read `last_command` from STATE.md frontmatter:
+   ```bash
+   grep "last_command:" .planning/STATE.md 2>/dev/null || echo ""
+   ```
+
+2. If `last_command` contains "next", increment CONSECUTIVE_COUNT.
+   Track the count by checking recent git log or STATE.md session entries for consecutive `/gsd-next` invocations.
+
+3. If CONSECUTIVE_COUNT >= 6:
+   Ask via AskUserQuestion:
+   - header: "Budget"
+   - question: "You've run /gsd-next 6+ times consecutively. Continue anyway?"
+   - options:
+     - "Yes" — Proceed (warn but allow)
+     - "No" — Pause and show /gsd-progress
+
+   If **no**: display "Pausing. Run `/gsd-progress` to see current state." and exit.
+
+4. If any other command found as last_command: CONSECUTIVE_COUNT = 0, proceed normally.
+</step>
+
+<step name="check_hard_stops">
+Before routing, evaluate hard-stop conditions. If any trigger, STOP and display the issue. Do NOT route to the next command.
+
+**HARD STOP 1 — Unresolved checkpoint:**
+```bash
+ls .planning/phases/*-*/.continue-here.md 2>/dev/null
+```
+If a `.continue-here.md` file is found in any phase directory:
+- Read and display its contents.
+- Message: `GSD > Unresolved checkpoint found. Resolve it before continuing.`
+- Exit.
+
+**HARD STOP 2 — Error state:**
+If `status` contains "error" OR `stopped_at` contains "ERROR":
+- Display error details from STATE.md.
+- Message: `GSD > Error state detected. Fix the error before continuing.`
+- Exit.
+
+**HARD STOP 3 — Verification gaps:**
+If `status` == "verifying":
+- Check for unchecked verification items:
+  ```bash
+  grep -r "\- \[ \]" .planning/phases/*-*/VERIFICATION.md 2>/dev/null
+  ```
+- If gaps found, display the gap list.
+- Message: `GSD > Verification incomplete. Address gaps before advancing.`
+- Exit.
 </step>
 
 <step name="determine_next_action">
@@ -61,9 +128,11 @@ If all plans in the current phase have summaries:
 If the current phase is complete and the next phase exists in ROADMAP:
 → Next action: `/gsd-discuss-phase <next-phase>`
 
-**Route 7: All phases complete → complete milestone**
+**Route 7: All phases complete → HARD STOP (milestone boundary)**
 If all phases are complete:
-→ Next action: `/gsd-complete-milestone`
+→ Do NOT invoke `/gsd-complete-milestone` automatically.
+→ Display: `GSD > Milestone complete. Run /gsd-complete-milestone to finalize.`
+→ Exit. This is a deliberate hard stop at the milestone boundary.
 
 **Route 8: Paused → resume**
 If STATE.md shows paused_at:
@@ -83,15 +152,23 @@ Display the determination:
   [One-line explanation of why this is the next step]
 ```
 
-Then immediately invoke the determined command via SlashCommand.
-Do not ask for confirmation — the whole point of `/gsd-next` is zero-friction advancement.
+Then immediately invoke the determined command via Skill().
+Use Skill() for command delegation — NOT Task(). Do not ask for confirmation.
 </step>
 
 </process>
 
+<anti_patterns>
+- Do NOT invoke /gsd-complete-milestone automatically at Route 7 — hard stop
+- Do NOT continue past hard stops — they exist to prevent blind automation
+- Do NOT use Task() for command delegation — Skill() only
+</anti_patterns>
+
 <success_criteria>
-- [ ] Project state correctly detected
-- [ ] Next action correctly determined from routing rules
-- [ ] Command invoked immediately without user confirmation
+- [ ] Project state correctly detected from STATE.md
+- [ ] Consecutive-call guard triggers at 6+ invocations
+- [ ] Hard stops enforced at milestone boundary, error state, verification gaps, unresolved checkpoints
+- [ ] Next action correctly determined from 8-route table
+- [ ] Command invoked via Skill() without user confirmation (except at hard stops)
 - [ ] Clear status shown before invoking
 </success_criteria>

--- a/get-shit-done/workflows/undo.md
+++ b/get-shit-done/workflows/undo.md
@@ -1,0 +1,264 @@
+<purpose>
+Safe git revert workflow. Rolls back GSD phase or plan commits using the phase manifest with dependency checks and a confirmation gate. Uses git revert --no-commit (NEVER git reset) to preserve history.
+</purpose>
+
+<required_reading>
+@~/.claude/get-shit-done/references/ui-brand.md
+@~/.claude/get-shit-done/references/gate-prompts.md
+</required_reading>
+
+<process>
+
+<step name="banner" priority="first">
+Display the stage banner:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ GSD ► UNDO
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+</step>
+
+<step name="parse_arguments">
+Parse $ARGUMENTS for the undo mode:
+
+- `--last N` → MODE=last, COUNT=N (integer, default 10 if N missing)
+- `--phase NN` → MODE=phase, TARGET_PHASE=NN (two-digit phase number)
+- `--plan NN-MM` → MODE=plan, TARGET_PLAN=NN-MM (phase-plan ID)
+
+If no valid argument is provided, display usage and exit:
+
+```
+Usage: /gsd-undo --last N | --phase NN | --plan NN-MM
+
+Modes:
+  --last N      Show last N GSD commits for interactive selection
+  --phase NN    Revert all commits for phase NN
+  --plan NN-MM  Revert all commits for plan NN-MM
+
+Examples:
+  /gsd-undo --last 5
+  /gsd-undo --phase 03
+  /gsd-undo --plan 03-02
+```
+</step>
+
+<step name="gather_commits">
+Based on MODE, gather candidate commits.
+
+**MODE=last:**
+
+Run:
+```bash
+git log --oneline --no-merges -${COUNT}
+```
+
+Filter for GSD conventional commits matching `type(scope): message` pattern (e.g., `feat(04-01):`, `docs(03):`, `fix(02-03):`).
+
+Display a numbered list of matching commits:
+```
+Recent GSD commits:
+  1. abc1234 feat(04-01): implement auth endpoint
+  2. def5678 docs(03-02): complete plan summary
+  3. ghi9012 fix(02-03): correct validation logic
+```
+
+Use AskUserQuestion to ask:
+- question: "Which commits to revert? Enter numbers (e.g., 1,3) or 'all'"
+- header: "Select"
+
+Parse the user's selection into COMMITS list.
+
+---
+
+**MODE=phase:**
+
+Read `.planning/.phase-manifest.json` if it exists.
+
+If the file exists and `manifest.phase == TARGET_PHASE`:
+  - Use `manifest.commit_log` entries as COMMITS
+  - Each entry is in format "hash message" — extract the hash portion
+
+If the file does not exist, or `manifest.phase != TARGET_PHASE`:
+  - Display: "Manifest is for phase {manifest.phase} (or missing), falling back to git log search"
+  - Fallback: run git log and filter for the target phase scope:
+    ```bash
+    git log --oneline --no-merges --all | grep -E "\(0*${TARGET_PHASE}[^0-9-]|\(0*${TARGET_PHASE}\):" | head -50
+    ```
+  - Use matching commits as COMMITS
+
+---
+
+**MODE=plan:**
+
+Run:
+```bash
+git log --oneline --no-merges --all | grep -E "\(${TARGET_PLAN}\)" | head -50
+```
+
+Use matching commits as COMMITS.
+
+---
+
+**Empty check:**
+
+If COMMITS is empty after gathering:
+```
+No commits found for ${MODE} ${TARGET}. Nothing to revert.
+```
+Exit cleanly.
+</step>
+
+<step name="dependency_check">
+**Only applies when MODE=phase.**
+
+Skip this step entirely for MODE=last and MODE=plan.
+
+Read `.planning/ROADMAP.md` inline.
+
+Search for phases that list a dependency on the target phase. Look for patterns like:
+- "Depends on: Phase ${TARGET_PHASE}"
+- "Depends on: ${TARGET_PHASE}"
+- "depends_on: [${TARGET_PHASE}]"
+
+For each dependent phase N found:
+1. Check if `.planning/phases/${N}-*/` directory exists
+2. If directory exists, check for any PLAN.md or SUMMARY.md files inside it
+
+If any downstream phase has started work, collect warnings:
+```
+⚠  Downstream dependency detected:
+   Phase ${N} depends on Phase ${TARGET_PHASE} and has started work.
+```
+
+If any warnings exist:
+- Display all warnings
+- Use AskUserQuestion with approve-revise-abort pattern:
+  - question: "Downstream phases have started work that depends on Phase ${TARGET_PHASE}. Proceed with revert anyway?"
+  - header: "Confirm"
+  - options: Proceed | Abort
+
+If user selects "Abort": exit with "Revert cancelled. No changes made."
+</step>
+
+<step name="confirm_revert">
+Display the confirmation gate using approve-revise-abort pattern from gate-prompts.md.
+
+Show:
+```
+The following commits will be reverted (in reverse chronological order):
+
+  {hash} — {message}
+  {hash} — {message}
+  ...
+
+Total: {N} commit(s) to revert
+```
+
+Use AskUserQuestion:
+- question: "Proceed with revert?"
+- header: "Approve?"
+- options: Approve | Abort
+
+If "Abort": display "Revert cancelled. No changes made." and exit.
+If "Approve": continue to execute_revert.
+</step>
+
+<step name="execute_revert">
+**HARD CONSTRAINT: Use git revert --no-commit. NEVER use git reset.**
+
+Sort COMMITS in reverse chronological order (newest first). If commits came from git log (already newest-first), they are already in correct order.
+
+For each commit hash in COMMITS:
+```bash
+git revert --no-commit ${HASH}
+```
+
+If any revert fails (merge conflict or error):
+1. Display the error message
+2. Run cleanup:
+   ```bash
+   git revert --abort
+   ```
+3. Display:
+   ```
+   ╔══════════════════════════════════════════════════════════════╗
+   ║  ERROR                                                       ║
+   ╚══════════════════════════════════════════════════════════════╝
+
+   Revert failed on commit ${HASH}.
+   Likely cause: merge conflict with subsequent changes.
+
+   **To fix:** Resolve the conflict manually or revert commits individually.
+   All pending reverts have been aborted — working tree is clean.
+   ```
+4. Exit with error.
+
+After all reverts are staged successfully, create a single commit:
+
+For MODE=phase:
+```bash
+git commit -m "revert(${TARGET_PHASE}): undo phase ${TARGET_PHASE} changes"
+```
+
+For MODE=plan:
+```bash
+git commit -m "revert(${TARGET_PLAN}): undo plan ${TARGET_PLAN} changes"
+```
+
+For MODE=last:
+```bash
+git commit -m "revert: undo ${N} selected commits"
+```
+</step>
+
+<step name="summary">
+Display the completion banner:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ GSD ► UNDO COMPLETE ✓
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+Show summary:
+```
+  ✓ ${N} commit(s) reverted
+  ✓ Single revert commit created: ${REVERT_HASH}
+```
+
+Show next steps:
+```
+───────────────────────────────────────────────────────────────
+
+## ▶ Next Up
+
+**Review state** — verify project is in expected state after revert
+
+`/gsd-progress`
+
+<sub>`/clear` first → fresh context window</sub>
+
+───────────────────────────────────────────────────────────────
+
+**Also available:**
+- `/gsd-execute-phase ${PHASE}` — re-execute if needed
+- `/gsd-undo --last 1` — undo the revert itself if something went wrong
+
+───────────────────────────────────────────────────────────────
+```
+</step>
+
+</process>
+
+<success_criteria>
+- [ ] Arguments parsed correctly for all three modes
+- [ ] --phase mode reads .planning/.phase-manifest.json and checks manifest.phase == target
+- [ ] --phase mode falls back to git log if manifest phase mismatch
+- [ ] Dependency check warns when downstream phases have started
+- [ ] Confirmation gate shown before any revert execution
+- [ ] Reverts use git revert --no-commit in reverse chronological order
+- [ ] Single commit created after all reverts staged
+- [ ] Error handling includes git revert --abort on failure
+- [ ] git reset is NEVER used anywhere in this workflow
+</success_criteria>


### PR DESCRIPTION
## Linked Issue

Closes #1669

## Summary

- Add `/gsd-explore` for Socratic ideation with output routing to 6 artifact types
- Add `/gsd-undo` for safe git revert with 3 modes and dependency checking
- Add `/gsd-import` for external plan/PRD import with conflict detection
- Enhance `/gsd-next` with hard stops, consecutive-call guard, and Skill() delegation (merges former /gsd-continue functionality)

## Test plan
- [ ] Verify explore.md workflow loads questioning.md and domain-probes.md
- [ ] Verify undo workflow reads .phase-manifest.json and uses git revert (not reset)
- [ ] Verify import workflow detects conflicts with BLOCKER/WARNING/INFO labels
- [ ] Verify next workflow stops at milestone boundary (Route 7) instead of auto-advancing
- [ ] Verify consecutive-call guard fires at 6+ invocations
- [ ] Verify zero PBR-isms in all new files

## Checklist

- [x] Issue linked above
- [x] Follows GSD style
- [x] No unnecessary dependencies added
- [x] Works on Windows
- [x] Existing tests pass

## Breaking Changes

None