### PR TITLE
feat: loop guard and safety rails for agent sessions

### DIFF
--- a/get-shit-done/bin/lib/loop-guard.cjs
+++ b/get-shit-done/bin/lib/loop-guard.cjs
@@ -1,0 +1,113 @@
+/**
+ * Loop Guard — Detects and prevents infinite tool-call loops in agent sessions.
+ *
+ * SHA-256 dedup of (toolName, params) pairs, ping-pong pattern detection
+ * (A-B or A-B-C repeating), and a global circuit breaker. In-memory only —
+ * no file writes, no persistence, no .planning/ dependency.
+ *
+ * Usage:
+ *   const guard = createLoopGuard({ circuitBreakTotal: 200 });
+ *   const result = guard.check('Read', { path: '/foo.js' });
+ *   // result.action: 'allow' | 'warn' | 'block' | 'circuit_break'
+ */
+'use strict';
+
+const crypto = require('crypto');
+
+const WARN_THRESHOLD = 3;
+const BLOCK_THRESHOLD = 5;
+const CIRCUIT_BREAK_TOTAL = 200;
+const HISTORY_SIZE = 30;
+const POLL_MULTIPLIER = 3;
+
+function hashCall(toolName, params) {
+  return crypto.createHash('sha256')
+    .update(toolName + JSON.stringify(params))
+    .digest('hex');
+}
+
+function detectPingPong(history) {
+  const MIN_REPEATS = 3;
+  for (const patternLength of [2, 3]) {
+    const required = patternLength * MIN_REPEATS;
+    if (history.length < required) continue;
+    const tail = history.slice(-required);
+    const pattern = tail.slice(0, patternLength);
+    // Pattern must contain at least 2 distinct hashes to be ping-pong
+    if (new Set(pattern).size < 2) continue;
+    let match = true;
+    for (let repeat = 1; repeat < MIN_REPEATS; repeat++) {
+      for (let i = 0; i < patternLength; i++) {
+        if (tail[repeat * patternLength + i] !== pattern[i]) {
+          match = false;
+          break;
+        }
+      }
+      if (!match) break;
+    }
+    if (match) return { detected: true, patternLength };
+  }
+  return { detected: false, patternLength: 0 };
+}
+
+/**
+ * Create a loop guard for a single agent session.
+ *
+ * @param {object} [opts]
+ * @param {string[]} [opts.pollTools] - Tool names expected to repeat (get higher thresholds)
+ * @param {number} [opts.circuitBreakTotal] - Max total calls before circuit break (default 200)
+ * @returns {{ check: Function, getStats: Function, reset: Function }}
+ */
+function createLoopGuard(opts) {
+  const pollTools = new Set((opts && opts.pollTools) ? opts.pollTools : []);
+  const circuitBreakTotal = (opts && typeof opts.circuitBreakTotal === 'number')
+    ? opts.circuitBreakTotal
+    : CIRCUIT_BREAK_TOTAL;
+  const counters = new Map();
+  let history = [];
+  let totalCalls = 0;
+
+  function check(toolName, params) {
+    totalCalls += 1;
+    if (totalCalls >= circuitBreakTotal) {
+      return { action: 'circuit_break', message: `Circuit breaker tripped: ${totalCalls} total calls.` };
+    }
+
+    const hash = hashCall(toolName, params);
+    const count = (counters.get(hash) || 0) + 1;
+    counters.set(hash, count);
+    history.push(hash);
+    if (history.length > HISTORY_SIZE) history.shift();
+
+    const pingPong = detectPingPong(history);
+    if (pingPong.detected) {
+      return { action: 'block', message: `Ping-pong loop detected: pattern length ${pingPong.patternLength}.` };
+    }
+
+    const multiplier = pollTools.has(toolName) ? POLL_MULTIPLIER : 1;
+    if (count >= BLOCK_THRESHOLD * multiplier) {
+      return { action: 'block', message: `"${toolName}" repeated ${count} times (limit ${BLOCK_THRESHOLD * multiplier}).` };
+    }
+    if (count >= WARN_THRESHOLD * multiplier) {
+      return { action: 'warn', message: `"${toolName}" repeated ${count} times (warn at ${WARN_THRESHOLD * multiplier}).` };
+    }
+    return { action: 'allow', message: null };
+  }
+
+  function getStats() {
+    return { totalCalls, uniqueCalls: counters.size, history: [...history] };
+  }
+
+  function reset() {
+    counters.clear();
+    history = [];
+    totalCalls = 0;
+  }
+
+  return { check, getStats, reset };
+}
+
+module.exports = {
+  WARN_THRESHOLD, BLOCK_THRESHOLD, CIRCUIT_BREAK_TOTAL,
+  hashCall, detectPingPong, createLoopGuard,
+};

