### PR TITLE
fix(workflows): remove deprecated --no-input flag from claude CLI calls

### DIFF
--- a/get-shit-done/workflows/review.md
+++ b/get-shit-done/workflows/review.md
@@ -148,7 +148,7 @@ gemini -p "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-revi
 
 **Claude (separate session):**
 ```bash
-claude -p "$(cat /tmp/gsd-review-prompt-{phase}.md)" --no-input 2>/dev/null > /tmp/gsd-review-claude-{phase}.md
+claude -p "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-review-claude-{phase}.md
 ```
 
 **Codex:**

--- a/tests/workflow-compat.test.cjs
+++ b/tests/workflow-compat.test.cjs
@@ -1,0 +1,62 @@
+/**
+ * Regression guard for #1759: the --no-input flag was removed from Claude Code
+ * >= v2.1.81 and causes an immediate crash ("error: unknown option '--no-input'").
+ *
+ * The -p / --print flag already handles non-interactive output so --no-input
+ * must never appear in workflow, command, or agent files.
+ */
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+
+/** Recursively collect all .md files under a directory. */
+function collectMdFiles(dir) {
+  const results = [];
+  if (!fs.existsSync(dir)) return results;
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...collectMdFiles(full));
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+const SCAN_DIRS = [
+  path.join(ROOT, 'get-shit-done', 'workflows'),
+  path.join(ROOT, 'get-shit-done', 'references'),
+  path.join(ROOT, 'commands', 'gsd'),
+  path.join(ROOT, 'agents'),
+];
+
+describe('workflow CLI compatibility (#1759)', () => {
+  test('no workflow/command/agent file uses the deprecated --no-input flag', () => {
+    const violations = [];
+
+    for (const dir of SCAN_DIRS) {
+      for (const file of collectMdFiles(dir)) {
+        const content = fs.readFileSync(file, 'utf-8');
+        if (content.includes('--no-input')) {
+          const rel = path.relative(ROOT, file);
+          violations.push(rel);
+        }
+      }
+    }
+
+    assert.strictEqual(
+      violations.length,
+      0,
+      [
+        '--no-input was removed in Claude Code >= v2.1.81 and must not appear in any workflow/command/agent file.',
+        'Use -p / --print instead (already implies non-interactive output).',
+        'Violations found:',
+        ...violations.map(v => '  ' + v),
+      ].join('\n')
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- `claude --no-input` was removed in Claude Code >= v2.1.81 and causes an immediate crash: `error: unknown option '--no-input'`
- The `-p` / `--print` flag already makes output non-interactive, so `--no-input` was redundant
- Adds a regression guard in `tests/workflow-compat.test.cjs` that scans all workflow, command, and agent `.md` files to ensure `--no-input` never reappears

## Files modified

- `get-shit-done/workflows/review.md` — removed `--no-input` from the `claude -p` invocation
- `tests/workflow-compat.test.cjs` — new regression test (TDD: written failing, then fixed)

## Test plan

- [x] `tests/workflow-compat.test.cjs` failed before the fix (confirmed)
- [x] `tests/workflow-compat.test.cjs` passes after the fix (confirmed)
- [x] Full `npm run test:coverage` run shows no new failures introduced by this change

Fixes #1759

🤖 Generated with [Claude Code](https://claude.com/claude-code)