### PR TITLE
fix: replace shell sleep with cross-platform Atomics.wait in planning lock

### DIFF
--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -581,8 +581,8 @@ function withPlanningLock(cwd, fn) {
           }
         } catch { continue; }
 
-        // Wait and retry
-        spawnSync('sleep', ['0.1'], { stdio: 'ignore' });
+        // Wait and retry (cross-platform, no shell dependency)
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 100);
         continue;
       }
       throw err;


### PR DESCRIPTION
## Summary
- Replaces `spawnSync('sleep', ['0.1'])` with `Atomics.wait()` in `withPlanningLock` for cross-platform compatibility
- `sleep` command doesn't exist on Windows, causing a tight busy-loop during lock contention
- `Atomics.wait()` provides a blocking 100ms wait, available in Node 22+ (project minimum)

Fixes #1692

## Test plan
- [x] All 2156 tests pass
- [ ] Verify lock contention behavior on Windows (no more CPU spike during retry)