### PR TITLE
feat: persistent knowledge layer — codebase indexing, context assembly, safety rails

### DIFF
--- a/commands/gsd/knowledge.md
+++ b/commands/gsd/knowledge.md
@@ -1,0 +1,100 @@
+---
+name: gsd:knowledge
+description: Initialize, index, and query the project knowledge layer — persistent codebase intelligence that survives context resets
+argument-hint: "<subcommand> [args]"
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+  - Glob
+  - Grep
+---
+
+<objective>
+Manage the GSD Knowledge Layer — a persistent, structured intelligence layer that indexes your codebase, tracks patterns/decisions/conventions, and provides relevance-scored context to every executor agent.
+</objective>
+
+<subcommands>
+
+## `init`
+Initialize the knowledge layer for this project. Creates `.planning/knowledge/` with schema-compliant JSON files. Safe to run multiple times.
+
+```bash
+node get-shit-done/bin/gsd-tools.cjs knowledge init
+```
+
+## `index`
+Full codebase index — scans all source files, computes SHA-256 hashes, extracts exports/imports, maps modules. Use `--incremental` for fast updates.
+
+```bash
+# Full rebuild
+node get-shit-done/bin/gsd-tools.cjs knowledge index
+
+# Incremental (only changed files since last index)
+node get-shit-done/bin/gsd-tools.cjs knowledge index --incremental
+```
+
+## `deps`
+Build the dependency graph — forward/reverse import maps, module-level dependencies, full-cycle circular dependency detection via Tarjan's SCC.
+
+```bash
+node get-shit-done/bin/gsd-tools.cjs knowledge deps
+```
+
+## `context`
+Assemble relevance-scored context for a task. Uses stemming, synonym expansion, confidence scoring, and token budgeting.
+
+```bash
+# Basic context assembly
+node get-shit-done/bin/gsd-tools.cjs knowledge context "add authentication to the API"
+
+# With diff awareness (boosts modules with recent changes)
+node get-shit-done/bin/gsd-tools.cjs knowledge context "fix the login bug" --diff
+
+# Per-agent budget
+node get-shit-done/bin/gsd-tools.cjs knowledge context "write tests" --agent executor --budget 8000
+```
+
+## `modules`
+List all indexed modules with file counts.
+
+```bash
+node get-shit-done/bin/gsd-tools.cjs knowledge modules
+```
+
+## `impact`
+Show which files and modules are affected by changes to a specific file (reverse dependency lookup).
+
+```bash
+node get-shit-done/bin/gsd-tools.cjs knowledge impact src/auth/middleware.js
+```
+
+## `staleness`
+Check if the knowledge index is stale and needs reindexing.
+
+```bash
+node get-shit-done/bin/gsd-tools.cjs knowledge staleness
+```
+
+</subcommands>
+
+<process>
+
+### First-time setup
+1. Run `knowledge init` to create the directory structure
+2. Run `knowledge index` to scan the codebase
+3. Run `knowledge deps` to build the dependency graph
+
+### Ongoing use
+- Run `knowledge index --incremental` after making changes
+- Run `knowledge context "<task>"` before starting work to get relevant context
+- Run `knowledge staleness` to check if reindexing is needed
+
+### How it integrates with GSD workflows
+The knowledge layer is automatically queried during:
+- **execute-phase**: Each executor agent receives relevance-scored context
+- **plan-phase**: Planner gets module/dependency awareness
+- **verify-work**: Verifier gets impact analysis for changed files
+
+</process>

