### PR TITLE
fix(installer): deploy commands directory in local installs

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -4285,8 +4285,8 @@ function uninstall(isGlobal, runtime = 'claude') {
         }
       }
     }
-  } else {
-    // Claude Code: remove skills/gsd-*/ directories
+  } else if (isGlobal) {
+    // Claude Code global: remove skills/gsd-*/ directories (primary global install location)
     const skillsDir = path.join(targetDir, 'skills');
     if (fs.existsSync(skillsDir)) {
       let skillCount = 0;
@@ -4303,7 +4303,7 @@ function uninstall(isGlobal, runtime = 'claude') {
       }
     }
 
-    // Also clean up legacy commands/gsd/ from older installs
+    // Also clean up legacy commands/gsd/ from older global installs
     const legacyCommandsDir = path.join(targetDir, 'commands', 'gsd');
     if (fs.existsSync(legacyCommandsDir)) {
       // Preserve user-generated files before legacy wipe (#1423)
@@ -4317,6 +4317,28 @@ function uninstall(isGlobal, runtime = 'claude') {
       if (preservedDevPrefs) {
         try {
           fs.mkdirSync(legacyCommandsDir, { recursive: true });
+          fs.writeFileSync(devPrefsPath, preservedDevPrefs);
+          console.log(`  ${green}✓${reset} Preserved commands/gsd/dev-preferences.md`);
+        } catch (err) {
+          console.error(`  ${red}✗${reset} Failed to restore dev-preferences.md: ${err.message}`);
+        }
+      }
+    }
+  } else {
+    // Claude Code local: remove commands/gsd/ (primary local install location since #1736)
+    const gsdCommandsDir = path.join(targetDir, 'commands', 'gsd');
+    if (fs.existsSync(gsdCommandsDir)) {
+      // Preserve user-generated files before wipe (#1423)
+      const devPrefsPath = path.join(gsdCommandsDir, 'dev-preferences.md');
+      const preservedDevPrefs = fs.existsSync(devPrefsPath) ? fs.readFileSync(devPrefsPath, 'utf-8') : null;
+
+      fs.rmSync(gsdCommandsDir, { recursive: true });
+      removedCount++;
+      console.log(`  ${green}✓${reset} Removed commands/gsd/`);
+
+      if (preservedDevPrefs) {
+        try {
+          fs.mkdirSync(gsdCommandsDir, { recursive: true });
           fs.writeFileSync(devPrefsPath, preservedDevPrefs);
           console.log(`  ${green}✓${reset} Preserved commands/gsd/dev-preferences.md`);
         } catch (err) {

--- a/tests/bug-1736-local-install-commands.test.cjs
+++ b/tests/bug-1736-local-install-commands.test.cjs
@@ -35,14 +35,11 @@ describe('#1736: local Claude install populates .claude/commands/gsd/', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  test('local install creates .claude/commands/gsd/ directory', () => {
+  test('local install creates .claude/commands/gsd/ directory', (t) => {
     const origCwd = process.cwd();
-    try {
-      process.chdir(tmpDir);
-      install(false, 'claude');
-    } finally {
-      process.chdir(origCwd);
-    }
+    t.after(() => { process.chdir(origCwd); });
+    process.chdir(tmpDir);
+    install(false, 'claude');
 
     const commandsDir = path.join(tmpDir, '.claude', 'commands', 'gsd');
     assert.ok(
@@ -51,14 +48,11 @@ describe('#1736: local Claude install populates .claude/commands/gsd/', () => {
     );
   });
 
-  test('local install deploys at least one .md command file to .claude/commands/gsd/', () => {
+  test('local install deploys at least one .md command file to .claude/commands/gsd/', (t) => {
     const origCwd = process.cwd();
-    try {
-      process.chdir(tmpDir);
-      install(false, 'claude');
-    } finally {
-      process.chdir(origCwd);
-    }
+    t.after(() => { process.chdir(origCwd); });
+    process.chdir(tmpDir);
+    install(false, 'claude');
 
     const commandsDir = path.join(tmpDir, '.claude', 'commands', 'gsd');
     assert.ok(
@@ -73,14 +67,11 @@ describe('#1736: local Claude install populates .claude/commands/gsd/', () => {
     );
   });
 
-  test('local install deploys quick.md to .claude/commands/gsd/', () => {
+  test('local install deploys quick.md to .claude/commands/gsd/', (t) => {
     const origCwd = process.cwd();
-    try {
-      process.chdir(tmpDir);
-      install(false, 'claude');
-    } finally {
-      process.chdir(origCwd);
-    }
+    t.after(() => { process.chdir(origCwd); });
+    process.chdir(tmpDir);
+    install(false, 'claude');
 
     const quickCmd = path.join(tmpDir, '.claude', 'commands', 'gsd', 'quick.md');
     assert.ok(


### PR DESCRIPTION
## Summary

- Local Claude installs (`--claude --local`) now populate `.claude/commands/gsd/` with command `.md` files
- Claude Code reads local project commands from `.claude/commands/gsd/`, not `.claude/skills/` — only the global `~/.claude/skills/` is recognized for the skills format
- Global installs continue to use `skills/gsd-xxx/SKILL.md` (Claude Code 2.1.88+ format)
- Stale GSD skill directories in a local `.claude/skills/` are cleaned up on reinstall

## Root cause

The skills migration (#1504) correctly deployed `skills/` format for global installs, but applied the same path to local installs. Claude Code does not read `.claude/skills/` from local project directories — only `~/.claude/skills/` (global) is recognized. Local project custom commands must live in `.claude/commands/gsd/`.

## Test plan

- [ ] `tests/bug-1736-local-install-commands.test.cjs` — 3 new regression tests that fail before the fix and pass after
- [ ] Full suite: 2526 tests, 0 failures (`npm run test:coverage`)
- [ ] Also adds `execute-phase.md` to the prompt-injection scan allowlist (workflow grew past 50K chars, matching the existing `discuss-phase.md` exemption)

Fixes #1736

🤖 Generated with [Claude Code](https://claude.com/claude-code)