### PR TITLE
test: add MODEL_ALIAS_MAP regression test (#1690)

### DIFF
--- a/tests/model-alias-map.test.cjs
+++ b/tests/model-alias-map.test.cjs
@@ -1,0 +1,27 @@
+/**
+ * GSD Tools Tests - MODEL_ALIAS_MAP
+ *
+ * Verifies that model aliases map to current Claude model IDs.
+ * Regression test for #1690: aliases were pointing to outdated model versions.
+ *
+ * Uses node:test and node:assert/strict (NOT Jest).
+ */
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { MODEL_ALIAS_MAP } = require('../get-shit-done/bin/lib/core.cjs');
+
+describe('MODEL_ALIAS_MAP (#1690 regression)', () => {
+  test('opus maps to claude-opus-4-6', () => {
+    assert.equal(MODEL_ALIAS_MAP.opus, 'claude-opus-4-6');
+  });
+
+  test('sonnet maps to claude-sonnet-4-6', () => {
+    assert.equal(MODEL_ALIAS_MAP.sonnet, 'claude-sonnet-4-6');
+  });
+
+  test('haiku maps to claude-haiku-4-5', () => {
+    assert.equal(MODEL_ALIAS_MAP.haiku, 'claude-haiku-4-5');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `tests/model-alias-map.test.cjs` with 3 assertions verifying opus→4-6, sonnet→4-6, haiku→4-5
- Prevents future regressions where model aliases silently resolve to outdated Claude model IDs
- Follow-up to PR #1691 which fixed the bug but did not include a regression test

Closes #1690

## Test plan
- [x] `node --test tests/model-alias-map.test.cjs` — 3/3 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)