--- a/get-shit-done/bin/gsd-tools.cjs
+++ b/get-shit-done/bin/gsd-tools.cjs
@@ -279,7 +279,7 @@ async function main() {
   const command = args[0];
 
   if (!command) {
-    error('Usage: gsd-tools <command> [args] [--raw] [--pick <field>] [--cwd <path>] [--ws <name>]\nCommands: state, resolve-model, find-phase, commit, verify-summary, verify, frontmatter, template, generate-slug, current-timestamp, list-todos, verify-path-exists, config-ensure-section, config-new-project, init, workstream, docs-init');
+    error('Usage: gsd-tools <command> [args] [--raw] [--pick <field>] [--cwd <path>] [--ws <name>]\nCommands: state, resolve-model, find-phase, commit, verify-summary, verify, frontmatter, template, generate-slug, current-timestamp, list-todos, verify-path-exists, config-ensure-section, config-new-project, init, workstream, docs-init, knowledge');
   }
 
   // Multi-repo guard: resolve project root for commands that read/write .planning/.
@@ -941,6 +941,72 @@ async function runCommand(command, args, cwd, raw) {
 
     case 'docs-init': {
       docs.cmdDocsInit(cwd, raw);
+      break;
+    }
+
+    // --- Knowledge Layer Commands --------------------------------------------
+    // FIX(review #5): lazy require to prevent require-time errors from
+    // breaking all gsd-tools commands.
+    case 'knowledge': {
+      const { output: coreOutput } = require('./lib/core.cjs');
+      const knowledge = require('./lib/knowledge/index.cjs');
+      const subcommand = args[1];
+
+      if (subcommand === 'init') {
+        const result = knowledge.initKnowledge(cwd);
+        coreOutput(result, raw);
+
+      } else if (subcommand === 'index') {
+        const incremental = args.includes('--incremental');
+        const result = incremental
+          ? knowledge.updateIndexIncremental(cwd)
+          : knowledge.buildIndex(cwd);
+        coreOutput(result, raw);
+
+      } else if (subcommand === 'deps') {
+        const result = knowledge.buildDependencyGraph(cwd);
+        coreOutput(result, raw);
+
+      } else if (subcommand === 'context') {
+        const taskDesc = args.slice(2).filter(a => !a.startsWith('--')).join(' ');
+        if (!taskDesc) error('Usage: knowledge context <task description>');
+        const agentIdx = args.indexOf('--agent');
+        const agent = agentIdx !== -1 ? args[agentIdx + 1] : undefined;
+        const budgetIdx = args.indexOf('--budget');
+        const budget = budgetIdx !== -1 ? parseInt(args[budgetIdx + 1], 10) : undefined;
+        const diffAware = args.includes('--diff');
+        const result = diffAware
+          ? knowledge.assembleDiffAwareContext(cwd, taskDesc, { agent, budget })
+          : knowledge.assembleContext(cwd, taskDesc, { agent, budget });
+        coreOutput(result, raw);
+
+      } else if (subcommand === 'modules') {
+        const result = knowledge.listModules(cwd);
+        coreOutput(result, raw);
+
+      } else if (subcommand === 'impact') {
+        const filePath = args[2];
+        if (!filePath) error('Usage: knowledge impact <file-path>');
+        const result = knowledge.getImpactedFiles(cwd, filePath);
+        coreOutput(result, raw);
+
+      } else if (subcommand === 'staleness') {
+        const ip = knowledge.indexPath(cwd);
+        if (!fs.existsSync(ip)) {
+          coreOutput({ stale: true, message: 'INDEX.json not found. Run: gsd-tools.cjs knowledge init && gsd-tools.cjs knowledge index' }, raw);
+        } else {
+          const index = knowledge.getIndex(cwd);
+          coreOutput({
+            stale: !index || index.last_mapped_commit === '0000000',
+            last_mapped_commit: index ? index.last_mapped_commit : null,
+            total_files: index ? (index.stats || {}).total_files : 0,
+            total_modules: index ? (index.stats || {}).total_modules : 0,
+          }, raw);
+        }
+
+      } else {
+        error('Unknown knowledge subcommand: ' + subcommand + '\nAvailable: init, index, deps, context, modules, impact, staleness');
+      }
       break;
     }
 

--- a/get-shit-done/bin/lib/knowledge/constants.cjs
+++ b/get-shit-done/bin/lib/knowledge/constants.cjs
@@ -1,0 +1,67 @@
+/**
+ * Knowledge Layer — Shared constants
+ * Ported from ACG's knowledge engine for GSD integration.
+ */
+'use strict';
+
+/** Schema version for all knowledge JSON files. */
+const VERSION = '1.0';
+
+/** Directories to ignore during codebase walks. */
+const IGNORE_DIRS = new Set([
+  '.git', 'node_modules', '.planning', 'dist', 'build', 'coverage',
+  '__pycache__', '.next', '.nuxt', '.svelte-kit', 'vendor', '.venv',
+  'venv', 'env', '.tox', '.mypy_cache', '.pytest_cache', '.turbo',
+  '.worktrees', 'gsd-local-patches',
+]);
+
+/** File extensions considered source code. */
+const CODE_EXTS = new Set([
+  '.js', '.jsx', '.ts', '.tsx', '.py', '.rb', '.go', '.rs', '.java',
+  '.c', '.cpp', '.h', '.hpp', '.cs', '.php', '.swift', '.kt', '.scala',
+  '.sh', '.bash', '.zsh', '.sql', '.html', '.css', '.scss', '.json',
+  '.yaml', '.yml', '.toml', '.xml', '.md', '.vue', '.svelte', '.astro',
+  '.cjs', '.mjs',
+]);
+
+/** Extension to language name mapping. */
+const LANG_MAP = {
+  '.js': 'javascript', '.jsx': 'javascript', '.cjs': 'javascript', '.mjs': 'javascript',
+  '.ts': 'typescript', '.tsx': 'typescript',
+  '.py': 'python', '.rb': 'ruby', '.go': 'go', '.rs': 'rust', '.java': 'java',
+  '.c': 'c', '.cpp': 'cpp', '.h': 'c', '.hpp': 'cpp', '.cs': 'csharp',
+  '.php': 'php', '.swift': 'swift', '.kt': 'kotlin', '.scala': 'scala',
+  '.sh': 'shell', '.bash': 'shell', '.zsh': 'shell',
+  '.sql': 'sql', '.html': 'html', '.css': 'css', '.scss': 'scss',
+  '.json': 'json', '.yaml': 'yaml', '.yml': 'yaml', '.toml': 'toml',
+  '.xml': 'xml', '.md': 'markdown', '.txt': 'text',
+  '.vue': 'vue', '.svelte': 'svelte', '.astro': 'astro',
+};
+
+/** Common English stop words removed from search queries. */
+const STOP_WORDS = new Set([
+  'the', 'a', 'an', 'is', 'are', 'was', 'were', 'be', 'been', 'being',
+  'have', 'has', 'had', 'do', 'does', 'did', 'will', 'would', 'could',
+  'should', 'may', 'might', 'shall', 'can', 'to', 'of', 'in', 'for',
+  'on', 'with', 'at', 'by', 'from', 'as', 'into', 'through', 'during',
+  'before', 'after', 'above', 'below', 'between', 'out', 'off', 'over',
+  'under', 'again', 'further', 'then', 'once', 'here', 'there', 'when',
+  'where', 'why', 'how', 'all', 'each', 'every', 'both', 'few', 'more',
+  'most', 'other', 'some', 'such', 'only', 'own', 'same', 'so', 'than',
+  'too', 'very', 'just', 'because', 'and', 'or', 'but', 'not', 'no',
+  'nor', 'if', 'that', 'this', 'it', 'its', 'i', 'we', 'they', 'them',
+  'my', 'our', 'your', 'his', 'her', 'their', 'what', 'which', 'who',
+  'whom', 'these', 'those', 'am', 'about', 'up', 'also', 'need', 'make',
+  'like', 'use', 'using', 'used', 'get', 'got', 'new', 'want',
+]);
+
+/** File extensions considered binary (skip during indexing). */
+const BINARY_EXTS = new Set([
+  '.png', '.jpg', '.jpeg', '.gif', '.bmp', '.ico', '.svg',
+  '.pdf', '.zip', '.tar', '.gz', '.tgz', '.bz2', '.7z', '.rar',
+  '.mp4', '.avi', '.mov', '.mkv', '.mp3', '.wav', '.flac',
+  '.woff', '.woff2', '.ttf', '.eot', '.otf',
+  '.exe', '.dll', '.so', '.dylib', '.bin',
+]);
+
+module.exports = { VERSION, IGNORE_DIRS, CODE_EXTS, LANG_MAP, STOP_WORDS, BINARY_EXTS };

--- a/get-shit-done/bin/lib/knowledge/context.cjs
+++ b/get-shit-done/bin/lib/knowledge/context.cjs
@@ -1,0 +1,466 @@
+/**
+ * Knowledge Layer — Smart context assembly
+ * Stemming, synonym expansion, relevance scoring, tiered module selection,
+ * and token-budgeted context assembly for agent queries.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { STOP_WORDS } = require('./constants.cjs');
+const {
+  safeRead, safeJsonRead, safeJsonWrite, tokenEstimate, removeStopWords,
+  withFileLock, knowledgeDir, indexPath, decisionsPath, patternsPath,
+  conventionsPath, assumptionsPath,
+} = require('./utils.cjs');
+const { getChangedFilesSince } = require('./git-diff.cjs');
+
+// --- Synonym Groups ----------------------------------------------------------
+
+const SYNONYM_GROUPS = [
+  ['auth', 'authentication', 'login', 'logout', 'signin', 'signup', 'session', 'token', 'jwt', 'oauth', 'credential', 'password'],
+  ['database', 'db', 'sql', 'query', 'schema', 'migration', 'table', 'orm', 'postgres', 'mysql', 'sqlite', 'mongo'],
+  ['api', 'endpoint', 'route', 'handler', 'controller', 'rest', 'graphql', 'request', 'response'],
+  ['test', 'spec', 'assert', 'coverage', 'mock', 'stub', 'fixture'],
+  ['deploy', 'deployment', 'release', 'publish', 'ship', 'rollout', 'ci', 'cd', 'pipeline'],
+  ['error', 'exception', 'throw', 'catch', 'fault', 'failure', 'crash', 'bug'],
+  ['config', 'configuration', 'settings', 'options', 'preferences', 'env', 'environment'],
+  ['security', 'vulnerability', 'xss', 'csrf', 'injection', 'sanitize', 'audit'],
+  ['cache', 'caching', 'memoize', 'redis', 'ttl', 'invalidate'],
+  ['monitor', 'monitoring', 'observability', 'metric', 'alert', 'health', 'logging', 'trace'],
+  ['performance', 'perf', 'optimize', 'bottleneck', 'latency', 'throughput', 'benchmark'],
+  ['state', 'store', 'redux', 'context', 'provider', 'reducer', 'dispatch'],
+  ['ui', 'component', 'render', 'view', 'template', 'layout', 'style', 'css'],
+  ['queue', 'worker', 'job', 'background', 'async', 'cron', 'scheduler'],
+  ['file', 'filesystem', 'read', 'write', 'stream', 'buffer', 'path', 'directory'],
+];
+
+const SYNONYM_MAP = new Map();
+for (const group of SYNONYM_GROUPS) {
+  for (const word of group) {
+    if (!SYNONYM_MAP.has(word)) SYNONYM_MAP.set(word, new Set());
+    for (const syn of group) { if (syn !== word) SYNONYM_MAP.get(word).add(syn); }
+  }
+}
+
+function expandSynonyms(terms) {
+  const synonyms = new Set();
+  const originalSet = new Set(terms);
+  for (const term of terms) {
+    const syns = SYNONYM_MAP.get(term);
+    if (syns) { for (const s of syns) { if (!originalSet.has(s)) synonyms.add(s); } }
+  }
+  return { original: terms, synonyms: [...synonyms] };
+}
+
+// --- Stemmer -----------------------------------------------------------------
+
+function stem(word) {
+  if (!word || word.length < 3) return word;
+  let w = word.toLowerCase();
+  if (w.endsWith('sses')) w = w.slice(0, -2);
+  else if (w.endsWith('ies')) w = w.slice(0, -2);
+  else if (w.endsWith('ss')) { /* keep */ }
+  else if (w.endsWith('s') && w.length > 3) w = w.slice(0, -1);
+  if (w.endsWith('eed') && w.length > 4) w = w.slice(0, -1);
+  else if (w.endsWith('ed') && w.length > 4 && /[aeiou]/.test(w.slice(0, -2))) {
+    w = w.slice(0, -2);
+    if (/([^aeiou])\1$/.test(w) && !/[lsz]$/.test(w.slice(0, -1))) w = w.slice(0, -1);
+  } else if (w.endsWith('ing') && w.length > 5 && /[aeiou]/.test(w.slice(0, -3))) {
+    w = w.slice(0, -3);
+    if (/([^aeiou])\1$/.test(w) && !/[lsz]$/.test(w.slice(0, -1))) w = w.slice(0, -1);
+  }
+  const step2 = [
+    ['ization', 'ize'], ['isation', 'ize'], ['ation', 'ate'], ['fulness', 'ful'],
+    ['ousness', 'ous'], ['iveness', 'ive'], ['ibility', 'ible'],
+    ['ment', ''], ['ness', ''], ['ence', ''], ['ance', ''],
+  ];
+  for (const [suffix, replacement] of step2) {
+    if (w.endsWith(suffix) && w.length - suffix.length >= 2) {
+      w = w.slice(0, -suffix.length) + replacement;
+      break;
+    }
+  }
+  const step3 = [
+    ['able', ''], ['ible', ''], ['ful', ''], ['ous', ''], ['ive', ''],
+    ['tion', 't'], ['sion', 's'], ['ly', ''], ['er', ''], ['est', ''],
+  ];
+  for (const [suffix, replacement] of step3) {
+    if (w.endsWith(suffix) && w.length - suffix.length >= 3) {
+      w = w.slice(0, -suffix.length) + replacement;
+      break;
+    }
+  }
+  return w;
+}
+
+function stemTerms(words) { return [...new Set(words.map(w => stem(w)))]; }
+
+// --- Relevance Scoring -------------------------------------------------------
+
+function scoreRelevance(term, module, moduleName) {
+  let score = 0;
+  const nameLower = (moduleName || '').toLowerCase();
+  const descLower = (module.description || '').toLowerCase();
+  const stemmedTerm = stem(term);
+
+  if (nameLower === term) score += 20;
+  else if (stem(nameLower) === stemmedTerm) score += 16;
+  else if (nameLower.includes(term)) score += 12;
+
+  if (descLower.includes(term)) score += 6;
+  else {
+    const descWords = descLower.split(/\W+/).filter(Boolean);
+    if (descWords.some(w => stem(w) === stemmedTerm)) score += 5;
+  }
+
+  const files = module.files || [];
+  for (const fp of files) { if (fp.toLowerCase().includes(term)) { score += 4; break; } }
+
+  const exports = module.exports || [];
+  for (const exp of exports) {
+    const el = exp.toLowerCase();
+    if (el.includes(term) || stem(el) === stemmedTerm) { score += 5; break; }
+  }
+
+  const patterns = module.patterns || [];
+  for (const pat of patterns) {
+    const pl = pat.toLowerCase();
+    if (pl.includes(term)) { score += 4; break; }
+  }
+
+  if (score > 0) {
+    const accessCount = module.access_count || 0;
+    if (accessCount > 0) score += Math.min(accessCount, 20) * 0.3;
+    if (module.last_accessed) {
+      const daysSince = (Date.now() - new Date(module.last_accessed).getTime()) / (1000 * 60 * 60 * 24);
+      if (daysSince < 1) score += 3; else if (daysSince < 7) score += 1;
+    }
+  }
+  return score;
+}
+
+function computeConfidence(entry, currentPhase) {
+  if (!entry) return 0;
+  let confidence = 0.5;
+  const status = (entry.status || '').toLowerCase();
+  if (status === 'active' || status === '') confidence += 0.1;
+  else if (status === 'superseded') confidence -= 0.3;
+  else if (status === 'deprecated') confidence -= 0.4;
+  const phase = entry.established_in_phase || entry.phase || 0;
+  const cp = currentPhase || 0;
+  if (cp > 0 && phase > 0) {
+    const phasesOld = cp - phase;
+    if (phasesOld >= 5) confidence += 0.2;
+    else if (phasesOld >= 2) confidence += 0.1;
+  }
+  const modules = entry.affected_modules || entry.modules_using || [];
+  if (modules.length >= 3) confidence += 0.1;
+  else if (modules.length >= 1) confidence += 0.05;
+  if (entry.last_referenced) {
+    const daysSinceRef = (Date.now() - new Date(entry.last_referenced).getTime()) / (1000 * 60 * 60 * 24);
+    if (daysSinceRef < 7) confidence += 0.1;
+    else if (daysSinceRef < 30) confidence += 0.05;
+  }
+  return Math.max(0, Math.min(1, confidence));
+}
+
+// --- Tiered module selection -------------------------------------------------
+// Extracted so assembleDiffAwareContext can re-derive tiers after boosting.
+
+function deriveTiers(moduleScores) {
+  const fullModules = moduleScores.slice(0, 2);
+  const gistModules = moduleScores.slice(2, 5);
+  const microModules = moduleScores.slice(5, 10);
+  const topModules = moduleScores.slice(0, 10);
+  return { fullModules, gistModules, microModules, topModules };
+}
+
+// --- Context Assembly --------------------------------------------------------
+
+const MAX_CONTEXT_TOKENS = 12000;
+const AGENT_BUDGETS = {
+  planner: 10000, executor: 8000, verifier: 7000,
+  researcher: 6000, debugger: 9000,
+};
+
+function assembleContext(cwd, taskDescription, opts) {
+  if (!cwd) throw new Error('assembleContext requires cwd');
+  if (!taskDescription) throw new Error('assembleContext requires taskDescription');
+
+  const options = opts || {};
+  const projectConfig = safeJsonRead(path.join(cwd, '.planning', 'config.json'));
+  let budget = options.budget;
+  if (!budget && options.agent) {
+    const userBudgets = (projectConfig && projectConfig.context_budgets) || {};
+    budget = userBudgets[options.agent] || AGENT_BUDGETS[options.agent];
+  }
+  if (!budget) budget = MAX_CONTEXT_TOKENS;
+
+  const index = safeJsonRead(indexPath(cwd));
+  if (!index) {
+    return {
+      relevant_modules: [], module_docs: [], decisions: [], patterns: [],
+      conventions: '', estimated_tokens: 0, budget_applied: false,
+    };
+  }
+
+  // Tokenize, stem, expand
+  const rawTerms = removeStopWords(
+    taskDescription.toLowerCase().split(/\W+/).filter(t => t.length > 0)
+  );
+  const terms = stemTerms(rawTerms);
+  const { synonyms } = expandSynonyms(rawTerms);
+  const synonymTerms = stemTerms(synonyms);
+
+  // Score modules
+  const moduleScores = [];
+  for (const [modName, modData] of Object.entries(index.modules || {})) {
+    let totalScore = 0;
+    for (const term of terms) totalScore += scoreRelevance(term, modData, modName);
+    for (const syn of synonymTerms) totalScore += scoreRelevance(syn, modData, modName) * 0.4;
+    if (totalScore > 0) moduleScores.push({ module: modName, score: totalScore, data: modData });
+  }
+  moduleScores.sort((a, b) => b.score - a.score);
+
+  return _buildContextFromScores(cwd, moduleScores, terms, budget, index, projectConfig);
+}
+
+/**
+ * Internal: build the full context result from sorted module scores.
+ * Shared between assembleContext and assembleDiffAwareContext.
+ */
+function _buildContextFromScores(cwd, moduleScores, terms, budget, index, projectConfig) {
+  const { fullModules, gistModules, microModules, topModules } = deriveTiers(moduleScores);
+
+  // Module docs
+  let moduleDocs = [];
+  for (const { module: modName } of fullModules) {
+    const safeName = modName.replace(/[^a-zA-Z0-9_-]/g, '-');
+    const docPath = path.join(knowledgeDir(cwd), 'modules', safeName);
+    if (fs.existsSync(docPath)) {
+      try {
+        const entries = fs.readdirSync(docPath).filter(f => f.endsWith('.md'));
+        for (const entry of entries) {
+          const content = safeRead(path.join(docPath, entry));
+          if (content) moduleDocs.push({ module: modName, file: entry, content });
+        }
+      } catch { /* skip */ }
+    }
+  }
+  moduleDocs = moduleDocs.slice(0, 5);
+
+  const gistSurrogates = gistModules.map(m => ({
+    module: m.module, score: m.score,
+    gist: (m.data && m.data.surrogate_gist) ||
+      `${m.module}: ${(m.data && m.data.description) || 'no description'}`,
+  }));
+  const microSurrogates = microModules.map(m => ({
+    module: m.module, score: m.score,
+    micro: (m.data && m.data.surrogate_micro) ||
+      `${m.module} (${((m.data && m.data.files) || []).length} files)`,
+  }));
+
+  // Update access tracking
+  try {
+    const ip = indexPath(cwd);
+    const idx = safeJsonRead(ip);
+    if (idx && idx.modules) {
+      const now = new Date().toISOString();
+      let changed = false;
+      for (const m of topModules) {
+        if (idx.modules[m.module]) {
+          idx.modules[m.module].access_count = (idx.modules[m.module].access_count || 0) + 1;
+          idx.modules[m.module].last_accessed = now;
+          changed = true;
+        }
+      }
+      if (changed) withFileLock(ip, () => safeJsonWrite(ip, idx));
+    }
+  } catch { /* best effort */ }
+
+  const currentPhase = projectConfig ? (projectConfig.current_phase || 0) : 0;
+
+  // Decisions
+  const registry = safeJsonRead(decisionsPath(cwd));
+  let relevantDecisions = [];
+  if (registry && registry.decisions) {
+    const topModuleNames = new Set(topModules.map(m => m.module));
+    for (const d of registry.decisions) {
+      const affectsRelevant = (d.affected_modules || []).some(m => topModuleNames.has(m));
+      const titleWords = (d.title || '').toLowerCase().split(/\W+/).filter(Boolean).map(stem);
+      const matchesTerm = terms.some(term => titleWords.includes(term));
+      if (affectsRelevant || matchesTerm) {
+        relevantDecisions.push({ ...d, confidence: computeConfidence(d, currentPhase) });
+      }
+    }
+  }
+  relevantDecisions.sort((a, b) => b.confidence - a.confidence);
+  relevantDecisions = relevantDecisions.slice(0, 10);
+
+  // Patterns
+  const catalog = safeJsonRead(patternsPath(cwd));
+  let relevantPatterns = [];
+  if (catalog && catalog.patterns) {
+    const topModuleNames = new Set(topModules.map(m => m.module));
+    for (const p of catalog.patterns) {
+      const usedByRelevant = (p.modules_using || []).some(m => topModuleNames.has(m));
+      const nameWords = (p.name || '').toLowerCase().split(/\W+/).filter(Boolean).map(stem);
+      const matchesTerm = terms.some(term => nameWords.includes(term));
+      if (usedByRelevant || matchesTerm) {
+        relevantPatterns.push({ ...p, confidence: computeConfidence(p, currentPhase) });
+      }
+    }
+  }
+  relevantPatterns.sort((a, b) => b.confidence - a.confidence);
+  relevantPatterns = relevantPatterns.slice(0, 10);
+
+  // Assumptions
+  let premises = [];
+  try {
+    const asmRegistry = safeJsonRead(assumptionsPath(cwd));
+    if (asmRegistry && Array.isArray(asmRegistry.assumptions)) {
+      premises = asmRegistry.assumptions
+        .filter(a => a.confidence === 'established')
+        .slice(0, 5)
+        .map(a => ({ id: a.id, statement: a.statement, type: a.type }));
+    }
+  } catch { /* no assumptions */ }
+
+  // Conventions
+  let conventions = safeRead(conventionsPath(cwd)) || '';
+  if (tokenEstimate(conventions) > 2000) conventions = conventions.slice(0, 8000);
+
+  // Token budget enforcement
+  let budgetApplied = false;
+  const estimate = () => {
+    return [
+      JSON.stringify(fullModules), JSON.stringify(moduleDocs),
+      JSON.stringify(gistSurrogates), JSON.stringify(microSurrogates),
+      JSON.stringify(relevantDecisions), JSON.stringify(relevantPatterns),
+      JSON.stringify(premises), conventions,
+    ].reduce((sum, part) => sum + tokenEstimate(part), 0);
+  };
+
+  let estimatedTokens = estimate();
+  if (estimatedTokens > budget) {
+    budgetApplied = true;
+    if (conventions.length > 1000) { conventions = conventions.slice(0, 1000); estimatedTokens = estimate(); }
+  }
+  if (estimatedTokens > budget && relevantPatterns.length > 5) {
+    relevantPatterns = relevantPatterns.slice(0, 5); estimatedTokens = estimate();
+  }
+  if (estimatedTokens > budget && relevantDecisions.length > 5) {
+    relevantDecisions = relevantDecisions.slice(0, 5); estimatedTokens = estimate();
+  }
+  if (estimatedTokens > budget && moduleDocs.length > 3) {
+    moduleDocs = moduleDocs.slice(0, 3); estimatedTokens = estimate();
+  }
+  if (estimatedTokens > budget) {
+    conventions = ''; estimatedTokens = estimate();
+  }
+
+  return {
+    relevant_modules: topModules.map(m => ({
+      module: m.module, score: m.score,
+      file_count: (m.data.files || []).length, description: m.data.description || '',
+    })),
+    module_docs: moduleDocs,
+    gist_modules: gistSurrogates,
+    micro_modules: microSurrogates,
+    decisions: relevantDecisions,
+    patterns: relevantPatterns,
+    premises,
+    conventions,
+    estimated_tokens: estimatedTokens,
+    budget_applied: budgetApplied,
+  };
+}
+
+// --- Diff-Aware Context ------------------------------------------------------
+// FIX(review #8): re-derive gist/micro tiers from boosted scores so all
+// returned arrays are consistent with the post-boost ordering.
+
+function assembleDiffAwareContext(cwd, taskDescription, opts) {
+  if (!cwd) throw new Error('assembleDiffAwareContext requires cwd');
+  if (!taskDescription) throw new Error('assembleDiffAwareContext requires taskDescription');
+
+  const options = opts || {};
+  const projectConfig = safeJsonRead(path.join(cwd, '.planning', 'config.json'));
+  let budget = options.budget;
+  if (!budget && options.agent) {
+    const userBudgets = (projectConfig && projectConfig.context_budgets) || {};
+    budget = userBudgets[options.agent] || AGENT_BUDGETS[options.agent];
+  }
+  if (!budget) budget = MAX_CONTEXT_TOKENS;
+
+  const index = safeJsonRead(indexPath(cwd));
+  if (!index) {
+    return {
+      relevant_modules: [], module_docs: [], decisions: [], patterns: [],
+      conventions: '', estimated_tokens: 0, budget_applied: false, diff_context: null,
+    };
+  }
+
+  // Tokenize, stem, expand (same as assembleContext)
+  const rawTerms = removeStopWords(
+    taskDescription.toLowerCase().split(/\W+/).filter(t => t.length > 0)
+  );
+  const terms = stemTerms(rawTerms);
+  const { synonyms } = expandSynonyms(rawTerms);
+  const synonymTerms = stemTerms(synonyms);
+
+  // Score modules
+  const moduleScores = [];
+  for (const [modName, modData] of Object.entries(index.modules || {})) {
+    let totalScore = 0;
+    for (const term of terms) totalScore += scoreRelevance(term, modData, modName);
+    for (const syn of synonymTerms) totalScore += scoreRelevance(syn, modData, modName) * 0.4;
+    if (totalScore > 0) moduleScores.push({ module: modName, score: totalScore, data: modData });
+  }
+
+  // Diff-boost before deriving tiers
+  let diffContext = null;
+  if (index.last_mapped_commit) {
+    let changes;
+    try { changes = getChangedFilesSince(cwd, index.last_mapped_commit); } catch { changes = null; }
+    if (changes) {
+      const changedFiles = [...(changes.added || []), ...(changes.modified || [])];
+      if (changedFiles.length > 0) {
+        const diffModules = new Set();
+        for (const file of changedFiles) {
+          const fileInfo = (index.files || {})[file];
+          if (fileInfo && fileInfo.module) diffModules.add(fileInfo.module);
+        }
+        for (const m of moduleScores) {
+          if (diffModules.has(m.module)) {
+            m.score += 15;
+            m.diff_boosted = true;
+          }
+        }
+        diffContext = { changed_files: changedFiles, diff_modules: [...diffModules] };
+      }
+    }
+  }
+
+  // Sort after boost so tiers are derived from final scores
+  moduleScores.sort((a, b) => b.score - a.score);
+
+  const base = _buildContextFromScores(cwd, moduleScores, terms, budget, index, projectConfig);
+
+  // Annotate diff_boosted on relevant_modules
+  const boostedSet = new Set(
+    moduleScores.filter(m => m.diff_boosted).map(m => m.module)
+  );
+  base.relevant_modules = base.relevant_modules.map(m =>
+    boostedSet.has(m.module) ? { ...m, diff_boosted: true } : m
+  );
+
+  return { ...base, diff_context: diffContext };
+}
+
+module.exports = {
+  stem, stemTerms, scoreRelevance, expandSynonyms, computeConfidence,
+  assembleContext, assembleDiffAwareContext,
+  MAX_CONTEXT_TOKENS, AGENT_BUDGETS,
+};

