### PR TITLE
fix(tests): allowlist execute-phase.md in prompt-injection scan

### DIFF
--- a/tests/prompt-injection-scan.test.cjs
+++ b/tests/prompt-injection-scan.test.cjs
@@ -52,6 +52,7 @@ const SCAN_EXTS = new Set(['.md', '.cjs', '.js', '.json']);
 const ALLOWLIST = new Set([
   'get-shit-done/bin/lib/security.cjs',        // The security module itself
   'get-shit-done/workflows/discuss-phase.md',  // Large workflow (~50K) with power mode + i18n
+  'get-shit-done/workflows/execute-phase.md',  // Large orchestration workflow (~51K) with wave execution + code-review gate
   'hooks/gsd-prompt-guard.js',                  // The prompt guard hook
   'tests/security.test.cjs',                    // Security tests
   'tests/prompt-injection-scan.test.cjs',       // This file


### PR DESCRIPTION
Fixes CI failure from #1630 merge. execute-phase.md grew to ~51K chars after the code_review_gate step was added, tripping the 50K size heuristic. The limit is calibrated for user-supplied input — trusted source files that legitimately exceed it are allowlisted individually (same pattern as discuss-phase.md). One-line change to ALLOWLIST in tests/prompt-injection-scan.test.cjs. All tests pass. Closes #1836