### PR TITLE
fix: stale hooks scanner ignores orphaned files from removed features

### DIFF
--- a/hooks/gsd-check-update.js
+++ b/hooks/gsd-check-update.js
@@ -81,12 +81,22 @@ const child = spawn(process.execPath, ['-e', `
 
   // Check for stale hooks — compare hook version headers against installed VERSION
   // Hooks are installed at configDir/hooks/ (e.g. ~/.claude/hooks/) (#1421)
+  // Only check hooks that GSD currently ships — orphaned files from removed features
+  // (e.g., gsd-intel-*.js) must be ignored to avoid permanent stale warnings (#1750)
+  const MANAGED_HOOKS = [
+    'gsd-check-update.js',
+    'gsd-context-monitor.js',
+    'gsd-prompt-guard.js',
+    'gsd-read-guard.js',
+    'gsd-statusline.js',
+    'gsd-workflow-guard.js',
+  ];
   let staleHooks = [];
   if (configDir) {
     const hooksDir = path.join(configDir, 'hooks');
     try {
       if (fs.existsSync(hooksDir)) {
-        const hookFiles = fs.readdirSync(hooksDir).filter(f => f.startsWith('gsd-') && f.endsWith('.js'));
+        const hookFiles = fs.readdirSync(hooksDir).filter(f => MANAGED_HOOKS.includes(f));
         for (const hookFile of hookFiles) {
           try {
             const content = fs.readFileSync(path.join(hooksDir, hookFile), 'utf8');

--- a/tests/orphaned-hooks.test.cjs
+++ b/tests/orphaned-hooks.test.cjs
@@ -1,0 +1,85 @@
+/**
+ * Regression test for #1750: orphaned hook files from removed features
+ * (e.g., gsd-intel-*.js) should NOT be flagged as stale by gsd-check-update.js.
+ *
+ * The stale hooks scanner should only check hooks that are part of the current
+ * distribution, not every gsd-*.js file in the hooks directory.
+ */
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const CHECK_UPDATE_PATH = path.join(__dirname, '..', 'hooks', 'gsd-check-update.js');
+const BUILD_HOOKS_PATH = path.join(__dirname, '..', 'scripts', 'build-hooks.js');
+
+describe('orphaned hooks stale detection (#1750)', () => {
+  test('stale hook scanner uses an allowlist of managed hooks, not a wildcard', () => {
+    const content = fs.readFileSync(CHECK_UPDATE_PATH, 'utf8');
+
+    // The scanner MUST NOT use a broad `startsWith('gsd-')` filter that catches
+    // orphaned files from removed features (gsd-intel-index.js, gsd-intel-prune.js, etc.)
+    // Instead, it should reference a known set of managed hook filenames.
+
+    // Extract the spawned child script (everything between the template literal backticks)
+    const childScriptMatch = content.match(/spawn\(process\.execPath,\s*\['-e',\s*`([\s\S]*?)`\]/);
+    assert.ok(childScriptMatch, 'should find the spawned child script');
+    const childScript = childScriptMatch[1];
+
+    // The child script must NOT have a broad gsd-*.js wildcard filter
+    const hasBroadFilter = /readdirSync\([^)]+\)\.filter\([^)]*startsWith\('gsd-'\)\s*&&[^)]*endsWith\('\.js'\)/s.test(childScript);
+    assert.ok(!hasBroadFilter,
+      'scanner must NOT use broad startsWith("gsd-") && endsWith(".js") filter — ' +
+      'this catches orphaned hooks from removed features (e.g., gsd-intel-index.js). ' +
+      'Use a MANAGED_HOOKS allowlist instead.');
+  });
+
+  test('managed hooks list in check-update matches build-hooks HOOKS_TO_COPY JS entries', () => {
+    // Extract JS hooks from build-hooks.js HOOKS_TO_COPY
+    const buildContent = fs.readFileSync(BUILD_HOOKS_PATH, 'utf8');
+    const hooksArrayMatch = buildContent.match(/HOOKS_TO_COPY\s*=\s*\[([\s\S]*?)\]/);
+    assert.ok(hooksArrayMatch, 'should find HOOKS_TO_COPY array');
+
+    const jsHooks = [];
+    const hookEntries = hooksArrayMatch[1].matchAll(/'([^']+\.js)'/g);
+    for (const m of hookEntries) {
+      jsHooks.push(m[1]);
+    }
+    assert.ok(jsHooks.length >= 5, `expected at least 5 JS hooks in HOOKS_TO_COPY, got ${jsHooks.length}`);
+
+    // The check-update hook should define its own managed hooks list
+    // that matches the JS entries from HOOKS_TO_COPY
+    const checkContent = fs.readFileSync(CHECK_UPDATE_PATH, 'utf8');
+    const childScriptMatch = checkContent.match(/spawn\(process\.execPath,\s*\['-e',\s*`([\s\S]*?)`\]/);
+    const childScript = childScriptMatch[1];
+
+    // Verify each JS hook from HOOKS_TO_COPY is referenced in the managed list
+    for (const hook of jsHooks) {
+      assert.ok(
+        childScript.includes(hook),
+        `managed hooks in check-update should include '${hook}' from HOOKS_TO_COPY`
+      );
+    }
+  });
+
+  test('orphaned hook filenames would NOT match the managed hooks list', () => {
+    const checkContent = fs.readFileSync(CHECK_UPDATE_PATH, 'utf8');
+    const childScriptMatch = checkContent.match(/spawn\(process\.execPath,\s*\['-e',\s*`([\s\S]*?)`\]/);
+    const childScript = childScriptMatch[1];
+
+    // These are real orphaned hooks from the removed intel feature
+    const orphanedHooks = [
+      'gsd-intel-index.js',
+      'gsd-intel-prune.js',
+      'gsd-intel-session.js',
+    ];
+
+    for (const orphan of orphanedHooks) {
+      assert.ok(
+        !childScript.includes(orphan),
+        `orphaned hook '${orphan}' must NOT be in the managed hooks list`
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Replaces broad `startsWith('gsd-') && endsWith('.js')` filter in `gsd-check-update.js` with explicit `MANAGED_HOOKS` allowlist
- Orphaned hook files from removed features (e.g., `gsd-intel-index.js`, `gsd-intel-prune.js`, `gsd-intel-session.js`) no longer trigger permanent "stale hooks" warning
- Adds 3 regression tests: no broad wildcard, managed list matches build-hooks.js, orphaned filenames excluded

Fixes #1750

## Root cause
The stale hooks scanner at line 89 of `gsd-check-update.js` filtered hooks directory entries with `f.startsWith('gsd-') && f.endsWith('.js')`, which matched ALL `gsd-*.js` files — including orphaned ones from removed features. These files lacked `// gsd-hook-version:` headers, so they were flagged as `hookVersion: 'unknown'` and `/gsd-update` couldn't clear them.

## Fix
Replace the wildcard with a `MANAGED_HOOKS` array containing the 6 JS hooks GSD currently ships. Only these files are checked for staleness.

## Test plan
- [x] `node --test tests/orphaned-hooks.test.cjs` — 3/3 pass
- [x] Full test suite — 2164/2164 pass, 0 regressions
- [ ] User with orphaned `gsd-intel-*.js` files confirms warning disappears after update

🤖 Generated with [Claude Code](https://claude.com/claude-code)