--- a/get-shit-done/bin/lib/safety.cjs
+++ b/get-shit-done/bin/lib/safety.cjs
@@ -1,0 +1,176 @@
+/**
+ * Safety Rails — Agent guardrails for autonomous improvement sessions.
+ *
+ * Protected-file detection, improvement-type classification, circuit breakers,
+ * scope checking, and merge-readiness validation. All functions are pure or
+ * read-only — no writes to .planning/, no JSON persistence, no file locking.
+ */
+'use strict';
+
+const fs = require('fs');
+const { spawnSync } = require('child_process');
+
+// --- Constants ---------------------------------------------------------------
+
+const SAFE_TYPES = new Set(['test-gap', 'stale-doc', 'pattern-violation']);
+const UNSAFE_TYPES = new Set(['feature', 'api-change', 'dependency-add', 'architecture']);
+const MAX_FILES_PER_IMPROVEMENT = 5;
+const BANNED_KEYWORDS = ['dependency', 'new package', 'api change', 'breaking change'];
+
+// --- Git helpers (array args only, no shell interpolation) --------------------
+
+function git(args, cwd) {
+  const result = spawnSync('git', args, {
+    cwd, stdio: 'pipe', encoding: 'utf-8', timeout: 30000,
+  });
+  return {
+    status: result.status,
+    stdout: result.stdout || '',
+    stderr: (result.stderr || '').trim(),
+  };
+}
+
+// --- Protected file detection ------------------------------------------------
+
+/**
+ * Returns files with uncommitted changes (unstaged + staged).
+ * Agents should not edit these files — the user is actively working on them.
+ */
+function getProtectedFiles(cwd) {
+  if (!cwd) return [];
+  const unstaged = git(['diff', '--name-only'], cwd);
+  const staged = git(['diff', '--name-only', '--staged'], cwd);
+  if (unstaged.status !== 0 && staged.status !== 0) return [];
+
+  const files = new Set();
+  const addLines = (output) => {
+    if (!output) return;
+    for (const line of output.split('\n')) {
+      const t = line.trim();
+      if (t) files.add(t);
+    }
+  };
+  if (unstaged.status === 0) addLines(unstaged.stdout);
+  if (staged.status === 0) addLines(staged.stdout);
+  return Array.from(files);
+}
+
+/**
+ * Check if a file path overlaps with any protected file or directory.
+ */
+function isFileProtected(filePath, protectedFiles) {
+  if (!filePath || !protectedFiles || protectedFiles.length === 0) return false;
+  const normalise = (p) => p.replace(/\\/g, '/');
+  const normalised = normalise(filePath);
+  for (const pf of protectedFiles) {
+    const normPf = normalise(pf);
+    if (normalised === normPf) return true;
+    if (normalised.startsWith(normPf + '/')) return true;
+    if (normPf.startsWith(normalised + '/')) return true;
+  }
+  return false;
+}
+
+// --- Improvement classification ----------------------------------------------
+
+/**
+ * Classify whether an improvement item is safe to auto-apply.
+ * Safe types (test-gap, stale-doc, pattern-violation) can be applied without
+ * human review. Everything else requires explicit approval.
+ */
+function isSafeImprovement(item) {
+  if (!item || !item.type) return { safe: false, reason: 'Missing improvement type' };
+  if (SAFE_TYPES.has(item.type)) return { safe: true, reason: 'Type "' + item.type + '" is safe' };
+  if (UNSAFE_TYPES.has(item.type)) return { safe: false, reason: 'Type "' + item.type + '" requires human review' };
+  return { safe: false, reason: 'Unknown type "' + item.type + '" defaults to unsafe' };
+}
+
+// --- Circuit breaker ---------------------------------------------------------
+
+/**
+ * Create a consecutive-failure circuit breaker.
+ * Trips after `max` consecutive failures. Resets on any success.
+ */
+function createCircuitBreaker(maxConsecutiveFailures) {
+  const max = typeof maxConsecutiveFailures === 'number' ? maxConsecutiveFailures : 3;
+  let consecutiveFailures = 0, totalFailures = 0, totalSuccesses = 0;
+  return {
+    recordSuccess() { totalSuccesses++; consecutiveFailures = 0; },
+    recordFailure() { totalFailures++; consecutiveFailures++; },
+    isTripped() { return consecutiveFailures >= max; },
+    getState() {
+      return {
+        consecutiveFailures,
+        tripped: consecutiveFailures >= max,
+        totalFailures,
+        totalSuccesses,
+      };
+    },
+    reset() { consecutiveFailures = 0; totalFailures = 0; totalSuccesses = 0; },
+  };
+}
+
+// --- Scope checking ----------------------------------------------------------
+
+/**
+ * Validate an improvement plan against scope limits.
+ * Rejects plans with banned keywords or too many files.
+ */
+function scopeCheck(planContent) {
+  if (!planContent) return { valid: true, reason: 'Empty plan', fileCount: 0 };
+  const lower = planContent.toLowerCase();
+  for (const keyword of BANNED_KEYWORDS) {
+    if (lower.includes(keyword)) {
+      return { valid: false, reason: 'Banned keyword: "' + keyword + '"', fileCount: 0 };
+    }
+  }
+  const filePattern = /(?:Create|Modify|Edit|Test):\s*(\S+)/gi;
+  const files = new Set();
+  let match;
+  while ((match = filePattern.exec(planContent)) !== null) files.add(match[1]);
+  if (files.size > MAX_FILES_PER_IMPROVEMENT) {
+    return {
+      valid: false,
+      reason: 'Plan touches ' + files.size + ' files (max ' + MAX_FILES_PER_IMPROVEMENT + ')',
+      fileCount: files.size,
+    };
+  }
+  return { valid: true, reason: 'Scope is acceptable', fileCount: files.size };
+}
+
+// --- Merge readiness ---------------------------------------------------------
+
+/**
+ * Validate merge readiness by running tests in a worktree.
+ * Accepts testArgs as string[] (array of args) to prevent command injection.
+ * Uses spawnSync with array args — no shell interpolation.
+ *
+ * @param {string} _cwd - Project root (unused, kept for API symmetry)
+ * @param {string} worktreePath - Path to the worktree to test
+ * @param {string[]} testArgs - Command as array, e.g. ['node', '--test', 'tests/']
+ */
+function validateMergeReadiness(_cwd, worktreePath, testArgs) {
+  if (!worktreePath) return { ready: false, reason: 'No worktree path', testOutput: '' };
+  try {
+    if (!fs.statSync(worktreePath).isDirectory()) {
+      return { ready: false, reason: 'Not a directory', testOutput: '' };
+    }
+  } catch {
+    return { ready: false, reason: 'Worktree does not exist', testOutput: '' };
+  }
+  if (!testArgs || !Array.isArray(testArgs) || testArgs.length === 0) {
+    return { ready: false, reason: 'No test command (must be an array of args)', testOutput: '' };
+  }
+  const result = spawnSync(testArgs[0], testArgs.slice(1), {
+    cwd: worktreePath, stdio: 'pipe', encoding: 'utf-8', timeout: 120000,
+  });
+  const testOutput = ((result.stdout || '') + '\n' + (result.stderr || '')).trim();
+  if (result.status === 0) return { ready: true, reason: 'All tests passed', testOutput };
+  return { ready: false, reason: 'Tests failed (exit ' + result.status + ')', testOutput };
+}
+
+module.exports = {
+  SAFE_TYPES, UNSAFE_TYPES, MAX_FILES_PER_IMPROVEMENT,
+  getProtectedFiles, isFileProtected, isSafeImprovement,
+  createCircuitBreaker, scopeCheck, validateMergeReadiness,
+};