--- a/get-shit-done/bin/lib/knowledge/dependencies.cjs
+++ b/get-shit-done/bin/lib/knowledge/dependencies.cjs
@@ -1,0 +1,203 @@
+/**
+ * Knowledge Layer — Dependency graph builder
+ * Builds forward/reverse import maps, detects circular dependencies
+ * via Tarjan's SCC algorithm, resolves path aliases, provides impact analysis.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { VERSION } = require('./constants.cjs');
+const { getFileLanguage, extractImports } = require('./source-analysis.cjs');
+const {
+  safeRead, safeJsonRead, safeJsonWrite, isoNow, withFileLock,
+  indexPath, depsPath,
+} = require('./utils.cjs');
+
+let _cachedAliases = null;
+let _cachedAliasesCwd = null;
+
+function loadPathAliases(cwd) {
+  if (_cachedAliases && _cachedAliasesCwd === cwd) return _cachedAliases;
+  _cachedAliasesCwd = cwd;
+  _cachedAliases = {};
+  for (const configFile of ['tsconfig.json', 'jsconfig.json']) {
+    const fp = path.join(cwd, configFile);
+    const config = safeJsonRead(fp);
+    if (config && config.compilerOptions && config.compilerOptions.paths) {
+      const baseUrl = config.compilerOptions.baseUrl || '.';
+      const basePath = path.resolve(cwd, baseUrl);
+      for (const [alias, targets] of Object.entries(config.compilerOptions.paths)) {
+        const prefix = alias.replace('/*', '');
+        const target = (targets[0] || '').replace('/*', '');
+        _cachedAliases[prefix] = path.resolve(basePath, target);
+      }
+      break;
+    }
+  }
+  return _cachedAliases;
+}
+
+function _resolveImports(imports, filePath, fileSet, aliases, cwd) {
+  const resolved = [];
+  for (const imp of imports) {
+    let resolvedPath;
+    if (!imp.startsWith('.') && !imp.startsWith('/')) {
+      let aliasResolved = false;
+      for (const [prefix, targetDir] of Object.entries(aliases)) {
+        if (imp === prefix || imp.startsWith(prefix + '/')) {
+          const rest = imp.slice(prefix.length).replace(/^\//, '');
+          resolvedPath = path.relative(cwd, path.join(targetDir, rest)).replace(/\\/g, '/');
+          aliasResolved = true;
+          break;
+        }
+      }
+      if (!aliasResolved) continue;
+    } else {
+      const importDir = path.dirname(filePath);
+      resolvedPath = path.posix.normalize(path.posix.join(importDir, imp)).replace(/\\/g, '/');
+    }
+    const candidates = [resolvedPath];
+    if (!path.extname(resolvedPath)) {
+      for (const ext of ['.js', '.ts', '.jsx', '.tsx', '.mjs', '.cjs', '/index.js', '/index.ts']) {
+        candidates.push(resolvedPath + ext);
+      }
+    }
+    for (const candidate of candidates) {
+      if (fileSet.has(candidate)) { resolved.push(candidate); break; }
+    }
+  }
+  return resolved;
+}
+
+// --- Tarjan's SCC for full-cycle detection -----------------------------------
+// FIX(review #7): detect A->B->C->A cycles, not just direct A<->B.
+
+function findCircularDeps(moduleDepsPlain) {
+  const nodes = Object.keys(moduleDepsPlain);
+  let index = 0;
+  const stack = [];
+  const onStack = new Set();
+  const indices = new Map();
+  const lowlinks = new Map();
+  const sccs = [];
+
+  function strongConnect(v) {
+    indices.set(v, index);
+    lowlinks.set(v, index);
+    index++;
+    stack.push(v);
+    onStack.add(v);
+
+    for (const w of (moduleDepsPlain[v] || [])) {
+      if (!indices.has(w)) {
+        strongConnect(w);
+        lowlinks.set(v, Math.min(lowlinks.get(v), lowlinks.get(w)));
+      } else if (onStack.has(w)) {
+        lowlinks.set(v, Math.min(lowlinks.get(v), indices.get(w)));
+      }
+    }
+
+    if (lowlinks.get(v) === indices.get(v)) {
+      const scc = [];
+      let w;
+      do {
+        w = stack.pop();
+        onStack.delete(w);
+        scc.push(w);
+      } while (w !== v);
+      // Only report SCCs with more than 1 node (those are cycles)
+      if (scc.length > 1) {
+        sccs.push(scc.sort());
+      }
+    }
+  }
+
+  for (const node of nodes) {
+    if (!indices.has(node)) {
+      strongConnect(node);
+    }
+  }
+
+  return sccs.map(scc => scc.join(' <-> '));
+}
+
+function buildDependencyGraph(cwd) {
+  const index = safeJsonRead(indexPath(cwd));
+  if (!index) throw new Error('INDEX.json not found. Run buildIndex() first.');
+
+  const forward = {};
+  const reverse = {};
+  const moduleDeps = {};
+  const fileSet = new Set(Object.keys(index.files));
+  const aliases = loadPathAliases(cwd);
+
+  for (const [filePath, fileInfo] of Object.entries(index.files)) {
+    let imports;
+    if (fileInfo.imports && fileInfo.imports.length > 0) {
+      imports = fileInfo.imports;
+    } else {
+      const content = safeRead(path.resolve(cwd, filePath));
+      if (!content) continue;
+      imports = extractImports(content, getFileLanguage(filePath));
+    }
+    const resolvedImports = _resolveImports(imports, filePath, fileSet, aliases, cwd);
+    if (resolvedImports.length > 0) {
+      forward[filePath] = resolvedImports;
+      for (const target of resolvedImports) {
+        if (!reverse[target]) reverse[target] = [];
+        reverse[target].push(filePath);
+      }
+    }
+  }
+
+  for (const [file, deps] of Object.entries(forward)) {
+    const sourceModule = (index.files[file] || {}).module;
+    if (!sourceModule) continue;
+    if (!moduleDeps[sourceModule]) moduleDeps[sourceModule] = new Set();
+    for (const dep of deps) {
+      const targetModule = (index.files[dep] || {}).module;
+      if (targetModule && targetModule !== sourceModule) moduleDeps[sourceModule].add(targetModule);
+    }
+  }
+
+  const moduleDepsPlain = {};
+  for (const [mod, deps] of Object.entries(moduleDeps)) moduleDepsPlain[mod] = [...deps];
+
+  const circular = findCircularDeps(moduleDepsPlain);
+
+  const totalEdges = Object.values(forward).reduce((sum, arr) => sum + arr.length, 0);
+  const depsData = { version: VERSION, last_updated: isoNow(), forward, reverse, module_deps: moduleDepsPlain, circular };
+  withFileLock(depsPath(cwd), () => safeJsonWrite(depsPath(cwd), depsData));
+
+  withFileLock(indexPath(cwd), () => {
+    const idx = safeJsonRead(indexPath(cwd));
+    if (idx && idx.stats) {
+      idx.stats.total_dependencies = totalEdges;
+      for (const [mod, deps] of Object.entries(moduleDepsPlain)) {
+        if (idx.modules[mod]) idx.modules[mod].dependencies = deps;
+      }
+      safeJsonWrite(indexPath(cwd), idx);
+    }
+  });
+
+  return { ok: true, total_edges: totalEdges, circular_count: circular.length, circular };
+}
+
+function getImpactedFiles(cwd, filePath) {
+  const deps = safeJsonRead(depsPath(cwd));
+  if (!deps) return { ok: false, error: 'DEPENDENCIES.json not found.' };
+  const normalized = filePath.replace(/\\/g, '/');
+  const impacted = deps.reverse[normalized] || [];
+  const index = safeJsonRead(indexPath(cwd));
+  const impactedModules = new Set();
+  if (index && index.files) {
+    for (const f of impacted) {
+      const fileInfo = index.files[f];
+      if (fileInfo && fileInfo.module) impactedModules.add(fileInfo.module);
+    }
+  }
+  return { ok: true, file: normalized, impacted_files: impacted, impacted_modules: [...impactedModules] };
+}
+
+module.exports = { buildDependencyGraph, getImpactedFiles, loadPathAliases, findCircularDeps };

--- a/get-shit-done/bin/lib/knowledge/git-diff.cjs
+++ b/get-shit-done/bin/lib/knowledge/git-diff.cjs
@@ -1,0 +1,60 @@
+/**
+ * Knowledge Layer — Git diff analysis
+ * Detects changed files since a given commit, categorizes changes.
+ */
+'use strict';
+
+const path = require('path');
+const { BINARY_EXTS, CODE_EXTS } = require('./constants.cjs');
+const { execGitSafe } = require('./utils.cjs');
+
+function getChangedFilesSince(cwd, sinceCommit) {
+  const result = { added: [], modified: [], deleted: [], renamed: [] };
+  if (!cwd || !sinceCommit) return result;
+
+  const filters = [
+    { key: 'added', args: ['diff', '--name-only', '--diff-filter=A', sinceCommit, 'HEAD'] },
+    { key: 'modified', args: ['diff', '--name-only', '--diff-filter=M', sinceCommit, 'HEAD'] },
+    { key: 'deleted', args: ['diff', '--name-only', '--diff-filter=D', sinceCommit, 'HEAD'] },
+  ];
+
+  for (const { key, args } of filters) {
+    const r = execGitSafe(cwd, args);
+    if (r.exitCode === 0 && r.stdout) {
+      result[key] = r.stdout.split('\n').filter(Boolean);
+    }
+  }
+
+  // Renamed files
+  const renamedResult = execGitSafe(cwd, ['diff', '--name-status', '--diff-filter=R', sinceCommit, 'HEAD']);
+  if (renamedResult.exitCode === 0 && renamedResult.stdout) {
+    for (const line of renamedResult.stdout.split('\n').filter(Boolean)) {
+      const parts = line.split('\t');
+      if (parts.length >= 3) {
+        result.renamed.push({ old: parts[1], new: parts[2] });
+      }
+    }
+  }
+
+  // Untracked files
+  const untrackedResult = execGitSafe(cwd, ['ls-files', '--others', '--exclude-standard']);
+  if (untrackedResult.exitCode === 0 && untrackedResult.stdout) {
+    for (const f of untrackedResult.stdout.split('\n').filter(Boolean)) {
+      if (!result.added.includes(f)) result.added.push(f);
+    }
+  }
+
+  return result;
+}
+
+function getCurrentHead(cwd) {
+  if (!cwd) return '0000000';
+  const result = execGitSafe(cwd, ['rev-parse', '--short', 'HEAD']);
+  return (result.exitCode === 0 && result.stdout) ? result.stdout : '0000000';
+}
+
+function isBinaryFile(filePath) {
+  return BINARY_EXTS.has(path.extname(filePath).toLowerCase());
+}
+
+module.exports = { getChangedFilesSince, getCurrentHead, isBinaryFile };

