### PR TITLE
fix(docs): correct mode and discuss_mode allowed values in planning-config.md

### DIFF
--- a/get-shit-done/references/planning-config.md
+++ b/get-shit-done/references/planning-config.md
@@ -225,7 +225,7 @@ Generated from `CONFIG_DEFAULTS` (core.cjs) and `VALID_CONFIG_KEYS` (config.cjs)
 | Key | Type | Default | Allowed Values | Description |
 |-----|------|---------|----------------|-------------|
 | `model_profile` | string | `"balanced"` | `"quality"`, `"balanced"`, `"budget"`, `"inherit"` | Model selection preset for subagents |
-| `mode` | string | (none) | `"code-first"`, `"plan-first"`, `"hybrid"` | Per-phase workflow mode controlling discuss/plan/execute flow |
+| `mode` | string | `"interactive"` | `"interactive"`, `"yolo"` | Operation mode: `"interactive"` shows gates and confirmations; `"yolo"` runs autonomously without prompts |
 | `granularity` | string | (none) | `"coarse"`, `"standard"`, `"fine"` | Planning depth for phase plans (migrated from deprecated `depth`) |
 | `commit_docs` | boolean | `true` | `true`, `false` | Commit .planning/ artifacts to git (auto-false if .planning/ is gitignored) |
 | `search_gitignored` | boolean | `false` | `true`, `false` | Include gitignored paths in broad rg searches via `--no-ignore` |
@@ -252,7 +252,7 @@ Set via `workflow.*` namespace in config.json (e.g., `"workflow": { "research": 
 | `workflow.ui_safety_gate` | boolean | `true` | `true`, `false` | Require safety gate approval for UI changes |
 | `workflow.text_mode` | boolean | `false` | `true`, `false` | Use plain-text numbered lists instead of AskUserQuestion menus |
 | `workflow.research_before_questions` | boolean | `false` | `true`, `false` | Run research before interactive questions in discuss phase |
-| `workflow.discuss_mode` | string | `"discuss"` | `"discuss"`, `"auto"`, `"analyze"` | Default mode for discuss-phase agent |
+| `workflow.discuss_mode` | string | `"discuss"` | `"discuss"`, `"assumptions"` | Default mode for discuss-phase: `"discuss"` runs interactive questioning; `"assumptions"` analyzes codebase and surfaces assumptions instead |
 | `workflow.skip_discuss` | boolean | `false` | `true`, `false` | Skip discuss phase entirely |
 | `workflow.use_worktrees` | boolean | `true` | `true`, `false` | Run executor agents in isolated git worktrees |
 | `workflow.subagent_timeout` | number | `300000` | Any positive integer (ms) | Timeout for parallel subagent tasks (default: 5 minutes) |

--- a/tests/config-field-docs.test.cjs
+++ b/tests/config-field-docs.test.cjs
@@ -164,6 +164,28 @@ describe('config-field-docs', () => {
     );
   });
 
+  test('mode field documents correct allowed values', () => {
+    // mode values are "interactive" and "yolo" per templates/config.json
+    // and workflows/new-project.md — NOT "code-first"/"plan-first"/"hybrid"
+    assert.ok(
+      content.includes('"interactive"') && content.includes('"yolo"'),
+      'mode field must document "interactive" and "yolo" as allowed values'
+    );
+    assert.ok(
+      !content.includes('"code-first"'),
+      'mode field must NOT document non-existent "code-first" value'
+    );
+  });
+
+  test('discuss_mode field documents correct allowed values', () => {
+    // discuss_mode values are "discuss" and "assumptions" per workflows/settings.md
+    // NOT "auto" or "analyze" (those are CLI flags, not config values)
+    assert.ok(
+      content.includes('"assumptions"'),
+      'discuss_mode must document "assumptions" as an allowed value'
+    );
+  });
+
   test('documents plan_checker alias for workflow.plan_check', () => {
     // plan_checker is the flat-key form in CONFIG_DEFAULTS; workflow.plan_check
     // is the canonical namespaced form. The doc should mention the alias.


### PR DESCRIPTION
## Fix PR

**Linked Issue:** Closes #1879

### What was broken

`planning-config.md` documented incorrect allowed values for two config fields:

1. **`mode`** — documented as `"code-first"`, `"plan-first"`, `"hybrid"` but the actual values are `"interactive"` and `"yolo"` (verified against `templates/config.json` line 2 and `workflows/new-project.md` line 534)

2. **`workflow.discuss_mode`** — documented as `"discuss"`, `"auto"`, `"analyze"` but the actual values are `"discuss"` and `"assumptions"` (verified against `workflows/settings.md` line 188). The values `"auto"` and `"analyze"` are CLI flags for the discuss-phase command, not config values.

### What this fix does

- Updates `mode` row: allowed values → `"interactive"`, `"yolo"` with accurate description
- Updates `discuss_mode` row: allowed values → `"discuss"`, `"assumptions"` with accurate description
- Adds 2 regression tests that verify correct values and reject stale ones

### Root cause

The original values were added in #1786 without cross-referencing against the actual source code (`templates/config.json`, `workflows/new-project.md`, `workflows/settings.md`).

### Testing

- [x] All 13 config-field-docs tests pass
- [x] New test verifies `"interactive"` and `"yolo"` are documented and `"code-first"` is NOT
- [x] New test verifies `"assumptions"` is documented as a discuss_mode value
- [x] Full test suite passes

### Checklist

- [x] I have read CONTRIBUTING.md
- [x] Tests added/updated
- [x] PR is scoped to a single concern
- [ ] CHANGELOG.md updated if this is a user-facing fix

Closes #1879

Generated with [Claude Code](https://claude.com/claude-code)