### PR TITLE
fix(install): register gsd-workflow-guard.js in settings.json hooks

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -5630,6 +5630,30 @@ function install(isGlobal, runtime = 'claude') {
       console.log(`  ${green}✓${reset} Configured read-before-edit guard hook`);
     }
 
+    // Configure PreToolUse hook for workflow context guard (#1767)
+    // Advises when file edits happen outside a GSD workflow. Opt-in via
+    // hooks.workflow_guard: true in .planning/config.json (default: false).
+    const workflowGuardCommand = isGlobal
+      ? buildHookCommand(targetDir, 'gsd-workflow-guard.js')
+      : 'node ' + dirName + '/hooks/gsd-workflow-guard.js';
+    const hasWorkflowGuardHook = settings.hooks[preToolEvent].some(entry =>
+      entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-workflow-guard'))
+    );
+
+    if (!hasWorkflowGuardHook) {
+      settings.hooks[preToolEvent].push({
+        matcher: 'Write|Edit',
+        hooks: [
+          {
+            type: 'command',
+            command: workflowGuardCommand,
+            timeout: 5
+          }
+        ]
+      });
+      console.log(`  ${green}✓${reset} Configured workflow context guard hook (opt-in via config)`);
+    }
+
     // Community hooks — registered on install but opt-in at runtime.
     // Each hook checks .planning/config.json for hooks.community: true
     // and exits silently (no-op) if not enabled. This lets users enable

--- a/tests/install-hooks-copy.test.cjs
+++ b/tests/install-hooks-copy.test.cjs
@@ -197,6 +197,17 @@ describe('install.js source correctness', () => {
     );
   });
 
+  test('gsd-workflow-guard.js has settings.json registration', () => {
+    assert.ok(
+      src.includes('hasWorkflowGuardHook'),
+      'install.js should check for existing workflow guard hook before registering'
+    );
+    assert.ok(
+      src.includes("'gsd-workflow-guard'") || src.includes('"gsd-workflow-guard"'),
+      'install.js should register gsd-workflow-guard in settings.json hooks'
+    );
+  });
+
   test('phantom gsd-check-update.sh is not in uninstall hook list', () => {
     const gsdHooksMatch = src.match(/const gsdHooks\s*=\s*\[([^\]]+)\]/);
     assert.ok(gsdHooksMatch, 'gsdHooks array should exist');


### PR DESCRIPTION
## Summary

- **Register the workflow guard hook in `settings.json`** during install, closing the gap where `gsd-workflow-guard.js` was copied to disk but never wired up as a PreToolUse entry
- **Add test coverage** to verify the registration pattern exists in `install.js`

## Background

GSD hooks have a two-step install pattern: the hook file is **copied to disk** (via `HOOKS_TO_COPY`) and then **registered in `settings.json`** so Claude Code actually invokes it. The workflow guard was missing the second step — it was dead weight on disk, and the `hooks.workflow_guard` config option in `.planning/config.json` was permanently inert no matter what value you set.

This is the same pattern used by the prompt-guard and read-guard hooks:

1. Build the command string (respecting `isGlobal` vs local install)
2. Check if the hook is already registered (idempotent — safe to re-run install)
3. Push the hook entry with the appropriate `matcher` and `timeout`

The hook remains **opt-in at runtime** — `gsd-workflow-guard.js` checks `hooks.workflow_guard` in `.planning/config.json` and exits silently if not enabled, so this change has zero impact on users who haven't explicitly opted in.

## What changed

| File | Change |
|------|--------|
| `bin/install.js` | Added registration block for `gsd-workflow-guard.js` as a PreToolUse hook (matcher: `Write\|Edit`, timeout: 5) — inserted after the read-guard registration and before the community hooks section |
| `tests/install-hooks-copy.test.cjs` | Added test verifying the `hasWorkflowGuardHook` check and `gsd-workflow-guard` string exist in `install.js` |

## Test plan

- [x] All 2202 existing tests pass (`npm test`)
- [x] New test verifies registration pattern exists in `install.js`
- [ ] Manual: fresh install should show "Configured workflow context guard hook (opt-in via config)" in output
- [ ] Manual: re-install should skip registration (idempotent check)
- [ ] Manual: enabling `hooks.workflow_guard: true` in `.planning/config.json` should now actually trigger the hook on Write/Edit

Fixes #1767

🤖 Generated with [Claude Code](https://claude.com/claude-code)