### PR TITLE
feat(commands): add /gsd-audit-fix for autonomous audit-to-fix pipeline

### DIFF
--- a/commands/gsd/audit-fix.md
+++ b/commands/gsd/audit-fix.md
@@ -1,7 +1,8 @@
 ---
+type: prompt
 name: gsd:audit-fix
 description: Autonomous audit-to-fix pipeline — find issues, classify, fix, test, commit
-argument-hint: "--source <audit|verify> [--severity <medium|high|all>] [--max N] [--dry-run]"
+argument-hint: "--source <audit-uat> [--severity <medium|high|all>] [--max N] [--dry-run]"
 allowed-tools:
   - Read
   - Write

--- a/get-shit-done/workflows/audit-fix.md
+++ b/get-shit-done/workflows/audit-fix.md
@@ -108,13 +108,14 @@ npm test 2>&1 | tail -20
 
 **c. If tests pass** — commit atomically:
 ```bash
-node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" commit "fix({scope}): resolve {ID} — {description}" --files {changed_files}
+git add {changed_files}
+git commit -m "fix({scope}): resolve {ID} — {description}"
 ```
 The commit message **must** include the finding ID (e.g., F-01) for traceability.
 
 **d. If tests fail** — revert changes, mark finding as `fix-failed`, and **stop the pipeline**:
 ```bash
-git checkout -- . 2>/dev/null
+git checkout -- {changed_files} 2>/dev/null
 ```
 Log the failure reason and stop processing — do not continue to the next finding.
 A test failure indicates the codebase may be in an unexpected state, so the pipeline

--- a/tests/audit-fix-command.test.cjs
+++ b/tests/audit-fix-command.test.cjs
@@ -73,6 +73,28 @@ describe('AUDIT-FIX: command file', () => {
     );
   });
 
+  test('has type: prompt in frontmatter', () => {
+    const content = fs.readFileSync(cmdPath, 'utf-8');
+    const frontmatter = content.split('---')[1] || '';
+    assert.ok(
+      frontmatter.includes('type: prompt'),
+      'must have type: prompt in frontmatter'
+    );
+  });
+
+  test('argument-hint reflects supported source values', () => {
+    const content = fs.readFileSync(cmdPath, 'utf-8');
+    const frontmatter = content.split('---')[1] || '';
+    assert.ok(
+      frontmatter.includes('--source <audit-uat>'),
+      'argument-hint must show --source <audit-uat> (the only currently supported value)'
+    );
+    assert.ok(
+      !frontmatter.includes('--source <audit|verify>'),
+      'argument-hint must not advertise unsupported verify source'
+    );
+  });
+
   test('references audit-fix.md workflow', () => {
     const content = fs.readFileSync(cmdPath, 'utf-8');
     assert.ok(
@@ -343,9 +365,9 @@ describe('AUDIT-FIX: test-then-commit pattern', () => {
     // Within the fix-loop step, test must come before commit
     const fixLoopStart = content.indexOf('fix-loop');
     const testIdx = content.indexOf('npm test', fixLoopStart);
-    const commitIdx = content.indexOf('gsd-tools.cjs" commit', fixLoopStart);
+    const commitIdx = content.indexOf('git commit', fixLoopStart);
     assert.ok(testIdx > -1, 'must have npm test in fix-loop');
-    assert.ok(commitIdx > -1, 'must have commit command in fix-loop');
+    assert.ok(commitIdx > -1, 'must have git commit in fix-loop');
     assert.ok(
       testIdx < commitIdx,
       'npm test must appear before commit in fix-loop (test-then-commit pattern)'
@@ -392,10 +414,10 @@ describe('AUDIT-FIX: revert on test failure', () => {
 
   test('test failure does not leave partial changes', () => {
     const content = fs.readFileSync(wfPath, 'utf-8');
-    // git checkout -- . is the revert mechanism
+    // git checkout scoped to changed files is the revert mechanism
     assert.ok(
-      content.includes('git checkout -- .'),
-      'must use git checkout -- . to clean partial changes on failure'
+      content.includes('git checkout -- {changed_files}'),
+      'must use git checkout -- {changed_files} to clean partial changes on failure'
     );
   });
 });


### PR DESCRIPTION
## Summary

- Adds `/gsd-audit-fix` command and workflow — an autonomous pipeline that chains audit → parse → classify → fix → test → commit
- Classifies findings as **auto-fixable** vs **manual-only** (erring on manual-only when uncertain), spawns gsd-executor agents for fixable issues, runs tests after each fix, and commits atomically with finding IDs for traceability
- Supports `--max N` (cap fixes), `--severity high|medium|all` (filter threshold), `--dry-run` (classification table only), and `--source <audit>` (currently only `audit-uat`)
- Reverts changes cleanly on test failure and stops the pipeline; surfaces manual-only findings for developer attention
- Includes 35 tests across 8 test groups validating command structure, workflow steps, flag documentation, classification heuristics, dry-run behavior, atomic commits, test-then-commit pattern, and revert-on-failure

## Files changed

| File | Description |
|------|-------------|
| `commands/gsd/audit-fix.md` | Command definition with frontmatter, flags, and workflow reference |
| `get-shit-done/workflows/audit-fix.md` | 6-step workflow: parse args → run audit → classify → present → fix loop → report |
| `tests/audit-fix-command.test.cjs` | 35 structural tests validating command + workflow correctness |

## Design decisions

- **Only `audit-uat` supported as `--source`** — per maintainer guidance, starting with a single audit source. The workflow validates `--source` and returns a clear error for unsupported values.
- **Conservative classifier** — heuristics err on `manual-only` when uncertain. Words like "consider", "evaluate", "design" trigger manual-only. Only findings with specific file references and clear single-file fixes qualify as auto-fixable.
- **Atomic commits with finding IDs** — each fix is committed individually with the finding ID (e.g., `F-01`) in the commit message for traceability.
- **`--dry-run` as standalone tool** — the classification table is designed to be useful on its own, even without proceeding to fixes.

## Test plan

- [x] All 35 new tests pass (`tests/audit-fix-command.test.cjs`)
- [x] Full test suite passes (2237 tests, 0 failures)
- [ ] Manual: run `/gsd-audit-fix --dry-run` on a project with UAT findings and verify classification table
- [ ] Manual: run `/gsd-audit-fix --max 1` and verify single finding is fixed, tested, and committed atomically
- [ ] Manual: verify `--source invalid` returns a clear error message

Closes #1735

🤖 Generated with [Claude Code](https://claude.com/claude-code)