--- a/tests/loop-guard.test.cjs
+++ b/tests/loop-guard.test.cjs
@@ -1,0 +1,161 @@
+/**
+ * Tests for loop-guard.cjs — agent loop detection and circuit breaking
+ */
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const { createLoopGuard, hashCall, detectPingPong } = require('../get-shit-done/bin/lib/loop-guard.cjs');
+
+describe('hashCall', () => {
+  it('produces consistent hashes for same input', () => {
+    const a = hashCall('Read', { path: '/foo.js' });
+    const b = hashCall('Read', { path: '/foo.js' });
+    assert.equal(a, b);
+  });
+
+  it('produces different hashes for different input', () => {
+    const a = hashCall('Read', { path: '/foo.js' });
+    const b = hashCall('Read', { path: '/bar.js' });
+    assert.notEqual(a, b);
+  });
+
+  it('produces different hashes for different tool names', () => {
+    const a = hashCall('Read', { path: '/foo.js' });
+    const b = hashCall('Edit', { path: '/foo.js' });
+    assert.notEqual(a, b);
+  });
+});
+
+describe('detectPingPong', () => {
+  it('returns false for short history', () => {
+    assert.equal(detectPingPong(['a', 'b']).detected, false);
+  });
+
+  it('detects A-B pattern repeated 3 times', () => {
+    const history = ['a', 'b', 'a', 'b', 'a', 'b'];
+    assert.equal(detectPingPong(history).detected, true);
+    assert.equal(detectPingPong(history).patternLength, 2);
+  });
+
+  it('detects A-B-C pattern repeated 3 times', () => {
+    const history = ['a', 'b', 'c', 'a', 'b', 'c', 'a', 'b', 'c'];
+    assert.equal(detectPingPong(history).detected, true);
+    assert.equal(detectPingPong(history).patternLength, 3);
+  });
+
+  it('rejects single-element repeats (not ping-pong)', () => {
+    const history = ['a', 'a', 'a', 'a', 'a', 'a'];
+    assert.equal(detectPingPong(history).detected, false);
+  });
+
+  it('returns false for non-repeating history', () => {
+    const history = ['a', 'b', 'c', 'd', 'e', 'f'];
+    assert.equal(detectPingPong(history).detected, false);
+  });
+});
+
+describe('createLoopGuard', () => {
+  it('allows first call', () => {
+    const guard = createLoopGuard();
+    const r = guard.check('Read', { path: '/foo.js' });
+    assert.equal(r.action, 'allow');
+    assert.equal(r.message, null);
+  });
+
+  it('warns on 3rd identical call', () => {
+    const guard = createLoopGuard();
+    guard.check('Read', { path: '/foo.js' });
+    guard.check('Read', { path: '/foo.js' });
+    const r = guard.check('Read', { path: '/foo.js' });
+    assert.equal(r.action, 'warn');
+    assert.ok(r.message.includes('3'));
+  });
+
+  it('blocks on 5th identical call', () => {
+    const guard = createLoopGuard();
+    for (let i = 0; i < 4; i++) guard.check('Read', { path: '/foo.js' });
+    const r = guard.check('Read', { path: '/foo.js' });
+    assert.equal(r.action, 'block');
+  });
+
+  it('detects ping-pong and returns block', () => {
+    const guard = createLoopGuard();
+    let lastResult;
+    for (let i = 0; i < 3; i++) {
+      lastResult = guard.check('Read', { path: '/a.js' });
+      if (lastResult.action === 'block') break;
+      lastResult = guard.check('Edit', { path: '/a.js' });
+      if (lastResult.action === 'block') break;
+    }
+    assert.equal(lastResult.action, 'block');
+    assert.ok(lastResult.message.length > 0);
+  });
+
+  it('circuit breaks after configured total calls', () => {
+    const guard = createLoopGuard({ circuitBreakTotal: 10 });
+    let result;
+    for (let i = 0; i < 10; i++) {
+      result = guard.check('tool' + i, { i });
+    }
+    assert.equal(result.action, 'circuit_break');
+    assert.ok(result.message.includes('10'));
+  });
+
+  it('uses default circuit break of 200', () => {
+    const guard = createLoopGuard();
+    // After 5 calls, should not trip
+    for (let i = 0; i < 5; i++) guard.check('tool' + i, { i });
+    const stats = guard.getStats();
+    assert.equal(stats.totalCalls, 5);
+  });
+
+  it('applies poll multiplier to threshold', () => {
+    const guard = createLoopGuard({ pollTools: ['BashOutput'] });
+    // BashOutput gets 3x threshold: warn at 9, block at 15
+    for (let i = 0; i < 8; i++) guard.check('BashOutput', { id: 'same' });
+    const r = guard.check('BashOutput', { id: 'same' });
+    assert.equal(r.action, 'warn');
+  });
+
+  it('does not apply multiplier to non-poll tools', () => {
+    const guard = createLoopGuard({ pollTools: ['BashOutput'] });
+    for (let i = 0; i < 4; i++) guard.check('Read', { path: '/foo.js' });
+    const r = guard.check('Read', { path: '/foo.js' });
+    assert.equal(r.action, 'block');
+  });
+
+  it('tracks stats correctly', () => {
+    const guard = createLoopGuard();
+    guard.check('Read', { path: '/a.js' });
+    guard.check('Read', { path: '/b.js' });
+    guard.check('Read', { path: '/a.js' });
+    const stats = guard.getStats();
+    assert.equal(stats.totalCalls, 3);
+    assert.equal(stats.uniqueCalls, 2);
+    assert.equal(stats.history.length, 3);
+  });
+
+  it('resets state', () => {
+    const guard = createLoopGuard();
+    guard.check('Read', { path: '/a.js' });
+    guard.check('Read', { path: '/a.js' });
+    guard.reset();
+    const stats = guard.getStats();
+    assert.equal(stats.totalCalls, 0);
+    assert.equal(stats.uniqueCalls, 0);
+    // After reset, same call should be allowed again
+    const r = guard.check('Read', { path: '/a.js' });
+    assert.equal(r.action, 'allow');
+  });
+
+  it('allows different calls without interference', () => {
+    const guard = createLoopGuard();
+    guard.check('Read', { path: '/a.js' });
+    guard.check('Read', { path: '/b.js' });
+    guard.check('Read', { path: '/c.js' });
+    guard.check('Read', { path: '/d.js' });
+    const r = guard.check('Read', { path: '/e.js' });
+    assert.equal(r.action, 'allow');
+  });
+});

