### PR TITLE
ci: auto-close draft PRs, gitignore Caliber outputs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,6 +29,8 @@ For **features**: the linked issue must have the `approved-feature` label before
 
 PRs that arrive without a labeled, approved issue are closed without review.
 
+> **No draft PRs.** Draft PRs are automatically closed. Only open a PR when your code is complete, tests pass, and the correct template is used. See [CONTRIBUTING.md](../CONTRIBUTING.md).
+
 See [CONTRIBUTING.md](../CONTRIBUTING.md) for the full process.
 
 ---

--- a/.github/workflows/close-draft-prs.yml
+++ b/.github/workflows/close-draft-prs.yml
@@ -1,0 +1,51 @@
+name: Close Draft PRs
+
+on:
+  pull_request:
+    types: [opened, reopened, converted_to_draft]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  close-if-draft:
+    name: Reject draft PRs
+    if: github.event.pull_request.draft == true
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment and close draft PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const repoUrl = context.repo.owner + '/' + context.repo.repo;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body: [
+                '## Draft PRs are not accepted',
+                '',
+                'This project only accepts completed pull requests. Draft PRs are automatically closed.',
+                '',
+                '**Why?** GSD requires all PRs to be ready for review when opened \u2014 with tests passing, the correct PR template used, and a linked approved issue. Draft PRs bypass these quality gates and create review overhead.',
+                '',
+                '### What to do instead',
+                '',
+                '1. Finish your implementation locally',
+                '2. Run `npm run test:coverage` and confirm all tests pass',
+                '3. Open a **non-draft** PR using the [correct template](https://github.com/' + repoUrl + '/blob/main/CONTRIBUTING.md#pull-request-guidelines)',
+                '',
+                'See [CONTRIBUTING.md](https://github.com/' + repoUrl + '/blob/main/CONTRIBUTING.md) for the full process.',
+              ].join('\n')
+            });
+
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              state: 'closed'
+            });
+
+            core.info('Closed draft PR #' + pr.number + ': ' + pr.title);

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,7 @@ PRs that arrive without a properly-labeled linked issue are closed automatically
 
 **Every PR must link to an approved issue.** PRs without a linked issue are closed without review, no exceptions.
 
+- **No draft PRs** — draft PRs are automatically closed. Only open a PR when it is complete, tested, and ready for review. If your work is not finished, keep it on your local branch until it is.
 - **Use the correct PR template** — there are separate templates for [Fix](.github/PULL_REQUEST_TEMPLATE/fix.md), [Enhancement](.github/PULL_REQUEST_TEMPLATE/enhancement.md), and [Feature](.github/PULL_REQUEST_TEMPLATE/feature.md). Using the wrong template or using the default template for a feature is a rejection reason.
 - **Link with a closing keyword** — use `Closes #123`, `Fixes #123`, or `Resolves #123` in the PR body. The CI check will fail and the PR will be auto-closed if no valid issue reference is found.
 - **One concern per PR** — bug fixes, enhancements, and features must be separate PRs


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #1762

## What this enhancement improves

Adds enforcement for the no-draft-PR policy and prevents Caliber-generated files from being accidentally committed.

## Before / After

**Before:** Draft PRs sit open indefinitely, bypassing quality gates. Caliber output files (CALIBER_LEARNINGS.md, .cursorrules, etc.) can be accidentally committed.

**After:** Draft PRs are automatically closed with an explanatory comment. All Caliber-generated files are gitignored.

## How it was implemented

1. `.github/workflows/close-draft-prs.yml` — GitHub Actions workflow that triggers on `opened`, `reopened`, and `converted_to_draft` events. Uses `actions/github-script@v7` (no shell interpolation of untrusted input).
2. `CONTRIBUTING.md` — Added "No draft PRs" as first bullet in Pull Request Guidelines.
3. `.github/pull_request_template.md` — Added draft PR warning in Reminder section.
4. `.gitignore` — Added Caliber outputs: `CALIBER_LEARNINGS.md`, `.cursorrules`, `.cursor/`, `AGENTS.md`, `.agents/`, `.opencode/`, `.github/instructions/`.

## Testing

### How I verified the enhancement works

- Validated YAML syntax with Python yaml parser
- Verified all Caliber files are matched by gitignore (`git check-ignore -v`)
- Full test suite passes (2175/2175)

### Platforms tested

- [x] macOS
- [x] N/A (CI workflow + gitignore, not platform-specific)

### Runtimes tested

- [x] N/A (infrastructure change, not runtime-specific)

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue
- [x] No scope changes

## Checklist

- [x] Issue linked above with `Closes #1762`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement
- [x] All existing tests pass (`npm test`)
- [x] No unnecessary dependencies added

## Breaking changes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)