### PR TITLE
fix(workflows): respect commit_docs:false in worktree merge and quick task commits

### DIFF
--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -526,8 +526,12 @@ Execute each selected wave in sequence. Within a wave: parallel if `PARALLELIZAT
        # Amend merge commit with restored files if any changed
        if ! git diff --quiet .planning/STATE.md .planning/ROADMAP.md 2>/dev/null || \
           [ -n "$DELETED_FILES" ]; then
-         git add .planning/STATE.md .planning/ROADMAP.md 2>/dev/null || true
-         git commit --amend --no-edit 2>/dev/null || true
+         # Only amend the commit with .planning/ files if commit_docs is enabled (#1783)
+         COMMIT_DOCS=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-get commit_docs 2>/dev/null || echo "true")
+         if [ "$COMMIT_DOCS" != "false" ]; then
+           git add .planning/STATE.md .planning/ROADMAP.md 2>/dev/null || true
+           git commit --amend --no-edit 2>/dev/null || true
+         fi
        fi
 
        # Remove the worktree

--- a/get-shit-done/workflows/quick.md
+++ b/get-shit-done/workflows/quick.md
@@ -634,8 +634,11 @@ After executor returns:
 
        if ! git diff --quiet .planning/STATE.md .planning/ROADMAP.md 2>/dev/null || \
           [ -n "$DELETED_FILES" ]; then
-         git add .planning/STATE.md .planning/ROADMAP.md 2>/dev/null || true
-         git commit --amend --no-edit 2>/dev/null || true
+         COMMIT_DOCS=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-get commit_docs 2>/dev/null || echo "true")
+         if [ "$COMMIT_DOCS" != "false" ]; then
+           git add .planning/STATE.md .planning/ROADMAP.md 2>/dev/null || true
+           git commit --amend --no-edit 2>/dev/null || true
+         fi
        fi
 
        git worktree remove "$WT" --force 2>/dev/null || true
@@ -773,7 +776,14 @@ Build file list:
 ```bash
 # Explicitly stage all artifacts before commit — PLAN.md may be untracked
 # if the executor ran without worktree isolation and committed docs early