--- a/get-shit-done/bin/lib/knowledge/index.cjs
+++ b/get-shit-done/bin/lib/knowledge/index.cjs
@@ -1,0 +1,45 @@
+/**
+ * Knowledge Layer — Facade module
+ * Single entry point for the entire knowledge engine.
+ * Re-exports all public APIs from sub-modules.
+ */
+'use strict';
+
+const { initKnowledge } = require('./init.cjs');
+const { buildIndex, updateIndexIncremental, getIndex, listModules } = require('./indexer.cjs');
+const { assembleContext, assembleDiffAwareContext } = require('./context.cjs');
+const { buildDependencyGraph, getImpactedFiles, findCircularDeps } = require('./dependencies.cjs');
+const { getChangedFilesSince, getCurrentHead } = require('./git-diff.cjs');
+const { createLoopGuard } = require('./loop-guard.cjs');
+const {
+  getProtectedFiles, isFileProtected, isSafeImprovement,
+  createCircuitBreaker, scopeCheck, validateMergeReadiness,
+} = require('./safety.cjs');
+const { knowledgeDir, indexPath } = require('./utils.cjs');
+
+module.exports = {
+  // Init
+  initKnowledge,
+
+  // Indexer
+  buildIndex, updateIndexIncremental, getIndex, listModules,
+
+  // Context
+  assembleContext, assembleDiffAwareContext,
+
+  // Dependencies
+  buildDependencyGraph, getImpactedFiles, findCircularDeps,
+
+  // Git
+  getChangedFilesSince, getCurrentHead,
+
+  // Loop Guard
+  createLoopGuard,
+
+  // Safety
+  getProtectedFiles, isFileProtected, isSafeImprovement,
+  createCircuitBreaker, scopeCheck, validateMergeReadiness,
+
+  // Paths
+  knowledgeDir, indexPath,
+};

--- a/get-shit-done/bin/lib/knowledge/indexer.cjs
+++ b/get-shit-done/bin/lib/knowledge/indexer.cjs
@@ -1,0 +1,334 @@
+/**
+ * Knowledge Layer — Codebase indexer
+ * Scans source files, computes SHA-256 hashes, detects modules,
+ * maps files to modules, and stores results in INDEX.json.
+ * Supports both full rebuild and incremental updates via git-diff.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { VERSION, IGNORE_DIRS, CODE_EXTS } = require('./constants.cjs');
+const { getFileLanguage, extractExports, extractImports, guessModule } = require('./source-analysis.cjs');
+const { getChangedFilesSince, getCurrentHead, isBinaryFile } = require('./git-diff.cjs');
+const {
+  safeRead, safeJsonRead, safeJsonWrite, sha256, ensureDir,
+  isoNow, withFileLock, knowledgeDir, indexPath, execGitSafe,
+} = require('./utils.cjs');
+
+// --- Directory Walker --------------------------------------------------------
+
+const MAX_FILES = 50_000;
+
+/**
+ * Walk a directory tree collecting source files.
+ * Returns { files: string[], truncated: boolean }.
+ * FIX(review #13): returns truncated flag when MAX_FILES cap is hit.
+ */
+function walkDir(dir) {
+  const results = [];
+  let truncated = false;
+  function walk(currentDir) {
+    if (results.length >= MAX_FILES) { truncated = true; return; }
+    let entries;
+    try { entries = fs.readdirSync(currentDir, { withFileTypes: true }); } catch { return; }
+    for (const entry of entries) {
+      if (results.length >= MAX_FILES) { truncated = true; return; }
+      if (IGNORE_DIRS.has(entry.name)) continue;
+      if (entry.name.startsWith('.') && entry.name !== '.env.example') continue;
+      if (entry.isSymbolicLink()) continue;
+      const full = path.join(currentDir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.isFile()) {
+        const ext = path.extname(entry.name).toLowerCase();
+        if (CODE_EXTS.has(ext)) results.push(full);
+      }
+    }
+  }
+  walk(dir);
+  return { files: results, truncated };
+}
+
+// --- Single File Indexing ----------------------------------------------------
+
+function indexSingleFile(filePath, cwd) {
+  const content = safeRead(filePath);
+  if (content === null) return null;
+  const rel = path.relative(cwd, filePath).replace(/\\/g, '/');
+  const lang = getFileLanguage(filePath);
+  const lines = content.split('\n').length;
+  const hash = sha256(content);
+  const exportsList = extractExports(content, lang);
+  const importsList = extractImports(content, lang);
+  const mod = guessModule(filePath, cwd);
+  let sizeBytes = 0;
+  try { sizeBytes = fs.statSync(filePath).size; } catch { /* ignore */ }
+  return {
+    path: rel, module: mod, hash, description: '',
+    language: lang, line_count: lines, size_bytes: sizeBytes,
+    exports: exportsList, imports: importsList,
+    patterns: [], last_mapped: isoNow(),
+  };
+}
+
+// --- Surrogate Generation ----------------------------------------------------
+
+function generateSurrogates(moduleName, moduleData) {
+  const files = moduleData.files || [];
+  const exports = moduleData.exports || [];
+  const deps = moduleData.dependencies || [];
+  const patterns = moduleData.patterns || [];
+  const desc = moduleData.description || '';
+
+  const topExports = exports.slice(0, 10).join(', ') || 'none';
+  const patList = patterns.slice(0, 5).join(', ') || 'none';
+  const depList = deps.slice(0, 5).join(', ') || 'none';
+
+  const gist = `Module: ${moduleName} | Files: ${files.length} | Exports: ${topExports} | Patterns: ${patList} | Deps: ${depList}${desc ? ' | ' + desc : ''}`;
+  const micro = `${moduleName}: ${desc || 'no description'} (${files.length} files, ${exports.length} exports)`;
+
+  return { surrogate_gist: gist, surrogate_micro: micro };
+}
+
+// --- Compute total exports ---------------------------------------------------
+
+function computeTotalExports(modules) {
+  return Object.values(modules).reduce((sum, m) => sum + (m.exports || []).length, 0);
+}
+
+// --- Full Index Build --------------------------------------------------------
+
+function buildIndex(cwd) {
+  const kd = knowledgeDir(cwd);
+  if (!fs.existsSync(kd)) {
+    throw new Error('Knowledge layer not initialized. Run gsd-tools.cjs knowledge init first.');
+  }
+
+  const ip = indexPath(cwd);
+  const existing = safeJsonRead(ip) || {
+    version: VERSION, last_mapped_commit: '0000000', last_updated: isoNow(),
+    stats: { total_files: 0, total_modules: 0, total_patterns: 0, total_exports: 0, total_dependencies: 0 },
+    modules: {}, files: {}, patterns: {},
+  };
+
+  const walkResult = walkDir(cwd);
+  const allFiles = walkResult.files;
+  let indexed = 0, skipped = 0, errors = 0;
+  existing.files = {};
+
+  for (const fp of allFiles) {
+    try {
+      const info = indexSingleFile(fp, cwd);
+      if (!info) { skipped++; continue; }
+      existing.files[info.path] = {
+        module: info.module, hash: info.hash, description: info.description,
+        patterns: info.patterns, last_mapped: info.last_mapped,
+        size_bytes: info.size_bytes, line_count: info.line_count,
+        exports: info.exports, imports: info.imports,
+      };
+      indexed++;
+    } catch { errors++; }
+  }
+
+  // Rebuild modules from file data
+  const modules = {};
+  for (const [fp, info] of Object.entries(existing.files)) {
+    const mod = info.module;
+    if (!modules[mod]) {
+      modules[mod] = { path: mod === 'root' ? '.' : mod, description: '', files: [], exports: [], dependencies: [], patterns: [] };
+    }
+    modules[mod].files.push(fp);
+  }
+
+  for (const [modName, modData] of Object.entries(modules)) {
+    const allExports = [];
+    for (const fp of modData.files) {
+      const fileEntry = existing.files[fp];
+      if (fileEntry && fileEntry.exports) allExports.push(...fileEntry.exports);
+    }
+    modData.exports = [...new Set(allExports)];
+    const surrogates = generateSurrogates(modName, modData);
+    modData.surrogate_gist = surrogates.surrogate_gist;
+    modData.surrogate_micro = surrogates.surrogate_micro;
+    if (modData.access_count === undefined) modData.access_count = 0;
+    if (modData.last_accessed === undefined) modData.last_accessed = null;
+  }
+
+  existing.modules = modules;
+  if (!existing.patterns) existing.patterns = {};
+
+  const headResult = execGitSafe(cwd, ['rev-parse', '--short', 'HEAD']);
+  if (headResult.exitCode === 0) existing.last_mapped_commit = headResult.stdout;
+
+  existing.stats = {
+    total_files: Object.keys(existing.files).length,
+    total_modules: Object.keys(existing.modules).length,
+    total_patterns: Object.keys(existing.patterns).length,
+    total_exports: computeTotalExports(modules),
+    total_dependencies: 0,
+  };
+  existing.last_updated = isoNow();
+
+  withFileLock(ip, () => safeJsonWrite(ip, existing));
+
+  return {
+    ok: true, indexed, skipped, errors,
+    total_files: existing.stats.total_files,
+    total_modules: existing.stats.total_modules,
+    truncated: walkResult.truncated,
+  };
+}
+
+// --- Incremental Index Update ------------------------------------------------
+
+function updateIndexIncremental(cwd) {
+  const startTime = Date.now();
+  const ip = indexPath(cwd);
+  let existing;
+
+  try { existing = safeJsonRead(ip); } catch {
+    const result = buildIndex(cwd);
+    return { ...result, deleted: 0, renamed: 0, fallback: true, duration_ms: Date.now() - startTime };
+  }
+
+  if (!existing || !existing.files || !existing.last_mapped_commit || existing.last_mapped_commit === '0000000') {
+    const result = buildIndex(cwd);
+    return { ...result, deleted: 0, renamed: 0, fallback: true, duration_ms: Date.now() - startTime };
+  }
+
+  const lastCommit = existing.last_mapped_commit;
+  const changes = getChangedFilesSince(cwd, lastCommit);
+  const totalIndexedFiles = Object.keys(existing.files).length;
+  const totalChangedCount = changes.added.length + changes.modified.length + changes.deleted.length + changes.renamed.length;
+  const rebuildRecommended = totalIndexedFiles > 0 && totalChangedCount > totalIndexedFiles * 0.5;
+
+  let indexed = 0, skipped = 0, errors = 0, deletedCount = 0, renamedCount = 0;
+
+  for (const df of changes.deleted) {
+    const rel = df.replace(/\\/g, '/');
+    if (existing.files[rel]) { delete existing.files[rel]; deletedCount++; }
+  }
+
+  for (const rename of changes.renamed) {
+    const oldRel = rename.old.replace(/\\/g, '/');
+    const oldEntry = existing.files[oldRel] || {};
+    delete existing.files[oldRel];
+    const absPath = path.resolve(cwd, rename.new);
+    if (fs.existsSync(absPath) && !isBinaryFile(rename.new)) {
+      const ext = path.extname(rename.new).toLowerCase();
+      if (CODE_EXTS.has(ext)) {
+        try {
+          const info = indexSingleFile(absPath, cwd);
+          if (info) {
+            existing.files[info.path] = {
+              module: info.module, hash: info.hash,
+              description: oldEntry.description || '', patterns: oldEntry.patterns || [],
+              last_mapped: info.last_mapped, size_bytes: info.size_bytes, line_count: info.line_count,
+              exports: info.exports, imports: info.imports,
+            };
+            indexed++;
+          }
+        } catch { errors++; }
+      }
+    }
+    renamedCount++;
+  }
+
+  const filesToProcess = [...new Set([...changes.added, ...changes.modified])];
+  for (const relFile of filesToProcess) {
+    const absPath = path.resolve(cwd, relFile);
+    if (!fs.existsSync(absPath)) { skipped++; continue; }
+    if (isBinaryFile(relFile)) { skipped++; continue; }
+    const ext = path.extname(relFile).toLowerCase();
+    if (!CODE_EXTS.has(ext)) { skipped++; continue; }
+    try {
+      const info = indexSingleFile(absPath, cwd);
+      if (!info) { skipped++; continue; }
+      if (existing.files[info.path] && existing.files[info.path].hash === info.hash) { skipped++; continue; }
+      existing.files[info.path] = {
+        module: info.module, hash: info.hash,
+        description: (existing.files[info.path] || {}).description || '',
+        patterns: (existing.files[info.path] || {}).patterns || [],
+        last_mapped: info.last_mapped, size_bytes: info.size_bytes, line_count: info.line_count,
+        exports: info.exports, imports: info.imports,
+      };
+      indexed++;
+    } catch { errors++; }
+  }
+
+  // Rebuild modules
+  const modules = {};
+  for (const [fp, info] of Object.entries(existing.files)) {
+    const mod = info.module;
+    if (!modules[mod]) {
+      modules[mod] = {
+        path: mod === 'root' ? '.' : mod,
+        description: (existing.modules && existing.modules[mod] || {}).description || '',
+        files: [], exports: [],
+        dependencies: (existing.modules && existing.modules[mod] || {}).dependencies || [],
+        patterns: (existing.modules && existing.modules[mod] || {}).patterns || [],
+      };
+    }
+    modules[mod].files.push(fp);
+  }
+
+  for (const [modName, modData] of Object.entries(modules)) {
+    // FIX(review #6): compute exports for each module during incremental update
+    const allExports = [];
+    for (const fp of modData.files) {
+      const fileEntry = existing.files[fp];
+      if (fileEntry && fileEntry.exports) allExports.push(...fileEntry.exports);
+    }
+    modData.exports = [...new Set(allExports)];
+
+    const surrogates = generateSurrogates(modName, modData);
+    modData.surrogate_gist = surrogates.surrogate_gist;
+    modData.surrogate_micro = surrogates.surrogate_micro;
+    const prev = existing.modules && existing.modules[modName];
+    modData.access_count = (prev && prev.access_count) || 0;
+    modData.last_accessed = (prev && prev.last_accessed) || null;
+  }
+
+  existing.modules = modules;
+  const head = getCurrentHead(cwd);
+  if (head !== '0000000') existing.last_mapped_commit = head;
+
+  // FIX(review #6): compute total_exports correctly instead of hardcoding 0
+  existing.stats = {
+    total_files: Object.keys(existing.files).length,
+    total_modules: Object.keys(existing.modules).length,
+    total_patterns: Object.keys(existing.patterns || {}).length,
+    total_exports: computeTotalExports(modules),
+    total_dependencies: (existing.stats && existing.stats.total_dependencies) || 0,
+  };
+  existing.last_updated = isoNow();
+
+  withFileLock(ip, () => safeJsonWrite(ip, existing));
+
+  return {
+    ok: true, indexed, skipped, errors, deleted: deletedCount, renamed: renamedCount,
+    total_files: existing.stats.total_files, fallback: false,
+    rebuild_recommended: rebuildRecommended, duration_ms: Date.now() - startTime,
+  };
+}
+
+// --- Query Helpers -----------------------------------------------------------
+
+function getIndex(cwd) { return safeJsonRead(indexPath(cwd), null); }
+
+function listModules(cwd) {
+  const index = safeJsonRead(indexPath(cwd));
+  if (!index || !index.modules) return { ok: true, modules: [] };
+  const modules = Object.entries(index.modules).map(([name, data]) => ({
+    name, file_count: (data.files || []).length, description: data.description || '',
+    exports_count: (data.exports || []).length,
+  }));
+  modules.sort((a, b) => b.file_count - a.file_count);
+  return { ok: true, modules };
+}
+
+module.exports = {
+  buildIndex, updateIndexIncremental, getIndex, listModules,
+  walkDir, generateSurrogates,
+};

