### PR TITLE
feat(workflows): integrate thinking-partner at workflow decision points

### DIFF
--- a/get-shit-done/references/thinking-models-discuss.md
+++ b/get-shit-done/references/thinking-models-discuss.md
@@ -1,0 +1,39 @@
+# Thinking Models: Discuss Cluster
+
+Structured reasoning models for the **discuss-phase** and **explore** workflows. Apply these at decision points when gray areas have genuine trade-offs, not on every question. Each model counters a specific documented failure mode.
+
+Source: Curated from [thinking-partner](https://github.com/mattnowdev/thinking-partner) model catalog (150+ models). Selected for direct applicability to GSD discussion and decision-capture workflows.
+
+## Conflict Resolution
+
+Reversibility Test and Constraint Analysis both analyze decisions before discussion begins. Run Reversibility Test FIRST (classify each decision by cost to reverse). Then Constraint Analysis (identify which decision locks down the most other decisions -- discuss that one first). Pre-Mortem applies AFTER initial positions are surfaced, to stress-test the emerging direction.
+
+## 1. Reversibility Test
+
+**Counters:** Spending equal analysis time on decisions that cost little to change and decisions that lock in architecture or user commitments.
+
+For each gray area under discussion, ask: "If we decide this one way and later change our minds, what does the reversal cost?" Classify each decision as REVERSIBLE (low cost to undo -- UI choices, copy, feature flags) or IRREVERSIBLE (high cost -- data model changes, API contracts, foundational library choices). Spend discussion depth proportional to irreversibility. Surface the IRREVERSIBLE decisions to the user explicitly.
+
+## 2. Constraint Analysis
+
+**Counters:** Discussing dependent decisions before the decision that constrains all of them.
+
+Identify which single decision in this discussion locks down the most other decisions. That is the constraining decision -- discuss it first. When one option forecloses or constrains options in another gray area, those gray areas are coupled. Name the coupling explicitly before the user commits to either.
+
+## 3. Pre-Mortem
+
+**Counters:** Optimistic convergence that ignores regret scenarios before commitments are made.
+
+Before finalizing the decisions from this discussion, assume the direction chosen turns out to be wrong six months from now. Name the 3 most likely reasons the user would regret the decision -- wrong assumption about usage, underestimated complexity to change later, dependency on something unstable. If any regret scenario is plausible, surface it before the user commits.
+
+## 4. Inversion
+
+**Counters:** Only considering what makes a decision right, without examining what would make it obviously wrong.
+
+For each proposed direction, invert the question: "What would have to be true for this decision to be clearly wrong?" List those conditions. If any inversion condition is likely or already present, it is a signal to reconsider the direction before committing. Inversion surfaces hidden assumptions faster than direct analysis.
+
+## 5. Second-Order Thinking
+
+**Counters:** Evaluating decisions only by their immediate effects, missing downstream consequences that emerge over time.
+
+For each option, ask: "If we choose this, what happens next?" -- then ask again about that result: "And then what happens?" First-order effects are obvious (e.g., "using library X saves setup time"). Second-order effects are the ones that matter (e.g., "library X's update cadence will force a major migration every 18 months"). Surface at least one second-order consequence for each direction before the user decides.

--- a/get-shit-done/workflows/discuss-phase-assumptions.md
+++ b/get-shit-done/workflows/discuss-phase-assumptions.md
@@ -348,6 +348,12 @@ Based on codebase analysis, here's what I'd go with:
 {Confidence badge} **{Assumption statement}**
 ↳ Evidence: {file paths cited}
 ↳ If wrong: {consequence}
+↳ {If IRREVERSIBLE: "IRREVERSIBLE — changing this later requires {specific cost from If wrong field}". If REVERSIBLE: omit this line.}
+
+Classification logic (apply per assumption during display):
+- IRREVERSIBLE if "If wrong" implies: migration required, breaking change, significant rework, data loss, or re-architecture
+- REVERSIBLE if "If wrong" implies: minor fix, config change, UI update, or feature toggle
+- Only display the classification line for IRREVERSIBLE assumptions (no clutter for simple cases)
 
 ### {Area Name 2}
 ...
@@ -356,6 +362,28 @@ Based on codebase analysis, here's what I'd go with:
 ### External Research Applied
 - {Topic}: {Finding} (Source: {URL})
 ```
+
+**Thinking partner** (only when `features.thinking_partner: true`):
+
+After displaying all assumptions above, count the number of assumptions classified as IRREVERSIBLE.
+
+```bash
+THINKING_PARTNER_ENABLED=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-get features.thinking_partner 2>/dev/null || echo "false")
+```
+
+If `THINKING_PARTNER_ENABLED=true` AND irreversible assumption count >= 1 AND NOT `--auto`:
+
+@get-shit-done/references/thinking-models-discuss.md
+
+Use AskUserQuestion:
+- header: "Thinking Partner"
+- question: "{N} assumption(s) marked IRREVERSIBLE above. Apply Reversibility Test analysis before proceeding?"
+- options:
+  - "Reversibility Test — surface the full reversal cost for each irreversible assumption and flag the riskiest one"
+  - "Skip — proceed to corrections"
+
+If "Reversibility Test" selected: apply the Reversibility Test model from @get-shit-done/references/thinking-models-discuss.md to each IRREVERSIBLE assumption, present the analysis, then continue to the "These all look right?" confirmation.
+If "Skip" or `THINKING_PARTNER_ENABLED=false` or `--auto`: continue to the "These all look right?" confirmation without interruption.
 
 **If `--auto`:**
 - If all assumptions are Confident or Likely: log assumptions, skip to write_context.

--- a/get-shit-done/workflows/discuss-phase.md
+++ b/get-shit-done/workflows/discuss-phase.md
@@ -466,6 +466,29 @@ Gray areas:
 - Empty State: What shows when no posts exist — EmptyState component exists in ui/
 - Content: What metadata displays (time, author, reactions count)
 ```
