### PR TITLE
feat(commands): add /gsd-undo safe revert for phases and plans

### DIFF
--- a/commands/gsd/undo.md
+++ b/commands/gsd/undo.md
@@ -1,0 +1,26 @@
+---
+name: gsd:undo
+description: Safe git revert command — undo GSD phase or plan commits without destroying history
+allowed-tools:
+  - Read
+  - Bash
+  - Grep
+  - Glob
+  - AskUserQuestion
+---
+<objective>
+Safely revert GSD commits using `git revert --no-commit`. Three modes:
+- `--last N` — show last N GSD commits for interactive selection
+- `--phase NN` — revert all commits for a specific phase
+- `--plan NN-MM` — revert commits for a specific plan only
+
+All reverts are collected into a single atomic commit. Never uses `git reset`.
+</objective>
+
+<execution_context>
+@~/.claude/get-shit-done/workflows/undo.md
+</execution_context>
+
+<process>
+Execute the undo workflow from @~/.claude/get-shit-done/workflows/undo.md end-to-end.
+</process>

--- a/get-shit-done/workflows/undo.md
+++ b/get-shit-done/workflows/undo.md
@@ -1,0 +1,134 @@
+<purpose>
+Safe git revert for GSD phase and plan commits. Uses only `git revert --no-commit`
+to preserve history. All reverts collected into a single atomic commit.
+</purpose>
+
+<required_reading>
+Read all files referenced by the invoking prompt's execution_context before starting.
+</required_reading>
+
+<process>
+
+## Step 1: Parse arguments
+
+Determine mode from user input:
+- `--last N` (default: `--last 10`) — interactive selection from recent GSD commits
+- `--phase NN` — revert all commits for phase NN
+- `--plan NN-MM` — revert commits for plan MM within phase NN
+
+If no arguments provided, default to `--last 10`.
+
+## Step 2: Identify target commits
+
+### Mode: --last N
+
+```bash
+# Show last N GSD conventional commits
+git log --oneline --grep="^feat\|^fix\|^refactor\|^test\|^docs\|^chore" -n ${N} --format="%H %s"
+```
+
+Present numbered list and ask user to select which commit(s) to revert (comma-separated numbers or ranges).
+
+### Mode: --phase NN
+
+```bash
+# Try phase manifest first
+MANIFEST=".planning/.phase-manifest.json"
+if [ -f "$MANIFEST" ]; then
+  # Extract commit hashes for phase NN from manifest
+  node -e "const m=JSON.parse(require('fs').readFileSync('$MANIFEST','utf8')); const p=m.phases?.['${PHASE}']; if(p?.commits) p.commits.forEach(c=>console.log(c))"
+fi
+```
+
+If no manifest or no commits found, fall back to git log:
+```bash
+# Filter by conventional commit scope matching phase number
+git log --oneline --all --format="%H %s" | grep -i "phase.${PHASE}\|phase-${PHASE}\|(${PHASE})\|(\$PHASE)"
+```
+
+Show matched commits and confirm scope with user.
+
+### Mode: --plan NN-MM
+
+```bash
+# Filter commits related to specific plan
+git log --oneline --all --format="%H %s" | grep -i "plan.${PLAN_ID}\|${PHASE}.*${PLAN_ID}"
+```
+
+Show matched commits and confirm.
+
+## Step 3: Dependency check
+
+For `--phase` and `--plan` modes, check if later phases reference the target:
+
+```bash
+# Check if any later phase directories reference the target phase
+for dir in .planning/phases/*/; do
+  PHASE_NUM=$(basename "$dir" | grep -oP '^\d+')
+  if [ "$PHASE_NUM" -gt "$TARGET_PHASE" ]; then
+    # Check PLAN.md files for references to the target phase
+    grep -l "phase.${TARGET_PHASE}\|Phase ${TARGET_PHASE}" "$dir"*.md 2>/dev/null
+  fi
+done
+```
+
+If dependencies found:
+```
+Warning: Later phases may depend on this work:
+  - Phase 05 PLAN.md references Phase 03 authentication module
+  - Phase 07 PLAN.md imports from Phase 03 auth middleware
+
+Reverting Phase 03 may break these phases. Continue anyway? [y/N]
+```
+
+Require explicit confirmation.
+
+## Step 4: Execute reverts
+
+```bash
+# Revert each commit in reverse chronological order (newest first)
+for HASH in ${COMMITS_REVERSED}; do
+  git revert --no-commit "$HASH" 2>&1 || {
+    echo "Conflict reverting $HASH — resolve manually or abort with: git revert --abort"
+    exit 1
+  }
+done
+```
+
+## Step 5: Atomic commit
+
+Ask user for a reason:
+```
+Reason for reverting (one line):
+```
+
+```bash
+git commit -m "revert(${SCOPE}): undo ${DESCRIPTION} — ${REASON}"
+```
+
+Commit message format: `revert(<phase>): undo phase NN — <user reason>`
+
+## Step 6: Report
+
+```
+## Undo Complete
+
+**Reverted:** {count} commit(s)
+**Scope:** {phase NN | plan NN-MM | selected commits}
+**Commit:** {new_commit_hash}
+
+The original commits are preserved in git history.
+To undo this revert: `git revert {new_commit_hash}`
+```
+
+</process>
+
+<success_criteria>
+- [ ] Correct mode detected from arguments
+- [ ] Phase manifest checked before git log fallback
+- [ ] Dependency warning shown for later phases
+- [ ] User confirmation required before executing
+- [ ] All reverts use git revert --no-commit (never git reset)
+- [ ] Single atomic commit with descriptive message
+- [ ] Conflict handling with abort instructions
+</success_criteria>

