### PR TITLE
fix(commands): replace undefined $GSD_TOOLS with resolved path

### DIFF
--- a/commands/gsd/workstreams.md
+++ b/commands/gsd/workstreams.md
@@ -34,30 +34,30 @@ If no subcommand given, default to `list`.
 ## Step 2: Execute Operation
 
 ### list
-Run: `node "$GSD_TOOLS" workstream list --raw --cwd "$CWD"`
+Run: `node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" workstream list --raw --cwd "$CWD"`
 Display the workstreams in a table format showing name, status, current phase, and progress.
 
 ### create
-Run: `node "$GSD_TOOLS" workstream create <name> --raw --cwd "$CWD"`
+Run: `node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" workstream create <name> --raw --cwd "$CWD"`
 After creation, display the new workstream path and suggest next steps:
 - `/gsd-new-milestone --ws <name>` to set up the milestone
 
 ### status
-Run: `node "$GSD_TOOLS" workstream status <name> --raw --cwd "$CWD"`
+Run: `node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" workstream status <name> --raw --cwd "$CWD"`
 Display detailed phase breakdown and state information.
 
 ### switch
-Run: `node "$GSD_TOOLS" workstream set <name> --raw --cwd "$CWD"`
+Run: `node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" workstream set <name> --raw --cwd "$CWD"`
 Also set `GSD_WORKSTREAM` for the current session when the runtime supports it.
 If the runtime exposes a session identifier, GSD also stores the active workstream
 session-locally so concurrent sessions do not overwrite each other.
 
 ### progress
-Run: `node "$GSD_TOOLS" workstream progress --raw --cwd "$CWD"`
+Run: `node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" workstream progress --raw --cwd "$CWD"`
 Display a progress overview across all workstreams.
 
 ### complete
-Run: `node "$GSD_TOOLS" workstream complete <name> --raw --cwd "$CWD"`
+Run: `node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" workstream complete <name> --raw --cwd "$CWD"`
 Archive the workstream to milestones/.
 
 ### resume

--- a/tests/gsd-tools-path-refs.test.cjs
+++ b/tests/gsd-tools-path-refs.test.cjs
@@ -1,0 +1,57 @@
+/**
+ * Regression guard for #1766: $GSD_TOOLS env var undefined
+ *
+ * All command files must use the resolved path to gsd-tools.cjs
+ * ($HOME/.claude/get-shit-done/bin/gsd-tools.cjs), not the undefined
+ * $GSD_TOOLS variable. This test catches any command file that
+ * references the undefined variable.
+ */
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const COMMANDS_DIR = path.join(__dirname, '..', 'commands', 'gsd');
+
+describe('command files: gsd-tools path references (#1766)', () => {
+  test('no command file references undefined $GSD_TOOLS variable', () => {
+    const files = fs.readdirSync(COMMANDS_DIR).filter(f => f.endsWith('.md'));
+    const violations = [];
+
+    for (const file of files) {
+      const content = fs.readFileSync(path.join(COMMANDS_DIR, file), 'utf-8');
+      // Match $GSD_TOOLS or "$GSD_TOOLS" or ${GSD_TOOLS} used as a path
+      // (not as a documentation reference)
+      const lines = content.split('\n');
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (/\$GSD_TOOLS\b/.test(line) && /node\s/.test(line)) {
+          violations.push(`${file}:${i + 1}: ${line.trim()}`);
+        }
+      }
+    }
+
+    assert.strictEqual(violations.length, 0,
+      'Command files must not reference undefined $GSD_TOOLS. ' +
+      'Use $HOME/.claude/get-shit-done/bin/gsd-tools.cjs instead.\n' +
+      'Violations:\n' + violations.join('\n'));
+  });
+
+  test('workstreams.md uses standard gsd-tools.cjs path', () => {
+    const content = fs.readFileSync(
+      path.join(COMMANDS_DIR, 'workstreams.md'), 'utf-8'
+    );
+    const nodeLines = content.split('\n').filter(l => /node\s/.test(l));
+
+    assert.ok(nodeLines.length > 0,
+      'workstreams.md should contain node invocations');
+
+    for (const line of nodeLines) {
+      assert.ok(
+        line.includes('gsd-tools.cjs'),
+        'Each node invocation must reference gsd-tools.cjs, got: ' + line.trim()
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #1766

## What was broken

All workstream commands (`list`, `create`, `status`, `switch`, `progress`, `complete`) fail with "module not found" because `commands/gsd/workstreams.md` references `$GSD_TOOLS` (6 occurrences) which is **never defined** — not by the installer, not by hooks, not by any other file.

## What this fix does

Replaces all 6 occurrences of `$GSD_TOOLS` with `$HOME/.claude/get-shit-done/bin/gsd-tools.cjs` — the standard path used by all 60+ other command files.

## Root cause

`workstreams.md` was written using a hypothetical `$GSD_TOOLS` environment variable that was never implemented. Same class of bug as the fix in PR #1236 for `stats.md`.

## Testing

### Regression test added?

- [x] Yes — `tests/gsd-tools-path-refs.test.cjs` with 2 tests:
  - Scans ALL command files for undefined `$GSD_TOOLS` references (catches this bug in any file)
  - Validates `workstreams.md` specifically uses the standard `gsd-tools.cjs` path

### Platforms tested

- [x] macOS
- [x] N/A (markdown command template fix, not platform-specific)

### Runtimes tested

- [x] Claude Code
- [x] N/A (path pattern is runtime-agnostic; installer transforms at deploy time)

## Checklist

- [x] Issue linked above with `Fixes #1766`
- [x] Linked issue has the `confirmed` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`npm test`) — 2172/2172 pass
- [x] No unnecessary dependencies added

## Breaking changes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)