### PR TITLE
feat(commands): add /gsd-import with conflict detection

### DIFF
--- a/commands/gsd/import.md
+++ b/commands/gsd/import.md
@@ -9,7 +9,7 @@ allowed-tools:
   - Bash
   - Grep
   - Glob
-  - Agent
+  - Task
   - AskUserQuestion
 ---
 <objective>

--- a/get-shit-done/workflows/import.md
+++ b/get-shit-done/workflows/import.md
@@ -36,21 +36,32 @@ Store the extracted filepath for subsequent steps.
 </step>
 
 <step name="validate_filepath">
-Validate the file path using security best practices.
+Validate the file path using `validatePath()` from `security.cjs`. This is **mandatory** —
+path validation must succeed before any file operations proceed.
 
-**Path validation:**
+**Path validation (unconditional — must run first):**
 ```bash
-# Validate the path exists and is a file
+# MANDATORY: Call validatePath() before any file access
+node -e "
+  const { validatePath } = require('$HOME/.claude/get-shit-done/bin/lib/security.cjs');
+  const result = validatePath(process.argv[1], process.cwd(), { allowAbsolute: true });
+  if (!result.safe) {
+    console.error('Path validation failed: ' + result.error);
+    process.exit(1);
+  }
+  console.log('Validated: ' + result.resolved);
+" "{filepath}"
+```
+
+**If validation fails, abort immediately — do not proceed to file existence or any other step.**
+
+After validation passes, check existence:
+```bash
 if [ ! -f "{filepath}" ]; then
   echo "File not found: {filepath}"
   exit 1
 fi
 ```
-
-**Security considerations:**
-- Reject paths containing `..` segments to prevent directory traversal
-- Validate the resolved path is a regular file (not a symlink to a sensitive location)
-- Use `validatePath()` from `security.cjs` if available in the project
 
 Read the file content. Detect the format:
 - **Markdown** — contains `#` headers, lists, code blocks
@@ -113,12 +124,31 @@ section, decision, or requirement in the external plan, check:
 ```
 
 **For each conflict, ask the user to choose a resolution:**
-- **Keep existing** — discard the conflicting section from the external plan
+- **Keep existing** — discard the conflicting section from the external plan (no artifact update needed)
 - **Accept external** — replace the existing decision with the external plan's version
 - **Merge both** — combine both perspectives (user provides guidance)
-- **Skip this section** — exclude from import, revisit later
+- **Skip this section** — exclude from import, revisit later (no artifact update needed)
 
 Wait for the user to resolve **every** conflict before proceeding to conversion.
+
+**MANDATORY: Write conflict resolutions back to durable artifacts.**
+After all conflicts are resolved, update the source-of-truth files to reflect the decisions:
+
+- **Accept external** resolutions: overwrite the conflicting section in the relevant artifact
+  (PROJECT.md for decision conflicts, REQUIREMENTS.md for requirement conflicts, ROADMAP.md
+  for scope overlaps) with the external plan's version.
+- **Merge both** resolutions: write the merged content (as confirmed by the user) into the
+  relevant artifact, replacing the old section.
+- Resolutions that do not change existing artifacts (**Keep existing**, **Skip this section**)
+  require no artifact write-back.
+
+This ensures conflict resolutions are persisted — not just acknowledged in conversation.
+Report each artifact update:
+```
+Updated .planning/PROJECT.md — replaced decision: "{old_decision}" → "{new_decision}"
+Updated .planning/REQUIREMENTS.md — revised REQ-{id}: "{updated_text}"
+```
+
 If no conflicts are detected, report:
 ```
 No conflicts detected against existing project decisions.

--- a/tests/import-command.test.cjs
+++ b/tests/import-command.test.cjs
@@ -223,6 +223,122 @@ describe('/gsd-import workflow — plan-checker validation', () => {
   });
 });
 
