### PR TITLE
fix: remove editorial parenthetical descriptions from product names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,7 +153,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [1.29.0] - 2026-03-25
 
 ### Added
-- **Windsurf runtime support** — Full installation and command conversion for Windsurf (Codeium)
+- **Windsurf runtime support** — Full installation and command conversion for Windsurf
 - **Agent skill injection** — Inject project-specific skills into subagents via `agent_skills` config section
 - **UI-phase and UI-review steps** in autonomous workflow
 - **Security scanning CI** — Prompt injection, base64, and secret scanning workflows

--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -125,21 +125,21 @@ npx get-shit-done-cc@latest
 npx get-shit-done-cc --claude --global   # ~/.claude/ にインストール
 npx get-shit-done-cc --claude --local    # ./.claude/ にインストール
 
-# OpenCode（オープンソース、無料モデル）
+# OpenCode
 npx get-shit-done-cc --opencode --global # ~/.config/opencode/ にインストール
 
 # Gemini CLI
 npx get-shit-done-cc --gemini --global   # ~/.gemini/ にインストール
 
-# Kilo（OpenCodeフォーク）
+# Kilo
 npx get-shit-done-cc --kilo --global     # ~/.config/kilo/ にインストール
 npx get-shit-done-cc --kilo --local      # ./.kilo/ にインストール
 
-# Codex（スキルファースト）
+# Codex
 npx get-shit-done-cc --codex --global    # ~/.codex/ にインストール
 npx get-shit-done-cc --codex --local     # ./.codex/ にインストール
 
-# Copilot（GitHub Copilot CLI）
+# Copilot
 npx get-shit-done-cc --copilot --global  # ~/.github/ にインストール
 npx get-shit-done-cc --copilot --local   # ./.github/ にインストール
 
@@ -147,7 +147,7 @@ npx get-shit-done-cc --copilot --local   # ./.github/ にインストール
 npx get-shit-done-cc --cursor --global      # ~/.cursor/ にインストール
 npx get-shit-done-cc --cursor --local       # ./.cursor/ にインストール
 
-# Antigravity（Google、スキルファースト、Geminiベース）
+# Antigravity
 npx get-shit-done-cc --antigravity --global # ~/.gemini/antigravity/ にインストール
 npx get-shit-done-cc --antigravity --local  # ./.agent/ にインストール
 
@@ -155,11 +155,11 @@ npx get-shit-done-cc --antigravity --local  # ./.agent/ にインストール
 npx get-shit-done-cc --augment --global     # ~/.augment/ にインストール
 npx get-shit-done-cc --augment --local      # ./.augment/ にインストール
 
-# Trae（ByteDance、スキルファースト）
+# Trae
 npx get-shit-done-cc --trae --global        # ~/.trae/ にインストール
 npx get-shit-done-cc --trae --local         # ./.trae/ にインストール
 
-# Cline（.clinerules使用）
+# Cline
 npx get-shit-done-cc --cline --global       # ~/.cline/ にインストール
 npx get-shit-done-cc --cline --local        # ./.clinerules にインストール
 

--- a/README.ko-KR.md
+++ b/README.ko-KR.md
@@ -125,21 +125,21 @@ npx get-shit-done-cc@latest
 npx get-shit-done-cc --claude --global   # ~/.claude/에 설치
 npx get-shit-done-cc --claude --local    # ./.claude/에 설치
 
-# OpenCode (오픈소스, 무료 모델)
+# OpenCode
 npx get-shit-done-cc --opencode --global # ~/.config/opencode/에 설치
 
 # Gemini CLI
 npx get-shit-done-cc --gemini --global   # ~/.gemini/에 설치
 
-# Kilo (OpenCode 포크)
+# Kilo
 npx get-shit-done-cc --kilo --global     # ~/.config/kilo/에 설치
 npx get-shit-done-cc --kilo --local      # ./.kilo/에 설치
 
-# Codex (스킬 우선)
+# Codex
 npx get-shit-done-cc --codex --global    # ~/.codex/에 설치
 npx get-shit-done-cc --codex --local     # ./.codex/에 설치
 
-# Copilot (GitHub Copilot CLI)
+# Copilot
 npx get-shit-done-cc --copilot --global  # ~/.github/에 설치
 npx get-shit-done-cc --copilot --local   # ./.github/에 설치
 
@@ -147,7 +147,7 @@ npx get-shit-done-cc --copilot --local   # ./.github/에 설치
 npx get-shit-done-cc --cursor --global      # ~/.cursor/에 설치
 npx get-shit-done-cc --cursor --local       # ./.cursor/에 설치
 
-# Antigravity (Google, 스킬 우선, Gemini 기반)
+# Antigravity
 npx get-shit-done-cc --antigravity --global # ~/.gemini/antigravity/에 설치
 npx get-shit-done-cc --antigravity --local  # ./.agent/에 설치
 
