### PR TITLE
feat(knowledge): add thinking models, few-shot examples, scan command, learnings, and status line

### DIFF
--- a/agents/gsd-debugger.md
+++ b/agents/gsd-debugger.md
@@ -957,6 +957,9 @@ Gather symptoms through questioning. Update file after EACH answer.
 </step>
 
 <step name="investigation_loop">
+At investigation decision points, apply structured reasoning:
+@~/.claude/get-shit-done/references/thinking-models-debug.md
+
 **Autonomous investigation. Update file continuously.**
 
 **Phase 0: Check knowledge base**

--- a/agents/gsd-executor.md
+++ b/agents/gsd-executor.md
@@ -95,6 +95,9 @@ grep -n "type=\"checkpoint" [plan-path]
 </step>
 
 <step name="execute_tasks">
+At execution decision points, apply structured reasoning:
+@~/.claude/get-shit-done/references/thinking-models-execution.md
+
 For each task:
 
 1. **If `type="auto"`:**
@@ -415,6 +418,56 @@ If any stubs exist, add a `## Known Stubs` section to the SUMMARY listing each s
 
 Omit section if nothing found.
 </summary_creation>
+
+<learnings_write>
+After SUMMARY.md is written, check if this is the last plan in the phase and if learnings are enabled:
+
+```bash
+LEARNINGS_ENABLED=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-get features.learnings 2>/dev/null || echo "false")
+REMAINING=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" state remaining-plans 2>/dev/null || echo "1")
+```
+
+If `LEARNINGS_ENABLED=true` AND `REMAINING=0` (this is the last plan in the phase):
+
+Write `.planning/phases/{padded_phase}-{phase_slug}/{padded_phase}-LEARNINGS.md` with this structure:
+
+```markdown
+# Phase {N}: {phase_name} - Learnings
+
+**Phase:** {padded_phase}
+**Completed:** {YYYY-MM-DD}
+**Plans executed:** {total_plans_in_phase}
+
+## What Worked Well
+
+- [Pattern or approach that saved time or produced quality output — be specific]
+
+## Pitfalls Encountered
+
+- [What went wrong, root cause, how resolved — include file/line if relevant]
+
+## Decisions Made During Execution
+
+- [Any Rule 4 decisions or architectural choices not in CONTEXT.md]
+
+## Patterns to Reuse
+
+- [Code patterns, file structures, or conventions worth replicating in future phases]
+
+## Recommendations for Future Phases
+
+- [What the next planner should know — dependencies, constraints, gotchas]
+```
+
+Fill each section from execution memory: what happened during this phase's plans, what was found, what was changed. Sections with nothing notable should say "None noted."
+
+Commit the LEARNINGS.md file alongside the phase-closing commit:
+```bash
+node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" commit "docs({phase}): write phase learnings" --files .planning/phases/{phase}-{slug}/{phase}-LEARNINGS.md
+```
+
+If `LEARNINGS_ENABLED=false` OR `REMAINING>0`: skip silently.
+</learnings_write>
 
 <self_check>
 After writing SUMMARY.md, verify claims before proceeding.

--- a/agents/gsd-phase-researcher.md
+++ b/agents/gsd-phase-researcher.md
@@ -461,6 +461,9 @@ Verified patterns from official sources:
 
 <execution_flow>
 
+At research decision points, apply structured reasoning:
+@~/.claude/get-shit-done/references/thinking-models-research.md
+
 ## Step 1: Receive Scope and Load Context
 
 Orchestrator provides: phase number/name, description/goal, requirements, constraints, output path.

--- a/agents/gsd-plan-checker.md
+++ b/agents/gsd-plan-checker.md
@@ -80,6 +80,9 @@ Same methodology (goal-backward), different timing, different subject matter.
 
 <verification_dimensions>
 
+For calibration on scoring and issue identification, reference these examples:
+@~/.claude/get-shit-done/references/few-shot-examples/plan-checker.md
+
 ## Dimension 1: Requirement Coverage
 
 **Question:** Does every phase requirement have task(s) addressing it?