+// ─── Workflow — path validation is unconditional ───────────────────────────
+
+describe('/gsd-import workflow — unconditional path validation', () => {
+  const content = fs.readFileSync(WORKFLOW_FILE, 'utf-8');
+
+  test('calls validatePath unconditionally (not advisory)', () => {
+    // Must NOT contain the old conditional phrasing
+    assert.ok(
+      !content.includes('if available'),
+      'workflow must not make validatePath conditional with "if available"'
+    );
+    // Must contain unconditional validatePath call
+    assert.ok(
+      content.includes('validatePath'),
+      'workflow must call validatePath'
+    );
+  });
+
+  test('path validation is marked as mandatory', () => {
+    const hasMandatory =
+      content.includes('mandatory') || content.includes('MANDATORY');
+    assert.ok(
+      hasMandatory,
+      'workflow must describe path validation as mandatory'
+    );
+  });
+
+  test('aborts if validation fails before any file operations', () => {
+    const hasAbort =
+      content.includes('abort immediately') ||
+      content.includes('do not proceed');
+    assert.ok(
+      hasAbort,
+      'workflow must abort if path validation fails'
+    );
+  });
+
+  test('validatePath runs before file existence check', () => {
+    const validateIdx = content.indexOf('validatePath');
+    const existenceIdx = content.indexOf('! -f');
+    assert.ok(
+      validateIdx > -1 && existenceIdx > -1 && validateIdx < existenceIdx,
+      'validatePath must appear before the file existence check'
+    );
+  });
+});
+
+// ─── Workflow — conflict resolution writes durable artifacts ───────────────
+
+describe('/gsd-import workflow — conflict resolution durability', () => {
+  const content = fs.readFileSync(WORKFLOW_FILE, 'utf-8');
+
+  test('Accept external resolution writes back to artifacts', () => {
+    // The workflow must instruct writing "Accept external" resolutions to artifacts
+    const hasWriteBack =
+      content.includes('Accept external') &&
+      (content.includes('overwrite the conflicting section') ||
+       content.includes('write') || content.includes('update'));
+    assert.ok(
+      hasWriteBack,
+      'Accept external resolutions must write back to durable artifacts'
+    );
+  });
+
+  test('Merge both resolution writes back to artifacts', () => {
+    const hasMergeWrite =
+      content.includes('Merge both') &&
+      (content.includes('write the merged content') ||
+       content.includes('replacing the old section'));
+    assert.ok(
+      hasMergeWrite,
+      'Merge both resolutions must write merged content to artifacts'
+    );
+  });
+
+  test('resolutions are persisted not just conversational', () => {
+    assert.ok(
+      content.includes('persisted') || content.includes('durable artifacts'),
+      'workflow must ensure conflict resolutions are persisted, not just conversational'
+    );
+  });
+
+  test('reports artifact updates after resolution', () => {
+    const hasReport =
+      content.includes('Updated .planning/PROJECT.md') ||
+      content.includes('Updated .planning/REQUIREMENTS.md') ||
+      content.includes('Report each artifact update');
+    assert.ok(
+      hasReport,
+      'workflow must report which artifacts were updated after conflict resolution'
+    );
+  });
+});
+
+// ─── Command — allowed-tools matches subagent pattern ──────────────────────
+
+describe('/gsd-import command — allowed-tools', () => {
+  const content = fs.readFileSync(COMMAND_FILE, 'utf-8');
+
+  test('allowed-tools lists Task for subagent spawning (not Agent)', () => {
+    // Extract the frontmatter section
+    const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
+    assert.ok(frontmatterMatch, 'must have YAML frontmatter');
+    const frontmatter = frontmatterMatch[1];
+
+    assert.ok(
+      frontmatter.includes('Task'),
+      'allowed-tools must include Task for subagent spawning'
+    );
+    assert.ok(
+      !frontmatter.includes('Agent'),
+      'allowed-tools must not list Agent — use Task for subagent pattern'
+    );
+  });
+});
+
 // ─── Workflow — output format ────────────────────────────────────────────────
 
 describe('/gsd-import workflow — output format', () => {


### PR DESCRIPTION
## Summary

- Adds `/gsd-import` command (`commands/gsd/import.md`) and workflow (`get-shit-done/workflows/import.md`) for importing external planning documents into GSD PLAN.md format
- Ships `--from <filepath>` mode first per maintainer guidance; `--prd` is stubbed with a "coming in a future release" message
- Conflict detection compares the external plan against PROJECT.md decisions and REQUIREMENTS.md requirements — presents a conflict table with resolution options (Keep existing / Accept external / Merge both / Skip) and **never auto-resolves**
- Handles missing PROJECT.md/REQUIREMENTS.md gracefully by importing as initial plan without conflict detection
- Optionally validates the generated PLAN.md via `gsd-plan-checker` (user can decline)
- Includes 22 tests in `tests/import-command.test.cjs` covering file existence, mode handling, conflict detection, missing artifact behavior, plan-checker integration, and output format

## How it works

1. Parse `--from <filepath>` argument (or show `--prd` deferral message)
2. Validate file path with security checks (traversal prevention, file existence)
3. Read existing `.planning/PROJECT.md`, `REQUIREMENTS.md`, `ROADMAP.md` if present
4. Detect and present conflicts as a resolution table — user resolves each before import proceeds
5. Convert external plan to GSD PLAN.md format with waves, tasks, success criteria, complexity estimates
6. Optionally validate via plan-checker agent
7. Report summary

## Test plan

- [x] All 22 new tests pass (`tests/import-command.test.cjs`)
- [x] Full test suite passes (2224 tests, 0 failures)
- [ ] Manual: run `/gsd-import --from some-plan.md` against a project with existing PROJECT.md
- [ ] Manual: run `/gsd-import --from some-plan.md` against a fresh project (no .planning/)
- [ ] Manual: run `/gsd-import --prd some-prd.md` and verify deferral message

Closes #1731

🤖 Generated with [Claude Code](https://claude.com/claude-code)