--- a/get-shit-done/bin/lib/knowledge/init.cjs
+++ b/get-shit-done/bin/lib/knowledge/init.cjs
@@ -1,0 +1,102 @@
+/**
+ * Knowledge Layer — Initialization
+ * Creates the .planning/knowledge/ directory structure with schema-compliant
+ * JSON and Markdown files. Safe to call repeatedly — never overwrites.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { VERSION } = require('./constants.cjs');
+const { knowledgeDir, safeJsonWrite, ensureDir, isoNow } = require('./utils.cjs');
+
+function initKnowledge(cwd) {
+  const kd = knowledgeDir(cwd);
+  const now = isoNow();
+  const created = [];
+
+  const dirs = [
+    '', 'modules', 'decisions', 'bugs', 'patterns', 'testing',
+    'performance', 'observations', 'assumptions',
+  ];
+  for (const d of dirs) ensureDir(path.join(kd, d));
+
+  const jsonFiles = {
+    'INDEX.json': {
+      version: VERSION, last_mapped_commit: '0000000', last_updated: now,
+      stats: { total_files: 0, total_modules: 0, total_patterns: 0, total_exports: 0, total_dependencies: 0 },
+      modules: {}, files: {}, patterns: {},
+    },
+    'DEPENDENCIES.json': {
+      version: VERSION, last_updated: now,
+      forward: {}, reverse: {}, module_deps: {}, circular: [],
+    },
+    'decisions/REGISTRY.json': {
+      version: VERSION, last_updated: now,
+      stats: { total: 0, active: 0, superseded: 0, deprecated: 0 },
+      decisions: [],
+    },
+    'bugs/REGISTRY.json': {
+      version: VERSION, last_updated: now,
+      stats: { total: 0, open: 0, resolved: 0, critical_open: 0 },
+      bugs: [],
+    },
+    'bugs/HOT-SPOTS.json': {
+      version: VERSION, last_updated: now,
+      threshold: 2, spots: [],
+    },
+    'patterns/CATALOG.json': {
+      version: VERSION, last_updated: now,
+      stats: { total: 0, structural: 0, behavioral: 0, other: 0 },
+      patterns: [],
+    },
+    'testing/COVERAGE-MAP.json': {
+      version: VERSION, last_updated: now,
+      target_coverage: 80,
+      overall: { statements: 0, branches: 0, functions: 0, lines: 0 },
+      coverage: [],
+    },
+    'testing/MISSING-TESTS.json': {
+      version: VERSION, last_updated: now, gaps: [],
+    },
+    'performance/BASELINES.json': {
+      version: VERSION, last_updated: now, metrics: [],
+    },
+    'assumptions/REGISTRY.json': {
+      version: VERSION, last_updated: now,
+      stats: { total: 0, established: 0, working: 0, open: 0 },
+      assumptions: [],
+    },
+  };
+
+  for (const [rel, data] of Object.entries(jsonFiles)) {
+    const fp = path.join(kd, rel);
+    ensureDir(path.dirname(fp));
+    if (!fs.existsSync(fp)) {
+      safeJsonWrite(fp, data);
+      created.push(rel);
+    }
+  }
+
+  const mdFiles = {
+    'CONVENTIONS.md': `# Project Conventions\n\n> Auto-maintained by GSD Knowledge Engine | Last updated: ${now}\n\n## Coding Conventions\n\n_No conventions recorded yet._\n\n## Naming Conventions\n\n_No conventions recorded yet._\n\n## File Organization\n\n_No conventions recorded yet._\n\n## Testing Conventions\n\n_No conventions recorded yet._\n`,
+  };
+
+  for (const [rel, content] of Object.entries(mdFiles)) {
+    const fp = path.join(kd, rel);
+    ensureDir(path.dirname(fp));
+    if (!fs.existsSync(fp)) {
+      fs.writeFileSync(fp, content, 'utf-8');
+      created.push(rel);
+    }
+  }
+
+  return {
+    ok: true,
+    knowledge_dir: kd,
+    created,
+    message: created.length ? 'Knowledge layer initialized' : 'Already initialized',
+  };
+}
+
+module.exports = { initKnowledge };

--- a/get-shit-done/bin/lib/knowledge/loop-guard.cjs
+++ b/get-shit-done/bin/lib/knowledge/loop-guard.cjs
@@ -1,0 +1,84 @@
+/**
+ * Knowledge Layer — Loop guard
+ * Detects and prevents infinite tool-call loops in agent sessions.
+ * SHA-256 dedup + ping-pong pattern detection + global circuit breaker.
+ */
+'use strict';
+
+const crypto = require('crypto');
+
+const WARN_THRESHOLD = 3;
+const BLOCK_THRESHOLD = 5;
+const CIRCUIT_BREAK_TOTAL = 200;
+const HISTORY_SIZE = 30;
+const POLL_MULTIPLIER = 3;
+
+function hashCall(toolName, params) {
+  return crypto.createHash('sha256').update(toolName + JSON.stringify(params)).digest('hex');
+}
+
+function detectPingPong(history) {
+  const MIN_REPEATS = 3;
+  for (const patternLength of [2, 3]) {
+    const required = patternLength * MIN_REPEATS;
+    if (history.length < required) continue;
+    const tail = history.slice(-required);
+    const pattern = tail.slice(0, patternLength);
+    if (new Set(pattern).size < 2) continue;
+    let match = true;
+    for (let repeat = 1; repeat < MIN_REPEATS; repeat++) {
+      for (let i = 0; i < patternLength; i++) {
+        if (tail[repeat * patternLength + i] !== pattern[i]) { match = false; break; }
+      }
+      if (!match) break;
+    }
+    if (match) return { detected: true, patternLength };
+  }
+  return { detected: false, patternLength: 0 };
+}
+
+function createLoopGuard(opts) {
+  const pollTools = new Set((opts && opts.pollTools) ? opts.pollTools : []);
+  const circuitBreakTotal = (opts && typeof opts.circuitBreakTotal === 'number')
+    ? opts.circuitBreakTotal
+    : CIRCUIT_BREAK_TOTAL;
+  const counters = new Map();
+  let history = [];
+  let totalCalls = 0;
+
+  function check(toolName, params) {
+    totalCalls += 1;
+    if (totalCalls >= circuitBreakTotal) {
+      return { action: 'circuit_break', message: `Circuit breaker tripped: ${totalCalls} total calls.` };
+    }
+    const hash = hashCall(toolName, params);
+    const count = (counters.get(hash) || 0) + 1;
+    counters.set(hash, count);
+    history.push(hash);
+    if (history.length > HISTORY_SIZE) history.shift();
+
+    const pingPong = detectPingPong(history);
+    if (pingPong.detected) {
+      return { action: 'block', message: `Ping-pong loop detected: pattern length ${pingPong.patternLength}.` };
+    }
+
+    const multiplier = pollTools.has(toolName) ? POLL_MULTIPLIER : 1;
+    if (count >= BLOCK_THRESHOLD * multiplier) {
+      return { action: 'block', message: `"${toolName}" repeated ${count} times (limit ${BLOCK_THRESHOLD * multiplier}).` };
+    }
+    if (count >= WARN_THRESHOLD * multiplier) {
+      return { action: 'warn', message: `"${toolName}" repeated ${count} times (warn at ${WARN_THRESHOLD * multiplier}).` };
+    }
+    return { action: 'allow', message: null };
+  }
+
+  function getStats() { return { totalCalls, uniqueCalls: counters.size, history: [...history] }; }
+  function reset() { counters.clear(); history = []; totalCalls = 0; }
+
+  return { check, getStats, reset };
+}
+
+module.exports = {
+  WARN_THRESHOLD, BLOCK_THRESHOLD, CIRCUIT_BREAK_TOTAL,
+  hashCall, detectPingPong, createLoopGuard,
+};

