### PR TITLE
fix(install): preserve non-array hook entries during uninstall

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -4432,7 +4432,7 @@ function uninstall(isGlobal, runtime = 'claude') {
         const before = JSON.stringify(settings.hooks[eventName]);
         settings.hooks[eventName] = settings.hooks[eventName]
           .map(entry => {
-            if (!entry.hooks || !Array.isArray(entry.hooks)) return null;
+            if (!entry.hooks || !Array.isArray(entry.hooks)) return entry;
             // Filter out individual GSD hooks, keep user hooks
             entry.hooks = entry.hooks.filter(h => !isGsdHookCommand(h.command));
             return entry.hooks.length > 0 ? entry : null;

--- a/tests/install-hooks-copy.test.cjs
+++ b/tests/install-hooks-copy.test.cjs
@@ -325,7 +325,7 @@ describe('uninstall settings cleanup preserves user hooks', () => {
   function filterGsdHooks(entries) {
     return entries
       .map(entry => {
-        if (!entry.hooks || !Array.isArray(entry.hooks)) return null;
+        if (!entry.hooks || !Array.isArray(entry.hooks)) return entry;
         entry.hooks = entry.hooks.filter(h => !isGsdHookCommand(h.command));
         return entry.hooks.length > 0 ? entry : null;
       })
@@ -370,6 +370,32 @@ describe('uninstall settings cleanup preserves user hooks', () => {
     const result = filterGsdHooks(entries);
     assert.strictEqual(result.length, 1, 'entry should survive');
     assert.strictEqual(result[0].hooks.length, 1, 'user hook should remain');
+  });
+
+  test('uninstall preserves non-array hook entries (#1825)', () => {
+    // Entries where entry.hooks is missing or not an array must be preserved as-is.
+    // Previously, `return null` caused .filter(Boolean) to silently drop them.
+    const nonArrayEntry = { matcher: 'Task', command: 'bash /my/custom-hook.sh' };
+    const missingHooksEntry = { type: 'command', command: 'echo hello' };
+    const entries = [
+      nonArrayEntry,
+      missingHooksEntry,
+      {
+        matcher: 'Bash',
+        hooks: [
+          { type: 'command', command: 'node /path/to/gsd-prompt-guard.js' },
+          { type: 'command', command: 'bash /my/custom-lint.sh' },
+        ],
+      },
+    ];
+
+    const result = filterGsdHooks(entries);
+    // The non-array entries must survive; the GSD hook inside the third entry must be stripped
+    assert.strictEqual(result.length, 3, 'non-array hook entries must be preserved (not silently dropped)');
+    assert.deepStrictEqual(result[0], nonArrayEntry, 'first non-array entry must survive unchanged');
+    assert.deepStrictEqual(result[1], missingHooksEntry, 'second non-array entry must survive unchanged');
+    assert.strictEqual(result[2].hooks.length, 1, 'GSD hook stripped from mixed entry');
+    assert.ok(result[2].hooks[0].command.includes('custom-lint'), 'user hook preserved in mixed entry');
   });
 
   test('all GSD hook names are recognized by isGsdHookCommand', () => {


### PR DESCRIPTION
## Summary

- During uninstall, `settings.json` hook event arrays are iterated to strip GSD hook entries
- The map callback returned `null` for entries where `entry.hooks` was missing or not an array, causing them to be silently removed by `.filter(Boolean)`
- Fixed by returning the entry unchanged instead of `null` for these unrecognised shapes

## Root cause

In `bin/install.js` line 4435, the consolidation in commit `175d89e` changed `return true` (preserve) to `return null` (discard) for non-array hook entries. This silently deletes third-party hook registrations with non-standard shapes.

## Fix

`return null` → `return entry` for the non-array guard in the per-event uninstall loop.

## Test

Added `uninstall preserves non-array hook entries (#1825)` to `tests/install-hooks-copy.test.cjs` in the "uninstall settings cleanup preserves user hooks" describe block. The test was confirmed failing before the fix and passing after.

Fixes #1825

🤖 Generated with [Claude Code](https://claude.com/claude-code)