### PR TITLE
feat(references): add few-shot calibration for plan-checker and verifier

### DIFF
--- a/agents/gsd-plan-checker.md
+++ b/agents/gsd-plan-checker.md
@@ -26,6 +26,10 @@ If the prompt contains a `<files_to_read>` block, you MUST use the `Read` tool t
 You are NOT the executor or verifier — you verify plans WILL work before execution burns context.
 </role>
 
+<required_reading>
+@~/.claude/get-shit-done/references/few-shot-examples/plan-checker.md
+</required_reading>
+
 <project_context>
 Before verifying, discover project context:
 

--- a/agents/gsd-verifier.md
+++ b/agents/gsd-verifier.md
@@ -22,6 +22,10 @@ If the prompt contains a `<files_to_read>` block, you MUST use the `Read` tool t
 **Critical mindset:** Do NOT trust SUMMARY.md claims. SUMMARYs document what Claude SAID it did. You verify what ACTUALLY exists in the code. These often differ.
 </role>
 
+<required_reading>
+@~/.claude/get-shit-done/references/few-shot-examples/verifier.md
+</required_reading>
+
 <project_context>
 Before verifying, discover project context:
 

--- a/get-shit-done/references/few-shot-examples/plan-checker.md
+++ b/get-shit-done/references/few-shot-examples/plan-checker.md
@@ -1,0 +1,107 @@
+# Few-Shot Calibration: Plan Checker
+
+Format version: 1.0
+
+Annotated examples calibrating plan-checker output quality. Each example shows an input scenario, the expected response, and why that response is correct.
+
+---
+
+## Example 1: Approve — Well-Structured Plan
+
+**Scenario:** Phase 3 (API Layer) plan with clear task decomposition, correct dependency ordering, testable success criteria, and realistic scope.
+
+**Input summary:**
+- 4 tasks across 2 waves
+- Each task has files_modified, success_criteria, and estimated_complexity
+- Dependencies correctly ordered (models before routes before middleware)
+- Success criteria are verifiable (specific endpoints, status codes, response shapes)
+
+**Expected response:**
+```
+## Plan Check: Phase 3 — API Layer
+
+**Verdict: APPROVED**
+
+The plan is well-structured with correct dependency ordering and verifiable success criteria.
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Task decomposition | ✅ | 4 tasks, appropriate granularity |
+| Dependency ordering | ✅ | Models → Routes → Middleware → Tests |
+| Success criteria | ✅ | Specific endpoints and status codes |
+| Scope alignment | ✅ | Matches REQUIREMENTS.md phase goals |
+| Risk identification | ✅ | Auth middleware complexity noted |
+```
+
+**Why this is correct:** All checks pass. The plan has no gaps between requirements and tasks, dependencies flow correctly, and criteria are testable (not vague like "API works").
+
+---
+
+## Example 2: Flag Gap — Missing Error Handling
+
+**Scenario:** Phase 5 (Payment Integration) plan that covers the happy path but omits error handling, retry logic, and webhook validation.
+
+**Input summary:**
+- 3 tasks: Stripe setup, payment flow, subscription management
+- No task for error handling or webhook signature verification
+- Success criteria mention "payment works" but not failure modes
+- REQUIREMENTS.md explicitly lists "graceful degradation on payment failure"
+
+**Expected response:**
+```
+## Plan Check: Phase 5 — Payment Integration
+
+**Verdict: REVISION REQUESTED**
+
+Critical gap: payment error handling and webhook security are absent despite being in REQUIREMENTS.md.
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Task decomposition | ⚠️ | Missing error handling task |
+| Dependency ordering | ✅ | Correct |
+| Success criteria | ❌ | "Payment works" is not verifiable — needs specific status codes and failure modes |
+| Scope alignment | ❌ | REQUIREMENTS.md REQ-5.3 (graceful degradation) has no covering task |
+| Risk identification | ❌ | No mention of webhook signature verification |
+
+### Issues (blocking)
+
+- **GAP-01:** No task covers error handling. REQ-5.3 requires graceful degradation on payment failure — add a task for retry logic, user-facing error messages, and partial-failure recovery.
+- **GAP-02:** Webhook endpoint has no signature verification. This is a security requirement — add to an existing task or create a new one.
+- **GAP-03:** Success criteria "payment works" is too vague. Replace with specific criteria: "POST /payments returns 201 on success, 402 on declined, 500 on gateway timeout."
+```
+
+**Why this is correct:** The plan has functional gaps traceable to specific requirements. The checker identifies the exact requirement IDs, suggests concrete fixes, and uses blocking severity because these are security and reliability issues (not stylistic).
+
+---
+
+## Example 3: Approve with Info — Minor Suggestion
+
+**Scenario:** Phase 2 (Database) plan that is complete but could benefit from an index on a frequently-queried column.
+
+**Input summary:**
+- 5 tasks covering schema, migrations, seed data, queries, tests
+- All requirements covered
+- No index on `users.email` despite login-by-email being a core flow
+
+**Expected response:**
+```
+## Plan Check: Phase 2 — Database Layer
+
+**Verdict: APPROVED**
+
+Plan covers all requirements. One optimization suggestion (non-blocking).
+
+| Check | Status | Notes |
+|-------|--------|-------|
+| Task decomposition | ✅ | 5 tasks, appropriate scope |
+| Dependency ordering | ✅ | Schema → Migrations → Seeds → Queries → Tests |
+| Success criteria | ✅ | Specific query patterns and expected results |
+| Scope alignment | ✅ | All REQ-2.x items covered |
+| Risk identification | ✅ | Migration rollback strategy documented |
+
+### Issues (info)
+
+- **INFO-01:** Consider adding an index on `users.email` — login-by-email is a core flow and will be queried on every auth request. Not blocking because the schema can be amended later without migration risk.
+```
+
+**Why this is correct:** The issue is a performance optimization, not a functional gap. INFO severity is correct because the plan is complete without it. The checker approves the plan (INFO issues don't block) while still surfacing the suggestion.

--- a/get-shit-done/references/few-shot-examples/verifier.md
+++ b/get-shit-done/references/few-shot-examples/verifier.md
@@ -1,0 +1,104 @@
+# Few-Shot Calibration: Verifier
+
+Format version: 1.0
+
+Annotated examples calibrating verifier output quality. Each example shows an input scenario, the expected response, and why that response is correct.
+
+---
+
+## Example 1: All Pass — Clean Verification
+
+**Scenario:** Phase 3 (API Layer) completed. All endpoints exist, tests pass, error handling present.
+
+**Input summary:**
+- PLAN.md lists 4 tasks, all have SUMMARY.md entries marked complete
+- Codebase has the expected files (routes/, models/, middleware/, tests/)
+- `npm test` passes with the expected test count
+- API endpoints respond with correct status codes
+
+**Expected response:**
+```
+## Verification: Phase 3 — API Layer
+
+**Result: ALL CRITERIA PASSED**
+
+| # | Criterion | Status | Evidence |
+|---|-----------|--------|----------|
+| 1 | REST endpoints return JSON responses | PASSED | curl /api/users returns 200 with Content-Type: application/json |
+| 2 | Authentication middleware validates JWT | PASSED | middleware/auth.js exists, tests/auth.test.js has 12 passing assertions |
+| 3 | Error responses use consistent format | PASSED | ErrorHandler class in middleware/errors.js, all routes use it |
+| 4 | Database queries use parameterized statements | PASSED | grep confirms no string concatenation in SQL, all use query params |
+```
+
+**Why this is correct:** Each criterion has specific evidence from the actual codebase — file paths, test counts, command output. The verifier checked what EXISTS, not what SUMMARY.md claimed. Evidence is concrete and reproducible.
+
+---
+
+## Example 2: Missing Artifact — Incomplete Phase
+
+**Scenario:** Phase 4 (Frontend) SUMMARY.md claims completion but the test file is empty and one component is missing.
+
+**Input summary:**
+- SUMMARY.md says "all components implemented, tests passing"
+- `src/components/Dashboard.tsx` referenced in plan but doesn't exist
+- `tests/frontend.test.ts` exists but contains only boilerplate (0 actual test assertions)
+- Other components exist and look correct
+
+**Expected response:**
+```
+## Verification: Phase 4 — Frontend
+
+**Result: 2 CRITERIA FAILED**
+
+| # | Criterion | Status | Evidence |
+|---|-----------|--------|----------|
+| 1 | Dashboard component renders user data | FAILED | src/components/Dashboard.tsx does not exist (referenced in PLAN.md task 2) |
+| 2 | Navigation between views works | PASSED | Router.tsx has correct route definitions, Link components verified |
+| 3 | Frontend tests cover critical paths | FAILED | tests/frontend.test.ts has 0 assertions — file is boilerplate only |
+| 4 | Responsive layout on mobile breakpoints | PASSED | Tailwind breakpoints confirmed in all component files |
+
+### Failed Criteria Detail
+
+**Criterion 1 — Dashboard component:**
+SUMMARY.md claims "Dashboard component with user data display." However, `src/components/Dashboard.tsx` does not exist on disk. The import in `App.tsx` line 12 will cause a build error.
+
+**Criterion 3 — Frontend tests:**
+SUMMARY.md claims "tests passing." The file `tests/frontend.test.ts` exists but contains only a `describe()` block with no `test()` or `it()` calls. This is a stub, not a test suite.
+```
+
+**Why this is correct:** The verifier caught the discrepancy between SUMMARY.md claims and actual codebase state. It checked for file existence (not just SUMMARY claims), verified test content (not just file presence), and provided actionable evidence (specific file paths, line numbers).
+
+---
+
+## Example 3: Wrong Export — Subtle Mismatch
+
+**Scenario:** Phase 6 (SDK) appears complete but the public API exports don't match the documented interface.
+
+**Input summary:**
+- PLAN.md says "export Client, Config, and Response types from index.ts"
+- `src/index.ts` exports `Client` and `Config` but not `Response` (it exports `APIResponse` instead)
+- All tests pass (they import `APIResponse` directly, not through the public API)
+- README shows `import { Client, Config, Response } from 'sdk'`
+
+**Expected response:**
+```
+## Verification: Phase 6 — SDK
+
+**Result: 1 CRITERION FAILED**
+
+| # | Criterion | Status | Evidence |
+|---|-----------|--------|----------|
+| 1 | Client class exported from index.ts | PASSED | `export { Client }` on line 3 |
+| 2 | Config type exported from index.ts | PASSED | `export { Config }` on line 4 |
+| 3 | Response type exported from index.ts | FAILED | index.ts exports `APIResponse`, not `Response` — naming mismatch |
+| 4 | SDK tests cover public API surface | PASSED | 18 tests, all pass |
+
+### Failed Criteria Detail
+
+**Criterion 3 — Response type export:**
+The plan and README document `Response` as the public type name, but `src/index.ts` line 5 exports `APIResponse`. Tests pass because they import directly from `src/types.ts`, bypassing the public API. A consumer using `import { Response } from 'sdk'` will get `undefined`.
+
+This is a naming mismatch, not missing functionality. Fix: either rename the export to `Response` or update the plan/README to document `APIResponse`.
+```
+
+**Why this is correct:** The verifier caught a subtle mismatch that tests missed (because tests bypass the public API). The evidence is precise — specific line numbers, specific export names, and the explanation of why tests didn't catch it. This is exactly the kind of issue goal-backward verification is designed to find.

--- a/tests/few-shot-calibration.test.cjs
+++ b/tests/few-shot-calibration.test.cjs
@@ -1,0 +1,100 @@
+/**
+ * Few-Shot Calibration Examples Tests
+ *
+ * Validates that few-shot calibration example files exist and are properly
+ * structured for the plan-checker and verifier agents.
+ */
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const EXAMPLES_DIR = path.join(__dirname, '..', 'get-shit-done', 'references', 'few-shot-examples');
+const AGENTS_DIR = path.join(__dirname, '..', 'agents');
+
+// ─── Plan-Checker Examples ──────────────────────────────────────────────────
+
+describe('few-shot: plan-checker examples', () => {
+  const filePath = path.join(EXAMPLES_DIR, 'plan-checker.md');
+
+  test('plan-checker.md exists', () => {
+    assert.ok(fs.existsSync(filePath), 'plan-checker.md should exist');
+  });
+
+  test('has format version at top', () => {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    assert.ok(
+      content.includes('Format version: 1.0'),
+      'plan-checker.md should declare format version 1.0'
+    );
+  });
+
+  test('has exactly 3 examples', () => {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const exampleHeadings = content.match(/^## Example \d+:/gm);
+    assert.ok(exampleHeadings, 'should have example headings');
+    assert.equal(exampleHeadings.length, 3, 'should have exactly 3 examples');
+  });
+
+  test('each example has "Why this is correct" annotation', () => {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const annotations = content.match(/\*\*Why this is correct:\*\*/g);
+    assert.ok(annotations, 'should have "Why this is correct" annotations');
+    assert.equal(annotations.length, 3, 'each of the 3 examples should have an annotation');
+  });
+});
+
+// ─── Verifier Examples ──────────────────────────────────────────────────────
+
+describe('few-shot: verifier examples', () => {
+  const filePath = path.join(EXAMPLES_DIR, 'verifier.md');
+
+  test('verifier.md exists', () => {
+    assert.ok(fs.existsSync(filePath), 'verifier.md should exist');
+  });
+
+  test('has format version at top', () => {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    assert.ok(
+      content.includes('Format version: 1.0'),
+      'verifier.md should declare format version 1.0'
+    );
+  });
+
+  test('has exactly 3 examples', () => {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const exampleHeadings = content.match(/^## Example \d+:/gm);
+    assert.ok(exampleHeadings, 'should have example headings');
+    assert.equal(exampleHeadings.length, 3, 'should have exactly 3 examples');
+  });
+
+  test('each example has "Why this is correct" annotation', () => {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const annotations = content.match(/\*\*Why this is correct:\*\*/g);
+    assert.ok(annotations, 'should have "Why this is correct" annotations');
+    assert.equal(annotations.length, 3, 'each of the 3 examples should have an annotation');
+  });
+});
+
+// ─── Agent References ───────────────────────────────────────────────────────
+
+describe('few-shot: agent references', () => {
+  test('gsd-plan-checker.md references plan-checker examples', () => {
+    const agentPath = path.join(AGENTS_DIR, 'gsd-plan-checker.md');
+    const content = fs.readFileSync(agentPath, 'utf-8');
+    assert.ok(
+      content.includes('few-shot-examples/plan-checker.md'),
+      'gsd-plan-checker.md should reference the plan-checker few-shot examples'
+    );
+  });
+
+  test('gsd-verifier.md references verifier examples', () => {
+    const agentPath = path.join(AGENTS_DIR, 'gsd-verifier.md');
+    const content = fs.readFileSync(agentPath, 'utf-8');
+    assert.ok(
+      content.includes('few-shot-examples/verifier.md'),
+      'gsd-verifier.md should reference the verifier few-shot examples'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add 3 annotated few-shot examples for the **plan-checker** agent (approve / flag-gap / approve-with-info) and 3 for the **verifier** agent (all-pass / missing-artifact / wrong-export)
- Each example includes input scenario, expected response, and a **"Why this is correct"** annotation explaining the reasoning behind the verdict
- Wire both agents to their examples via `<required_reading>` blocks inserted between `</role>` and `<project_context>`
- Add test coverage verifying file existence, example count, annotation presence, format versioning, and agent cross-references

## Motivation

Few-shot examples improve agent output quality more reliably than pure instruction because they demonstrate calibrated judgment rather than just describing it. The annotations teach the agent *why* a particular response is correct, helping it generalize to novel inputs rather than pattern-matching templates.

The three examples per agent were chosen to cover the decision boundary:

**Plan-checker:** approve (clean pass), flag-gap (blocking issues traceable to requirements), approve-with-info (non-blocking suggestion that doesn't hold up the plan)

**Verifier:** all-pass (concrete codebase evidence), missing-artifact (SUMMARY claims vs reality), wrong-export (subtle mismatch that tests miss because they bypass the public API)

## Format versioning

Both files include `Format version: 1.0` at the top, making it possible to evolve the example structure in the future without breaking existing references.

## Files changed

| File | Change |
|------|--------|
| `get-shit-done/references/few-shot-examples/plan-checker.md` | New: 3 annotated examples |
| `get-shit-done/references/few-shot-examples/verifier.md` | New: 3 annotated examples |
| `agents/gsd-plan-checker.md` | Add `<required_reading>` block |
| `agents/gsd-verifier.md` | Add `<required_reading>` block |
| `tests/few-shot-calibration.test.cjs` | New: 10 test assertions |

## Test plan

- [x] `npm test` passes (2217 tests, 0 failures)
- [ ] Verify plan-checker agent loads examples via `<required_reading>` at runtime
- [ ] Verify verifier agent loads examples via `<required_reading>` at runtime
- [ ] Spot-check that agent output quality improves on ambiguous plan/verification scenarios

Closes #1723

🤖 Generated with [Claude Code](https://claude.com/claude-code)