@@ -155,11 +155,11 @@ npx get-shit-done-cc --antigravity --local  # ./.agent/에 설치
 npx get-shit-done-cc --augment --global     # ~/.augment/에 설치
 npx get-shit-done-cc --augment --local      # ./.augment/에 설치
 
-# Trae (ByteDance, 스킬 우선)
+# Trae
 npx get-shit-done-cc --trae --global        # ~/.trae/에 설치
 npx get-shit-done-cc --trae --local         # ./.trae/에 설치
 
-# Cline (.clinerules 사용)
+# Cline
 npx get-shit-done-cc --cline --global       # ~/.cline/에 설치
 npx get-shit-done-cc --cline --local        # ./.clinerules에 설치
 

--- a/README.md
+++ b/README.md
@@ -137,21 +137,21 @@ npx get-shit-done-cc@latest
 npx get-shit-done-cc --claude --global   # Install to ~/.claude/
 npx get-shit-done-cc --claude --local    # Install to ./.claude/
 
-# OpenCode (open source, free models)
+# OpenCode
 npx get-shit-done-cc --opencode --global # Install to ~/.config/opencode/
 
 # Gemini CLI
 npx get-shit-done-cc --gemini --global   # Install to ~/.gemini/
 
-# Kilo (OpenCode fork)
+# Kilo
 npx get-shit-done-cc --kilo --global     # Install to ~/.config/kilo/
 npx get-shit-done-cc --kilo --local      # Install to ./.kilo/
 
-# Codex (skills-first)
+# Codex
 npx get-shit-done-cc --codex --global    # Install to ~/.codex/
 npx get-shit-done-cc --codex --local     # Install to ./.codex/
 
-# Copilot (GitHub Copilot CLI)
+# Copilot
 npx get-shit-done-cc --copilot --global  # Install to ~/.github/
 npx get-shit-done-cc --copilot --local   # Install to ./.github/
 
@@ -159,11 +159,11 @@ npx get-shit-done-cc --copilot --local   # Install to ./.github/
 npx get-shit-done-cc --cursor --global      # Install to ~/.cursor/
 npx get-shit-done-cc --cursor --local       # Install to ./.cursor/
 
-# Windsurf (Codeium, VS Code-based)
+# Windsurf
 npx get-shit-done-cc --windsurf --global    # Install to ~/.windsurf/
 npx get-shit-done-cc --windsurf --local     # Install to ./.windsurf/
 
-# Antigravity (Google, skills-first, Gemini-based)
+# Antigravity
 npx get-shit-done-cc --antigravity --global # Install to ~/.gemini/antigravity/
 npx get-shit-done-cc --antigravity --local  # Install to ./.agent/
 
@@ -171,11 +171,11 @@ npx get-shit-done-cc --antigravity --local  # Install to ./.agent/
 npx get-shit-done-cc --augment --global     # Install to ~/.augment/
 npx get-shit-done-cc --augment --local      # Install to ./.augment/
 
-# Trae (ByteDance, skills-first)
+# Trae
 npx get-shit-done-cc --trae --global        # Install to ~/.trae/
 npx get-shit-done-cc --trae --local         # Install to ./.trae/
 
-# Cline (uses .clinerules)
+# Cline
 npx get-shit-done-cc --cline --global       # Install to ~/.cline/
 npx get-shit-done-cc --cline --local        # Install to ./.clinerules
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -151,11 +151,11 @@ npx get-shit-done-cc --antigravity --local
 npx get-shit-done-cc --augment --global     # Install to ~/.augment/
 npx get-shit-done-cc --augment --local      # Install to ./.augment/
 
-# Trae (ByteDance, skills-first)
+# Trae
 npx get-shit-done-cc --trae --global        # Install to ~/.trae/
 npx get-shit-done-cc --trae --local         # Install to ./.trae/
 
-# Cline (usa .clinerules)
+# Cline
 npx get-shit-done-cc --cline --global       # Install to ~/.cline/
 npx get-shit-done-cc --cline --local        # Install to ./.clinerules
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -123,21 +123,21 @@ npx get-shit-done-cc@latest
 npx get-shit-done-cc --claude --global   # 安装到 ~/.claude/
 npx get-shit-done-cc --claude --local    # 安装到 ./.claude/
 
-# OpenCode（开源，可用免费模型）
+# OpenCode
 npx get-shit-done-cc --opencode --global # 安装到 ~/.config/opencode/
 
 # Gemini CLI
 npx get-shit-done-cc --gemini --global   # 安装到 ~/.gemini/
 
-# Kilo（OpenCode 分支）
+# Kilo
 npx get-shit-done-cc --kilo --global     # 安装到 ~/.config/kilo/
 npx get-shit-done-cc --kilo --local      # 安装到 ./.kilo/
 
