### PR TITLE
fix: add missing 'act as' injection pattern to prompt guard hook

### DIFF
--- a/hooks/gsd-prompt-guard.js
+++ b/hooks/gsd-prompt-guard.js
@@ -22,6 +22,7 @@ const INJECTION_PATTERNS = [
   /forget\s+(all\s+)?(your\s+)?instructions/i,
   /override\s+(system|previous)\s+(prompt|instructions)/i,
   /you\s+are\s+now\s+(?:a|an|the)\s+/i,
+  /act\s+as\s+(?:a|an|the)\s+(?!plan|phase|wave)/i,
   /pretend\s+(?:you(?:'re| are)\s+|to\s+be\s+)/i,
   /from\s+now\s+on,?\s+you\s+(?:are|will|should|must)/i,
   /(?:print|output|reveal|show|display|repeat)\s+(?:your\s+)?(?:system\s+)?(?:prompt|instructions)/i,


### PR DESCRIPTION
## Summary
- Adds `act as a/an/the` prompt injection pattern to `gsd-prompt-guard.js` hook
- Matches the pattern already in `security.cjs` (line 131), including the `(?!plan|phase|wave)` negative lookahead
- Closes the defense-in-depth gap where this common injection vector was unchecked in the hook layer

Fixes #1696

## Test plan
- [x] All 2156 tests pass
- [x] `npm run build:hooks` succeeds (syntax validation passes)
- [ ] Verify hook fires advisory warning when writing `act as a helpful assistant` to `.planning/` files
- [ ] Verify `act as a plan` does NOT trigger (negative lookahead exception)