--- a/agents/gsd-planner.md
+++ b/agents/gsd-planner.md
@@ -1022,6 +1022,9 @@ cat "$phase_dir"/*-DISCOVERY.md 2>/dev/null  # From mandatory discovery
 </step>
 
 <step name="break_into_tasks">
+At decision points during plan creation, apply structured reasoning:
+@~/.claude/get-shit-done/references/thinking-models-planning.md
+
 Decompose phase into tasks. **Think dependencies first, not sequence.**
 
 For each task:
@@ -1059,6 +1062,8 @@ for each plan B in plan_order:
 ```
 
 **Rule:** Same-wave plans must have zero `files_modified` overlap. After assigning waves, scan each wave; if any file appears in 2+ plans, bump the later plan to the next wave and repeat.
+
+See `@~/.claude/get-shit-done/references/wave-execution.md` for the full wave assignment algorithm, feature flag documentation, git lock retry patterns for parallel executors, and the phase manifest schema.
 </step>
 
 <step name="group_into_plans">

--- a/agents/gsd-verifier.md
+++ b/agents/gsd-verifier.md
@@ -53,6 +53,10 @@ Then verify each level against the actual codebase.
 
 <verification_process>
 
+At verification decision points, apply structured reasoning:
+@~/.claude/get-shit-done/references/thinking-models-verification.md
+@~/.claude/get-shit-done/references/few-shot-examples/verifier.md
+
 ## Step 0: Check for Previous Verification
 
 ```bash
@@ -461,33 +465,6 @@ Classify status using this decision tree IN ORDER (most restrictive first):
 
 **Score:** `verified_truths / total_truths`
 
-## Step 9b: Filter Deferred Items
-
-Before reporting gaps, check if any identified gaps are explicitly addressed in later phases of the current milestone. This prevents false-positive gap reports for items intentionally scheduled for future work.
-
-**Load the full milestone roadmap:**
-
-```bash
-ROADMAP_DATA=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" roadmap analyze --raw)
-```
-
-Parse the JSON to extract all phases. Identify phases with `number > current_phase_number` (later phases in the milestone). For each later phase, extract its `goal` and `success_criteria`.
-
-**For each potential gap identified in Step 9:**
-
-1. Check if the gap's failed truth or missing item is covered by a later phase's goal or success criteria
-2. **Match criteria:** The gap's concern appears in a later phase's goal text, success criteria text, or the later phase's name clearly suggests it covers this area of work
-3. If a match is found → move the gap to the `deferred` list, recording which phase addresses it and the matching evidence (goal text or success criterion)
-4. If the gap does not match any later phase → keep it as a real `gap`
-
-**Important:** Be conservative when matching. Only defer a gap when there is clear, specific evidence in a later phase's roadmap section. Vague or tangential matches should NOT cause a gap to be deferred — when in doubt, keep it as a real gap.
-
-**Deferred items do NOT affect the status determination.** After filtering, recalculate:
-
-- If the gaps list is now empty and no human verification items exist → `passed`
-- If the gaps list is now empty but human verification items exist → `human_needed`
-- If the gaps list still has items → `gaps_found`
-
 ## Step 10: Structure Gap Output (If Gaps Found)
 
 Before writing VERIFICATION.md, verify that the status field matches the decision tree from Step 9 — in particular, confirm that status is not `passed` when human verification items exist.
@@ -511,17 +488,6 @@ gaps:
 - `reason`: Brief explanation
 - `artifacts`: Files with issues
 - `missing`: Specific things to add/fix
-
-If Step 9b identified deferred items, add a `deferred` section after `gaps`:
-
-```yaml
-deferred:  # Items addressed in later phases — not actionable gaps
-  - truth: "Observable truth not yet met"
-    addressed_in: "Phase 5"
-    evidence: "Phase 5 success criteria: 'Implement RuntimeConfigC FFI bindings'"
-```
-
-Deferred items are informational only — they do not require closure plans.
 
 **Group related gaps by concern** — if multiple truths fail from the same root cause, note this to help the planner create focused plans.
 
@@ -557,10 +523,6 @@ gaps: # Only if status: gaps_found
         issue: "What's wrong"
     missing:
       - "Specific thing to add/fix"
-deferred: # Only if deferred items exist (Step 9b)
-  - truth: "Observable truth addressed in a later phase"
-    addressed_in: "Phase N"
-    evidence: "Matching goal or success criteria text"
 human_verification: # Only if status: human_needed
   - test: "What to do"
     expected: "What should happen"
@@ -584,15 +546,6 @@ human_verification: # Only if status: human_needed
 | 2   | {truth} | ✗ FAILED   | {what's wrong} |
 
 **Score:** {N}/{M} truths verified
-
-### Deferred Items
-
-Items not yet met but explicitly addressed in later milestone phases.
-Only include this section if deferred items exist (from Step 9b).
-
-| # | Item | Addressed In | Evidence |
-|---|------|-------------|----------|
-| 1 | {truth} | Phase {N} | {matching goal or success criteria} |
 
 ### Required Artifacts
 
@@ -757,9 +710,7 @@ return <div>No messages</div>  // Always shows "no messages"
 - [ ] Behavioral spot-checks run on runnable code (or skipped with reason)
 - [ ] Human verification items identified
 - [ ] Overall status determined
-- [ ] Deferred items filtered against later milestone phases (Step 9b)
 - [ ] Gaps structured in YAML frontmatter (if gaps_found)
-- [ ] Deferred items structured in YAML frontmatter (if deferred items exist)
 - [ ] Re-verification metadata included (if previous existed)
 - [ ] VERIFICATION.md created with complete report
 - [ ] Results returned to orchestrator (NOT committed)

--- a/commands/gsd/scan.md
+++ b/commands/gsd/scan.md
@@ -1,0 +1,75 @@
+---
+name: gsd:scan
+description: Rapid codebase assessment using a single mapper agent. Lighter than /gsd-map-codebase.
+argument-hint: "[--focus tech|arch|quality|concerns]"
+allowed-tools:
+  - Read
+  - Bash
+  - Glob
+  - Grep
+  - Write
+  - Task
+---
+
+<objective>
+Perform a rapid, focused codebase assessment by spawning a single gsd-codebase-mapper agent for one focus area.
+
+**Default focus:** `tech+arch` (produces STACK.md, INTEGRATIONS.md, ARCHITECTURE.md, STRUCTURE.md)
+
+Use `--focus` to target a specific area:
+- `tech` — STACK.md, INTEGRATIONS.md
+- `arch` — ARCHITECTURE.md, STRUCTURE.md
+- `quality` — CONVENTIONS.md, TESTING.md
+- `concerns` — CONCERNS.md
+
+**Scan vs map-codebase:** Scan spawns 1 agent for 1 focus area. Map-codebase spawns 4 parallel agents covering all 7 documents. Use scan for quick targeted assessment; use map-codebase for comprehensive coverage.
+</objective>
+
+<execution_context>
+@~/.claude/get-shit-done/workflows/scan.md
+</execution_context>
+
+<context>
+Arguments: $ARGUMENTS (parsed for --focus flag)
+
+**Load project state if exists:**
+Check for .planning/STATE.md - loads context if project already initialized.
+
+**This command can run:**
+- Before or after /gsd-new-project
+- Anytime to quickly assess or refresh understanding of a specific codebase area
+- As a lighter alternative to /gsd-map-codebase when full coverage is not needed
+</context>
+
+<when_to_use>
+**Use scan for:**
+- Quick snapshot of one area (e.g., just the tech stack)
+- Rapid orientation in a new codebase
+- Refreshing a specific focus area without remapping everything
+- When context budget is tight and full map-codebase is too expensive
+
+**Use map-codebase instead for:**
+- Comprehensive coverage across all 7 documents
+- Initial brownfield project setup (need full picture)
+- Before major architecture decisions (need concerns + quality too)
+</when_to_use>
+
+<process>
+1. Parse `--focus` from arguments (default: `tech+arch`)
+2. Validate focus value against allowed list: tech, arch, quality, concerns, tech+arch
+3. Check if .planning/codebase/ already has documents for the target focus area
+4. Create .planning/codebase/ directory if needed
+5. Spawn one gsd-codebase-mapper agent with the resolved focus
+6. Verify output documents exist with line counts
+7. Run secret scan on output files
+8. Commit codebase documents
+9. Display summary with files written and next steps
+</process>
+
+<success_criteria>
+- [ ] .planning/codebase/ directory exists
+- [ ] Target documents written for the selected focus area
+- [ ] Documents have substantive content (>20 lines each)
+- [ ] No secrets detected in output files
+- [ ] User sees summary of what was produced and next steps
+</success_criteria>

--- a/get-shit-done/references/few-shot-examples/plan-checker.md
+++ b/get-shit-done/references/few-shot-examples/plan-checker.md
@@ -1,0 +1,73 @@
+---
+component: plan-checker
+version: 1
+last_calibrated: 2026-03-24
+---
+
+# Plan-Checker Few-Shot Examples
+
+## Positive Examples
+
+### Example 1: BLOCKER flagged for vague task action missing file and function names
+
+**Input:** Plan task with action: "Implement the authentication feature for the API routes."
+
+**Output:**
+
+> ```yaml
+> issues:
+>   - dimension: task_completeness
+>     severity: BLOCKER
+>     finding: "Task T1 action says 'implement the authentication feature' without naming target files, functions to create, or middleware to apply. Executor cannot determine what to build."
+>     affected_field: "<action>"
+>     suggested_fix: "Specify: create authMiddleware in src/middleware/auth.js, apply to routes in src/routes/api.js lines 12-45, verify with integration test"
+> ```
+
+**Why this is good:** The checker cited the specific dimension (task_completeness), quoted the problematic text, explained why it is a blocker (executor cannot determine what to build), and gave a concrete fix with file paths and function names. The finding is actionable -- the planner knows exactly what to add.
+
+### Example 2: BLOCKER for same-wave file conflict between two plans
+
+**Input:** Two plans in wave 1 -- Plan 01 modifies `get-shit-done/workflows/execute-phase.md`, Plan 02 also modifies `get-shit-done/workflows/execute-phase.md`. No `depends_on` declared.
+
+**Output:**
+
+> ```yaml
+> issues:
+>   - dimension: dependency_correctness
+>     severity: BLOCKER
+>     finding: "Plans 01 and 02 both modify get-shit-done/workflows/execute-phase.md in wave 1 with no depends_on relationship. Concurrent execution will cause merge conflicts or lost changes."
+>     affected_field: "files_modified"
+>     suggested_fix: "Either move Plan 02 to wave 2 with depends_on: ['01'] or consolidate the file changes into a single plan"
+> ```
+
+**Why this is good:** The checker identified a real structural problem -- two plans modifying the same file in the same wave without a dependency relationship. It cited dependency_correctness, named both plans, the conflicting file, and provided two alternative fixes.
+
+## Negative Examples
+
+### Example 1: All dimensions pass when verify commands are missing
+
+**Input:** Plan with 3 tasks. Task T2 has `<verify></verify>` (empty). Task T3 has `<verify>echo "done"</verify>` (trivial, cannot distinguish pass from fail).
+
+**Output:**
+
+> ## CHECK PASSED
+> Plans: 1 | Tasks: 3 | Dimensions: 10 | Issues: 0
+
+**Why this is bad:** The checker missed two violations. verification_derivation requires verify commands to be runnable and test actual output -- an empty verify block is a BLOCKER. Verify commands must distinguish pass from fail -- `echo "done"` always returns 0 regardless of implementation state. Both should have been flagged.
+
+### Example 2: False positive INFO for a correctly-sized plan
+
+**Input:** Plan with 3 tasks, 6 unique files, 1 dependency. All within limits.
+
+**Output:**
+
+> ```yaml
+> issues:
+>   - dimension: scope_sanity
+>     severity: INFO
+>     finding: "Plan has 3 tasks -- consider splitting into smaller plans for faster iteration"
+>     affected_field: "task count"
+>     suggested_fix: "Split tasks into separate plans"
+> ```
+
+**Why this is bad:** The checker flagged a non-issue. scope_sanity allows 2-3 tasks per plan -- 3 tasks is within limits. The checker applied a personal preference ("smaller is better") rather than the documented threshold. This wastes planner time on false positives and erodes trust in the checker's judgment. A correct check would produce no issue for this plan.

--- a/get-shit-done/references/few-shot-examples/verifier.md
+++ b/get-shit-done/references/few-shot-examples/verifier.md
@@ -1,0 +1,109 @@
+---
+component: verifier
+version: 2
+last_calibrated: 2026-03-25
+calibration_source: "Adapted from thinking-partner verification corpus"
+---
+
+# Verifier Few-Shot Examples
+
+## Positive Examples
+
+### Example 1: Thorough multi-level artifact verification with real gap discovery
+
+**Input:** Must-have artifact: `get-shit-done/workflows/context-bridge.md: >50 lines`
+
+**Output:**
+
+> **L1 (Existence):** EXISTS -- `get-shit-done/workflows/context-bridge.md` found, 187 lines.
+> **L2 (Substantive):** SUBSTANTIVE -- No TODO/FIXME markers, 4 defined sections (`updateContextTier`, `getContextBudget`, `injectContextWarning`, `resetTierState`), non-trivial logic with config reads and threshold calculations.
+> **L3 (Wired):** WIRED -- Referenced by `get-shit-done/workflows/execute-phase.md` at step 3. Called by `agents/gsd-executor.md` via @-reference include. Arguments verified: receives planning directory path matching the expected parameter.
+> **Status: PASSED**
+
+**Why this is good:** The verifier checked all three levels independently with specific evidence at each level -- file path, line count, exported symbols, import location, and argument verification. It did not stop at "file exists" but traced wiring through to actual usage with correct arguments.
+
+### Example 2: Correct FAILED classification with grep evidence
+
+**Input:** Must-have truth: `validate-commit.js rejects commits missing scope parentheses`
+
+**Output:**
+
+> **Method:** Ran `grep -n "scope" get-shit-done/bin/validate-commit.js` to locate scope validation logic.
+> **Evidence:** Lines 34-41 show regex `/^(feat|fix|refactor|test|docs|chore|wip)\(/` which requires opening paren after type. However, no test for MISSING closing paren exists -- the regex accepts `feat(: description` (missing scope content and closing paren).
+> **Ran:** `echo "feat(: test" | node get-shit-done/bin/validate-commit.js` -- exit code 0 (accepted).
+> **Status: FAILED** -- Commit messages with empty scope `feat(: desc)` are accepted. The truth "rejects commits missing scope parentheses" does not hold for empty-scope edge case.
+
+**Why this is good:** The verifier did not trust the code's intent -- it ran an actual test with an edge case input and reported the specific failure. Evidence includes the regex, the test command, the exit code, and why the truth does not hold.
+
+### Example 3: Catching missing wiring (calibration-derived gap pattern)
+
+**Input:** Must-have key_link: `check-subagent-output.js imports and calls feedback-loop.js extractFeedback()`
+
+**Output:**
+
+> **Method:** Ran `grep -n "feedback-loop\|extractFeedback" get-shit-done/bin/check-subagent-output.js`.
+> **Evidence:** Zero matches. The file `feedback-loop.js` exists (172 lines, substantive), and `tests/feedback-loop.test.js` passes (229 lines). But `check-subagent-output.js` never imports or calls it.
+> **Cross-check:** `grep -rn "require.*feedback-loop" get-shit-done/bin/` returns zero results across all scripts.
+> **Status: FAILED** -- The artifact exists and is tested, but is completely orphaned. The key_link "imports and calls" does not hold. This is a **missing wiring** gap.
+
+**Why this is good:** The verifier caught a common calibration pattern: code that exists, is tested, but is never actually wired into the system. L1 and L2 pass, but L3 (wiring) fails. This pattern accounts for 37% of all gaps found in calibration corpus.
+
+### Example 4: Catching missing config schema entries (calibration-derived gap pattern)
+
+**Input:** Must-have truth: `Config toggles features.architecture_graph and features.architecture_guard exist with defaults`
+
+**Output:**
+
+> **Method:** Ran `grep "architecture_graph\|architecture_guard" get-shit-done/bin/lib/config-schema.json`.
+> **Evidence:** Zero matches in schema. However, `grep "architecture" get-shit-done/bin/lib/config.cjs` shows both flags in CONFIG_DEFAULTS (lines 426, 428).
+> **Gap:** Defaults exist in code but schema validation doesn't know about them. `configValidate()` would strip these fields on load, making the defaults unreachable.
+> **Status: FAILED** -- Config flags work in code but are invisible to schema validation. This is a **missing wiring** gap between config layers.
+
+**Why this is good:** The verifier checked multiple config layers (schema vs defaults vs code) rather than just one. Config wiring requires schema + defaults + code to agree -- checking only one layer misses layer-mismatch bugs.
+
+### Example 5: Distinguishing planning gaps from execution failures
+
+**Input:** Must-have truth: `All MSYS regex patterns consolidated into shared module`
+
+**Output:**
+
+> **Method:** Ran `grep -rn "\/\[a-zA-Z\]\/" get-shit-done/bin/` to find inline MSYS regex.
+> **Evidence:** 2 matches in `commands/gsd/misc.md` (lines 26, 487). These were NOT in the original plan scope -- Phase 148 extracted code into misc.md AFTER Phase 149's plan was written.
+> **Assessment:** The executor correctly completed all planned tasks. The gap is a **planning ordering issue**, not an execution failure.
+> **Status: PASS_WITH_NOTES** -- Executor did what was planned. Unconsolidated regex noted as follow-up, not as a failure of this phase.
+
+**Why this is good:** The verifier distinguished between what was planned vs what exists now. Code that changed AFTER plan creation is a planning gap, not an executor failure. This prevents false FAIL verdicts on correctly-executed work.
+
+## Calibration-Derived Gap Patterns
+
+Based on analysis of verification corpus (80% pass rate, 8 gaps):
+
+| Pattern | Count | % of Gaps | What to Check |
+|---------|-------|-----------|---------------|
+| Missing wiring | 3 | 37% | File exists + tested but never imported/called by consumer |
+| Missing tests | 2 | 25% | Feature works but test file excluded from CI or never runs |
+| Other | 3 | 38% | Config layer mismatches, planning ordering issues, schema gaps |
+
+## Negative Examples
+
+### Example 1: Blanket pass with no per-criterion evidence
+
+**Input:** Must-haves: 5 truths, 3 artifacts, 2 key_links from plan frontmatter.
+
+**Output:**
+
+> All must-haves have been verified. The implementation matches the plan requirements. Files exist and are properly connected. Status: PASSED.
+> must_haves_checked: 10, must_haves_passed: 10
+
+**Why this is bad:** No individual must-have is listed or checked. No file paths, no line numbers, no grep output, no level-by-level breakdown. The verifier restated the must-haves as passing without showing any evidence. This would miss stubs, orphaned exports, and broken wiring.
+
+### Example 2: File existence check without substance or wiring verification
+
+**Input:** Must-have artifact: `get-shit-done/bin/lib/audit-checks/index.cjs: >100 lines`
+
+**Output:**
+
+> **L1 (Existence):** EXISTS -- File found at `get-shit-done/bin/lib/audit-checks/index.cjs`, 142 lines.
+> **Status: PASSED**
+
+**Why this is bad:** The verifier stopped at Level 1. The file has 142 lines but could contain `// TODO: implement all checks` with stub functions returning empty objects. Level 2 (substantive) and Level 3 (wired) were skipped entirely. A file that exists but is never imported or contains only placeholder code should not pass.

--- a/get-shit-done/references/thinking-models-debug.md
+++ b/get-shit-done/references/thinking-models-debug.md
@@ -1,0 +1,33 @@
+# Thinking Models: Debug Cluster
+
+Structured reasoning models for the **debugger** agent. Apply these at decision points during investigation, not continuously. Each model counters a specific documented failure mode.
+
+Source: Curated from [thinking-partner](https://github.com/mattnowdev/thinking-partner) model catalog (150+ models). Selected for direct applicability to GSD debugging workflow.
+
+## Conflict Resolution
+
+**Fault Tree and Hypothesis-Driven are sequential:** Fault Tree FIRST (generate the tree of possible causes), Hypothesis-Driven SECOND (test each branch systematically). Fault Tree provides the map; Hypothesis-Driven provides the discipline to traverse it.
+
+## 1. Fault Tree Analysis
+
+**Counters:** Jumping to conclusions without systematically mapping failure paths.
+
+Before testing any hypothesis, build a fault tree: start with the observed symptom as the root node, then branch into all possible causes at each level (hardware, software, configuration, data, environment). Use AND/OR gates -- some failures require multiple conditions (AND), others have independent triggers (OR). This tree becomes your investigation roadmap. Prioritize branches by likelihood and testability, but do NOT prune branches just because they seem unlikely -- unlikely causes that are easy to test should be tested early.
+
+## 2. Hypothesis-Driven Investigation
+
+**Counters:** Making random changes and hoping something works -- the "shotgun debugging" anti-pattern.
+
+For each hypothesis from the fault tree, follow the strict protocol: PREDICT ("If hypothesis H is correct, then test T should produce result R"), TEST (execute exactly one test), OBSERVE (record the actual result), CONCLUDE (matched = SUPPORTED, failed = ELIMINATED, unexpected = new evidence). Never skip the PREDICT step -- without a prediction, you cannot distinguish a meaningful result from noise. Never change more than one variable per test -- if you change two things and the bug disappears, you don't know which change fixed it.
+
+## 3. Occam's Razor
+
+**Counters:** Pursuing elaborate explanations when simple ones have not been ruled out.
+
+Before investigating complex multi-component interaction bugs, race conditions, or framework-level issues, verify the simple explanations first: typo in variable name, wrong file path, missing import, incorrect config value, stale cache, wrong environment variable. These "boring" causes account for the majority of bugs. Only escalate to complex hypotheses AFTER the simple ones are eliminated. If your current hypothesis requires 3+ things to go wrong simultaneously, step back and look for a single-point failure.
+
+## 4. Counterfactual Thinking
+
+**Counters:** Failing to isolate causation by not asking "what if we changed just this one thing?"
+
+When you have a hypothesis about the root cause, construct a counterfactual: "If I change ONLY this one variable/config/line, the bug should disappear (or appear)." Execute the counterfactual test. If the bug persists after your targeted change, your hypothesis is wrong -- the cause is elsewhere. If the bug disappears, you have strong causal evidence. This is more powerful than correlation ("the bug appeared after deploy X") because it tests the mechanism, not just the timeline.

--- a/get-shit-done/references/thinking-models-execution.md
+++ b/get-shit-done/references/thinking-models-execution.md
@@ -1,0 +1,39 @@
+# Thinking Models: Execution Cluster
+
+Structured reasoning models for the **executor** agent. Apply these at decision points during task execution, not continuously. Each model counters a specific documented failure mode.
+
+Source: Curated from [thinking-partner](https://github.com/mattnowdev/thinking-partner) model catalog (150+ models). Selected for direct applicability to GSD execution workflow.
+
+## Conflict Resolution
+
+**Forcing Function and First Principles both push toward "do it now".** Run First Principles FIRST (understand the constraint), Forcing Function SECOND (create the mechanism). Sequential, not competing.
+
+## 1. Circle of Concern vs Circle of Control
+
+**Counters:** Executor trying to fix things outside its scope -- upstream bugs, unrelated tech debt, infrastructure issues.
+
+Before modifying any code not explicitly listed in the plan's `<files>` section, ask: Is this in my Circle of Control (plan scope) or my Circle of Concern (things I notice but shouldn't fix)? If Circle of Concern: document it as a deviation note or deferred item, do NOT fix it. The executor's job is to build what the plan says, not to improve the codebase. Scope creep from "while I'm here" fixes is the #1 cause of executor overruns.
+
+## 2. Forcing Function
+
+**Counters:** Deferring hard decisions to runtime instead of resolving them at build time.
+
+When you encounter an ambiguous requirement or unclear integration point, create a forcing function that makes the decision explicit NOW rather than hiding it behind a TODO or runtime check. Examples: use a TypeScript `never` type to force exhaustive switches, add a build-time assertion for required config values, create an interface that forces callers to handle error cases. If a decision truly cannot be made at build time, document it as a `checkpoint:decision` deviation -- do not silently defer.
+
+## 3. First Principles Thinking
+
+**Counters:** Copying patterns from existing code without understanding whether they fit the current task.
+
+Before copying a pattern from another file or phase, decompose WHY that pattern exists: What constraint does it satisfy? Does your current task have the same constraint? If not, the pattern may be cargo cult. Build your implementation from the task's actual requirements, not from the nearest existing example. When in doubt, the plan's `<action>` steps define what to build -- derive the implementation from those, not from adjacent code.
+
+## 4. Occam's Razor
+
+**Counters:** Over-engineering simple tasks with unnecessary abstractions, generics, or future-proofing.
+
+Before adding an abstraction layer, generic type parameter, factory pattern, or configuration option, ask: Does the plan REQUIRE this flexibility? If the plan says "create a function that does X", create a function that does X -- not a configurable, extensible, pluggable framework that could theoretically do X through Y through Z. The simplest implementation that satisfies the plan's `<done>` condition is the correct one. Add complexity only when the plan explicitly calls for it.
+
+## 5. Chesterton's Fence
+
+**Counters:** Removing or modifying existing code without understanding why it was written that way.
+
+Before removing, replacing, or significantly modifying existing code that the plan touches, determine WHY it exists. Check: git blame for the commit that introduced it, comments explaining the rationale, test cases that exercise it, the PLAN.md or SUMMARY.md that created it. If the purpose is unclear, keep it and add a comment noting the uncertainty -- do NOT remove code whose purpose you don't understand. If the plan explicitly says to remove it, still document what it did in the deviation notes.

--- a/get-shit-done/references/thinking-models-planning.md
+++ b/get-shit-done/references/thinking-models-planning.md
@@ -1,0 +1,51 @@
+# Thinking Models: Planning Cluster
+
+Structured reasoning models for the **planner** and **roadmapper** agents. Apply these at decision points during plan creation, not continuously. Each model counters a specific documented failure mode.
+
+Source: Curated from [thinking-partner](https://github.com/mattnowdev/thinking-partner) model catalog (150+ models). Selected for direct applicability to GSD planning workflow.
+
+## Conflict Resolution
+
+Pre-Mortem and Constraint Analysis both analyze risk at different granularities. Run Constraint Analysis FIRST (identify the hardest constraint), then Pre-Mortem (enumerate failure modes around that constraint and the rest of the plan).
+
+## 1. Pre-Mortem Analysis
+
+**Counters:** Optimistic plan decomposition that ignores failure modes.
+
+Before finalizing this plan, assume it has already failed. List the 3 most likely reasons for failure -- missing dependency, wrong decomposition, underestimated complexity -- and add mitigation steps or acceptance criteria that would catch each failure early.
+
+## 2. MECE Decomposition
+
+**Counters:** Overlapping tasks (merge conflicts) or gapped tasks (missing requirements).
+
+Verify this task breakdown is MECE at the REQUIREMENT level: (1) list every requirement from the phase goal, (2) confirm each maps to exactly one task's `<done>`, (3) if two tasks modify the same file, confirm they modify DIFFERENT sections or serve DIFFERENT requirements, (4) flag any requirement not covered by any task.
+
+## 3. Constraint Analysis
+
+**Counters:** Deferring the hardest constraint to the last task, causing late-stage failures.
+
+Identify the single hardest constraint in this phase -- the one thing that, if it doesn't work, makes everything else irrelevant. Schedule that constraint as Task 1 or 2, not last. If the constraint involves an external API or unfamiliar library, add a spike/proof-of-concept task before the main implementation.
+
+## 4. Reversibility Test
+
+**Counters:** Over-analyzing cheap decisions, under-analyzing costly ones.
+
+For each significant decision in this plan, classify as REVERSIBLE (can change later with low cost) or IRREVERSIBLE (changing later requires migration, breaking changes, or significant rework). Spend analysis time proportional to irreversibility. For irreversible decisions, document the rationale in the plan.
+
+## 5. Curse of Knowledge Counter
+
+**Counters:** Plan-to-executor ambiguity from compressed instructions.
+
+For each `<action>` step, re-read it as if you have NEVER seen this codebase. Is every noun unambiguous (which file? which function? which endpoint?)? Is every verb specific (add WHERE? modify HOW?)? If a step could be interpreted two ways, rewrite it. Include file paths, function names, and expected behavior in every action step.
+
+## 6. Base Rate Neglect Counter
+
+**Counters:** Planners ignoring low-confidence research caveats.
+
+Before finalizing the plan, read ALL `[NEEDS DECISION]` items and LOW-confidence recommendations from SUMMARY.md. For each: either (a) create a `checkpoint:decision` task to resolve it, or (b) document why the risk is acceptable in the plan's deviation notes. LOW-confidence items that are silently accepted become undocumented technical debt.
+
+## Gap Closure Mode: Root-Cause Check
+
+**Applies only when:** Planner enters gap closure mode (triggered by `gaps_found` in VERIFICATION.md).
+
+Before writing the fix plan, apply a single "why" round: Why did this gap occur? Was it a plan deficiency (wrong task), an execution miss (correct task, wrong implementation), or a changed assumption (environment/dependency shift)? The fix plan must target the root cause category, not just the symptom.

--- a/get-shit-done/references/thinking-models-research.md
+++ b/get-shit-done/references/thinking-models-research.md
@@ -1,0 +1,39 @@
+# Thinking Models: Research Cluster
+
+Structured reasoning models for the **researcher** and **synthesizer** agents. Apply these at decision points during research and synthesis, not continuously. Each model counters a specific documented failure mode.
+
+Source: Curated from [thinking-partner](https://github.com/mattnowdev/thinking-partner) model catalog (150+ models). Selected for direct applicability to GSD research workflow.
+
+## Conflict Resolution
+
+**First Principles and Steel Man both expand scope** -- run First Principles FIRST (decompose the problem), then Steel Man (strengthen alternatives). Don't run simultaneously.
+
+## 1. First Principles Thinking
+
+**Counters:** Accepting surface-level explanations without decomposing into fundamental components.
+
+Before accepting any technology recommendation or architectural pattern, decompose it to its fundamental constraints: What problem does this solve? What are the non-negotiable requirements? What are the physical/logical limits? Build your recommendation UP from these constraints rather than DOWN from conventional wisdom. If you cannot explain WHY a recommendation is correct from first principles, flag it as `[LOW]` regardless of source count.
+
+## 2. Simpson's Paradox Awareness
+
+**Counters:** Synthesizer aggregating conflicting research without checking for confounding splits.
+
+When combining findings from multiple research documents that show contradictory results, check whether the contradiction disappears when you split by a hidden variable: framework version, deployment target, project scale, or use case category. A library that benchmarks faster overall may be slower for YOUR specific workload. Before resolving contradictions by majority vote, ask: "Is there a subgroup split that explains why both findings are correct in their own context?"
+
+## 3. Survivorship Bias
+
+**Counters:** Only finding successful examples while missing failures and abandoned approaches.
+
+After gathering evidence FOR a recommended approach, actively search for projects that ABANDONED it. Check GitHub issues for "migrated away from", "replaced X with", or "problems with X at scale". A technology with 10 success stories and 100 quiet failures looks great until you check the graveyard. Weight negative evidence (migration-away stories, deprecation notices, unresolved issues) MORE heavily than positive evidence -- failures are underreported.
+
+## 4. Confirmation Bias Counter
+
+**Counters:** Searching for evidence that confirms initial hypothesis while ignoring disconfirming evidence.
+
+After forming your initial recommendation, spend one full research cycle searching AGAINST it. Use search terms like "{technology} problems", "{technology} alternatives", "why not {technology}", "{technology} vs {competitor}". For each piece of disconfirming evidence found, either (a) refute it with higher-confidence sources, or (b) add it as a caveat to your recommendation. If you cannot find ANY criticism of your recommendation, your search was too narrow -- widen it.
+
+## 5. Steel Man
+
+**Counters:** Dismissing alternative approaches without giving them their strongest possible form.
+
+Before recommending against an alternative technology or approach, construct its STRONGEST possible case. What would a passionate advocate say? What use cases does it serve better than your recommendation? What trade-offs favor it? Present the steel-manned alternative alongside your recommendation with an honest comparison. If the steel-manned alternative is competitive, flag the decision as `[NEEDS DECISION]` rather than making a unilateral recommendation.

--- a/get-shit-done/references/thinking-models-verification.md
+++ b/get-shit-done/references/thinking-models-verification.md
@@ -1,0 +1,44 @@
+# Thinking Models: Verification Cluster
+
+Structured reasoning models for the **verifier** and **plan-checker** agents. Apply these during verification passes, not continuously. Each model counters a specific documented failure mode.
+
+Source: Curated from [thinking-partner](https://github.com/mattnowdev/thinking-partner) model catalog (150+ models). Selected for direct applicability to GSD verification workflow.
+
+## Conflict Resolution
+
+**Inversion** and **Confirmation Bias Counter** both look for failures but serve different purposes. Run them in sequence:
+
+1. **Inversion FIRST** (brainstorm): generate 3 ways this could be wrong
+2. **Confirmation Bias Counter SECOND** (structured check): find one partial requirement, one misleading test, one uncovered error path
+
+Inversion generates the list; Confirmation Bias Counter is the discipline to verify items on it.
+
+## 1. Inversion
+
+**Counters:** Verifiers confirming success rather than finding failures.
+
+Instead of checking what IS correct, list 3 specific ways this implementation could be WRONG despite passing tests: missing edge cases, silent data loss, race conditions, unhandled error paths. For each, write a concrete check (grep for pattern, test with specific input, verify error handling exists). Additionally, check whether any documented DEVIATION in SUMMARY.md changes the meaning or applicability of a must-have. If a must-have was written assuming approach A but the executor used approach B, the must-have may need reinterpretation, not literal checking.
+
+## 2. Chesterton's Fence
+
+**Counters:** Flagging purposeful code as dead or unnecessary.
+
+Before flagging any existing code as dead, redundant, or overcomplicated, determine WHY it was written that way. Check git blame, comments, test cases, and the PLAN.md that created it. If the reason is unclear, flag as "purpose unknown -- recommend keeping with WARNING, not removing" and include the git blame hash for the commit that introduced it.
+
+## 3. Confirmation Bias Counter
+
+**Counters:** Verifiers primed by SUMMARY.md claims to see success.
+
+After your initial verification pass, do a DISCONFIRMATION pass: (1) find one requirement that is only partially met, (2) find one test that passes but does not actually test the stated behavior, (3) find one error path that has no test coverage. Report these even if overall verification passes.
+
+## 4. Planning Fallacy Calibration
+
+**Counters:** Accepting over-scoped plans as reasonable (plan-checker).
+
+For each task estimated as "simple" or "small", check: does it touch more than 2 files? Does it require understanding an unfamiliar API? Does it modify shared infrastructure? If yes to any, flag as likely underestimated. Plans with >5 tasks or tasks touching >4 files per task are over-scoped.
+
+## 5. Counterfactual Thinking
+
+**Counters:** Plans that assume success at every step with no error recovery (plan-checker).
+
+For each plan, ask: "What would happen if the executor followed this plan EXACTLY as written but encountered a common failure: dependency version mismatch, API returning unexpected format, file already modified by prior plan?" If the plan has no contingency path and the `<action>` steps assume success at every point, flag as WARNING: "No error recovery path for task T{n}."

--- a/get-shit-done/references/ui-brand.md
+++ b/get-shit-done/references/ui-brand.md
@@ -23,6 +23,33 @@ Use for major workflow transitions.
 - `PHASE {N} COMPLETE ✓`
 - `MILESTONE COMPLETE 🎉`
 
+### Status Line
+
+Append a status line to stage banners at workflow transitions (planning, execution, verification). Shows current phase context at a glance.
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ GSD ► {STAGE NAME}
+ Phase {N}: {phase_name} | {model_profile} | {context_tier}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+**Status line values:**
+- `{N}`: current phase number from STATE.md
+- `{phase_name}`: phase slug (e.g., `knowledge-quality-uplift`)
+- `{model_profile}`: from `gsd-tools config-get model_profile` — one of `quality / balanced / budget / adaptive` (default: `balanced`)
+- `{context_tier}`: from context-budget.md thresholds — one of `PEAK / GOOD / DEGRADING / POOR`
+
+**Context tier resolution:**
+```bash
+MODEL_PROFILE=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-get model_profile 2>/dev/null || echo "balanced")
+CONTEXT_WINDOW=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-get context_window_tokens 2>/dev/null || echo "200000")
+# Tier: PEAK (<30% used), GOOD (30-50%), DEGRADING (50-70%), POOR (70%+)
+# Workflows derive tier from current context usage at render time
+```
+
+**Omit the status line** when: phase number is not available (pre-init), or in error boxes and checkpoint boxes (status line is for stage banners only).
+
 ---
 
 ## Checkpoint Boxes
@@ -108,9 +135,9 @@ Always at end of major completions.
 
 **{Identifier}: {Name}** — {one-line description}
 
-`/clear` then:
-
 `{copy-paste command}`
+
+<sub>`/clear` first → fresh context window</sub>
 
 ───────────────────────────────────────────────────────────────
 

--- a/get-shit-done/workflows/scan.md
+++ b/get-shit-done/workflows/scan.md
@@ -1,0 +1,285 @@
+<purpose>
+Rapid single-focus codebase analysis. Spawns one gsd-codebase-mapper agent for a targeted assessment.
+
+Lighter than /gsd-map-codebase (1 agent, 1 focus area vs 4 parallel agents, 7 documents).
+
+Output: .planning/codebase/ with documents for the selected focus area.
+</purpose>
+
+<available_agent_types>
+Valid GSD subagent types (use exact names):
+- gsd-codebase-mapper -- Maps project structure and dependencies
+</available_agent_types>
+
+<process>
+
+<step name="banner">
+Display the scan banner:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ GSD ► SCANNING CODEBASE
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+</step>
+
+<step name="parse_arguments">
+Extract `--focus` value from `$ARGUMENTS`.
+
+**Valid focus values:**
+- `tech` -- Produces STACK.md, INTEGRATIONS.md
+- `arch` -- Produces ARCHITECTURE.md, STRUCTURE.md
+- `quality` -- Produces CONVENTIONS.md, TESTING.md
+- `concerns` -- Produces CONCERNS.md
+- `tech+arch` -- Produces STACK.md, INTEGRATIONS.md, ARCHITECTURE.md, STRUCTURE.md (DEFAULT)
+
+If `--focus` is absent or not provided, set `FOCUS=tech+arch`.
+
+If `--focus` value is not in the valid list above, display an error and stop:
+```
+GSD > Unknown focus area: "{value}"
+GSD > Valid options: tech, arch, quality, concerns, tech+arch
+```
+
+This validation prevents unexpected behavior from invalid input.
+</step>
+
+<step name="check_existing">
+Check if .planning/codebase/ already has documents for the target focus area:
+
+```bash
+ls .planning/codebase/ 2>/dev/null
+```
+
+**Map focus to expected files:**
+- `tech` -- STACK.md, INTEGRATIONS.md
+- `arch` -- ARCHITECTURE.md, STRUCTURE.md
+- `quality` -- CONVENTIONS.md, TESTING.md
+- `concerns` -- CONCERNS.md
+- `tech+arch` -- STACK.md, INTEGRATIONS.md, ARCHITECTURE.md, STRUCTURE.md
+
+If target files already exist, ask the user:
+
+```
+GSD > Found existing analysis for {FOCUS} focus area:
+GSD > {list existing files}
+GSD >
+GSD > Refresh these documents? (yes/no)
+```
+
+If user says no, display the existing files with line counts and stop.
+If user says yes (or no existing files), continue to next step.
+</step>
+
+<step name="ensure_directory">
+Create the output directory if it does not exist:
+
+```bash
+mkdir -p .planning/codebase
+```
+</step>
+
+<step name="spawn_mapper">
+Spawn a single gsd-codebase-mapper agent for the resolved focus area.
+
+Display before spawning:
+```
+◆ Spawning codebase mapper (focus: {FOCUS})...
+```
+
+Load agent skills:
+```bash
+AGENT_SKILLS_MAPPER=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" agent-skills gsd-codebase-mapper 2>/dev/null)
+```
+
+**If FOCUS is `tech`:**
+
+```
+Task(
+  subagent_type="gsd-codebase-mapper",
+  description="Scan codebase: tech focus",
+  prompt="Focus: tech
+
+Analyze this codebase for technology stack and external integrations.
+
+Write these documents to .planning/codebase/:
+- STACK.md - Languages, runtime, frameworks, dependencies, configuration
+- INTEGRATIONS.md - External APIs, databases, auth providers, webhooks
+
+Explore thoroughly. Write documents directly using templates. Return confirmation only.
+${AGENT_SKILLS_MAPPER}"
+)
+```
+
+**If FOCUS is `arch`:**
+
+```
+Task(
+  subagent_type="gsd-codebase-mapper",
+  description="Scan codebase: arch focus",
+  prompt="Focus: arch
+
+Analyze this codebase architecture and directory structure.
+
+Write these documents to .planning/codebase/:
+- ARCHITECTURE.md - Pattern, layers, data flow, abstractions, entry points
+- STRUCTURE.md - Directory layout, key locations, naming conventions
+
+Explore thoroughly. Write documents directly using templates. Return confirmation only.
+${AGENT_SKILLS_MAPPER}"
+)
+```
+
+**If FOCUS is `quality`:**
+
+```
+Task(
+  subagent_type="gsd-codebase-mapper",
+  description="Scan codebase: quality focus",
+  prompt="Focus: quality
+
+Analyze this codebase for coding conventions and testing patterns.
+
+Write these documents to .planning/codebase/:
+- CONVENTIONS.md - Code style, naming, patterns, error handling
+- TESTING.md - Framework, structure, mocking, coverage
+
+Explore thoroughly. Write documents directly using templates. Return confirmation only.
+${AGENT_SKILLS_MAPPER}"
+)
+```
+
+**If FOCUS is `concerns`:**
+
+```
+Task(
+  subagent_type="gsd-codebase-mapper",
+  description="Scan codebase: concerns focus",
+  prompt="Focus: concerns
+
+Analyze this codebase for technical debt, known issues, and areas of concern.
+
+Write this document to .planning/codebase/:
+- CONCERNS.md - Tech debt, bugs, security, performance, fragile areas
+
+Explore thoroughly. Write document directly using template. Return confirmation only.
+${AGENT_SKILLS_MAPPER}"
+)
+```
+
+**If FOCUS is `tech+arch` (default):**
+
+```
+Task(
+  subagent_type="gsd-codebase-mapper",
+  description="Scan codebase: tech+arch focus",
+  prompt="Focus: tech and arch combined
+
+Analyze this codebase for technology stack, external integrations, architecture, and directory structure.
+
+Write these documents to .planning/codebase/:
+- STACK.md - Languages, runtime, frameworks, dependencies, configuration
+- INTEGRATIONS.md - External APIs, databases, auth providers, webhooks
+- ARCHITECTURE.md - Pattern, layers, data flow, abstractions, entry points
+- STRUCTURE.md - Directory layout, key locations, naming conventions
+
+Explore thoroughly. Write documents directly using templates. Return confirmation only.
+${AGENT_SKILLS_MAPPER}"
+)
+```
+
+When the mapper completes, check for `## Mapping Complete` in the output. If missing, display a warning:
+```
+GSD > Warning: Mapper output may be incomplete (no completion marker found)
+```
+</step>
+
+<step name="secret_scan">
+**CRITICAL SECURITY CHECK:** Scan output files for accidentally leaked secrets before committing.
+
+```bash
+grep -E '(sk-[a-zA-Z0-9]{20,}|sk_live_|sk_test_|ghp_[a-zA-Z0-9]{36}|gho_[a-zA-Z0-9]{36}|AKIA[A-Z0-9]{16}|-----BEGIN.*PRIVATE KEY|eyJ[a-zA-Z0-9_-]+\.eyJ)' .planning/codebase/*.md 2>/dev/null && echo "SECRETS_FOUND" || echo "CLEAN"
+```
+
+**If SECRETS_FOUND:**
+
+```
+GSD > SECURITY ALERT: Potential secrets detected in codebase documents!
+GSD > [show grep output]
+GSD >
+GSD > Review the flagged content. Reply "safe to proceed" if not actually sensitive,
+GSD > or edit the files to remove secrets first.
+```
+
+Wait for user confirmation before continuing.
+
+**If CLEAN:**
+
+Continue to commit step.
+</step>
+
+<step name="commit">
+Commit the scanned documents:
+
+```bash
+node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" commit "docs(planning): scan codebase ({FOCUS})" --files .planning/codebase/
+```
+</step>
+
+<step name="summary">
+Display completion summary:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ GSD ► SCAN COMPLETE ✓
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+List files written with line counts:
+```bash
+wc -l .planning/codebase/*.md
+```
+
+```
+Scanned codebase (focus: {FOCUS}):
+- {file1}.md ({N} lines)
+- {file2}.md ({N} lines)
+...
+```
+
+Display next steps:
+
+```
+───────────────────────────────────────────────────────────────
+
+## ▶ Next Up
+
+**Full coverage** -- map all 7 documents
+
+`/gsd-map-codebase`
+
+<sub>`/clear` first → fresh context window</sub>
+
+───────────────────────────────────────────────────────────────
+
+**Also available:**
+- `/gsd-scan --focus quality` -- scan another area
+- `/gsd-new-project` -- initialize project planning
+- `/gsd-plan-phase` -- plan next phase
+
+───────────────────────────────────────────────────────────────
+```
+
+End workflow.
+</step>
+
+</process>
+
+<success_criteria>
+- Single gsd-codebase-mapper agent spawned (NOT 4 parallel agents)
+- Target documents written for the selected focus area
+- No empty documents (each should have >20 lines)
+- Secret scan completed before commit
+- Clear completion summary with file list and line counts
+- User offered next steps in GSD style
+</success_criteria>


### PR DESCRIPTION
## Linked Issue

Closes #1670

## Summary

- Add 5 thinking model reference docs with structured reasoning models for complex decisions
- Add 2 few-shot calibration examples for plan-checker and verifier agents
- Add /gsd-scan command for rapid single-agent codebase assessment
- Add LEARNINGS.md write/read system (gated behind features.learnings)
- Add status line format to stage banners (phase, model profile, context tier)
- Wire thinking model and few-shot @-references into 6 agent files

## Test plan
- [ ] Verify 5 thinking model docs exist and are under 150 lines each
- [ ] Verify plan-checker and verifier agents load few-shot examples
- [ ] Verify /gsd-scan spawns single gsd-codebase-mapper agent (not 4)
- [ ] Verify LEARNINGS.md write is gated behind features.learnings config flag
- [ ] Verify status line renders in plan-phase and execute-phase banners
- [ ] Run existing test suite to confirm no regressions

## Checklist

- [x] Issue linked above
- [x] Follows GSD style
- [x] No unnecessary dependencies added
- [x] Works on Windows
- [x] Existing tests pass

## Breaking Changes

None