-# Codex（以 skills 为主）
+# Codex
 npx get-shit-done-cc --codex --global    # 安装到 ~/.codex/
 npx get-shit-done-cc --codex --local     # 安装到 ./.codex/
 
-# Copilot（GitHub Copilot CLI）
+# Copilot
 npx get-shit-done-cc --copilot --global  # 安装到 ~/.github/
 npx get-shit-done-cc --copilot --local   # 安装到 ./.github/
 
@@ -145,7 +145,7 @@ npx get-shit-done-cc --copilot --local   # 安装到 ./.github/
 npx get-shit-done-cc --cursor --global   # 安装到 ~/.cursor/
 npx get-shit-done-cc --cursor --local    # 安装到 ./.cursor/
 
-# Antigravity（Google，以 skills 为主，基于 Gemini）
+# Antigravity
 npx get-shit-done-cc --antigravity --global # 安装到 ~/.gemini/antigravity/
 npx get-shit-done-cc --antigravity --local  # 安装到 ./.agent/
 
@@ -153,11 +153,11 @@ npx get-shit-done-cc --antigravity --local  # 安装到 ./.agent/
 npx get-shit-done-cc --augment --global     # 安装到 ~/.augment/
 npx get-shit-done-cc --augment --local      # 安装到 ./.augment/
 
-# Trae（字节跳动，以 skills 为主）
+# Trae
 npx get-shit-done-cc --trae --global     # 安装到 ~/.trae/
 npx get-shit-done-cc --trae --local      # 安装到 ./.trae/
 
-# Cline（使用 .clinerules）
+# Cline
 npx get-shit-done-cc --cline --global       # 安装到 ~/.cline/
 npx get-shit-done-cc --cline --local        # 安装到 ./.clinerules
 

--- a/bin/install.js
+++ b/bin/install.js
@@ -1121,7 +1121,7 @@ function convertClaudeAgentToCursorAgent(content) {
 }
 
 // --- Windsurf converters ---
-// Windsurf (by Codeium) uses a tool set similar to Cursor (both VS Code-based).
+// Windsurf uses a tool set similar to Cursor.
 // Config lives in .windsurf/ (local) and ~/.windsurf/ (global).
 
 // Tool name mapping from Claude Code to Windsurf Cascade
@@ -1239,7 +1239,7 @@ function convertClaudeAgentToWindsurfAgent(content) {
 }
 
 // --- Augment converters ---
