### PR TITLE
feat(review): add per-CLI model selection via config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+- **Review model configuration** — Per-CLI model selection for /gsd-review via `review.models.<cli>` config keys. Falls back to CLI defaults when not set. (#1849)
+
 ## [1.34.2] - 2026-04-06
 
 ### Changed

--- a/get-shit-done/bin/lib/config.cjs
+++ b/get-shit-done/bin/lib/config.cjs
@@ -47,6 +47,8 @@ function isValidConfigKey(keyPath) {
   if (VALID_CONFIG_KEYS.has(keyPath)) return true;
   // Allow agent_skills.<agent-type> with any agent type string
   if (/^agent_skills\.[a-zA-Z0-9_-]+$/.test(keyPath)) return true;
+  // Allow review.models.<cli-name> for per-CLI model selection in /gsd-review
+  if (/^review\.models\.[a-zA-Z0-9_-]+$/.test(keyPath)) return true;
   // Allow features.<feature_name> — dynamic namespace for feature flags.
   // Intentionally open-ended so new flags (e.g., features.global_learnings) work
   // without updating VALID_CONFIG_KEYS each time.
@@ -64,6 +66,7 @@ const CONFIG_KEY_SUGGESTIONS = {
   'workflow.review': 'workflow.code_review',
   'workflow.code_review_level': 'workflow.code_review_depth',
   'workflow.review_depth': 'workflow.code_review_depth',
+  'review.model': 'review.models.<cli-name>',
 };
 
 function validateKnownConfigKeyPath(keyPath) {

--- a/get-shit-done/references/planning-config.md
+++ b/get-shit-done/references/planning-config.md
@@ -235,6 +235,7 @@ Generated from `CONFIG_DEFAULTS` (core.cjs) and `VALID_CONFIG_KEYS` (config.cjs)
 | `context_window` | number | `200000` | `200000`, `1000000` | Context window size; set `1000000` for 1M-context models |
 | `resolve_model_ids` | boolean\|string | `false` | `false`, `true`, `"omit"` | Map model aliases to full Claude IDs; `"omit"` returns empty string |
 | `context` | string\|null | `null` | `"dev"`, `"research"`, `"review"` | Execution context profile that adjusts agent behavior: `"dev"` for development tasks, `"research"` for investigation/exploration, `"review"` for code review workflows |
+| `review.models.<cli>` | string\|null | `null` | Any model ID string | Per-CLI model override for /gsd-review (e.g., `review.models.gemini`). Falls back to CLI default when null. |
 
 ### Workflow Fields
 

--- a/get-shit-done/workflows/review.md
+++ b/get-shit-done/workflows/review.md
@@ -139,26 +139,47 @@ Write to a temp file: `/tmp/gsd-review-prompt-{phase}.md`
 </step>
 
 <step name="invoke_reviewers">
+Read model preferences from planning config. Null/missing values fall back to CLI defaults.
+
+```bash
+GEMINI_MODEL=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-get review.models.gemini --raw 2>/dev/null)
+CLAUDE_MODEL=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-get review.models.claude --raw 2>/dev/null)
+CODEX_MODEL=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-get review.models.codex --raw 2>/dev/null)
+OPENCODE_MODEL=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-get review.models.opencode --raw 2>/dev/null)
+```
+
 For each selected CLI, invoke in sequence (not parallel — avoid rate limits):
 
 **Gemini:**
 ```bash
-gemini -p "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-review-gemini-{phase}.md
+if [ -n "$GEMINI_MODEL" ]; then
+  gemini -m "$GEMINI_MODEL" -p "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-review-gemini-{phase}.md
+else
+  gemini -p "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-review-gemini-{phase}.md
+fi
 ```
 
 **Claude (separate session):**
 ```bash
-claude -p "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-review-claude-{phase}.md
+if [ -n "$CLAUDE_MODEL" ]; then
+  claude --model "$CLAUDE_MODEL" -p "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-review-claude-{phase}.md
+else
+  claude -p "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-review-claude-{phase}.md
+fi
 ```
 
 **Codex:**
 ```bash
-codex exec --skip-git-repo-check "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-review-codex-{phase}.md
+if [ -n "$CODEX_MODEL" ]; then
+  codex exec --model "$CODEX_MODEL" --skip-git-repo-check "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-review-codex-{phase}.md
+else
+  codex exec --skip-git-repo-check "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-review-codex-{phase}.md
+fi
 ```
 
 **CodeRabbit:**
 
-Note: CodeRabbit reviews the current git diff/working tree — it does not accept a prompt. It may take up to 5 minutes. Use `timeout: 360000` on the Bash tool call.
+Note: CodeRabbit reviews the current git diff/working tree — it does not accept a prompt or model flag. It may take up to 5 minutes. Use `timeout: 360000` on the Bash tool call.
 
 ```bash
 coderabbit review --prompt-only 2>/dev/null > /tmp/gsd-review-coderabbit-{phase}.md
@@ -166,7 +187,11 @@ coderabbit review --prompt-only 2>/dev/null > /tmp/gsd-review-coderabbit-{phase}
 
 **OpenCode (via GitHub Copilot):**
 ```bash
-cat /tmp/gsd-review-prompt-{phase}.md | opencode run - 2>/dev/null > /tmp/gsd-review-opencode-{phase}.md
+if [ -n "$OPENCODE_MODEL" ]; then
+  cat /tmp/gsd-review-prompt-{phase}.md | opencode run --model "$OPENCODE_MODEL" - 2>/dev/null > /tmp/gsd-review-opencode-{phase}.md
+else
+  cat /tmp/gsd-review-prompt-{phase}.md | opencode run - 2>/dev/null > /tmp/gsd-review-opencode-{phase}.md
+fi
 if [ ! -s /tmp/gsd-review-opencode-{phase}.md ]; then
   echo "OpenCode review failed or returned empty output." > /tmp/gsd-review-opencode-{phase}.md
 fi

--- a/get-shit-done/workflows/review.md
+++ b/get-shit-done/workflows/review.md
@@ -142,17 +142,17 @@ Write to a temp file: `/tmp/gsd-review-prompt-{phase}.md`
 Read model preferences from planning config. Null/missing values fall back to CLI defaults.
 
 ```bash
-GEMINI_MODEL=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-get review.models.gemini --raw 2>/dev/null)
-CLAUDE_MODEL=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-get review.models.claude --raw 2>/dev/null)
-CODEX_MODEL=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-get review.models.codex --raw 2>/dev/null)
-OPENCODE_MODEL=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-get review.models.opencode --raw 2>/dev/null)
+GEMINI_MODEL=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-get review.models.gemini --raw 2>/dev/null || true)
+CLAUDE_MODEL=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-get review.models.claude --raw 2>/dev/null || true)
+CODEX_MODEL=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-get review.models.codex --raw 2>/dev/null || true)
+OPENCODE_MODEL=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-get review.models.opencode --raw 2>/dev/null || true)
 ```
 
 For each selected CLI, invoke in sequence (not parallel — avoid rate limits):
 
 **Gemini:**
 ```bash
-if [ -n "$GEMINI_MODEL" ]; then
+if [ -n "$GEMINI_MODEL" ] && [ "$GEMINI_MODEL" != "null" ]; then
   gemini -m "$GEMINI_MODEL" -p "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-review-gemini-{phase}.md
 else
   gemini -p "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-review-gemini-{phase}.md
@@ -161,7 +161,7 @@ fi
 
 **Claude (separate session):**
 ```bash
-if [ -n "$CLAUDE_MODEL" ]; then
+if [ -n "$CLAUDE_MODEL" ] && [ "$CLAUDE_MODEL" != "null" ]; then
   claude --model "$CLAUDE_MODEL" -p "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-review-claude-{phase}.md
 else
   claude -p "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-review-claude-{phase}.md
@@ -170,7 +170,7 @@ fi
 
 **Codex:**
 ```bash
-if [ -n "$CODEX_MODEL" ]; then
+if [ -n "$CODEX_MODEL" ] && [ "$CODEX_MODEL" != "null" ]; then
   codex exec --model "$CODEX_MODEL" --skip-git-repo-check "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-review-codex-{phase}.md
 else
   codex exec --skip-git-repo-check "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-review-codex-{phase}.md
@@ -187,7 +187,7 @@ coderabbit review --prompt-only 2>/dev/null > /tmp/gsd-review-coderabbit-{phase}
 
 **OpenCode (via GitHub Copilot):**
 ```bash
-if [ -n "$OPENCODE_MODEL" ]; then
+if [ -n "$OPENCODE_MODEL" ] && [ "$OPENCODE_MODEL" != "null" ]; then
   cat /tmp/gsd-review-prompt-{phase}.md | opencode run --model "$OPENCODE_MODEL" - 2>/dev/null > /tmp/gsd-review-opencode-{phase}.md
 else
   cat /tmp/gsd-review-prompt-{phase}.md | opencode run - 2>/dev/null > /tmp/gsd-review-opencode-{phase}.md

--- a/tests/review-model-config.test.cjs
+++ b/tests/review-model-config.test.cjs
@@ -1,0 +1,107 @@
+/**
+ * Review Model Config Tests (#1849)
+ *
+ * Verifies the review.models.<cli> dynamic config key pattern:
+ *   - isValidConfigKey accepts review.models.<cli-name>
+ *   - validateKnownConfigKeyPath suggests review.models.<cli-name> for review.model
+ *   - End-to-end round-trip via config-set / config-get for both model IDs and null
+ */
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
+
+describe('review.models.<cli> config key', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+    // Ensure config exists for set/get
+    runGsdTools('config-ensure-section', tmpDir, { HOME: tmpDir, USERPROFILE: tmpDir });
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('isValidConfigKey accepts review.models.gemini', () => {
+    // Exercised via config-set, which calls isValidConfigKey internally and
+    // errors out if the key is not valid.
+    const result = runGsdTools(
+      ['config-set', 'review.models.gemini', 'gemini-3.1-pro-preview'],
+      tmpDir,
+      { HOME: tmpDir, USERPROFILE: tmpDir }
+    );
+    assert.ok(result.success, `config-set should succeed for review.models.gemini: ${result.error}`);
+  });
+
+  test('isValidConfigKey accepts review.models.codex', () => {
+    const result = runGsdTools(
+      ['config-set', 'review.models.codex', 'gpt-5-codex'],
+      tmpDir,
+      { HOME: tmpDir, USERPROFILE: tmpDir }
+    );
+    assert.ok(result.success, `config-set should succeed for review.models.codex: ${result.error}`);
+  });
+
+  test('review.model is rejected and suggests review.models.<cli-name>', () => {
+    // The suggestion path goes through validateKnownConfigKeyPath, which is
+    // called before isValidConfigKey in cmdConfigSet.
+    const result = runGsdTools(
+      ['config-set', 'review.model', 'gemini-3.1-pro-preview'],
+      tmpDir,
+      { HOME: tmpDir, USERPROFILE: tmpDir }
+    );
+    assert.ok(!result.success, 'config-set should fail for review.model');
+    assert.ok(
+      result.error.includes('review.models.<cli-name>'),
+      `error should suggest review.models.<cli-name>, got: ${result.error}`
+    );
+  });
+
+  test('round-trip: config-set then config-get for a model ID', () => {
+    const setResult = runGsdTools(
+      ['config-set', 'review.models.gemini', 'gemini-3.1-pro-preview'],
+      tmpDir,
+      { HOME: tmpDir, USERPROFILE: tmpDir }
+    );
+    assert.ok(setResult.success, `config-set failed: ${setResult.error}`);
+
+    const getResult = runGsdTools(
+      ['config-get', 'review.models.gemini', '--raw'],
+      tmpDir,
+      { HOME: tmpDir, USERPROFILE: tmpDir }
+    );
+    assert.ok(getResult.success, `config-get failed: ${getResult.error}`);
+    assert.strictEqual(
+      getResult.output,
+      'gemini-3.1-pro-preview',
+      'config-get should return the value set via config-set'
+    );
+  });
+
+  test('round-trip: config-set null then config-get returns "null"', () => {
+    // The issue spec documents null as the "fall back to CLI default" sentinel.
+    // cmdConfigSet does not parse 'null' as JSON null — it stores the literal
+    // string 'null'. config-get --raw returns the string 'null', and the
+    // workflow's `[ "$VAR" != "null" ]` guard handles this.
+    const setResult = runGsdTools(
+      ['config-set', 'review.models.gemini', 'null'],
+      tmpDir,
+      { HOME: tmpDir, USERPROFILE: tmpDir }
+    );
+    assert.ok(setResult.success, `config-set null failed: ${setResult.error}`);
+
+    const getResult = runGsdTools(
+      ['config-get', 'review.models.gemini', '--raw'],
+      tmpDir,
+      { HOME: tmpDir, USERPROFILE: tmpDir }
+    );
+    assert.ok(getResult.success, `config-get failed: ${getResult.error}`);
+    assert.strictEqual(
+      getResult.output,
+      'null',
+      'config-get should return the literal string "null" so the workflow guard can match it'
+    );
+  });
+});


### PR DESCRIPTION
## Enhancement PR

---

## Linked Issue

Closes #1849

---

## What this enhancement improves

The `/gsd:review` workflow invokes external AI CLIs (Gemini, Claude, Codex, OpenCode) without any model selection flags. This means users have no control over which model each CLI uses for reviews, leading to inconsistent quality and no cost/quality tradeoff control.

## Before / After

**Before:**

```bash
gemini -p "$(cat /tmp/gsd-review-prompt.md)"
claude -p "$(cat /tmp/gsd-review-prompt.md)"
codex exec --skip-git-repo-check "$(cat /tmp/gsd-review-prompt.md)"
```

All CLIs use their default models with no override mechanism.

**After:**

```bash
# Users configure in .planning/config.json:
# { "review": { "models": { "gemini": "gemini-3.1-pro-preview" } } }

GEMINI_MODEL=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-get review.models.gemini --raw 2>/dev/null)
if [ -n "$GEMINI_MODEL" ]; then
  gemini -m "$GEMINI_MODEL" -p "$(cat /tmp/gsd-review-prompt.md)"
else
  gemini -p "$(cat /tmp/gsd-review-prompt.md)"  # falls back to CLI default
fi
```

## How it was implemented

1. **`config.cjs`** -- Added `review.models.<cli-name>` dynamic pattern to `isValidConfigKey()`, following the same approach as `agent_skills.<agent-type>` and `features.<feature_name>`. Added key suggestion for common typo (`review.model`).

2. **`review.md`** -- Added config-get reads at the start of `invoke_reviewers` step. Each CLI invocation conditionally passes a `-m`/`--model` flag when a model is configured. CodeRabbit is excluded (no model flag support).

3. **`planning-config.md`** -- Added `review.models.<cli>` to the config reference table.

4. **`CHANGELOG.md`** -- Added entry under `[Unreleased]`.

## Testing

### How I verified the enhancement works

- Verified `isValidConfigKey('review.models.gemini')` returns `true`
- Verified `isValidConfigKey('review.model')` triggers the key suggestion
- Null/missing values correctly fall back (no `-m` flag passed)

### Platforms tested

- [x] Windows (including backslash path handling)
- [ ] macOS
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Codex
- [ ] N/A (not runtime-specific)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue -- no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

---

## Checklist

- [x] Issue linked above with `Closes #1849`
- [x] Changes are scoped to the approved enhancement -- nothing extra included
- [ ] All existing tests pass (`npm test`)
- [ ] New or updated tests cover the enhanced behavior
- [x] CHANGELOG.md updated
- [x] Documentation updated if behavior or output changed
- [ ] No unnecessary dependencies added

## Breaking changes

None