--- a/get-shit-done/bin/lib/knowledge/safety.cjs
+++ b/get-shit-done/bin/lib/knowledge/safety.cjs
@@ -1,0 +1,115 @@
+/**
+ * Knowledge Layer — Safety rails
+ * Protected-file detection, improvement-type classification, circuit breakers,
+ * scope checking, and merge-readiness validation.
+ */
+'use strict';
+
+const fs = require('fs');
+const { spawnSync } = require('child_process');
+
+const SAFE_TYPES = new Set(['test-gap', 'stale-doc', 'pattern-violation']);
+const UNSAFE_TYPES = new Set(['feature', 'api-change', 'dependency-add', 'architecture']);
+const MAX_FILES_PER_IMPROVEMENT = 5;
+const BANNED_KEYWORDS = ['dependency', 'new package', 'api change', 'breaking change'];
+
+function git(args, cwd) {
+  const result = spawnSync('git', args, { cwd, stdio: 'pipe', encoding: 'utf-8', timeout: 30000 });
+  return { status: result.status, stdout: result.stdout || '', stderr: (result.stderr || '').trim() };
+}
+
+function getProtectedFiles(cwd) {
+  if (!cwd) return [];
+  const unstaged = git(['diff', '--name-only'], cwd);
+  const staged = git(['diff', '--name-only', '--staged'], cwd);
+  if (unstaged.status !== 0 && staged.status !== 0) return [];
+  const files = new Set();
+  const addLines = (output) => {
+    if (!output) return;
+    for (const line of output.split('\n')) { const t = line.trim(); if (t) files.add(t); }
+  };
+  if (unstaged.status === 0) addLines(unstaged.stdout);
+  if (staged.status === 0) addLines(staged.stdout);
+  return Array.from(files);
+}
+
+function isFileProtected(filePath, protectedFiles) {
+  if (!filePath || !protectedFiles || protectedFiles.length === 0) return false;
+  const normalise = (p) => p.replace(/\\/g, '/');
+  const normalised = normalise(filePath);
+  for (const pf of protectedFiles) {
+    const normPf = normalise(pf);
+    if (normalised === normPf) return true;
+    if (normalised.startsWith(normPf + '/')) return true;
+    if (normPf.startsWith(normalised + '/')) return true;
+  }
+  return false;
+}
+
+function isSafeImprovement(item) {
+  if (!item || !item.type) return { safe: false, reason: 'Missing improvement type' };
+  if (SAFE_TYPES.has(item.type)) return { safe: true, reason: 'Type "' + item.type + '" is safe' };
+  if (UNSAFE_TYPES.has(item.type)) return { safe: false, reason: 'Type "' + item.type + '" requires human review' };
+  return { safe: false, reason: 'Unknown type "' + item.type + '" defaults to unsafe' };
+}
+
+function createCircuitBreaker(maxConsecutiveFailures) {
+  const max = typeof maxConsecutiveFailures === 'number' ? maxConsecutiveFailures : 3;
+  let consecutiveFailures = 0, totalFailures = 0, totalSuccesses = 0;
+  return {
+    recordSuccess() { totalSuccesses++; consecutiveFailures = 0; },
+    recordFailure() { totalFailures++; consecutiveFailures++; },
+    isTripped() { return consecutiveFailures >= max; },
+    getState() { return { consecutiveFailures, tripped: consecutiveFailures >= max, totalFailures, totalSuccesses }; },
+    reset() { consecutiveFailures = 0; totalFailures = 0; totalSuccesses = 0; },
+  };
+}
+
+function scopeCheck(planContent) {
+  if (!planContent) return { valid: true, reason: 'Empty plan', fileCount: 0 };
+  const lower = planContent.toLowerCase();
+  for (const keyword of BANNED_KEYWORDS) {
+    if (lower.includes(keyword)) return { valid: false, reason: 'Banned keyword: "' + keyword + '"', fileCount: 0 };
+  }
+  const filePattern = /(?:Create|Modify|Edit|Test):\s*(\S+)/gi;
+  const files = new Set();
+  let match;
+  while ((match = filePattern.exec(planContent)) !== null) files.add(match[1]);
+  if (files.size > MAX_FILES_PER_IMPROVEMENT) {
+    return { valid: false, reason: 'Plan touches ' + files.size + ' files (max ' + MAX_FILES_PER_IMPROVEMENT + ')', fileCount: files.size };
+  }
+  return { valid: true, reason: 'Scope is acceptable', fileCount: files.size };
+}
+
+/**
+ * Validate merge readiness by running tests in a worktree.
+ * FIX(review #4): accepts an args array instead of a string to prevent
+ * command injection. The first element is the command, rest are arguments.
+ * Uses spawnSync with array args — no shell interpolation.
+ *
+ * @param {string} _cwd - Project root (unused, kept for API symmetry)
+ * @param {string} worktreePath - Path to the worktree to test
+ * @param {string[]} testArgs - Command as array, e.g. ['node', '--test', 'tests/']
+ * @returns {{ ready: boolean, reason: string, testOutput: string }}
+ */
+function validateMergeReadiness(_cwd, worktreePath, testArgs) {
+  if (!worktreePath) return { ready: false, reason: 'No worktree path', testOutput: '' };
+  try {
+    if (!fs.statSync(worktreePath).isDirectory()) return { ready: false, reason: 'Not a directory', testOutput: '' };
+  } catch { return { ready: false, reason: 'Worktree does not exist', testOutput: '' }; }
+  if (!testArgs || !Array.isArray(testArgs) || testArgs.length === 0) {
+    return { ready: false, reason: 'No test command (must be an array of args)', testOutput: '' };
+  }
+  const result = spawnSync(testArgs[0], testArgs.slice(1), {
+    cwd: worktreePath, stdio: 'pipe', encoding: 'utf-8', timeout: 120000,
+  });
+  const testOutput = ((result.stdout || '') + '\n' + (result.stderr || '')).trim();
+  if (result.status === 0) return { ready: true, reason: 'All tests passed', testOutput };
+  return { ready: false, reason: 'Tests failed (exit ' + result.status + ')', testOutput };
+}
+
+module.exports = {
+  SAFE_TYPES, UNSAFE_TYPES, MAX_FILES_PER_IMPROVEMENT,
+  getProtectedFiles, isFileProtected, isSafeImprovement,
+  createCircuitBreaker, scopeCheck, validateMergeReadiness,
+};

--- a/get-shit-done/bin/lib/knowledge/source-analysis.cjs
+++ b/get-shit-done/bin/lib/knowledge/source-analysis.cjs
@@ -1,0 +1,72 @@
+/**
+ * Knowledge Layer — Source code analysis
+ * Language detection, export/import extraction, module guessing.
+ */
+'use strict';
+
+const path = require('path');
+const { LANG_MAP, IGNORE_DIRS } = require('./constants.cjs');
+
+function getFileLanguage(filePath) {
+  return LANG_MAP[path.extname(filePath).toLowerCase()] || 'unknown';
+}
+
+function extractExports(content, lang) {
+  const exports = [];
+  if (['javascript', 'typescript'].includes(lang)) {
+    const pats = [
+      /export\s+(?:default\s+)?(?:function|class|const|let|var)\s+(\w+)/g,
+      /module\.exports\s*=\s*\{([^}]+)\}/g,
+      /exports\.(\w+)\s*=/g,
+    ];
+    for (const p of pats) {
+      let m;
+      while ((m = p.exec(content)) !== null) {
+        if (m[1] && m[1].includes(',')) {
+          m[1].split(',').map(s => s.trim()).filter(Boolean).forEach(e => exports.push(e));
+        } else if (m[1]) exports.push(m[1].trim());
+      }
+    }
+  } else if (lang === 'python') {
+    const pats = [/^def\s+(\w+)/gm, /^class\s+(\w+)/gm];
+    for (const p of pats) { let m; while ((m = p.exec(content)) !== null) exports.push(m[1]); }
+  } else if (lang === 'go') {
+    const p = /^func\s+(\p{Lu}\w*)/gmu;
+    let m;
+    while ((m = p.exec(content)) !== null) exports.push(m[1]);
+  } else if (lang === 'rust') {
+    const p = /^pub\s+(?:fn|struct|enum|trait|type|const)\s+(\w+)/gm;
+    let m;
+    while ((m = p.exec(content)) !== null) exports.push(m[1]);
+  }
+  return [...new Set(exports)];
+}
+
+function extractImports(content, lang) {
+  const imports = [];
+  if (['javascript', 'typescript'].includes(lang)) {
+    const pats = [
+      /(?:import|require)\s*\(?['"]([^'"]+)['"]\)?/g,
+      /from\s+['"]([^'"]+)['"]/g,
+    ];
+    for (const p of pats) { let m; while ((m = p.exec(content)) !== null) imports.push(m[1]); }
+  } else if (lang === 'python') {
+    const pats = [/^import\s+(\S+)/gm, /^from\s+(\S+)\s+import/gm];
+    for (const p of pats) { let m; while ((m = p.exec(content)) !== null) imports.push(m[1]); }
+  } else if (lang === 'go') {
+    const p = /^\s*"([^"]+)"/gm;
+    let m;
+    while ((m = p.exec(content)) !== null) imports.push(m[1]);
+  }
+  return [...new Set(imports)];
+}
+
+function guessModule(filePath, cwd) {
+  const rel = path.relative(cwd, filePath).replace(/\\/g, '/');
+  const parts = rel.split('/');
+  const filtered = parts.filter(p => !IGNORE_DIRS.has(p));
+  if (filtered.length <= 1) return 'root';
+  return filtered[0] + (filtered.length > 2 ? '/' + filtered[1] : '');
+}
+
+module.exports = { getFileLanguage, extractExports, extractImports, guessModule };

--- a/get-shit-done/bin/lib/knowledge/utils.cjs
+++ b/get-shit-done/bin/lib/knowledge/utils.cjs
@@ -1,0 +1,146 @@
+/**
+ * Knowledge Layer — Utility functions
+ * Self-contained utilities for the knowledge engine. No dependency on GSD core
+ * to keep the knowledge layer portable and independently testable.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+const { spawnSync } = require('child_process');
+
+// --- File I/O ----------------------------------------------------------------
+
+function safeRead(filePath) {
+  try { return fs.readFileSync(filePath, 'utf-8'); } catch { return null; }
+}
+
+function safeJsonRead(filePath, fallback) {
+  try { return JSON.parse(fs.readFileSync(filePath, 'utf-8')); }
+  catch { return fallback !== undefined ? fallback : null; }
+}
+
+function safeJsonWrite(filePath, data) {
+  ensureDir(path.dirname(filePath));
+  const tmpPath = filePath + '.tmp.' + process.pid;
+  try {
+    fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2) + '\n', 'utf-8');
+    fs.renameSync(tmpPath, filePath);
+  } catch (err) {
+    try { fs.unlinkSync(tmpPath); } catch { /* cleanup */ }
+    throw err;
+  }
+}
+
+function ensureDir(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+// --- Hashing -----------------------------------------------------------------
+
+function sha256(content) {
+  return crypto.createHash('sha256').update(content, 'utf-8').digest('hex');
+}
+
+// --- Date/Time ---------------------------------------------------------------
+
+function isoNow() { return new Date().toISOString(); }
+
+// --- Text Processing ---------------------------------------------------------
+
+const { STOP_WORDS } = require('./constants.cjs');
+
+function tokenEstimate(text) {
+  if (!text) return 0;
+  return Math.ceil(String(text).length / 4);
+}
+
+function removeStopWords(words) {
+  return words.filter(w => w.length > 2 && !STOP_WORDS.has(w.toLowerCase()));
+}
+
+// --- File Locking ------------------------------------------------------------
+// FIX(review #12): acquireLock uses exponential backoff with Atomics.wait.
+// When Atomics.wait is unavailable (e.g., main thread in some runtimes),
+// the fallback checks elapsed time before each retry to avoid tight spin.
+
+const LOCK_TIMEOUT_MS = 5000;
+const LOCK_RETRY_MS = 50;
+const STALE_LOCK_MS = 30000;
+
+function acquireLock(lockPath, timeout) {
+  const maxWait = typeof timeout === 'number' ? timeout : LOCK_TIMEOUT_MS;
+  const start = Date.now();
+  let delay = LOCK_RETRY_MS;
+  while (Date.now() - start < maxWait) {
+    try {
+      fs.writeFileSync(lockPath, String(process.pid), { flag: 'wx' });
+      return;
+    } catch {
+      try {
+        const stat = fs.statSync(lockPath);
+        if (Date.now() - stat.mtimeMs > STALE_LOCK_MS) {
+          fs.unlinkSync(lockPath);
+          continue;
+        }
+      } catch { continue; }
+      const remaining = maxWait - (Date.now() - start);
+      if (remaining <= 0) break;
+      const wait = Math.min(delay, remaining);
+      try { Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, wait); }
+      catch {
+        // Atomics.wait unavailable — burn elapsed time check only, no busy-spin.
+        // The while-loop condition (Date.now() - start < maxWait) prevents spinning
+        // because `delay` grows exponentially and we break when remaining <= 0.
+      }
+      delay = Math.min(delay * 2, 1000);
+    }
+  }
+  throw new Error('Could not acquire lock ' + lockPath + ' within ' + maxWait + 'ms');
+}
+
+function releaseLock(lockPath) {
+  try { fs.unlinkSync(lockPath); } catch { /* already released */ }
+}
+
+function withFileLock(filePath, fn) {
+  const lockPath = filePath + '.lock';
+  acquireLock(lockPath);
+  try { return fn(); } finally { releaseLock(lockPath); }
+}
+
+// --- Git Helpers -------------------------------------------------------------
+
+function execGitSafe(cwd, args) {
+  try {
+    const result = spawnSync('git', args, {
+      cwd, stdio: 'pipe', encoding: 'utf-8', timeout: 30000,
+    });
+    return {
+      exitCode: result.status === null ? 1 : result.status,
+      stdout: (result.stdout || '').trim(),
+      stderr: (result.stderr || '').trim(),
+    };
+  } catch (err) {
+    return { exitCode: 1, stdout: '', stderr: err.message || String(err) };
+  }
+}
+
+// --- Path Helpers ------------------------------------------------------------
+
+function knowledgeDir(cwd) { return path.join(cwd, '.planning', 'knowledge'); }
+function indexPath(cwd) { return path.join(knowledgeDir(cwd), 'INDEX.json'); }
+function depsPath(cwd) { return path.join(knowledgeDir(cwd), 'DEPENDENCIES.json'); }
+function decisionsPath(cwd) { return path.join(knowledgeDir(cwd), 'decisions', 'REGISTRY.json'); }
+function patternsPath(cwd) { return path.join(knowledgeDir(cwd), 'patterns', 'CATALOG.json'); }
+function conventionsPath(cwd) { return path.join(knowledgeDir(cwd), 'CONVENTIONS.md'); }
+function assumptionsPath(cwd) { return path.join(knowledgeDir(cwd), 'assumptions', 'REGISTRY.json'); }
+
+module.exports = {
+  safeRead, safeJsonRead, safeJsonWrite, ensureDir,
+  sha256, isoNow, tokenEstimate, removeStopWords,
+  withFileLock, execGitSafe,
+  knowledgeDir, indexPath, depsPath, decisionsPath,
+  patternsPath, conventionsPath, assumptionsPath,
+};