-git add ${file_list} 2>/dev/null
+# Filter .planning/ files from staging if commit_docs is disabled (#1783)
+COMMIT_DOCS=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-get commit_docs 2>/dev/null || echo "true")
+if [ "$COMMIT_DOCS" = "false" ]; then
+  file_list_filtered=$(echo "${file_list}" | tr ' ' '\n' | grep -v '^\.planning/' | tr '\n' ' ')
+  git add ${file_list_filtered} 2>/dev/null
+else
+  git add ${file_list} 2>/dev/null
+fi
 node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" commit "docs(quick-${quick_id}): ${DESCRIPTION}" --files ${file_list}
 ```
 

--- a/tests/commit-docs-bypass.test.cjs
+++ b/tests/commit-docs-bypass.test.cjs
@@ -1,0 +1,98 @@
+/**
+ * commit_docs bypass guard tests (#1783)
+ *
+ * When users set commit_docs: false during /gsd-new-project, .planning/
+ * files should never be staged or committed. The gsd-tools.cjs commit
+ * wrapper already checks this flag, but three locations in execute-phase.md
+ * and quick.md used raw `git add .planning/` commands that bypassed it.
+ *
+ * These tests verify that every `git add .planning/` invocation (explicit
+ * or via file_list) is preceded by a commit_docs config check.
+ */
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const EXECUTE_PHASE_PATH = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'execute-phase.md');
+const QUICK_PATH = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'quick.md');
+
+describe('commit_docs bypass guard (#1783)', () => {
+
+  test('execute-phase.md: every git add .planning/ has a commit_docs guard', () => {
+    const content = fs.readFileSync(EXECUTE_PHASE_PATH, 'utf-8');
+    const lines = content.split('\n');
+
+    for (let i = 0; i < lines.length; i++) {
+      if (/git add\b.*\.planning\//.test(lines[i])) {
+        // Search backwards from this line for a config-get commit_docs check
+        const windowStart = Math.max(0, i - 10);
+        const window = lines.slice(windowStart, i).join('\n');
+        assert.ok(
+          window.includes('config-get commit_docs'),
+          `git add .planning/ at line ${i + 1} in execute-phase.md must be guarded by a commit_docs config check`
+        );
+      }
+    }
+  });
+
+  test('quick.md: every git add .planning/ has a commit_docs guard', () => {
+    const content = fs.readFileSync(QUICK_PATH, 'utf-8');
+    const lines = content.split('\n');
+
+    for (let i = 0; i < lines.length; i++) {
+      if (/git add\b.*\.planning\//.test(lines[i])) {
+        const windowStart = Math.max(0, i - 10);
+        const window = lines.slice(windowStart, i).join('\n');
+        assert.ok(
+          window.includes('config-get commit_docs'),
+          `git add .planning/ at line ${i + 1} in quick.md must be guarded by a commit_docs config check`
+        );
+      }
+    }
+  });
+
+  test('quick.md: git add ${file_list} has a commit_docs guard for .planning/ filtering', () => {
+    const content = fs.readFileSync(QUICK_PATH, 'utf-8');
+    const lines = content.split('\n');
+
+    // Find the line(s) that do `git add ${file_list}` — this variable
+    // includes .planning/STATE.md so it needs a commit_docs guard too
+    for (let i = 0; i < lines.length; i++) {
+      if (/git add\s+\$\{?file_list/.test(lines[i])) {
+        const windowStart = Math.max(0, i - 10);
+        const window = lines.slice(windowStart, i + 1).join('\n');
+        assert.ok(
+          window.includes('config-get commit_docs'),
+          `git add \${file_list} at line ${i + 1} in quick.md must be guarded by a commit_docs check ` +
+          `because file_list includes .planning/ files`
+        );
+      }
+    }
+  });
+
+  test('no raw git add .planning/ without commit_docs guard in any workflow', () => {
+    const workflows = [
+      { name: 'execute-phase.md', path: EXECUTE_PHASE_PATH },
+      { name: 'quick.md', path: QUICK_PATH },
+    ];
+
+    for (const wf of workflows) {
+      const content = fs.readFileSync(wf.path, 'utf-8');
+
+      // Find all occurrences of git add that reference .planning/
+      const regex = /git add\b[^\n]*\.planning\//g;
+      let match;
+      while ((match = regex.exec(content)) !== null) {
+        // Get the 500-char window before this match
+        const before = content.slice(Math.max(0, match.index - 500), match.index);
+        assert.ok(
+          before.includes('config-get commit_docs'),
+          `${wf.name}: found unguarded git add .planning/ near offset ${match.index}. ` +
+          `All raw git add .planning/ commands must check commit_docs config first.`
+        );
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

When a user chooses `commit_docs: false` during `/gsd-new-project` setup, the expectation is that `.planning/` files stay local and never get committed. The `gsd-tools.cjs commit` wrapper correctly checks this flag (see `commands.cjs` line 265) and skips `.planning/` files — but three locations in the workflow markdown files used raw `git add .planning/` commands that bypassed the wrapper entirely.

This meant that even after explicitly opting out, users would still see `.planning/STATE.md` and `.planning/ROADMAP.md` showing up in their commits. A confusing experience when you've specifically said "no" to committing docs!

## Root cause

Three raw `git add` invocations bypass the `gsd-tools.cjs commit` wrapper:

1. **`execute-phase.md` (line ~529)** — The worktree merge protection step amends the merge commit with `.planning/STATE.md` and `.planning/ROADMAP.md` without checking `commit_docs`
2. **`quick.md` (line ~637)** — Identical worktree merge protection code (duplicated from execute-phase)
3. **`quick.md` (line ~776)** — `git add ${file_list}` stages all artifacts including `.planning/STATE.md` before the `gsd-tools.cjs commit` call gets a chance to filter them

## Fix

Each of the three locations now checks the `commit_docs` config flag via `gsd-tools.cjs config-get commit_docs` before staging any `.planning/` files:

- For the worktree merge protection blocks (locations 1 and 2): the `git add` + `git commit --amend` is wrapped in an `if [ "$COMMIT_DOCS" != "false" ]` guard
- For the file_list staging (location 3): when `commit_docs` is false, `.planning/` paths are filtered out of the file list before `git add`

The `gsd-tools.cjs commit` wrapper on the next line already handles this correctly — these raw `git add` calls were the only paths that bypassed the check.

## Safety

- When `commit_docs` is `true` (the default), behavior is completely unchanged
- The `config-get` call falls back to `"true"` if the config tool is unavailable, so existing installs without the flag are unaffected
- The fix uses the same `gsd-tools.cjs config-get` mechanism that the commit wrapper already relies on — no new dependencies

## Test plan

- [x] New test file `tests/commit-docs-bypass.test.cjs` verifies that every `git add .planning/` occurrence in both workflow files is preceded by a `commit_docs` config check
- [x] Full test suite passes (2205 tests, 0 failures)

Fixes #1783

🤖 Generated with [Claude Code](https://claude.com/claude-code)