### PR TITLE
fix: remove unsupported --no-input flag from claude CLI command

### DIFF
--- a/get-shit-done/workflows/review.md
+++ b/get-shit-done/workflows/review.md
@@ -62,7 +62,7 @@ fi
 
 Rules:
 - If `SELF_CLI="none"` → invoke ALL available CLIs (no skip)
-- If `SELF_CLI="claude"` → skip claude, use gemini/codex
+- If `SELF_CLI="claude"` → skip claude, use all other available CLIs
 - If `SELF_CLI="auto"` → the executing AI identifies itself and skips its own CLI
 - At least one DIFFERENT CLI must be available for the review to proceed.
 </step>
@@ -148,7 +148,7 @@ gemini -p "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-revi
 
 **Claude (separate session):**
 ```bash
-claude -p "$(cat /tmp/gsd-review-prompt-{phase}.md)" --no-input 2>/dev/null > /tmp/gsd-review-claude-{phase}.md
+claude -p "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-review-claude-{phase}.md
 ```
 
 **Codex:**


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

Fixes #1759

---

## What was broken

1. The review workflow invokes `claude -p "..." --no-input`, but `--no-input` is not a valid flag in Claude Code CLI (>= v2.1.81). This causes the review step to crash with `error: unknown option '--no-input'`.
2. The `SELF_CLI="claude"` rule description hardcodes `use gemini/codex`, but the workflow supports 5 CLIs (gemini, claude, codex, coderabbit, opencode).

## What this fix does

1. Removes the `--no-input` flag. The `-p` (`--print`) flag already handles non-interactive output (print and exit), making `--no-input` redundant.
2. Changes `use gemini/codex` to `use all other available CLIs` to accurately reflect multi-CLI support.

## Root cause

The `--no-input` flag was added assuming it was a valid Claude Code CLI option, but it was never part of the CLI's supported flags. The `-p` flag has always been sufficient for non-interactive mode.

## Testing

### How I verified the fix

```bash
# Before fix — crashes
$ claude -p "hello" --no-input
error: unknown option '--no-input'

# After fix — works correctly
$ claude -p "hello"
Hello! How can I help you today?
```

### Regression test added?

- [ ] Yes — added a test that would have caught this bug
- [x] No — explain why: This is a workflow `.md` file (not executable code). The fix removes a CLI flag from a documentation/instruction file. There is no testable code path in the GSD test suite for CLI invocation strings inside workflow markdown.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [ ] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [ ] CHANGELOG.md updated if this is a user-facing fix
- [x] No unnecessary dependencies added

## Breaking changes

None