--- a/tests/knowledge.test.cjs
+++ b/tests/knowledge.test.cjs
@@ -1,0 +1,544 @@
+/**
+ * Tests for the Knowledge Layer integration
+ * Addresses all review feedback from PR #1465 including:
+ * - Ping-pong detection assertion (review #9)
+ * - Incremental non-fallback path (review #10)
+ * - Circular dependency detection (review #10)
+ * - getImpactedFiles (review #10)
+ * - assembleDiffAwareContext (review #10)
+ * - validateMergeReadiness (review #10)
+ * - walkDir truncation warning (review #10)
+ */
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const { createTempGitProject, createTempDir, cleanup, runGsdTools } = require('./helpers.cjs');
+
+const {
+  initKnowledge, buildIndex, updateIndexIncremental, getIndex,
+  listModules, assembleContext, assembleDiffAwareContext,
+  buildDependencyGraph, getImpactedFiles, findCircularDeps,
+  createLoopGuard,
+  getProtectedFiles, isFileProtected, isSafeImprovement,
+  createCircuitBreaker, scopeCheck, validateMergeReadiness,
+} = require('../get-shit-done/bin/lib/knowledge/index.cjs');
+
+const { walkDir } = require('../get-shit-done/bin/lib/knowledge/indexer.cjs');
+
+// --- Helpers -----------------------------------------------------------------
+
+function writeSourceFile(dir, relPath, content) {
+  const fp = path.join(dir, relPath);
+  fs.mkdirSync(path.dirname(fp), { recursive: true });
+  fs.writeFileSync(fp, content, 'utf-8');
+}
+
+function gitCommit(dir, msg) {
+  spawnSync('git', ['add', '-A'], { cwd: dir, stdio: 'pipe' });
+  spawnSync('git', ['commit', '-m', msg], { cwd: dir, stdio: 'pipe' });
+}
+
+// --- Init Tests --------------------------------------------------------------
+
+describe('Knowledge Layer: initKnowledge', () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = createTempGitProject('gsd-knowledge-init-'); });
+  afterEach(() => cleanup(tmpDir));
+
+  it('creates the knowledge directory structure', () => {
+    const result = initKnowledge(tmpDir);
+    assert.equal(result.ok, true);
+    assert.ok(result.created.length > 0);
+    assert.ok(fs.existsSync(path.join(tmpDir, '.planning', 'knowledge', 'INDEX.json')));
+    assert.ok(fs.existsSync(path.join(tmpDir, '.planning', 'knowledge', 'CONVENTIONS.md')));
+    assert.ok(fs.existsSync(path.join(tmpDir, '.planning', 'knowledge', 'decisions', 'REGISTRY.json')));
+    assert.ok(fs.existsSync(path.join(tmpDir, '.planning', 'knowledge', 'patterns', 'CATALOG.json')));
+  });
+
+  it('is idempotent — second call creates nothing', () => {
+    initKnowledge(tmpDir);
+    const result2 = initKnowledge(tmpDir);
+    assert.equal(result2.ok, true);
+    assert.equal(result2.created.length, 0);
+    assert.equal(result2.message, 'Already initialized');
+  });
+});
+
+// --- Indexer Tests ------------------------------------------------------------
+
+describe('Knowledge Layer: buildIndex', () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = createTempGitProject('gsd-knowledge-index-');
+    initKnowledge(tmpDir);
+  });
+  afterEach(() => cleanup(tmpDir));
+
+  it('indexes source files and creates INDEX.json', () => {
+    writeSourceFile(tmpDir, 'src/app.js', 'const express = require("express");\nmodule.exports = { app };');
+    writeSourceFile(tmpDir, 'src/utils.js', 'function helper() { return 1; }\nmodule.exports = { helper };');
+    gitCommit(tmpDir, 'add src');
+
+    const result = buildIndex(tmpDir);
+    assert.equal(result.ok, true);
+    assert.ok(result.indexed >= 2);
+    assert.ok(result.total_files >= 2);
+    assert.ok(result.total_modules >= 1);
+
+    const index = getIndex(tmpDir);
+    assert.ok(index);
+    assert.ok(index.files['src/app.js']);
+    assert.ok(index.files['src/utils.js']);
+  });
+
+  it('extracts exports from indexed files', () => {
+    writeSourceFile(tmpDir, 'lib/math.js', 'function add(a, b) { return a + b; }\nmodule.exports = { add };');
+    gitCommit(tmpDir, 'add lib');
+
+    buildIndex(tmpDir);
+    const index = getIndex(tmpDir);
+    const fileInfo = index.files['lib/math.js'];
+    assert.ok(fileInfo);
+    assert.ok(fileInfo.exports.includes('add'));
+  });
+
+  it('computes total_exports correctly in stats', () => {
+    writeSourceFile(tmpDir, 'lib/a.js', 'module.exports = { foo, bar };');
+    writeSourceFile(tmpDir, 'lib/b.js', 'module.exports = { baz };');
+    gitCommit(tmpDir, 'add exports');
+
+    buildIndex(tmpDir);
+    const index = getIndex(tmpDir);
+    assert.ok(index.stats.total_exports >= 3, `Expected >= 3 exports, got ${index.stats.total_exports}`);
+  });
+
+  it('returns truncated flag (false for small repos)', () => {
+    writeSourceFile(tmpDir, 'src/a.js', 'const x = 1;');
+    gitCommit(tmpDir, 'add file');
+
+    const result = buildIndex(tmpDir);
+    assert.equal(result.truncated, false);
+  });
+});
+
+// --- walkDir Tests -----------------------------------------------------------
+
+describe('Knowledge Layer: walkDir', () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = createTempDir('gsd-knowledge-walk-'); });
+  afterEach(() => cleanup(tmpDir));
+
+  it('returns truncated: false for small directories', () => {
+    writeSourceFile(tmpDir, 'a.js', 'const x = 1;');
+    writeSourceFile(tmpDir, 'b.js', 'const y = 2;');
+    const result = walkDir(tmpDir);
+    assert.equal(result.truncated, false);
+    assert.ok(result.files.length >= 2);
+  });
+
+  it('skips ignored directories', () => {
+    writeSourceFile(tmpDir, 'src/a.js', 'x');
+    writeSourceFile(tmpDir, 'node_modules/pkg/index.js', 'y');
+    const result = walkDir(tmpDir);
+    const paths = result.files.map(f => path.relative(tmpDir, f));
+    assert.ok(paths.some(p => p.includes('src')));
+    assert.ok(!paths.some(p => p.includes('node_modules')));
+  });
+
+  it('skips symlinks', () => {
+    writeSourceFile(tmpDir, 'real/a.js', 'x');
+    try {
+      fs.symlinkSync(path.join(tmpDir, 'real'), path.join(tmpDir, 'linked'), 'dir');
+    } catch { return; } // Skip if symlinks not supported
+    const result = walkDir(tmpDir);
+    const paths = result.files.map(f => path.relative(tmpDir, f));
+    assert.ok(!paths.some(p => p.startsWith('linked')));
+  });
+});
+
+// --- Incremental Index Tests -------------------------------------------------
+
+describe('Knowledge Layer: updateIndexIncremental', () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = createTempGitProject('gsd-knowledge-incr-');
+    initKnowledge(tmpDir);
+  });
+  afterEach(() => cleanup(tmpDir));
+
+  it('falls back to full build on first run', () => {
+    writeSourceFile(tmpDir, 'src/app.js', 'const x = 1;');
+    gitCommit(tmpDir, 'add src');
+
+    const result = updateIndexIncremental(tmpDir);
+    assert.equal(result.ok, true);
+    assert.equal(result.fallback, true);
+  });
+
+  it('incrementally updates after file changes', () => {
+    // Full build first
+    writeSourceFile(tmpDir, 'src/app.js', 'module.exports = { orig: 1 };');
+    gitCommit(tmpDir, 'add src');
+    buildIndex(tmpDir);
+
+    // Make a change and commit
+    writeSourceFile(tmpDir, 'src/new-file.js', 'module.exports = { added: true };');
+    gitCommit(tmpDir, 'add new file');
+
+    const result = updateIndexIncremental(tmpDir);
+    assert.equal(result.ok, true);
+    assert.equal(result.fallback, false);
+    assert.ok(result.indexed >= 1, 'Should have indexed at least the new file');
+
+    const index = getIndex(tmpDir);
+    assert.ok(index.files['src/new-file.js'], 'New file should be in the index');
+  });
+
+  it('computes total_exports correctly (not hardcoded 0)', () => {
+    writeSourceFile(tmpDir, 'lib/a.js', 'module.exports = { foo, bar };');
+    gitCommit(tmpDir, 'add lib');
+    buildIndex(tmpDir);
+
+    writeSourceFile(tmpDir, 'lib/b.js', 'module.exports = { baz };');
+    gitCommit(tmpDir, 'add b');
+
+    const result = updateIndexIncremental(tmpDir);
+    assert.equal(result.ok, true);
+    const index = getIndex(tmpDir);
+    assert.ok(index.stats.total_exports >= 3, `Expected >= 3 exports, got ${index.stats.total_exports}`);
+  });
+});
+
+// --- Context Assembly Tests --------------------------------------------------
+
+describe('Knowledge Layer: assembleContext', () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = createTempGitProject('gsd-knowledge-ctx-');
+    initKnowledge(tmpDir);
+    writeSourceFile(tmpDir, 'src/auth/login.js', 'function authenticate(user) { return true; }\nmodule.exports = { authenticate };');
+    writeSourceFile(tmpDir, 'src/api/routes.js', 'const express = require("express");\nfunction getRoutes() {}\nmodule.exports = { getRoutes };');
+    writeSourceFile(tmpDir, 'src/db/connection.js', 'function connect() {}\nmodule.exports = { connect };');
+    gitCommit(tmpDir, 'add src');
+    buildIndex(tmpDir);
+  });
+  afterEach(() => cleanup(tmpDir));
+
+  it('returns relevant modules for auth-related query', () => {
+    const ctx = assembleContext(tmpDir, 'fix the authentication login flow');
+    assert.ok(ctx.relevant_modules.length > 0);
+    const authModule = ctx.relevant_modules.find(m => m.module.includes('auth'));
+    assert.ok(authModule, 'Should find auth module');
+    assert.ok(authModule.score > 0);
+  });
+
+  it('respects token budget', () => {
+    const ctx = assembleContext(tmpDir, 'add database queries', { budget: 500 });
+    assert.ok(ctx.estimated_tokens <= 600);
+  });
+
+  it('returns empty for no-match query', () => {
+    const ctx = assembleContext(tmpDir, 'quantum entanglement physics');
+    assert.equal(ctx.relevant_modules.length, 0);
+  });
+});
+
+// --- Diff-Aware Context Tests ------------------------------------------------
+
+describe('Knowledge Layer: assembleDiffAwareContext', () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = createTempGitProject('gsd-knowledge-diff-');
+    initKnowledge(tmpDir);
+    writeSourceFile(tmpDir, 'src/auth/login.js', 'function authenticate(user) { return true; }\nmodule.exports = { authenticate };');
+    writeSourceFile(tmpDir, 'src/api/routes.js', 'function getRoutes() {}\nmodule.exports = { getRoutes };');
+    gitCommit(tmpDir, 'add src');
+    buildIndex(tmpDir);
+  });
+  afterEach(() => cleanup(tmpDir));
+
+  it('returns context with diff_context when files changed', () => {
+    writeSourceFile(tmpDir, 'src/auth/login.js', 'function authenticate(user) { return false; }\nmodule.exports = { authenticate };');
+    gitCommit(tmpDir, 'modify auth');
+
+    const ctx = assembleDiffAwareContext(tmpDir, 'fix authentication');
+    // Diff context should report the changed file
+    if (ctx.diff_context) {
+      assert.ok(Array.isArray(ctx.diff_context.changed_files));
+    }
+    assert.ok(ctx.relevant_modules.length > 0);
+  });
+
+  it('returns null diff_context when no changes since last index', () => {
+    const ctx = assembleDiffAwareContext(tmpDir, 'fix authentication');
+    // No changes since buildIndex, so diff_context should be null or have no files
+    assert.ok(ctx.relevant_modules !== undefined);
+  });
+
+  it('gist and micro modules are consistent with boosted ordering', () => {
+    // Add more modules so we get gist/micro tiers
+    writeSourceFile(tmpDir, 'src/cache/redis.js', 'function getCache() {}\nmodule.exports = { getCache };');
+    writeSourceFile(tmpDir, 'src/queue/worker.js', 'function processJob() {}\nmodule.exports = { processJob };');
+    writeSourceFile(tmpDir, 'src/monitor/health.js', 'function checkHealth() {}\nmodule.exports = { checkHealth };');
+    gitCommit(tmpDir, 'add more modules');
+    buildIndex(tmpDir);
+
+    // Now change auth file so it gets boosted
+    writeSourceFile(tmpDir, 'src/auth/login.js', 'function authenticate(u) { return u != null; }\nmodule.exports = { authenticate };');
+    gitCommit(tmpDir, 'modify auth');
+
+    const ctx = assembleDiffAwareContext(tmpDir, 'fix authentication');
+    // All modules in relevant_modules should have scores >= gist scores >= micro scores
+    if (ctx.relevant_modules.length > 0 && ctx.gist_modules && ctx.gist_modules.length > 0) {
+      const minRelevantScore = Math.min(...ctx.relevant_modules.map(m => m.score));
+      const maxGistScore = Math.max(...ctx.gist_modules.map(m => m.score));
+      assert.ok(minRelevantScore >= maxGistScore,
+        `Top modules (min ${minRelevantScore}) should score >= gist modules (max ${maxGistScore})`);
+    }
+  });
+});
+
+// --- Dependency Graph Tests --------------------------------------------------
+
+describe('Knowledge Layer: buildDependencyGraph', () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = createTempGitProject('gsd-knowledge-deps-');
+    initKnowledge(tmpDir);
+  });
+  afterEach(() => cleanup(tmpDir));
+
+  it('builds forward and reverse dependency maps', () => {
+    writeSourceFile(tmpDir, 'src/a.js', 'const b = require("./b");\nmodule.exports = { a: 1 };');
+    writeSourceFile(tmpDir, 'src/b.js', 'const c = require("./c");\nmodule.exports = { b: 2 };');
+    writeSourceFile(tmpDir, 'src/c.js', 'module.exports = { c: 3 };');
+    gitCommit(tmpDir, 'add files');
+    buildIndex(tmpDir);
+
+    const result = buildDependencyGraph(tmpDir);
+    assert.equal(result.ok, true);
+    assert.ok(result.total_edges >= 2);
+  });
+
+  it('returns impact analysis for a file', () => {
+    writeSourceFile(tmpDir, 'src/a.js', 'const b = require("./b");\nmodule.exports = { a: 1 };');
+    writeSourceFile(tmpDir, 'src/b.js', 'module.exports = { b: 2 };');
+    gitCommit(tmpDir, 'add files');
+    buildIndex(tmpDir);
+    buildDependencyGraph(tmpDir);
+
+    const impact = getImpactedFiles(tmpDir, 'src/b.js');
+    assert.equal(impact.ok, true);
+    assert.ok(impact.impacted_files.includes('src/a.js'), 'a.js depends on b.js');
+  });
+});
+
+// --- Circular Dependency Detection (Tarjan's SCC) ----------------------------
+
+describe('Knowledge Layer: findCircularDeps', () => {
+  it('detects direct A<->B cycles', () => {
+    const deps = { A: ['B'], B: ['A'] };
+    const circular = findCircularDeps(deps);
+    assert.equal(circular.length, 1);
+    assert.ok(circular[0].includes('A'));
+    assert.ok(circular[0].includes('B'));
+  });
+
+  it('detects transitive A->B->C->A cycles', () => {
+    const deps = { A: ['B'], B: ['C'], C: ['A'] };
+    const circular = findCircularDeps(deps);
+    assert.equal(circular.length, 1);
+    assert.ok(circular[0].includes('A'));
+    assert.ok(circular[0].includes('B'));
+    assert.ok(circular[0].includes('C'));
+  });
+
+  it('returns empty for acyclic graphs', () => {
+    const deps = { A: ['B'], B: ['C'], C: [] };
+    const circular = findCircularDeps(deps);
+    assert.equal(circular.length, 0);
+  });
+
+  it('detects multiple independent cycles', () => {
+    const deps = { A: ['B'], B: ['A'], C: ['D'], D: ['C'], E: [] };
+    const circular = findCircularDeps(deps);
+    assert.equal(circular.length, 2);
+  });
+});
+
+// --- Loop Guard Tests --------------------------------------------------------
+
+describe('Knowledge Layer: createLoopGuard', () => {
+  it('allows first few calls', () => {
+    const guard = createLoopGuard();
+    const r = guard.check('Read', { path: '/foo.js' });
+    assert.equal(r.action, 'allow');
+  });
+
+  it('warns on repeated identical calls', () => {
+    const guard = createLoopGuard();
+    guard.check('Read', { path: '/foo.js' });
+    guard.check('Read', { path: '/foo.js' });
+    const r = guard.check('Read', { path: '/foo.js' });
+    assert.equal(r.action, 'warn');
+  });
+
+  it('blocks after threshold', () => {
+    const guard = createLoopGuard();
+    for (let i = 0; i < 4; i++) guard.check('Read', { path: '/foo.js' });
+    const r = guard.check('Read', { path: '/foo.js' });
+    assert.equal(r.action, 'block');
+  });
+
+  it('detects ping-pong patterns and returns block action', () => {
+    const guard = createLoopGuard();
+    let lastResult;
+    // Need 3 full repetitions of the 2-element pattern = 6 alternations
+    for (let i = 0; i < 3; i++) {
+      lastResult = guard.check('Read', { path: '/a.js' });
+      if (lastResult.action === 'block') break;
+      lastResult = guard.check('Edit', { path: '/a.js' });
+      if (lastResult.action === 'block') break;
+    }
+    // The ping-pong or repeated-call detection should have triggered a block
+    assert.equal(lastResult.action, 'block', 'Should detect ping-pong or repeated pattern');
+    assert.ok(lastResult.message.length > 0);
+  });
+
+  it('circuit breaks on total calls', () => {
+    const guard = createLoopGuard({ circuitBreakTotal: 30 });
+    let result;
+    for (let i = 0; i < 30; i++) {
+      result = guard.check('tool' + i, { i });
+    }
+    assert.equal(result.action, 'circuit_break');
+  });
+
+  it('respects poll tool multiplier', () => {
+    const guard = createLoopGuard({ pollTools: ['BashOutput'] });
+    // BashOutput gets 3x threshold, so 14 calls should still be warn, not block
+    for (let i = 0; i < 8; i++) guard.check('BashOutput', { id: 'same' });
+    const r = guard.check('BashOutput', { id: 'same' });
+    assert.equal(r.action, 'warn');
+  });
+});
+
+// --- Safety Tests ------------------------------------------------------------
+
+describe('Knowledge Layer: safety', () => {
+  it('classifies safe improvement types', () => {
+    assert.ok(isSafeImprovement({ type: 'test-gap' }).safe);
+    assert.ok(isSafeImprovement({ type: 'stale-doc' }).safe);
+    assert.ok(!isSafeImprovement({ type: 'feature' }).safe);
+    assert.ok(!isSafeImprovement({ type: 'api-change' }).safe);
+    assert.ok(!isSafeImprovement({ type: 'unknown-thing' }).safe);
+  });
+
+  it('checks file protection', () => {
+    assert.ok(isFileProtected('src/app.js', ['src/app.js']));
+    assert.ok(isFileProtected('src/auth/login.js', ['src/auth']));
+    assert.ok(!isFileProtected('src/other.js', ['src/app.js']));
+  });
+
+  it('validates scope', () => {
+    assert.ok(scopeCheck('Create: src/a.js\nModify: src/b.js').valid);
+    assert.ok(!scopeCheck('Create: a.js\nCreate: b.js\nCreate: c.js\nCreate: d.js\nCreate: e.js\nCreate: f.js').valid);
+    assert.ok(!scopeCheck('This is a breaking change to the API').valid);
+  });
+
+  it('circuit breaker trips after consecutive failures', () => {
+    const cb = createCircuitBreaker(3);
+    assert.ok(!cb.isTripped());
+    cb.recordFailure();
+    cb.recordFailure();
+    assert.ok(!cb.isTripped());
+    cb.recordFailure();
+    assert.ok(cb.isTripped());
+  });
+
+  it('circuit breaker resets on success', () => {
+    const cb = createCircuitBreaker(3);
+    cb.recordFailure();
+    cb.recordFailure();
+    cb.recordSuccess();
+    assert.ok(!cb.isTripped());
+    assert.equal(cb.getState().consecutiveFailures, 0);
+  });
+});
+
+// --- validateMergeReadiness Tests --------------------------------------------
+
+describe('Knowledge Layer: validateMergeReadiness', () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = createTempDir('gsd-knowledge-merge-'); });
+  afterEach(() => cleanup(tmpDir));
+
+  it('rejects when no worktree path', () => {
+    const r = validateMergeReadiness(tmpDir, null, ['echo', 'ok']);
+    assert.equal(r.ready, false);
+    assert.ok(r.reason.includes('No worktree'));
+  });
+
+  it('rejects when worktree does not exist', () => {
+    const r = validateMergeReadiness(tmpDir, '/nonexistent/path', ['echo', 'ok']);
+    assert.equal(r.ready, false);
+    assert.ok(r.reason.includes('does not exist'));
+  });
+
+  it('rejects when testArgs is not an array', () => {
+    const r = validateMergeReadiness(tmpDir, tmpDir, 'echo ok');
+    assert.equal(r.ready, false);
+    assert.ok(r.reason.includes('array'));
+  });
+
+  it('passes when test command succeeds', () => {
+    const r = validateMergeReadiness(tmpDir, tmpDir, ['node', '-e', 'process.exit(0)']);
+    assert.equal(r.ready, true);
+    assert.ok(r.reason.includes('passed'));
+  });
+
+  it('fails when test command fails', () => {
+    const r = validateMergeReadiness(tmpDir, tmpDir, ['node', '-e', 'process.exit(1)']);
+    assert.equal(r.ready, false);
+    assert.ok(r.reason.includes('Tests failed'));
+  });
+});
+
+// --- CLI Integration Test ----------------------------------------------------
+
+describe('Knowledge Layer: CLI integration', () => {
+  let tmpDir;
+  beforeEach(() => {
+    tmpDir = createTempGitProject('gsd-knowledge-cli-');
+  });
+  afterEach(() => cleanup(tmpDir));
+
+  it('knowledge init works via CLI', () => {
+    const result = runGsdTools(['knowledge', 'init', '--raw'], tmpDir);
+    assert.equal(result.success, true);
+    const json = JSON.parse(result.output);
+    assert.equal(json.ok, true);
+    assert.ok(fs.existsSync(path.join(tmpDir, '.planning', 'knowledge', 'INDEX.json')));
+  });
+
+  it('knowledge index works via CLI', () => {
+    runGsdTools(['knowledge', 'init', '--raw'], tmpDir);
+    writeSourceFile(tmpDir, 'src/app.js', 'module.exports = { x: 1 };');
+    gitCommit(tmpDir, 'add src');
+
+    const result = runGsdTools(['knowledge', 'index', '--raw'], tmpDir);
+    assert.equal(result.success, true);
+    const json = JSON.parse(result.output);
+    assert.equal(json.ok, true);
+    assert.ok(json.total_files >= 1);
+  });
+
+  it('unknown knowledge subcommand fails gracefully', () => {
+    const result = runGsdTools(['knowledge', 'nonexistent', '--raw'], tmpDir);
+    assert.equal(result.success, false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1782. Rewrite of #1465 with all review feedback addressed.

- **Codebase indexer** with SHA-256 hashing, incremental updates via git-diff, multi-language export/import extraction (JS/TS/Python/Go/Rust)
- **Smart context assembly** with Porter stemming, synonym expansion, confidence scoring, tiered module selection, and hard token budgets per agent type
- **Dependency graph** with forward/reverse import maps, path alias resolution, full-cycle circular detection via Tarjan's SCC, and reverse-impact analysis
- **Loop guard** with SHA-256 dedup, A-B ping-pong pattern detection, and configurable circuit breaker (default 200)
- **Safety rails** with protected-file detection, improvement-type classification, scope checking, and circuit breakers
- **CLI integration** via `gsd-tools.cjs knowledge {init,index,deps,context,modules,impact,staleness}` (lazy require)
- **Slash command** `/gsd:knowledge` with full documentation

### Review fixes from #1465

| # | Issue | Fix |
|---|-------|-----|
| 1 | Command injection in `validateMergeReadiness` | Accepts `string[]` args array, not string splitting |
| 2 | Unconditional top-level `require` breaks all commands | Lazy require inside `case 'knowledge':` block |
| 3 | `updateIndexIncremental` hardcodes `total_exports: 0` | Computes from module data like `buildIndex` does |
| 4 | Circular detection depth-1 only | Tarjan's SCC algorithm for full-cycle detection |
| 5 | Diff-boost inconsistency across arrays | Re-derives gist/micro tiers from post-boost scores |
| 6 | Ping-pong test doesn't assert detection | Asserts `action === 'block'` |
| 7 | `acquireLock` tight spin fallback | Exponential backoff with elapsed-time guard |
| 8 | `walkDir` silent truncation | Returns `{ files, truncated }` object |
| 9 | Dead `bugsPath` export | Removed from `utils.cjs` |

### Issues addressed

- **#108** — Monorepo awareness via module detection and package workspace scanning
- **#81, #859, #776** — Agent stuck in loops → loop-guard with ping-pong detection
- **#657** — STATE.md corruption → atomic JSON writes with file locking
- **#443** — Foundation for continuous/autonomous improvement loop

## Test plan

- [x] 43 new tests covering all modules (init, indexer, context, deps, diff-aware context, loop guard, safety, validateMergeReadiness, walkDir, circular deps, CLI integration)
- [x] All existing GSD tests still pass (2250/2250)
- [x] Uses centralized test helpers from `tests/helpers.cjs`
- [x] Tests use `node:test` + `node:assert/strict` per CONTRIBUTING.md


🤖 Generated with [Claude Code](https://claude.com/claude-code)