+
+**Thinking partner** (only when `features.thinking_partner: true`):
+
+Count the number of gray areas identified above where choosing one option constrains or forecloses options in at least one other gray area. These are "interacting" gray areas.
+
+```bash
+THINKING_PARTNER_ENABLED=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-get features.thinking_partner 2>/dev/null || echo "false")
+```
+
+If `THINKING_PARTNER_ENABLED=true` AND interacting gray area count >= 3 AND NOT `--auto`:
+
+@get-shit-done/references/thinking-models-discuss.md
+
+Use AskUserQuestion:
+- header: "Thinking Partner"
+- question: "3+ interacting decisions detected — some choices here constrain each other. Apply structured reasoning before we discuss?"
+- options:
+  - "Reversibility Test + Constraint Analysis — classify which decisions are hardest to reverse, then identify which one locks down the others"
+  - "Pre-Mortem — enumerate the most likely regret scenarios before committing to a direction"
+  - "Skip — proceed to discussion without structured analysis"
+
+If model selected: apply the model inline using @get-shit-done/references/thinking-models-discuss.md guidance, present the output to the user, then continue to present_gray_areas.
+If "Skip" or `THINKING_PARTNER_ENABLED=false` or `--auto`: continue to present_gray_areas without interruption.
 </step>
 
 <step name="present_gray_areas">