--- a/tests/undo-command.test.cjs
+++ b/tests/undo-command.test.cjs
@@ -1,0 +1,99 @@
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+describe('undo command', () => {
+  test('command file exists', () => {
+    const p = path.join(__dirname, '..', 'commands', 'gsd', 'undo.md');
+    assert.ok(fs.existsSync(p), 'commands/gsd/undo.md should exist');
+  });
+
+  test('workflow file exists', () => {
+    const p = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'undo.md');
+    assert.ok(fs.existsSync(p), 'get-shit-done/workflows/undo.md should exist');
+  });
+
+  test('command file has correct frontmatter', () => {
+    const p = path.join(__dirname, '..', 'commands', 'gsd', 'undo.md');
+    const content = fs.readFileSync(p, 'utf-8');
+    assert.ok(content.includes('name: gsd:undo'), 'should have correct command name');
+    assert.ok(content.includes('description:'), 'should have description frontmatter');
+  });
+
+  test('documents all three modes: --last, --phase, --plan', () => {
+    const p = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'undo.md');
+    const content = fs.readFileSync(p, 'utf-8');
+    assert.ok(content.includes('--last'), 'workflow should document --last mode');
+    assert.ok(content.includes('--phase'), 'workflow should document --phase mode');
+    assert.ok(content.includes('--plan'), 'workflow should document --plan mode');
+  });
+
+  test('includes dependency check for downstream phases', () => {
+    const p = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'undo.md');
+    const content = fs.readFileSync(p, 'utf-8');
+    assert.ok(
+      content.includes('Dependency check') || content.includes('dependency'),
+      'workflow should include dependency checking'
+    );
+    assert.ok(
+      content.includes('later phase') || content.includes('Later phases'),
+      'workflow should warn about downstream phase dependencies'
+    );
+  });
+
+  test('uses only git revert --no-commit, never git reset as a command', () => {
+    const p = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'undo.md');
+    const content = fs.readFileSync(p, 'utf-8');
+    assert.ok(
+      content.includes('git revert --no-commit'),
+      'workflow must use git revert --no-commit'
+    );
+    // Extract code blocks and verify none contain git reset as a command
+    const codeBlocks = content.match(/```[\s\S]*?```/g) || [];
+    const codeContent = codeBlocks.join('\n');
+    assert.ok(
+      !codeContent.includes('git reset'),
+      'workflow code blocks must never use git reset'
+    );
+  });
+
+  test('produces single atomic commit with revert() prefix', () => {
+    const p = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'undo.md');
+    const content = fs.readFileSync(p, 'utf-8');
+    assert.ok(
+      content.includes('atomic commit') || content.includes('Atomic commit'),
+      'workflow should describe atomic commit step'
+    );
+    assert.ok(
+      content.includes('revert('),
+      'commit message should use revert() conventional commit prefix'
+    );
+  });
+
+  test('includes conflict handling with abort instructions', () => {
+    const p = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'undo.md');
+    const content = fs.readFileSync(p, 'utf-8');
+    assert.ok(
+      content.includes('Conflict') || content.includes('conflict'),
+      'workflow should handle revert conflicts'
+    );
+    assert.ok(
+      content.includes('git revert --abort'),
+      'workflow should mention git revert --abort for conflict resolution'
+    );
+  });
+
+  test('checks phase manifest before falling back to git log', () => {
+    const p = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'undo.md');
+    const content = fs.readFileSync(p, 'utf-8');
+    assert.ok(
+      content.includes('phase-manifest') || content.includes('.phase-manifest.json'),
+      'workflow should check phase manifest for commit hashes'
+    );
+    assert.ok(
+      content.includes('fall back') || content.includes('fallback') || content.includes('If no manifest'),
+      'workflow should fall back to git log when manifest unavailable'
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `/gsd-undo` command with three modes for safely reverting GSD work without destroying git history: `--last N` (interactive selection from recent commits), `--phase NN` (revert all phase commits), `--plan NN-MM` (revert specific plan commits)
- Uses only `git revert --no-commit` (never `git reset`), checks phase manifest before falling back to git log, warns about downstream phase dependencies, and collects all reverts into a single atomic commit with `revert()` conventional commit prefix
- Includes command definition, workflow, and 9 tests covering all modes, dependency checks, conflict handling, and safety invariants

## New files

- `commands/gsd/undo.md` — command frontmatter and execution_context reference
- `get-shit-done/workflows/undo.md` — full 6-step workflow (parse args, identify commits, dependency check, execute reverts, atomic commit, report)
- `tests/undo-command.test.cjs` — 9 tests validating file existence, all three modes documented, dependency checking, no git reset in code blocks, atomic commit with revert() prefix, conflict handling with abort instructions, and phase manifest fallback

## Test plan

- [x] All 2210 tests pass (0 failures)
- [x] Verify command file has correct frontmatter and execution_context
- [x] Verify workflow documents all three modes (--last, --phase, --plan)
- [x] Verify workflow checks phase manifest before git log fallback
- [x] Verify no `git reset` appears in any code blocks
- [x] Verify conflict handling mentions `git revert --abort`

Closes #1730

Generated with [Claude Code](https://claude.com/claude-code)