-// Augment (auggie CLI) uses a tool set similar to Cursor/Windsurf (VS Code-based).
+// Augment uses a tool set similar to Cursor/Windsurf.
 // Config lives in .augment/ (local) and ~/.augment/ (global).
 
 const claudeToAugmentTools = {
@@ -3134,7 +3134,7 @@ function convertClaudeToOpencodeFrontmatter(content, { isAgent = false } = {}) {
   return `---\n${newFrontmatter}\n---${body}`;
 }
 
-// Kilo CLI — fork of OpenCode, same conversion logic, different config paths.
+// Kilo CLI — same conversion logic as OpenCode, different config paths.
 function convertClaudeToKiloFrontmatter(content, { isAgent = false } = {}) {
   // Replace tool name references in content (applies to all files)
   let convertedContent = content;

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -110,17 +110,17 @@ npx get-shit-done-cc@latest
 npx get-shit-done-cc --claude --global   # 安装到 ~/.claude/
 npx get-shit-done-cc --claude --local    # 安装到 ./.claude/
 
-# OpenCode（开源，免费模型）
+# OpenCode
 npx get-shit-done-cc --opencode --global # 安装到 ~/.config/opencode/
 
 # Gemini CLI
 npx get-shit-done-cc --gemini --global   # 安装到 ~/.gemini/
 
-# Kilo（OpenCode 分支）
+# Kilo
 npx get-shit-done-cc --kilo --global     # 安装到 ~/.config/kilo/
 npx get-shit-done-cc --kilo --local      # 安装到 ./.kilo/
 
-# Codex（技能优先）
+# Codex
 npx get-shit-done-cc --codex --global    # 安装到 ~/.codex/
 npx get-shit-done-cc --codex --local     # 安装到 ./.codex/
 

--- a/tests/product-name-purity.test.cjs
+++ b/tests/product-name-purity.test.cjs
@@ -1,0 +1,110 @@
+/**
+ * Regression guard for #1777: product names must not have parenthetical descriptions.
+ *
+ * Community PRs repeatedly add editorial commentary in parentheses next to
+ * product names (licensing, parent company, architecture). This test scans
+ * all README files and ensures install-block comment lines contain only the
+ * product name — no parenthetical text of any kind.
+ */
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+
+// Product names that appear in install blocks as comment headers
+const PRODUCTS = [
+  'Claude Code', 'Claude', 'OpenCode', 'Kilo', 'Codex', 'Copilot',
+  'Cursor', 'Windsurf', 'Antigravity', 'Trae', 'Cline', 'Augment',
+  'Gemini', 'Gemini CLI',
+];
+
+// README files to scan (root + i18n variants + docs)
+const README_FILES = [
+  'README.md',
+  'README.ko-KR.md',
+  'README.ja-JP.md',
+  'README.zh-CN.md',
+  'README.pt-BR.md',
+  'docs/zh-CN/README.md',
+  'docs/ko-KR/README.md',
+  'docs/ja-JP/README.md',
+  'docs/pt-BR/README.md',
+  'docs/README.md',
+].filter(f => fs.existsSync(path.join(ROOT, f)));
+
+describe('product name purity (#1777)', () => {
+  test('no README install-block comments contain parenthetical descriptions', () => {
+    const violations = [];
+
+    for (const file of README_FILES) {
+      const content = fs.readFileSync(path.join(ROOT, file), 'utf-8');
+      const lines = content.split('\n');
+
+      for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        // Match shell comment lines that start with # followed by a product name
+        // and then have parenthetical text: # ProductName (something)
+        // Also match fullwidth parens used in CJK: # ProductName（something）
+        const match = line.match(/^#\s+(\S+(?:\s+\S+)?)\s*[（(].+[）)]/);
+        if (!match) continue;
+
+        const name = match[1];
+        // Check if this is actually a product name line (not a random comment)
+        const isProduct = PRODUCTS.some(p =>
+          name === p || name.startsWith(p)
+        );
+        if (isProduct) {
+          violations.push([
+            file + ':' + (i + 1),
+            line.trim(),
+          ].join(' — '));
+        }
+      }
+    }
+
+    assert.strictEqual(
+      violations.length, 0,
+      [
+        'Product names in README install blocks must not have parenthetical descriptions.',
+        'Found violations:',
+        ...violations.map(v => '  ' + v),
+      ].join('\n')
+    );
+  });
+
+  test('CHANGELOG does not include parenthetical product descriptions', () => {
+    const changelog = path.join(ROOT, 'CHANGELOG.md');
+    if (!fs.existsSync(changelog)) return;
+
+    const content = fs.readFileSync(changelog, 'utf-8');
+    const violations = [];
+
+    for (const product of PRODUCTS) {
+      // Match "ProductName (something)" but not "ProductName (v1.2.3)" (version refs are ok)
+      const pattern = new RegExp(
+        product.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
+        '\\s*\\([^)]*(?!v?\\d+\\.\\d)[^)]*\\)',
+        'g'
+      );
+      const matches = content.match(pattern);
+      if (matches) {
+        for (const m of matches) {
+          // Skip version references like "Claude Code (v1.32.0)"
+          if (/\(v?\d+\.\d+/.test(m)) continue;
+          violations.push(m);
+        }
+      }
+    }
+
+    assert.strictEqual(
+      violations.length, 0,
+      [
+        'CHANGELOG must not include parenthetical product descriptions.',
+        'Found:',
+        ...violations.map(v => '  ' + v),
+      ].join('\n')
+    );
+  });
+});


### PR DESCRIPTION
## Fix

### Linked issue

Fixes #1777

### Root cause

Community PRs repeatedly add parenthetical descriptions next to product names in install blocks — licensing model, parent company, architecture details, implementation notes. These are opinionated, inaccurate, or irrelevant. Product listings should contain only the product name.

### What changed

**8 files cleaned across 5 languages:**

| File | Violations Fixed |
|------|-----------------|
| `README.md` | 8 — OpenCode, Kilo, Codex, Copilot, Windsurf, Antigravity, Trae, Cline |
| `README.ko-KR.md` | 7 — same products (Korean translations) |
| `README.ja-JP.md` | 7 — same products (Japanese, fullwidth parens) |
| `README.zh-CN.md` | 7 — same products (Chinese, fullwidth parens) |
| `README.pt-BR.md` | 2 — Trae, Cline |
| `docs/zh-CN/README.md` | 3 — OpenCode, Kilo, Codex |
| `bin/install.js` | 3 — code comments for Windsurf, Augment, Kilo |
| `CHANGELOG.md` | 1 — Windsurf |

**Regression test added:** `tests/product-name-purity.test.cjs`
- Scans all README files for `# ProductName (...)` pattern in install blocks
- Scans CHANGELOG for parenthetical product descriptions
- Catches this pattern automatically for any future PRs

### Testing

```
npm run test:coverage  # 2203 pass, 0 fail
node --test tests/product-name-purity.test.cjs  # 2 pass
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)