--- a/get-shit-done/workflows/explore.md
+++ b/get-shit-done/workflows/explore.md
@@ -1,0 +1,417 @@
+<purpose>
+Socratic ideation workflow. Guide a structured discovery conversation using questioning.md
+principles and domain-probes.md for tech-specific follow-ups. At the end, route outputs to
+the correct GSD artifact locations (notes, todos, seeds, research questions, requirements,
+or new phases).
+
+Output: Up to 4 artifacts written to .planning/ paths and committed.
+</purpose>
+
+<required_reading>
+Read all files referenced by the invoking prompt's execution_context before starting:
+@~/.claude/get-shit-done/references/questioning.md
+@~/.claude/get-shit-done/references/domain-probes.md
+@~/.claude/get-shit-done/references/ui-brand.md
+</required_reading>
+
+<available_agent_types>
+Valid GSD subagent types (use exact names):
+- gsd-phase-researcher -- Deep-dive research on a topic
+</available_agent_types>
+
+<process>
+
+<step name="banner">
+Display the explore banner:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ GSD ► EXPLORING
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+If `.planning/` exists, read STATE.md and ROADMAP.md inline for project context:
+
+```bash
+cat .planning/STATE.md 2>/dev/null
+cat .planning/ROADMAP.md 2>/dev/null
+```
+
+Display a brief context line if project state was found:
+```
+Project: {milestone_name} | Phase {N}: {phase_name} | Status: {status}
+```
+
+If no `.planning/` exists, display:
+```
+No active project. Exploring freely.
+```
+</step>
+
+<step name="socratic_conversation">
+Run a Socratic dialogue using questioning.md principles and domain-probes.md patterns.
+
+**Starting the conversation:**
+
+If `$ARGUMENTS` contains a topic or idea:
+- Acknowledge the topic and ask an open-ended question to explore it further
+- Example: "Interesting -- {topic}. What prompted this? What problem are you trying to solve?"
+
+If `$ARGUMENTS` is empty:
+- Ask what's on their mind:
+  ```
+  AskUserQuestion(
+    header: "Explore",
+    question: "What idea or question do you want to explore?",
+    options: []
+  )
+  ```
+
+**Conversation flow (5-8 exchanges max):**
+
+1. **Start open.** Let the user dump their mental model. Don't interrupt with structure.
+
+2. **Follow energy.** Whatever they emphasize, dig into that. What excited them? What problem sparked this?
+
+3. **Apply domain probes.** When the user mentions a technology area (auth, database, API, real-time, etc.), use 2-3 relevant probes from domain-probes.md to surface hidden assumptions and trade-offs. Don't run through them as a checklist -- pick the most relevant based on context.
+
+4. **Challenge vagueness.** Never accept fuzzy answers. "Good" means what? "Users" means who? "Simple" means how?
+
+5. **Make the abstract concrete.** "Walk me through using this." "What does that actually look like?"
+
+6. **Mid-conversation research offer.** After 2-3 exchanges, if the topic would benefit from deeper investigation, offer:
+   ```
+   AskUserQuestion(
+     header: "Research?",
+     question: "Want me to research this further before we continue?",
+     options: [
+       { label: "Yes", description: "Spawn a researcher to dig deeper" },
+       { label: "No", description: "Keep exploring together" }
+     ]
+   )
+   ```
+
+   If yes, spawn a research subagent:
+   ```
+   Task(
+     subagent_type="gsd-phase-researcher",
+     description="Research: {topic}",
+     prompt="Research the following topic in depth: {topic}
+
+   Context from conversation so far:
+   {summary of key points discussed}
+
+   Focus on:
+   - What approaches exist
+   - Trade-offs and pitfalls
+   - Recommendations for this specific context
+
+   Write findings to .planning/research/{topic-slug}.md"
+   )
+   ```
+
+   After research completes, summarize key findings and continue the conversation.
+
+7. **Know when to stop.** After 5-8 exchanges, or when the conversation reaches natural closure, move to output routing. Don't force more questions when clarity has been reached.
+
+**Anti-patterns (from questioning.md):**
+- Checklist walking -- going through domains regardless of what they said
+- Canned questions -- "What's your core value?" regardless of context
+- Interrogation -- firing questions without building on answers
+- Shallow acceptance -- taking vague answers without probing
+</step>
+
+<step name="output_routing">
+After the conversation, summarize the key insights discovered, then propose up to 4 concrete outputs from this list:
+
+**Available output types:**
+
+| Type | Description | Destination |
+|------|-------------|-------------|
+| Note | Captures a thought for later review | `.planning/notes/{YYYY-MM-DD}-{slug}.md` |
+| Todo | An actionable task to complete | `.planning/todos/pending/{NNN}-{slug}.md` |
+| Seed | A future capability idea with trigger conditions | `.planning/seeds/SEED-{NNN}-{slug}.md` |
+| Research question | A question needing deeper investigation | `.planning/research/questions.md` |
+| Requirement | A validated requirement for the project | `.planning/REQUIREMENTS.md` |
+| New phase | A new phase to add to the roadmap | `.planning/ROADMAP.md` |
+
+**Proposing outputs:**
+
+Present a numbered list of proposed outputs based on what emerged from the conversation:
+
+```
+Based on our conversation, here's what I'd suggest capturing:
+
+1. **Note** -- "{summary of the thought}"
+2. **Seed** -- "{future capability idea}"
+3. **Research question** -- "{question needing investigation}"
+4. **Todo** -- "{actionable next step}"
+```
+
+**Thinking partner** (only when `features.thinking_partner: true`):
+
+Before confirming outputs, assess whether the conversation surfaced 2 or more mutually exclusive approaches to the same goal — strategies where choosing one means not choosing the other. This is NOT multiple complementary outputs; it is competing directions for the same capability.
+
+```bash
+THINKING_PARTNER_ENABLED=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-get features.thinking_partner 2>/dev/null || echo "false")
+```
+
+If `THINKING_PARTNER_ENABLED=true` AND mutually exclusive approach count >= 2 AND NOT `--auto`:
+
+@get-shit-done/references/thinking-models-discuss.md
+
+Use AskUserQuestion:
+- header: "Thinking Partner"
+- question: "2+ competing approaches detected. Apply structured reasoning before committing to a direction?"
+- options:
+  - "Second-Order Thinking — trace the downstream consequences of each approach beyond the obvious first effect"
+  - "Inversion — identify what would make each approach obviously wrong"
+  - "Skip — I know which direction I want"
+
+If model selected: apply the selected model from @get-shit-done/references/thinking-models-discuss.md to each competing approach, present the analysis, then continue to the outputs confirmation.
+If "Skip" or `THINKING_PARTNER_ENABLED=false` or `--auto`: continue to outputs confirmation without interruption.
+
+Then confirm with the user:
+
+```
+AskUserQuestion(
+  header: "Outputs?",
+  question: "Which outputs should I create? (list numbers, 'all', or 'none')",
+  options: [
+    { label: "All", description: "Create all proposed outputs" },
+    { label: "Let me pick", description: "I'll specify which ones" },
+    { label: "None", description: "Just wanted to think out loud" }
+  ]
+)
+```
+
+If "Let me pick" -- ask which numbers to create.
+If "None" -- skip to summary step.
+If "All" -- create all proposed outputs.
+</step>
+
+<step name="create_artifacts">
+For each confirmed output, create the artifact at the correct GSD path.
+
+**Slug generation** (used by all artifact types):
+```bash
+SLUG=$(echo "{title}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed 's/^-\|-$//g')
+```
+
+---
+
+**Note:**
+
+Write `.planning/notes/{YYYY-MM-DD}-{slug}.md`:
+
+```bash
+mkdir -p .planning/notes
+```
+
+```markdown
+---
+date: "{YYYY-MM-DD HH:mm}"
+promoted: false
+---
+
+{Note content from conversation}
+```
+
+---
+
+**Todo:**
+
+Scan for highest existing number:
+```bash
+HIGHEST=$(ls .planning/todos/pending/*.md .planning/todos/completed/*.md 2>/dev/null | sed 's/.*\///' | grep -oE '^[0-9]+' | sort -n | tail -1)
+NEXT=$(printf "%03d" $(( ${HIGHEST:-0} + 1 )))
+```
+
+Write `.planning/todos/pending/{NEXT}-{slug}.md`:
+
+```bash
+mkdir -p .planning/todos/pending
+```
+
+```markdown
+---
+title: "{todo title}"
+status: pending
+priority: P2
+source: "/gsd-explore"
+created: {YYYY-MM-DD}
+theme: general
+---
+
+## Goal
+
+{Description of what needs to be done}
+
+## Context
+
+Captured during /gsd-explore session on {YYYY-MM-DD}.
+
+## Acceptance Criteria
+
+- [ ] {primary criterion}
+```
+
+---
+
+**Seed:**
+
+Scan for highest existing seed number:
+```bash
+HIGHEST=$(ls .planning/seeds/SEED-*.md 2>/dev/null | sed 's/.*SEED-//' | grep -oE '^[0-9]+' | sort -n | tail -1)
+NEXT=$(printf "%03d" $(( ${HIGHEST:-0} + 1 )))
+```
+
+Write `.planning/seeds/SEED-{NEXT}-{slug}.md`:
+
+```bash
+mkdir -p .planning/seeds
+```
+
+```markdown
+---
+id: SEED-{NEXT}
+status: dormant
+planted: {YYYY-MM-DD}
+trigger_when: "{trigger condition from conversation}"
+scope: "{Small|Medium|Large}"
+---
+
+# SEED-{NEXT}: {Idea title}
+
+## Why This Matters
+
+{Why this idea is worth capturing}
+
+## When to Surface
+
+**Trigger:** {trigger condition}
+
+This seed should be presented during `/gsd-new-milestone` when the milestone
+scope matches these conditions:
+- {condition 1}
+- {condition 2}
+
+## Scope Estimate
+
+**{scope}** -- {elaboration}
+
+## Notes
+
+Captured during /gsd-explore session on {YYYY-MM-DD}.
+```
+
+---
+
+**Research question:**
+
+Append to `.planning/research/questions.md` (create file if it does not exist):
+
+```bash
+mkdir -p .planning/research
+```
+
+If file does not exist, create it with a header first:
+```markdown
+# Research Questions
+
+Questions captured for future investigation.
+
+---
+```
+
+Append:
+```markdown
+- [ ] {Question text} -- Source: /gsd-explore ({YYYY-MM-DD})
+```
+
+---
+
+**Requirement:**
+
+Append to `.planning/REQUIREMENTS.md` with the next available requirement ID.
+
+Read the file first to find the highest existing ID pattern, then increment.
+
+Append the new requirement following the existing format in the file.
+
+---
+
+**New phase:**
+
+Append a new phase entry to `.planning/ROADMAP.md` following the existing phase format in the file.
+
+Read the file first to determine the next phase number and follow the established structure.
+</step>
+
+<step name="commit">
+Commit all created artifacts:
+
+```bash
+node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" commit "docs(explore): add {output-types} from /gsd-explore session" --files {list of created files}
+```
+
+Where `{output-types}` is a comma-separated list of what was created (e.g., "note, seed, todo").
+</step>
+
+<step name="summary">
+Display completion banner:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ GSD ► EXPLORE COMPLETE ✓
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+List artifacts created:
+```
+Created:
+  ✓ Note: .planning/notes/{filename}
+  ✓ Seed: .planning/seeds/{filename}
+  ✓ Research question: appended to .planning/research/questions.md
+```
+
+Display next steps in GSD style:
+
+```
+───────────────────────────────────────────────────────────────
+
+## ▶ Next Up
+
+**Explore more** -- continue ideating
+
+`/gsd-explore`
+
+<sub>`/clear` first → fresh context window</sub>
+
+───────────────────────────────────────────────────────────────
+
+**Also available:**
+- `/gsd-note` -- quick idea capture (no conversation)
+- `/gsd-plant-seed` -- plant a seed with full trigger details
+- `/gsd-plan-phase` -- plan next phase from captured ideas
+
+───────────────────────────────────────────────────────────────
+```
+
+End workflow.
+</step>
+
+</process>
+
+<success_criteria>
+- [ ] Socratic conversation uses questioning.md principles (open questions, follow energy, challenge vagueness)
+- [ ] Domain probes from domain-probes.md applied when tech topics emerge
+- [ ] Mid-conversation research option offered via gsd-phase-researcher Task()
+- [ ] Output routing covers all 6 types: notes, todos, seeds, research questions, requirements, new phases
+- [ ] User confirms which outputs to create before writing
+- [ ] Seeds use SEED-{NNN} sequential numbering
+- [ ] Todos use {NNN} sequential numbering from existing files
+- [ ] All artifacts written to correct .planning/ paths
+- [ ] Created artifacts committed via gsd-tools
+- [ ] GSD banner style used throughout (no PBR formatting)
+</success_criteria>


### PR DESCRIPTION
## Linked Issue

Closes #1678

## What

Add structured reasoning via thinking-partner mental models at 3 workflow decision points.

## Why

Complex gray areas with multiple interacting trade-offs benefit from systematic mental model application rather than ad-hoc conversation.

## How

- New `thinking-models-discuss.md` reference doc (5 models)
- Conditional blocks in discuss-phase, discuss-phase-assumptions, and explore workflows
- Hard-coded thresholds prevent over-invocation (3+ gray areas, 2+ approaches)
- Gated behind `features.thinking_partner` (default: false)
- Skipped entirely in --auto mode

## Testing

### Platforms tested
- [x] Windows (including backslash path handling)

### Runtimes tested
- [x] Claude Code

### Test details
- Verified config-get fallback returns "false" when flag absent
- Verified --auto mode skips thinking partner blocks
- Verified AskUserQuestion format in all 3 workflows

## Checklist
- [x] Issue linked above
- [x] Follows GSD style
- [x] No unnecessary dependencies added
- [x] Works on Windows
- [x] Templates/references updated
- [x] Existing tests pass

## Breaking Changes

None