--- a/tests/safety.test.cjs
+++ b/tests/safety.test.cjs
@@ -1,0 +1,248 @@
+/**
+ * Tests for safety.cjs — agent guardrails for autonomous improvement sessions
+ */
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { createTempGitProject, createTempDir, cleanup } = require('./helpers.cjs');
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const {
+  getProtectedFiles, isFileProtected, isSafeImprovement,
+  createCircuitBreaker, scopeCheck, validateMergeReadiness,
+  SAFE_TYPES, UNSAFE_TYPES, MAX_FILES_PER_IMPROVEMENT,
+} = require('../get-shit-done/bin/lib/safety.cjs');
+
+// --- getProtectedFiles -------------------------------------------------------
+
+describe('getProtectedFiles', () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = createTempGitProject('gsd-safety-protect-'); });
+  afterEach(() => cleanup(tmpDir));
+
+  it('returns empty when no uncommitted changes', () => {
+    const files = getProtectedFiles(tmpDir);
+    assert.deepEqual(files, []);
+  });
+
+  it('returns unstaged modified files', () => {
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'PROJECT.md'), '# Changed\n');
+    const files = getProtectedFiles(tmpDir);
+    assert.ok(files.includes('.planning/PROJECT.md'));
+  });
+
+  it('returns staged files', () => {
+    const newFile = path.join(tmpDir, 'staged.js');
+    fs.writeFileSync(newFile, 'const x = 1;\n');
+    spawnSync('git', ['add', 'staged.js'], { cwd: tmpDir, stdio: 'pipe' });
+    const files = getProtectedFiles(tmpDir);
+    assert.ok(files.includes('staged.js'));
+  });
+
+  it('returns empty for null cwd', () => {
+    assert.deepEqual(getProtectedFiles(null), []);
+  });
+});
+
+// --- isFileProtected ---------------------------------------------------------
+
+describe('isFileProtected', () => {
+  it('matches exact path', () => {
+    assert.ok(isFileProtected('src/app.js', ['src/app.js']));
+  });
+
+  it('matches file inside protected directory', () => {
+    assert.ok(isFileProtected('src/auth/login.js', ['src/auth']));
+  });
+
+  it('matches protected directory inside file path', () => {
+    assert.ok(isFileProtected('src/auth', ['src/auth/login.js']));
+  });
+
+  it('does not match unrelated paths', () => {
+    assert.ok(!isFileProtected('src/other.js', ['src/app.js']));
+  });
+
+  it('normalizes backslashes', () => {
+    assert.ok(isFileProtected('src\\app.js', ['src/app.js']));
+  });
+
+  it('returns false for empty inputs', () => {
+    assert.ok(!isFileProtected(null, ['src/app.js']));
+    assert.ok(!isFileProtected('src/app.js', null));
+    assert.ok(!isFileProtected('src/app.js', []));
+  });
+});
+
+// --- isSafeImprovement -------------------------------------------------------
+
+describe('isSafeImprovement', () => {
+  it('classifies safe types', () => {
+    for (const type of SAFE_TYPES) {
+      const result = isSafeImprovement({ type });
+      assert.ok(result.safe, `${type} should be safe`);
+    }
+  });
+
+  it('classifies unsafe types', () => {
+    for (const type of UNSAFE_TYPES) {
+      const result = isSafeImprovement({ type });
+      assert.ok(!result.safe, `${type} should be unsafe`);
+    }
+  });
+
+  it('defaults unknown types to unsafe', () => {
+    const result = isSafeImprovement({ type: 'unknown-thing' });
+    assert.ok(!result.safe);
+    assert.ok(result.reason.includes('Unknown'));
+  });
+
+  it('rejects missing type', () => {
+    assert.ok(!isSafeImprovement({}).safe);
+    assert.ok(!isSafeImprovement(null).safe);
+  });
+});
+
+// --- createCircuitBreaker ----------------------------------------------------
+
+describe('createCircuitBreaker', () => {
+  it('is not tripped initially', () => {
+    const cb = createCircuitBreaker(3);
+    assert.ok(!cb.isTripped());
+  });
+
+  it('trips after consecutive failures', () => {
+    const cb = createCircuitBreaker(3);
+    cb.recordFailure();
+    cb.recordFailure();
+    assert.ok(!cb.isTripped());
+    cb.recordFailure();
+    assert.ok(cb.isTripped());
+  });
+
+  it('resets consecutive count on success', () => {
+    const cb = createCircuitBreaker(3);
+    cb.recordFailure();
+    cb.recordFailure();
+    cb.recordSuccess();
+    assert.ok(!cb.isTripped());
+    assert.equal(cb.getState().consecutiveFailures, 0);
+  });
+
+  it('tracks total failures through resets', () => {
+    const cb = createCircuitBreaker(3);
+    cb.recordFailure();
+    cb.recordSuccess();
+    cb.recordFailure();
+    assert.equal(cb.getState().totalFailures, 2);
+    assert.equal(cb.getState().totalSuccesses, 1);
+  });
+
+  it('reset clears all counters', () => {
+    const cb = createCircuitBreaker(3);
+    cb.recordFailure();
+    cb.recordSuccess();
+    cb.reset();
+    const state = cb.getState();
+    assert.equal(state.consecutiveFailures, 0);
+    assert.equal(state.totalFailures, 0);
+    assert.equal(state.totalSuccesses, 0);
+  });
+
+  it('defaults to max 3 if not specified', () => {
+    const cb = createCircuitBreaker();
+    cb.recordFailure();
+    cb.recordFailure();
+    assert.ok(!cb.isTripped());
+    cb.recordFailure();
+    assert.ok(cb.isTripped());
+  });
+});
+
+// --- scopeCheck --------------------------------------------------------------
+
+describe('scopeCheck', () => {
+  it('accepts empty plan', () => {
+    assert.ok(scopeCheck('').valid);
+    assert.ok(scopeCheck(null).valid);
+  });
+
+  it('accepts plan within file limit', () => {
+    const plan = 'Create: src/a.js\nModify: src/b.js';
+    const result = scopeCheck(plan);
+    assert.ok(result.valid);
+    assert.equal(result.fileCount, 2);
+  });
+
+  it('rejects plan exceeding file limit', () => {
+    const files = Array.from({ length: 6 }, (_, i) => `Create: src/${i}.js`).join('\n');
+    const result = scopeCheck(files);
+    assert.ok(!result.valid);
+    assert.ok(result.reason.includes('files'));
+  });
+
+  it('rejects banned keywords', () => {
+    assert.ok(!scopeCheck('This is a breaking change to the API').valid);
+    assert.ok(!scopeCheck('Add new package for logging').valid);
+    assert.ok(!scopeCheck('This adds a dependency on lodash').valid);
+    assert.ok(!scopeCheck('This is an api change').valid);
+  });
+
+  it('deduplicates files', () => {
+    const plan = 'Create: src/a.js\nModify: src/a.js\nEdit: src/b.js';
+    const result = scopeCheck(plan);
+    assert.ok(result.valid);
+    assert.equal(result.fileCount, 2);
+  });
+});
+
+// --- validateMergeReadiness --------------------------------------------------
+
+describe('validateMergeReadiness', () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = createTempDir('gsd-safety-merge-'); });
+  afterEach(() => cleanup(tmpDir));
+
+  it('rejects null worktree path', () => {
+    const r = validateMergeReadiness(tmpDir, null, ['echo', 'ok']);
+    assert.equal(r.ready, false);
+    assert.ok(r.reason.includes('No worktree'));
+  });
+
+  it('rejects nonexistent worktree', () => {
+    const r = validateMergeReadiness(tmpDir, '/nonexistent/path', ['echo', 'ok']);
+    assert.equal(r.ready, false);
+    assert.ok(r.reason.includes('does not exist'));
+  });
+
+  it('rejects non-array testArgs', () => {
+    const r = validateMergeReadiness(tmpDir, tmpDir, 'echo ok');
+    assert.equal(r.ready, false);
+    assert.ok(r.reason.includes('array'));
+  });
+
+  it('rejects empty testArgs array', () => {
+    const r = validateMergeReadiness(tmpDir, tmpDir, []);
+    assert.equal(r.ready, false);
+  });
+
+  it('reports ready when tests pass', () => {
+    const r = validateMergeReadiness(tmpDir, tmpDir, ['node', '-e', 'process.exit(0)']);
+    assert.equal(r.ready, true);
+    assert.ok(r.reason.includes('passed'));
+  });
+
+  it('reports not ready when tests fail', () => {
+    const r = validateMergeReadiness(tmpDir, tmpDir, ['node', '-e', 'process.exit(1)']);
+    assert.equal(r.ready, false);
+    assert.ok(r.reason.includes('Tests failed'));
+  });
+
+  it('captures test output', () => {
+    const r = validateMergeReadiness(tmpDir, tmpDir, ['node', '-e', 'console.log("hello"); process.exit(0)']);
+    assert.ok(r.testOutput.includes('hello'));
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1845

Two new lib modules for agent loop detection and autonomous improvement guardrails. Extracted from the loop guard and safety rails components of #1465, which the reviewer noted "have standalone value and could be extracted into a separate, focused PR."

**No CLI subcommands. No persistent state. No `.planning/` dependency. No file locking.** These are pure library functions for orchestrators and agents to consume.

- **`loop-guard.cjs`** (~100 lines) — SHA-256 dedup of tool calls, ping-pong pattern detection (A-B and A-B-C repeating sequences), configurable global circuit breaker, poll-tool multiplier for expected-repetitive tools
- **`safety.cjs`** (~160 lines) — protected-file detection from git working tree, improvement-type classification (safe vs. requires human review), consecutive-failure circuit breaker, scope checking with banned keywords and file-count limits, merge-readiness validation via `spawnSync` with args array (no command injection)

### Design decisions

- **In-memory only**: loop guard state lives for one agent session, then disappears. No context rot.
- **No new commands**: these are `require()`-able library modules, not user-facing CLI surface.
- **Args array, not string splitting**: `validateMergeReadiness` accepts `string[]` to prevent command injection (addressed review feedback from #1465).
- **Flat files in `lib/`**: follows GSD's existing module pattern, not a subdirectory.

## Test plan

- [x] 51 new tests across both modules
- [x] All 2655 existing tests still pass (7 pre-existing `code_review_gate` failures on upstream main, unrelated)
- [x] Tests use centralized helpers from `tests/helpers.cjs` per CONTRIBUTING.md
- [x] `node:test` + `node:assert/strict` framework


🤖 Generated with [Claude Code](https://claude.com/claude-code)