### PR TITLE
ci: automate npm publish on GitHub release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,75 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    strategy:
+      fail-fast: true
+      matrix:
+        node-version: [22, 24]
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests with coverage
+        run: npm run test:coverage
+
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify version matches release tag
+        run: |
+          PACKAGE_VERSION="v$(node -p "require('./package.json').version")"
+          RELEASE_TAG="${{ github.event.release.tag_name }}"
+          if [ "$PACKAGE_VERSION" != "$RELEASE_TAG" ]; then
+            echo "::error::package.json version ($PACKAGE_VERSION) does not match release tag ($RELEASE_TAG)"
+            exit 1
+          fi
+
+      - name: Verify hooks/dist completeness
+        run: |
+          npm run build:hooks
+          echo "--- hooks/dist contents ---"
+          ls -la hooks/dist/
+
+      - name: Publish to npm
+        run: npm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/publish.yml` triggered on `release: published`
- Runs the full test matrix (Node 22 + 24) before publishing
- Verifies `package.json` version matches the release tag
- Verifies `hooks/dist/` completeness after `build:hooks`
- Publishes with `--provenance` for supply chain transparency

## Motivation

v1.33.0 was released on GitHub (Apr 5) but never published to npm — users are stuck on v1.32.0 which has missing `.sh` hooks causing `PreToolUse hook error` on every Bash tool call.

Manual `npm publish` is error-prone and creates version drift between GitHub and npm. This workflow ensures every GitHub release automatically lands on npm after passing tests.

## Setup required

Add `NPM_TOKEN` as a repository secret (Settings > Secrets and variables > Actions). The token needs publish permission for the `get-shit-done-cc` package.

## Test plan

- [ ] Verify workflow syntax is valid (Actions tab shows no parse errors)
- [ ] Add `NPM_TOKEN` secret and create a test release to confirm end-to-end flow
- [ ] Confirm version mismatch between `package.json` and tag correctly blocks publish

Closes #1711