### PR TITLE
fix: add Kilo path replacement in copyFlattenedCommands

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -3398,10 +3398,12 @@ function copyFlattenedCommands(srcDir, destDir, prefix, pathPrefix, runtime) {
       const globalClaudeHomeRegex = /\$HOME\/\.claude\//g;
       const localClaudeRegex = /\.\/\.claude\//g;
       const opencodeDirRegex = /~\/\.opencode\//g;
+      const kiloDirRegex = /~\/\.kilo\//g;
       content = content.replace(globalClaudeRegex, pathPrefix);
       content = content.replace(globalClaudeHomeRegex, pathPrefix);
       content = content.replace(localClaudeRegex, `./${getDirName(runtime)}/`);
       content = content.replace(opencodeDirRegex, pathPrefix);
+      content = content.replace(kiloDirRegex, pathPrefix);
       content = processAttribution(content, getCommitAttribution(runtime));
       content = runtime === 'kilo'
         ? convertClaudeToKiloFrontmatter(content)


### PR DESCRIPTION
## Summary
- Adds `kiloDirRegex` (`~/.kilo/`) replacement alongside existing `opencodeDirRegex` (`~/.opencode/`) in `copyFlattenedCommands`
- Prevents latent bug if any future command/workflow files contain hardcoded `~/.kilo/` paths

Fixes #1709

## Test plan
- [x] All 2156 tests pass
- [ ] Verify Kilo install produces correct paths: `npx get-shit-done-cc --kilo --global`