### PR TITLE
feat: support CodeBuddy runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **English** · [Português](README.pt-BR.md) · [简体中文](README.zh-CN.md) · [日本語](README.ja-JP.md) · [한국어](README.ko-KR.md)
 
-**A light-weight and powerful meta-prompting, context engineering and spec-driven development system for Claude Code, OpenCode, Gemini CLI, Kilo, Codex, Copilot, Cursor, Windsurf, Antigravity, Augment, Trae, and Cline.**
+**A light-weight and powerful meta-prompting, context engineering and spec-driven development system for Claude Code, OpenCode, Gemini CLI, Kilo, Codex, Copilot, Cursor, Windsurf, Antigravity, Augment, Trae, CodeBuddy, and Cline.**
 
 **Solves context rot — the quality degradation that happens as Claude fills its context window.**
 
@@ -106,12 +106,12 @@ npx get-shit-done-cc@latest
 ```
 
 The installer prompts you to choose:
-1. **Runtime** — Claude Code, OpenCode, Gemini, Kilo, Codex, Copilot, Cursor, Windsurf, Antigravity, Augment, Trae, Cline, or all (interactive multi-select — pick multiple runtimes in a single install session)
+1. **Runtime** — Claude Code, OpenCode, Gemini, Kilo, Codex, Copilot, Cursor, Windsurf, Antigravity, Augment, Trae, CodeBuddy, Cline, or all (interactive multi-select — pick multiple runtimes in a single install session)
 2. **Location** — Global (all projects) or local (current project only)
 
 Verify with:
 - Claude Code / Gemini / Copilot / Antigravity: `/gsd-help`
-- OpenCode / Kilo / Augment / Trae: `/gsd-help`
+- OpenCode / Kilo / Augment / Trae / CodeBuddy: `/gsd-help`
 - Codex: `$gsd-help`
 - Cline: GSD installs via `.clinerules` — verify by checking `.clinerules` exists
 
@@ -175,6 +175,10 @@ npx get-shit-done-cc --augment --local      # Install to ./.augment/
 npx get-shit-done-cc --trae --global        # Install to ~/.trae/
 npx get-shit-done-cc --trae --local         # Install to ./.trae/
 
+# CodeBuddy
+npx get-shit-done-cc --codebuddy --global   # Install to ~/.codebuddy/
+npx get-shit-done-cc --codebuddy --local    # Install to ./.codebuddy/
+
 # Cline
 npx get-shit-done-cc --cline --global       # Install to ~/.cline/
 npx get-shit-done-cc --cline --local        # Install to ./.clinerules
@@ -184,7 +188,7 @@ npx get-shit-done-cc --all --global      # Install to all directories
 ```
 
 Use `--global` (`-g`) or `--local` (`-l`) to skip the location prompt.
-Use `--claude`, `--opencode`, `--gemini`, `--kilo`, `--codex`, `--copilot`, `--cursor`, `--windsurf`, `--antigravity`, `--augment`, `--trae`, `--cline`, or `--all` to skip the runtime prompt.
+Use `--claude`, `--opencode`, `--gemini`, `--kilo`, `--codex`, `--copilot`, `--cursor`, `--windsurf`, `--antigravity`, `--augment`, `--trae`, `--codebuddy`, `--cline`, or `--all` to skip the runtime prompt.
 Use `--sdk` to also install the GSD SDK CLI (`gsd-sdk`) for headless autonomous execution.
 
 </details>
@@ -846,6 +850,7 @@ npx get-shit-done-cc --windsurf --global --uninstall
 npx get-shit-done-cc --antigravity --global --uninstall
 npx get-shit-done-cc --augment --global --uninstall
 npx get-shit-done-cc --trae --global --uninstall
+npx get-shit-done-cc --codebuddy --global --uninstall
 npx get-shit-done-cc --cline --global --uninstall
 
 # Local installs (current project)
@@ -860,6 +865,7 @@ npx get-shit-done-cc --windsurf --local --uninstall
 npx get-shit-done-cc --antigravity --local --uninstall
 npx get-shit-done-cc --augment --local --uninstall
 npx get-shit-done-cc --trae --local --uninstall
+npx get-shit-done-cc --codebuddy --local --uninstall
 npx get-shit-done-cc --cline --local --uninstall
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -4,7 +4,7 @@
 
 [English](README.md) · [Português](README.pt-BR.md) · **简体中文** · [日本語](README.ja-JP.md) · [한국어](README.ko-KR.md)
 
-**一个轻量但强大的元提示、上下文工程与规格驱动开发系统，适用于 Claude Code、OpenCode、Gemini CLI、Kilo、Codex、Copilot、Cursor、Windsurf、Antigravity、Augment、Trae 和 Cline。**
+**一个轻量但强大的元提示、上下文工程与规格驱动开发系统，适用于 Claude Code、OpenCode、Gemini CLI、Kilo、Codex、Copilot、Cursor、Windsurf、Antigravity、Augment、Trae、CodeBuddy 和 Cline。**
 
 **它解决的是 context rot：随着 Claude 的上下文窗口被填满，输出质量逐步劣化的问题。**
 
@@ -92,12 +92,12 @@ npx get-shit-done-cc@latest
 ```
 
 安装器会提示你选择：
-1. **运行时**：Claude Code、OpenCode、Gemini、Kilo、Codex、Copilot、Cursor、Windsurf、Antigravity、Augment、Trae、Cline，或全部
+1. **运行时**：Claude Code、OpenCode、Gemini、Kilo、Codex、Copilot、Cursor、Windsurf、Antigravity、Augment、Trae、CodeBuddy、Cline，或全部
 2. **安装位置**：全局（所有项目）或本地（仅当前项目）
 
 安装后可这样验证：
 - Claude Code / Gemini / Copilot / Antigravity：`/gsd-help`
-- OpenCode / Kilo / Augment / Trae：`/gsd-help`
+- OpenCode / Kilo / Augment / Trae / CodeBuddy：`/gsd-help`
 - Codex：`$gsd-help`
 - Cline：GSD 通过 `.clinerules` 安装 — 检查 `.clinerules` 是否存在
 
@@ -157,6 +157,10 @@ npx get-shit-done-cc --augment --local      # 安装到 ./.augment/
 npx get-shit-done-cc --trae --global     # 安装到 ~/.trae/
 npx get-shit-done-cc --trae --local      # 安装到 ./.trae/
 
+# CodeBuddy
+npx get-shit-done-cc --codebuddy --global # 安装到 ~/.codebuddy/
+npx get-shit-done-cc --codebuddy --local  # 安装到 ./.codebuddy/
+
 # Cline
 npx get-shit-done-cc --cline --global       # 安装到 ~/.cline/
 npx get-shit-done-cc --cline --local        # 安装到 ./.clinerules
@@ -166,7 +170,7 @@ npx get-shit-done-cc --all --global      # 安装到所有目录
 ```
 
 使用 `--global`（`-g`）或 `--local`（`-l`）可以跳过安装位置提示。
-使用 `--claude`、`--opencode`、`--gemini`、`--kilo`、`--codex`、`--copilot`、`--cursor`、`--windsurf`、`--antigravity`、`--augment`、`--trae`、`--cline` 或 `--all` 可以跳过运行时提示。
+使用 `--claude`、`--opencode`、`--gemini`、`--kilo`、`--codex`、`--copilot`、`--cursor`、`--windsurf`、`--antigravity`、`--augment`、`--trae`、`--codebuddy`、`--cline` 或 `--all` 可以跳过运行时提示。
 
 </details>
 

--- a/bin/install.js
+++ b/bin/install.js
@@ -70,6 +70,7 @@ const hasCursor = args.includes('--cursor');
 const hasWindsurf = args.includes('--windsurf');
 const hasAugment = args.includes('--augment');
 const hasTrae = args.includes('--trae');
+const hasCodebuddy = args.includes('--codebuddy');
 const hasBoth = args.includes('--both'); // Legacy flag, keeps working
 const hasAll = args.includes('--all');
 const hasUninstall = args.includes('--uninstall') || args.includes('-u');
@@ -77,7 +78,7 @@ const hasUninstall = args.includes('--uninstall') || args.includes('-u');
 // Runtime selection - can be set by flags or interactive prompt
 let selectedRuntimes = [];
 if (hasAll) {
-  selectedRuntimes = ['claude', 'kilo', 'opencode', 'gemini', 'codex', 'copilot', 'antigravity', 'cursor', 'windsurf', 'augment', 'trae'];
+  selectedRuntimes = ['claude', 'kilo', 'opencode', 'gemini', 'codex', 'copilot', 'antigravity', 'cursor', 'windsurf', 'augment', 'trae', 'codebuddy'];
 } else if (hasBoth) {
   selectedRuntimes = ['claude', 'opencode'];
 } else {
@@ -92,6 +93,7 @@ if (hasAll) {
   if (hasWindsurf) selectedRuntimes.push('windsurf');
   if (hasAugment) selectedRuntimes.push('augment');
   if (hasTrae) selectedRuntimes.push('trae');
+  if (hasCodebuddy) selectedRuntimes.push('codebuddy');
 }
 
 // WSL + Windows Node.js detection
@@ -140,6 +142,7 @@ function getDirName(runtime) {
   if (runtime === 'windsurf') return '.windsurf';
   if (runtime === 'augment') return '.augment';
   if (runtime === 'trae') return '.trae';
+  if (runtime === 'codebuddy') return '.codebuddy';
   return '.claude';
 }
 
@@ -172,6 +175,7 @@ function getConfigDirFromHome(runtime, isGlobal) {
   if (runtime === 'windsurf') return "'.windsurf'";
   if (runtime === 'augment') return "'.augment'";
   if (runtime === 'trae') return "'.trae'";
+  if (runtime === 'codebuddy') return "'.codebuddy'";
   return "'.claude'";
 }
 
@@ -334,6 +338,17 @@ function getGlobalDir(runtime, explicitDir = null) {
     return path.join(os.homedir(), '.trae');
   }
 
+  if (runtime === 'codebuddy') {
+    // CodeBuddy: --config-dir > CODEBUDDY_CONFIG_DIR > ~/.codebuddy
+    if (explicitDir) {
+      return expandTilde(explicitDir);
+    }
+    if (process.env.CODEBUDDY_CONFIG_DIR) {
+      return expandTilde(process.env.CODEBUDDY_CONFIG_DIR);
+    }
+    return path.join(os.homedir(), '.codebuddy');
+  }
+
 
   // Claude Code: --config-dir > CLAUDE_CONFIG_DIR > ~/.claude
   if (explicitDir) {
@@ -355,7 +370,7 @@ const banner = '\n' +
   '\n' +
   '  Get Shit Done ' + dim + 'v' + pkg.version + reset + '\n' +
   '  A meta-prompting, context engineering and spec-driven\n' +
-  '  development system for Claude Code, OpenCode, Gemini, Kilo, Codex, Copilot, Antigravity, Cursor, Windsurf, Augment and Trae by TÂCHES.\n';
+  '  development system for Claude Code, OpenCode, Gemini, Kilo, Codex, Copilot, Antigravity, Cursor, Windsurf, Augment, Trae and CodeBuddy by TÂCHES.\n';
 
 // Parse --config-dir argument
 function parseConfigDirArg() {
@@ -393,7 +408,7 @@ if (hasUninstall) {
 
 // Show help if requested
 if (hasHelp) {
-  console.log(`  ${yellow}Usage:${reset} npx get-shit-done-cc [options]\n\n  ${yellow}Options:${reset}\n    ${cyan}-g, --global${reset}              Install globally (to config directory)\n    ${cyan}-l, --local${reset}               Install locally (to current directory)\n    ${cyan}--claude${reset}                  Install for Claude Code only\n    ${cyan}--opencode${reset}                Install for OpenCode only\n    ${cyan}--gemini${reset}                  Install for Gemini only\n    ${cyan}--kilo${reset}                    Install for Kilo only\n    ${cyan}--codex${reset}                   Install for Codex only\n    ${cyan}--copilot${reset}                 Install for Copilot only\n    ${cyan}--antigravity${reset}             Install for Antigravity only\n    ${cyan}--cursor${reset}                  Install for Cursor only\n    ${cyan}--windsurf${reset}                Install for Windsurf only\n    ${cyan}--augment${reset}                 Install for Augment only\n    ${cyan}--trae${reset}                    Install for Trae only\n    ${cyan}--all${reset}                     Install for all runtimes\n    ${cyan}-u, --uninstall${reset}           Uninstall GSD (remove all GSD files)\n    ${cyan}-c, --config-dir <path>${reset}   Specify custom config directory\n    ${cyan}-h, --help${reset}                Show this help message\n    ${cyan}--force-statusline${reset}        Replace existing statusline config\n\n  ${yellow}Examples:${reset}\n    ${dim}# Interactive install (prompts for runtime and location)${reset}\n    npx get-shit-done-cc\n\n    ${dim}# Install for Claude Code globally${reset}\n    npx get-shit-done-cc --claude --global\n\n    ${dim}# Install for Gemini globally${reset}\n    npx get-shit-done-cc --gemini --global\n\n    ${dim}# Install for Kilo globally${reset}\n    npx get-shit-done-cc --kilo --global\n\n    ${dim}# Install for Codex globally${reset}\n    npx get-shit-done-cc --codex --global\n\n    ${dim}# Install for Copilot globally${reset}\n    npx get-shit-done-cc --copilot --global\n\n    ${dim}# Install for Copilot locally${reset}\n    npx get-shit-done-cc --copilot --local\n\n    ${dim}# Install for Antigravity globally${reset}\n    npx get-shit-done-cc --antigravity --global\n\n    ${dim}# Install for Antigravity locally${reset}\n    npx get-shit-done-cc --antigravity --local\n\n    ${dim}# Install for Cursor globally${reset}\n    npx get-shit-done-cc --cursor --global\n\n    ${dim}# Install for Cursor locally${reset}\n    npx get-shit-done-cc --cursor --local\n\n    ${dim}# Install for Windsurf globally${reset}\n    npx get-shit-done-cc --windsurf --global\n\n    ${dim}# Install for Windsurf locally${reset}\n    npx get-shit-done-cc --windsurf --local\n\n    ${dim}# Install for Augment globally${reset}\n    npx get-shit-done-cc --augment --global\n\n    ${dim}# Install for Augment locally${reset}\n    npx get-shit-done-cc --augment --local\n\n    ${dim}# Install for Trae globally${reset}\n    npx get-shit-done-cc --trae --global\n\n    ${dim}# Install for Trae locally${reset}\n    npx get-shit-done-cc --trae --local\n\n    ${dim}# Install for all runtimes globally${reset}\n    npx get-shit-done-cc --all --global\n\n    ${dim}# Install to custom config directory${reset}\n    npx get-shit-done-cc --kilo --global --config-dir ~/.kilo-work\n\n    ${dim}# Install to current project only${reset}\n    npx get-shit-done-cc --claude --local\n\n    ${dim}# Uninstall GSD from Cursor globally${reset}\n    npx get-shit-done-cc --cursor --global --uninstall\n\n  ${yellow}Notes:${reset}\n    The --config-dir option is useful when you have multiple configurations.\n    It takes priority over CLAUDE_CONFIG_DIR / OPENCODE_CONFIG_DIR / GEMINI_CONFIG_DIR / KILO_CONFIG_DIR / CODEX_HOME / COPILOT_CONFIG_DIR / ANTIGRAVITY_CONFIG_DIR / CURSOR_CONFIG_DIR / WINDSURF_CONFIG_DIR / AUGMENT_CONFIG_DIR / TRAE_CONFIG_DIR environment variables.\n`);
+  console.log(`  ${yellow}Usage:${reset} npx get-shit-done-cc [options]\n\n  ${yellow}Options:${reset}\n    ${cyan}-g, --global${reset}              Install globally (to config directory)\n    ${cyan}-l, --local${reset}               Install locally (to current directory)\n    ${cyan}--claude${reset}                  Install for Claude Code only\n    ${cyan}--opencode${reset}                Install for OpenCode only\n    ${cyan}--gemini${reset}                  Install for Gemini only\n    ${cyan}--kilo${reset}                    Install for Kilo only\n    ${cyan}--codex${reset}                   Install for Codex only\n    ${cyan}--copilot${reset}                 Install for Copilot only\n    ${cyan}--antigravity${reset}             Install for Antigravity only\n    ${cyan}--cursor${reset}                  Install for Cursor only\n    ${cyan}--windsurf${reset}                Install for Windsurf only\n    ${cyan}--augment${reset}                 Install for Augment only\n    ${cyan}--trae${reset}                    Install for Trae only\n    ${cyan}--codebuddy${reset}              Install for CodeBuddy only\n    ${cyan}--all${reset}                     Install for all runtimes\n    ${cyan}-u, --uninstall${reset}           Uninstall GSD (remove all GSD files)\n    ${cyan}-c, --config-dir <path>${reset}   Specify custom config directory\n    ${cyan}-h, --help${reset}                Show this help message\n    ${cyan}--force-statusline${reset}        Replace existing statusline config\n\n  ${yellow}Examples:${reset}\n    ${dim}# Interactive install (prompts for runtime and location)${reset}\n    npx get-shit-done-cc\n\n    ${dim}# Install for Claude Code globally${reset}\n    npx get-shit-done-cc --claude --global\n\n    ${dim}# Install for Gemini globally${reset}\n    npx get-shit-done-cc --gemini --global\n\n    ${dim}# Install for Kilo globally${reset}\n    npx get-shit-done-cc --kilo --global\n\n    ${dim}# Install for Codex globally${reset}\n    npx get-shit-done-cc --codex --global\n\n    ${dim}# Install for Copilot globally${reset}\n    npx get-shit-done-cc --copilot --global\n\n    ${dim}# Install for Copilot locally${reset}\n    npx get-shit-done-cc --copilot --local\n\n    ${dim}# Install for Antigravity globally${reset}\n    npx get-shit-done-cc --antigravity --global\n\n    ${dim}# Install for Antigravity locally${reset}\n    npx get-shit-done-cc --antigravity --local\n\n    ${dim}# Install for Cursor globally${reset}\n    npx get-shit-done-cc --cursor --global\n\n    ${dim}# Install for Cursor locally${reset}\n    npx get-shit-done-cc --cursor --local\n\n    ${dim}# Install for Windsurf globally${reset}\n    npx get-shit-done-cc --windsurf --global\n\n    ${dim}# Install for Windsurf locally${reset}\n    npx get-shit-done-cc --windsurf --local\n\n    ${dim}# Install for Augment globally${reset}\n    npx get-shit-done-cc --augment --global\n\n    ${dim}# Install for Augment locally${reset}\n    npx get-shit-done-cc --augment --local\n\n    ${dim}# Install for Trae globally${reset}\n    npx get-shit-done-cc --trae --global\n\n    ${dim}# Install for Trae locally${reset}\n    npx get-shit-done-cc --trae --local\n\n    ${dim}# Install for CodeBuddy globally${reset}\n    npx get-shit-done-cc --codebuddy --global\n\n    ${dim}# Install for CodeBuddy locally${reset}\n    npx get-shit-done-cc --codebuddy --local\n\n    ${dim}# Install for all runtimes globally${reset}\n    npx get-shit-done-cc --all --global\n\n    ${dim}# Install to custom config directory${reset}\n    npx get-shit-done-cc --kilo --global --config-dir ~/.kilo-work\n\n    ${dim}# Install to current project only${reset}\n    npx get-shit-done-cc --claude --local\n\n    ${dim}# Uninstall GSD from Cursor globally${reset}\n    npx get-shit-done-cc --cursor --global --uninstall\n\n  ${yellow}Notes:${reset}\n    The --config-dir option is useful when you have multiple configurations.\n    It takes priority over CLAUDE_CONFIG_DIR / OPENCODE_CONFIG_DIR / GEMINI_CONFIG_DIR / KILO_CONFIG_DIR / CODEX_HOME / COPILOT_CONFIG_DIR / ANTIGRAVITY_CONFIG_DIR / CURSOR_CONFIG_DIR / WINDSURF_CONFIG_DIR / AUGMENT_CONFIG_DIR / TRAE_CONFIG_DIR / CODEBUDDY_CONFIG_DIR environment variables.\n`);
   process.exit(0);
 }
 
@@ -1464,6 +1479,59 @@ function convertClaudeCommandToTraeSkill(content, skillName) {
 
 function convertClaudeAgentToTraeAgent(content) {
   let converted = convertClaudeToTraeMarkdown(content);
+
+  const { frontmatter, body } = extractFrontmatterAndBody(converted);
+  if (!frontmatter) return converted;
+
+  const name = extractFrontmatterField(frontmatter, 'name') || 'unknown';
+  const description = extractFrontmatterField(frontmatter, 'description') || '';
+
+  const cleanFrontmatter = `---\nname: ${yamlIdentifier(name)}\ndescription: ${yamlQuote(toSingleLine(description))}\n---`;
+
+  return `${cleanFrontmatter}\n${body}`;
+}
+
+function convertSlashCommandsToCodebuddySkillMentions(content) {
+  return content.replace(/\/gsd:([a-z0-9-]+)/g, (_, commandName) => {
+    return `/gsd-${commandName}`;
+  });
+}
+
+function convertClaudeToCodebuddyMarkdown(content) {
+  let converted = convertSlashCommandsToCodebuddySkillMentions(content);
+  // CodeBuddy uses the same tool names as Claude Code (Bash, Edit, Read, Write, etc.)
+  // No tool name conversion needed
+  converted = converted.replace(/\$ARGUMENTS\b/g, '{{GSD_ARGS}}');
+  converted = converted.replace(/`\.\/CLAUDE\.md`/g, '`CODEBUDDY.md`');
+  converted = converted.replace(/\.\/CLAUDE\.md/g, 'CODEBUDDY.md');
+  converted = converted.replace(/`CLAUDE\.md`/g, '`CODEBUDDY.md`');
+  converted = converted.replace(/\bCLAUDE\.md\b/g, 'CODEBUDDY.md');
+  converted = converted.replace(/\.claude\/skills\//g, '.codebuddy/skills/');
+  converted = converted.replace(/\.\/\.claude\//g, './.codebuddy/');
+  converted = converted.replace(/\.claude\//g, '.codebuddy/');
+  converted = converted.replace(/\*\*Known Claude Code bug \(classifyHandoffIfNeeded\):\*\*[^\n]*\n/g, '');
+  converted = converted.replace(/- \*\*classifyHandoffIfNeeded false failure:\*\*[^\n]*\n/g, '');
+  converted = converted.replace(/\bClaude Code\b/g, 'CodeBuddy');
+  return converted;
+}
+
+function convertClaudeCommandToCodebuddySkill(content, skillName) {
+  const converted = convertClaudeToCodebuddyMarkdown(content);
+  const { frontmatter, body } = extractFrontmatterAndBody(converted);
+  let description = `Run GSD workflow ${skillName}.`;
+  if (frontmatter) {
+    const maybeDescription = extractFrontmatterField(frontmatter, 'description');
+    if (maybeDescription) {
+      description = maybeDescription;
+    }
+  }
+  description = toSingleLine(description);
+  const shortDescription = description.length > 180 ? `${description.slice(0, 177)}...` : description;
+  return `---\nname: ${yamlIdentifier(skillName)}\ndescription: ${shortDescription}\n---\n${body}`;
+}
+
+function convertClaudeAgentToCodebuddyAgent(content) {
+  let converted = convertClaudeToCodebuddyMarkdown(content);
 
   const { frontmatter, body } = extractFrontmatterAndBody(converted);
   if (!frontmatter) return converted;
@@ -3647,6 +3715,69 @@ function copyCommandsAsTraeSkills(srcDir, skillsDir, prefix, pathPrefix, runtime
 }
 
 /**
+ * Copy Claude commands as CodeBuddy skills — one folder per skill with SKILL.md.
+ * CodeBuddy uses the same tool names as Claude Code, but has its own config directory structure.
+ */
+function copyCommandsAsCodebuddySkills(srcDir, skillsDir, prefix, pathPrefix, runtime) {
+  if (!fs.existsSync(srcDir)) {
+    return;
+  }
+
+  fs.mkdirSync(skillsDir, { recursive: true });
+
+  const existing = fs.readdirSync(skillsDir, { withFileTypes: true });
+  for (const entry of existing) {
+    if (entry.isDirectory() && entry.name.startsWith(`${prefix}-`)) {
+      fs.rmSync(path.join(skillsDir, entry.name), { recursive: true });
+    }
+  }
+
+  function recurse(currentSrcDir, currentPrefix) {
+    const entries = fs.readdirSync(currentSrcDir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const srcPath = path.join(currentSrcDir, entry.name);
+      if (entry.isDirectory()) {
+        recurse(srcPath, `${currentPrefix}-${entry.name}`);
+        continue;
+      }
+
+      if (!entry.name.endsWith('.md')) {
+        continue;
+      }
+
+      const baseName = entry.name.replace('.md', '');
+      const skillName = `${currentPrefix}-${baseName}`;
+      const skillDir = path.join(skillsDir, skillName);
+      fs.mkdirSync(skillDir, { recursive: true });
+
+      let content = fs.readFileSync(srcPath, 'utf8');
+      const globalClaudeRegex = /~\/\.claude\//g;
+      const globalClaudeHomeRegex = /\$HOME\/\.claude\//g;
+      const localClaudeRegex = /\.\/\.claude\//g;
+      const bareGlobalClaudeRegex = /~\/\.claude\b/g;
+      const bareGlobalClaudeHomeRegex = /\$HOME\/\.claude\b/g;
+      const bareLocalClaudeRegex = /\.\/\.claude\b/g;
+      const codebuddyDirRegex = /~\/\.codebuddy\//g;
+      const normalizedPathPrefix = pathPrefix.replace(/\/$/, '');
+      content = content.replace(globalClaudeRegex, pathPrefix);
+      content = content.replace(globalClaudeHomeRegex, pathPrefix);
+      content = content.replace(localClaudeRegex, `./${getDirName(runtime)}/`);
+      content = content.replace(bareGlobalClaudeRegex, normalizedPathPrefix);
+      content = content.replace(bareGlobalClaudeHomeRegex, normalizedPathPrefix);
+      content = content.replace(bareLocalClaudeRegex, `./${getDirName(runtime)}`);
+      content = content.replace(codebuddyDirRegex, pathPrefix);
+      content = processAttribution(content, getCommitAttribution(runtime));
+      content = convertClaudeCommandToCodebuddySkill(content, skillName);
+
+      fs.writeFileSync(path.join(skillDir, 'SKILL.md'), content);
+    }
+  }
+
+  recurse(srcDir, prefix);
+}
+
+/**
  * Copy Claude commands as Copilot skills — one folder per skill with SKILL.md.
  * Applies CONV-01 (structure), CONV-02 (allowed-tools), CONV-06 (paths), CONV-07 (command names).
  */
@@ -4145,6 +4276,7 @@ function uninstall(isGlobal, runtime = 'claude') {
   const isWindsurf = runtime === 'windsurf';
   const isAugment = runtime === 'augment';
   const isTrae = runtime === 'trae';
+  const isCodebuddy = runtime === 'codebuddy';
   const dirName = getDirName(runtime);
 
   // Get the target directory based on runtime and install type
@@ -4167,6 +4299,7 @@ function uninstall(isGlobal, runtime = 'claude') {
   if (runtime === 'windsurf') runtimeLabel = 'Windsurf';
   if (runtime === 'augment') runtimeLabel = 'Augment';
   if (runtime === 'trae') runtimeLabel = 'Trae';
+  if (runtime === 'codebuddy') runtimeLabel = 'CodeBuddy';
 
   console.log(`  Uninstalling GSD from ${cyan}${runtimeLabel}${reset} at ${cyan}${locationLabel}${reset}\n`);
 
@@ -4193,8 +4326,8 @@ function uninstall(isGlobal, runtime = 'claude') {
       }
       console.log(`  ${green}✓${reset} Removed GSD commands from command/`);
     }
-  } else if (isCodex || isCursor || isWindsurf || isTrae) {
-    // Codex/Cursor/Windsurf/Trae: remove skills/gsd-*/SKILL.md skill directories
+  } else if (isCodex || isCursor || isWindsurf || isTrae || isCodebuddy) {
+    // Codex/Cursor/Windsurf/Trae/CodeBuddy: remove skills/gsd-*/SKILL.md skill directories
     const skillsDir = path.join(targetDir, 'skills');
     if (fs.existsSync(skillsDir)) {
       let skillCount = 0;
@@ -5083,6 +5216,7 @@ function install(isGlobal, runtime = 'claude') {
   const isWindsurf = runtime === 'windsurf';
   const isAugment = runtime === 'augment';
   const isTrae = runtime === 'trae';
+  const isCodebuddy = runtime === 'codebuddy';
   const dirName = getDirName(runtime);
   const src = path.join(__dirname, '..');
 
@@ -5117,6 +5251,7 @@ function install(isGlobal, runtime = 'claude') {
   if (isWindsurf) runtimeLabel = 'Windsurf';
   if (isAugment) runtimeLabel = 'Augment';
   if (isTrae) runtimeLabel = 'Trae';
+  if (isCodebuddy) runtimeLabel = 'CodeBuddy';
 
   console.log(`  Installing for ${cyan}${runtimeLabel}${reset} to ${cyan}${locationLabel}${reset}\n`);
 
@@ -5218,6 +5353,16 @@ function install(isGlobal, runtime = 'claude') {
     const skillsDir = path.join(targetDir, 'skills');
     const gsdSrc = path.join(src, 'commands', 'gsd');
     copyCommandsAsTraeSkills(gsdSrc, skillsDir, 'gsd', pathPrefix, runtime);
+    const installedSkillNames = listCodexSkillNames(skillsDir);
+    if (installedSkillNames.length > 0) {
+      console.log(`  ${green}✓${reset} Installed ${installedSkillNames.length} skills to skills/`);
+    } else {
+      failures.push('skills/gsd-*');
+    }
+  } else if (isCodebuddy) {
+    const skillsDir = path.join(targetDir, 'skills');
+    const gsdSrc = path.join(src, 'commands', 'gsd');
+    copyCommandsAsCodebuddySkills(gsdSrc, skillsDir, 'gsd', pathPrefix, runtime);
     const installedSkillNames = listCodexSkillNames(skillsDir);
     if (installedSkillNames.length > 0) {
       console.log(`  ${green}✓${reset} Installed ${installedSkillNames.length} skills to skills/`);
@@ -5357,6 +5502,8 @@ function install(isGlobal, runtime = 'claude') {
           content = convertClaudeAgentToAugmentAgent(content);
         } else if (isTrae) {
           content = convertClaudeAgentToTraeAgent(content);
+        } else if (isCodebuddy) {
+          content = convertClaudeAgentToCodebuddyAgent(content);
         }
         const destName = isCopilot ? entry.name.replace('.md', '.agent.md') : entry.name;
         fs.writeFileSync(path.join(agentsDest, destName), content);
@@ -6017,29 +6164,31 @@ function promptRuntime(callback) {
     '1': 'claude',
     '2': 'antigravity',
     '3': 'augment',
-    '4': 'codex',
-    '5': 'copilot',
-    '6': 'cursor',
-    '7': 'gemini',
-    '8': 'kilo',
-    '9': 'opencode',
-    '10': 'trae',
-    '11': 'windsurf'
+    '4': 'codebuddy',
+    '5': 'codex',
+    '6': 'copilot',
+    '7': 'cursor',
+    '8': 'gemini',
+    '9': 'kilo',
+    '10': 'opencode',
+    '11': 'trae',
+    '12': 'windsurf'
   };
-  const allRuntimes = ['claude', 'antigravity', 'augment', 'codex', 'copilot', 'cursor', 'gemini', 'kilo', 'opencode', 'trae', 'windsurf'];
+  const allRuntimes = ['claude', 'antigravity', 'augment', 'codebuddy', 'codex', 'copilot', 'cursor', 'gemini', 'kilo', 'opencode', 'trae', 'windsurf'];
 
   console.log(`  ${yellow}Which runtime(s) would you like to install for?${reset}\n\n  ${cyan}1${reset}) Claude Code  ${dim}(~/.claude)${reset}
   ${cyan}2${reset}) Antigravity  ${dim}(~/.gemini/antigravity)${reset}
   ${cyan}3${reset}) Augment      ${dim}(~/.augment)${reset}
-  ${cyan}4${reset}) Codex        ${dim}(~/.codex)${reset}
-  ${cyan}5${reset}) Copilot      ${dim}(~/.copilot)${reset}
-  ${cyan}6${reset}) Cursor       ${dim}(~/.cursor)${reset}
-  ${cyan}7${reset}) Gemini       ${dim}(~/.gemini)${reset}
-  ${cyan}8${reset}) Kilo         ${dim}(~/.config/kilo)${reset}
-  ${cyan}9${reset}) OpenCode     ${dim}(~/.config/opencode)${reset}
-  ${cyan}10${reset}) Trae         ${dim}(~/.trae)${reset}
-  ${cyan}11${reset}) Windsurf     ${dim}(~/.codeium/windsurf)${reset}
-  ${cyan}12${reset}) All
+  ${cyan}4${reset}) CodeBuddy    ${dim}(~/.codebuddy)${reset}
+  ${cyan}5${reset}) Codex        ${dim}(~/.codex)${reset}
+  ${cyan}6${reset}) Copilot      ${dim}(~/.copilot)${reset}
+  ${cyan}7${reset}) Cursor       ${dim}(~/.cursor)${reset}
+  ${cyan}8${reset}) Gemini       ${dim}(~/.gemini)${reset}
+  ${cyan}9${reset}) Kilo         ${dim}(~/.config/kilo)${reset}
+  ${cyan}10${reset}) OpenCode     ${dim}(~/.config/opencode)${reset}
+  ${cyan}11${reset}) Trae         ${dim}(~/.trae)${reset}
+  ${cyan}12${reset}) Windsurf     ${dim}(~/.codeium/windsurf)${reset}
+  ${cyan}13${reset}) All
 
   ${dim}Select multiple: 1,2,6 or 1 2 6${reset}
 `);
@@ -6050,7 +6199,7 @@ function promptRuntime(callback) {
     const input = answer.trim() || '1';
 
     // "All" shortcut
-    if (input === '12') {
+    if (input === '13') {
       callback(allRuntimes);
       return;
     }
@@ -6211,6 +6360,10 @@ if (process.env.GSD_TEST_MODE) {
     convertClaudeCommandToTraeSkill,
     convertClaudeAgentToTraeAgent,
     copyCommandsAsTraeSkills,
+    convertClaudeToCodebuddyMarkdown,
+    convertClaudeCommandToCodebuddySkill,
+    convertClaudeAgentToCodebuddyAgent,
+    copyCommandsAsCodebuddySkills,
     writeManifest,
     reportLocalPatches,
     validateHookFields,

--- a/tests/codebuddy-install.test.cjs
+++ b/tests/codebuddy-install.test.cjs
@@ -1,0 +1,257 @@
+process.env.GSD_TEST_MODE = '1';
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { createTempDir, cleanup } = require('./helpers.cjs');
+
+const {
+  getDirName,
+  getGlobalDir,
+  getConfigDirFromHome,
+  convertClaudeToCodebuddyMarkdown,
+  convertClaudeCommandToCodebuddySkill,
+  convertClaudeAgentToCodebuddyAgent,
+  copyCommandsAsCodebuddySkills,
+  install,
+  uninstall,
+  writeManifest,
+} = require('../bin/install.js');
+
+describe('CodeBuddy runtime directory mapping', () => {
+  test('maps CodeBuddy to .codebuddy for local installs', () => {
+    assert.strictEqual(getDirName('codebuddy'), '.codebuddy');
+  });
+
+  test('maps CodeBuddy to ~/.codebuddy for global installs', () => {
+    assert.strictEqual(getGlobalDir('codebuddy'), path.join(os.homedir(), '.codebuddy'));
+  });
+
+  test('returns .codebuddy config fragments for local and global installs', () => {
+    assert.strictEqual(getConfigDirFromHome('codebuddy', false), "'.codebuddy'");
+    assert.strictEqual(getConfigDirFromHome('codebuddy', true), "'.codebuddy'");
+  });
+});
+
+describe('getGlobalDir (CodeBuddy)', () => {
+  let originalCodebuddyConfigDir;
+
+  beforeEach(() => {
+    originalCodebuddyConfigDir = process.env.CODEBUDDY_CONFIG_DIR;
+  });
+
+  afterEach(() => {
+    if (originalCodebuddyConfigDir !== undefined) {
+      process.env.CODEBUDDY_CONFIG_DIR = originalCodebuddyConfigDir;
+    } else {
+      delete process.env.CODEBUDDY_CONFIG_DIR;
+    }
+  });
+
+  test('returns ~/.codebuddy with no env var or explicit dir', () => {
+    delete process.env.CODEBUDDY_CONFIG_DIR;
+    const result = getGlobalDir('codebuddy');
+    assert.strictEqual(result, path.join(os.homedir(), '.codebuddy'));
+  });
+
+  test('returns explicit dir when provided', () => {
+    const result = getGlobalDir('codebuddy', '/custom/codebuddy-path');
+    assert.strictEqual(result, '/custom/codebuddy-path');
+  });
+
+  test('respects CODEBUDDY_CONFIG_DIR env var', () => {
+    process.env.CODEBUDDY_CONFIG_DIR = '~/custom-codebuddy';
+    const result = getGlobalDir('codebuddy');
+    assert.strictEqual(result, path.join(os.homedir(), 'custom-codebuddy'));
+  });
+
+  test('explicit dir takes priority over CODEBUDDY_CONFIG_DIR', () => {
+    process.env.CODEBUDDY_CONFIG_DIR = '~/from-env';
+    const result = getGlobalDir('codebuddy', '/explicit/path');
+    assert.strictEqual(result, '/explicit/path');
+  });
+
+  test('does not break other runtimes', () => {
+    assert.strictEqual(getGlobalDir('claude'), path.join(os.homedir(), '.claude'));
+    assert.strictEqual(getGlobalDir('codex'), path.join(os.homedir(), '.codex'));
+  });
+});
+
+describe('CodeBuddy markdown conversion', () => {
+  test('converts Claude-specific references to CodeBuddy equivalents', () => {
+    const input = [
+      'Claude Code reads CLAUDE.md before using .claude/skills/.',
+      'Run /gsd:plan-phase with $ARGUMENTS.',
+      'Use Bash(command) and Edit(file).',
+    ].join('\n');
+
+    const result = convertClaudeToCodebuddyMarkdown(input);
+
+    assert.ok(result.includes('CodeBuddy reads CODEBUDDY.md before using .codebuddy/skills/.'), result);
+    assert.ok(result.includes('/gsd-plan-phase'), result);
+    assert.ok(result.includes('{{GSD_ARGS}}'), result);
+    // CodeBuddy uses the same tool names as Claude Code — no conversion needed
+    assert.ok(result.includes('Bash('), result);
+    assert.ok(result.includes('Edit('), result);
+  });
+
+  test('converts commands and agents to CodeBuddy frontmatter', () => {
+    const command = `---
+name: gsd:new-project
+description: Initialize a project
+---
+
+Use .claude/skills/ and /gsd:help.
+`;
+    const agent = `---
+name: gsd-planner
+description: Planner agent
+tools: Read, Write
+color: blue
+---
+
+Read CLAUDE.md before acting.
+`;
+
+    const convertedCommand = convertClaudeCommandToCodebuddySkill(command, 'gsd-new-project');
+    const convertedAgent = convertClaudeAgentToCodebuddyAgent(agent);
+
+    assert.ok(convertedCommand.includes('name: gsd-new-project'), convertedCommand);
+    assert.ok(convertedCommand.includes('.codebuddy/skills/'), convertedCommand);
+    assert.ok(convertedCommand.includes('/gsd-help'), convertedCommand);
+
+    assert.ok(convertedAgent.includes('name: gsd-planner'), convertedAgent);
+    assert.ok(!convertedAgent.includes('color:'), convertedAgent);
+    assert.ok(convertedAgent.includes('CODEBUDDY.md'), convertedAgent);
+  });
+});
+
+describe('copyCommandsAsCodebuddySkills', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempDir('gsd-codebuddy-copy-');
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('creates one skill directory per GSD command', () => {
+    const srcDir = path.join(__dirname, '..', 'commands', 'gsd');
+    const skillsDir = path.join(tmpDir, '.codebuddy', 'skills');
+
+    copyCommandsAsCodebuddySkills(srcDir, skillsDir, 'gsd', '$HOME/.codebuddy/', 'codebuddy');
+
+    const generated = path.join(skillsDir, 'gsd-help', 'SKILL.md');
+    assert.ok(fs.existsSync(generated), generated);
+
+    const content = fs.readFileSync(generated, 'utf8');
+    assert.ok(content.includes('name: gsd-help'), content);
+  });
+});
+
+describe('CodeBuddy local install/uninstall', () => {
+  let tmpDir;
+  let previousCwd;
+
+  beforeEach(() => {
+    tmpDir = createTempDir('gsd-codebuddy-install-');
+    previousCwd = process.cwd();
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(previousCwd);
+    cleanup(tmpDir);
+  });
+
+  test('installs GSD into ./.codebuddy and removes it cleanly', () => {
+    const result = install(false, 'codebuddy');
+    const targetDir = path.join(tmpDir, '.codebuddy');
+
+    // CodeBuddy supports settings.json hooks (Claude Code compatible)
+    assert.strictEqual(result.runtime, 'codebuddy');
+    assert.ok(result.settingsPath, 'should have settingsPath (CodeBuddy supports hooks)');
+
+    assert.ok(fs.existsSync(path.join(targetDir, 'skills', 'gsd-help', 'SKILL.md')));
+    assert.ok(fs.existsSync(path.join(targetDir, 'get-shit-done', 'VERSION')));
+    assert.ok(fs.existsSync(path.join(targetDir, 'agents')));
+
+    const manifest = writeManifest(targetDir, 'codebuddy');
+    assert.ok(Object.keys(manifest.files).some(file => file.startsWith('skills/gsd-help/')), JSON.stringify(manifest));
+
+    uninstall(false, 'codebuddy');
+
+    assert.ok(!fs.existsSync(path.join(targetDir, 'skills', 'gsd-help')), 'CodeBuddy skill directory removed');
+    assert.ok(!fs.existsSync(path.join(targetDir, 'get-shit-done')), 'get-shit-done removed');
+  });
+});
+
+describe('E2E: CodeBuddy uninstall skills cleanup', () => {
+  let tmpDir;
+  let previousCwd;
+
+  beforeEach(() => {
+    tmpDir = createTempDir('gsd-codebuddy-uninstall-');
+    previousCwd = process.cwd();
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(previousCwd);
+    cleanup(tmpDir);
+  });
+
+  test('removes all gsd-* skill directories on --codebuddy --uninstall', () => {
+    const targetDir = path.join(tmpDir, '.codebuddy');
+    install(false, 'codebuddy');
+
+    const skillsDir = path.join(targetDir, 'skills');
+    assert.ok(fs.existsSync(skillsDir), 'skills dir exists after install');
+
+    const installedSkills = fs.readdirSync(skillsDir, { withFileTypes: true })
+      .filter(e => e.isDirectory() && e.name.startsWith('gsd-'));
+    assert.ok(installedSkills.length > 0, `found ${installedSkills.length} gsd-* skill dirs before uninstall`);
+
+    uninstall(false, 'codebuddy');
+
+    if (fs.existsSync(skillsDir)) {
+      const remainingGsd = fs.readdirSync(skillsDir, { withFileTypes: true })
+        .filter(e => e.isDirectory() && e.name.startsWith('gsd-'));
+      assert.strictEqual(remainingGsd.length, 0,
+        `Expected 0 gsd-* skill dirs after uninstall, found: ${remainingGsd.map(e => e.name).join(', ')}`);
+    }
+  });
+
+  test('preserves non-GSD skill directories during --codebuddy --uninstall', () => {
+    const targetDir = path.join(tmpDir, '.codebuddy');
+    install(false, 'codebuddy');
+
+    const customSkillDir = path.join(targetDir, 'skills', 'my-custom-skill');
+    fs.mkdirSync(customSkillDir, { recursive: true });
+    fs.writeFileSync(path.join(customSkillDir, 'SKILL.md'), '# My Custom Skill\n');
+
+    assert.ok(fs.existsSync(path.join(customSkillDir, 'SKILL.md')), 'custom skill exists before uninstall');
+
+    uninstall(false, 'codebuddy');
+
+    assert.ok(fs.existsSync(path.join(customSkillDir, 'SKILL.md')),
+      'Non-GSD skill directory should be preserved after CodeBuddy uninstall');
+  });
+
+  test('removes engine directory on --codebuddy --uninstall', () => {
+    const targetDir = path.join(tmpDir, '.codebuddy');
+    install(false, 'codebuddy');
+
+    assert.ok(fs.existsSync(path.join(targetDir, 'get-shit-done', 'VERSION')),
+      'engine exists before uninstall');
+
+    uninstall(false, 'codebuddy');
+
+    assert.ok(!fs.existsSync(path.join(targetDir, 'get-shit-done')),
+      'get-shit-done engine should be removed after CodeBuddy uninstall');
+  });
+});

--- a/tests/copilot-install.test.cjs
+++ b/tests/copilot-install.test.cjs
@@ -139,8 +139,8 @@ describe('Source code integration (Copilot)', () => {
     assert.ok(src.includes('--copilot'), 'help text has --copilot option');
   });
 
-  test('CLI-02: promptRuntime runtimeMap has Copilot as option 5', () => {
-    assert.ok(src.includes("'5': 'copilot'"), 'runtimeMap has 5 -> copilot');
+  test('CLI-02: promptRuntime runtimeMap has Copilot as option 6', () => {
+    assert.ok(src.includes("'6': 'copilot'"), 'runtimeMap has 6 -> copilot');
   });
 
   test('CLI-02: promptRuntime allRuntimes array includes copilot', () => {

--- a/tests/kilo-install.test.cjs
+++ b/tests/kilo-install.test.cjs
@@ -221,12 +221,12 @@ describe('Source code integration (Kilo)', () => {
     assert.ok(src.includes("'kilo'"), '--all includes kilo runtime');
   });
 
-  test('promptRuntime runtimeMap has Kilo as option 8', () => {
-    assert.ok(src.includes("'8': 'kilo'"), 'runtimeMap has 8 -> kilo');
+  test('promptRuntime runtimeMap has Kilo as option 9', () => {
+    assert.ok(src.includes("'9': 'kilo'"), 'runtimeMap has 9 -> kilo');
   });
 
   test('prompt text shows Kilo above OpenCode without marketing copy', () => {
-    assert.ok(src.includes('8${reset}) Kilo'), 'prompt lists Kilo as option 8');
+    assert.ok(src.includes('9${reset}) Kilo'), 'prompt lists Kilo as option 9');
     assert.ok(!src.includes('the #1 AI coding platform on OpenRouter'), 'prompt does not include marketing tagline');
   });
 

--- a/tests/multi-runtime-select.test.cjs
+++ b/tests/multi-runtime-select.test.cjs
@@ -21,16 +21,17 @@ const runtimeMap = {
   '1': 'claude',
   '2': 'antigravity',
   '3': 'augment',
-  '4': 'codex',
-  '5': 'copilot',
-  '6': 'cursor',
-  '7': 'gemini',
-  '8': 'kilo',
-  '9': 'opencode',
-  '10': 'trae',
-  '11': 'windsurf'
+  '4': 'codebuddy',
+  '5': 'codex',
+  '6': 'copilot',
+  '7': 'cursor',
+  '8': 'gemini',
+  '9': 'kilo',
+  '10': 'opencode',
+  '11': 'trae',
+  '12': 'windsurf'
 };
-const allRuntimes = ['claude', 'antigravity', 'augment', 'codex', 'copilot', 'cursor', 'gemini', 'kilo', 'opencode', 'trae', 'windsurf'];
+const allRuntimes = ['claude', 'antigravity', 'augment', 'codebuddy', 'codex', 'copilot', 'cursor', 'gemini', 'kilo', 'opencode', 'trae', 'windsurf'];
 
 /**
  * Simulate the parsing logic from promptRuntime without requiring readline.
@@ -39,7 +40,7 @@ const allRuntimes = ['claude', 'antigravity', 'augment', 'codex', 'copilot', 'cu
 function parseRuntimeInput(input) {
   input = input.trim() || '1';
 
-  if (input === '12') {
+  if (input === '13') {
     return allRuntimes;
   }
 
@@ -60,41 +61,42 @@ describe('multi-runtime selection parsing', () => {
     assert.deepStrictEqual(parseRuntimeInput('1'), ['claude']);
     assert.deepStrictEqual(parseRuntimeInput('2'), ['antigravity']);
     assert.deepStrictEqual(parseRuntimeInput('3'), ['augment']);
-    assert.deepStrictEqual(parseRuntimeInput('4'), ['codex']);
-    assert.deepStrictEqual(parseRuntimeInput('5'), ['copilot']);
-    assert.deepStrictEqual(parseRuntimeInput('6'), ['cursor']);
+    assert.deepStrictEqual(parseRuntimeInput('4'), ['codebuddy']);
+    assert.deepStrictEqual(parseRuntimeInput('5'), ['codex']);
+    assert.deepStrictEqual(parseRuntimeInput('6'), ['copilot']);
+    assert.deepStrictEqual(parseRuntimeInput('7'), ['cursor']);
   });
 
   test('comma-separated choices return multiple runtimes', () => {
-    assert.deepStrictEqual(parseRuntimeInput('1,5,7'), ['claude', 'copilot', 'gemini']);
+    assert.deepStrictEqual(parseRuntimeInput('1,6,8'), ['claude', 'copilot', 'gemini']);
     assert.deepStrictEqual(parseRuntimeInput('2,3'), ['antigravity', 'augment']);
-    assert.deepStrictEqual(parseRuntimeInput('3,4'), ['augment', 'codex']);
+    assert.deepStrictEqual(parseRuntimeInput('3,5'), ['augment', 'codex']);
   });
 
   test('space-separated choices return multiple runtimes', () => {
-    assert.deepStrictEqual(parseRuntimeInput('1 5 7'), ['claude', 'copilot', 'gemini']);
-    assert.deepStrictEqual(parseRuntimeInput('6 8'), ['cursor', 'kilo']);
+    assert.deepStrictEqual(parseRuntimeInput('1 6 8'), ['claude', 'copilot', 'gemini']);
+    assert.deepStrictEqual(parseRuntimeInput('7 9'), ['cursor', 'kilo']);
   });
 
   test('mixed comma and space separators work', () => {
-    assert.deepStrictEqual(parseRuntimeInput('1, 5, 7'), ['claude', 'copilot', 'gemini']);
-    assert.deepStrictEqual(parseRuntimeInput('2 , 6'), ['antigravity', 'cursor']);
+    assert.deepStrictEqual(parseRuntimeInput('1, 6, 8'), ['claude', 'copilot', 'gemini']);
+    assert.deepStrictEqual(parseRuntimeInput('2 , 7'), ['antigravity', 'cursor']);
   });
 
   test('single choice for opencode', () => {
-    assert.deepStrictEqual(parseRuntimeInput('9'), ['opencode']);
+    assert.deepStrictEqual(parseRuntimeInput('10'), ['opencode']);
   });
 
   test('single choice for trae', () => {
-    assert.deepStrictEqual(parseRuntimeInput('10'), ['trae']);
+    assert.deepStrictEqual(parseRuntimeInput('11'), ['trae']);
   });
 
   test('single choice for windsurf', () => {
-    assert.deepStrictEqual(parseRuntimeInput('11'), ['windsurf']);
+    assert.deepStrictEqual(parseRuntimeInput('12'), ['windsurf']);
   });
 
-  test('choice 12 returns all runtimes', () => {
-    assert.deepStrictEqual(parseRuntimeInput('12'), allRuntimes);
+  test('choice 13 returns all runtimes', () => {
+    assert.deepStrictEqual(parseRuntimeInput('13'), allRuntimes);
   });
 
   test('empty input defaults to claude', () => {
@@ -103,29 +105,29 @@ describe('multi-runtime selection parsing', () => {
   });
 
   test('invalid choices are ignored, falls back to claude if all invalid', () => {
-    assert.deepStrictEqual(parseRuntimeInput('13'), ['claude']);
+    assert.deepStrictEqual(parseRuntimeInput('14'), ['claude']);
     assert.deepStrictEqual(parseRuntimeInput('0'), ['claude']);
     assert.deepStrictEqual(parseRuntimeInput('abc'), ['claude']);
   });
 
   test('invalid choices mixed with valid are filtered out', () => {
-    assert.deepStrictEqual(parseRuntimeInput('1,13,5'), ['claude', 'copilot']);
+    assert.deepStrictEqual(parseRuntimeInput('1,14,6'), ['claude', 'copilot']);
     assert.deepStrictEqual(parseRuntimeInput('abc 3 xyz'), ['augment']);
   });
 
   test('duplicate choices are deduplicated', () => {
     assert.deepStrictEqual(parseRuntimeInput('1,1,1'), ['claude']);
-    assert.deepStrictEqual(parseRuntimeInput('5,5,7,7'), ['copilot', 'gemini']);
+    assert.deepStrictEqual(parseRuntimeInput('6,6,8,8'), ['copilot', 'gemini']);
   });
 
   test('preserves selection order', () => {
-    assert.deepStrictEqual(parseRuntimeInput('7,1,5'), ['gemini', 'claude', 'copilot']);
-    assert.deepStrictEqual(parseRuntimeInput('8,2,6'), ['kilo', 'antigravity', 'cursor']);
+    assert.deepStrictEqual(parseRuntimeInput('8,1,6'), ['gemini', 'claude', 'copilot']);
+    assert.deepStrictEqual(parseRuntimeInput('9,2,7'), ['kilo', 'antigravity', 'cursor']);
   });
 });
 
 describe('install.js source contains multi-select support', () => {
-  test('runtimeMap is defined with all 11 runtimes', () => {
+  test('runtimeMap is defined with all 12 runtimes', () => {
     for (const [key, name] of Object.entries(runtimeMap)) {
       assert.ok(
         installSrc.includes(`'${key}': '${name}'`),
@@ -142,21 +144,21 @@ describe('install.js source contains multi-select support', () => {
     }
   });
 
-  test('all shortcut uses option 12', () => {
+  test('all shortcut uses option 13', () => {
     assert.ok(
-      installSrc.includes("if (input === '12')"),
-      'all shortcut uses option 12'
+      installSrc.includes("if (input === '13')"),
+      'all shortcut uses option 13'
     );
   });
 
-  test('prompt lists Trae as option 10 and All as option 12', () => {
+  test('prompt lists Trae as option 11 and All as option 13', () => {
     assert.ok(
-      installSrc.includes('10${reset}) Trae'),
-      'prompt lists Trae as option 10'
+      installSrc.includes('11${reset}) Trae'),
+      'prompt lists Trae as option 11'
     );
     assert.ok(
-      installSrc.includes('12${reset}) All'),
-      'prompt lists All as option 12'
+      installSrc.includes('13${reset}) All'),
+      'prompt lists All as option 13'
     );
   });
 

--- a/tests/stale-colon-refs.test.cjs
+++ b/tests/stale-colon-refs.test.cjs
@@ -66,6 +66,7 @@ function isTestInput(filePath, line) {
     'tests/copilot-install.test.cjs',
     'tests/codex-config.test.cjs',
     'tests/trae-install.test.cjs',
+    'tests/codebuddy-install.test.cjs',
   ];
 
   if (conversionTestFiles.includes(rel)) {


### PR DESCRIPTION
## Feature: Support CodeBuddy Runtime

Closes #1886

### Feature summary

Adds CodeBuddy (Tencent Cloud AI coding IDE/CLI) as a first-class runtime in the GSD installer, with full support for skills, agents, hooks, install/uninstall, and documentation.

### What changed

#### New files
| File | Purpose |
|------|---------|
| `tests/codebuddy-install.test.cjs` | 15 tests: directory mapping, env vars, markdown conversion, skill copying, install/uninstall E2E |

#### Modified files
| File | Change |
|------|--------|
| `bin/install.js` | Add `--codebuddy` flag, runtime support, converters, interactive menu, help text, uninstall, test exports |
| `tests/multi-runtime-select.test.cjs` | Update runtime numbering after CodeBuddy insertion |
| `tests/copilot-install.test.cjs` | Update Copilot option number (5→6) |
| `tests/kilo-install.test.cjs` | Update Kilo option number (8→9) |
| `README.md` | Add CodeBuddy to header, runtime list, install/uninstall examples |
| `README.zh-CN.md` | Same updates for Chinese localization |

### Implementation notes

- **CodeBuddy uses identical tool names to Claude Code** — no tool name mapping needed
- **Hook system is fully compatible with Claude Code spec** — all GSD hooks configured in settings.json
- **Path conversion**: `CLAUDE.md` → `CODEBUDDY.md`, `.claude/` → `.codebuddy/`
- Follows the **exact same pattern** as the Trae runtime addition

### Test coverage

15 new tests in `tests/codebuddy-install.test.cjs`. Full suite: **2626 pass / 3 fail** (all 3 are pre-existing).

### Platforms tested

- [x] macOS (Apple Silicon, Node 24)
- [ ] Windows
- [ ] Linux

### Runtimes tested

- [x] CodeBuddy (primary target)
- [x] Claude Code (no regression)
- [x] Trae (no regression)
- [x] Copilot (no regression)
- [x] Kilo (no regression)

### Final checklist

- [x] Issue linked: Closes #1886
- [x] All acceptance criteria met
- [x] Existing tests pass (`npm test`)
- [x] New tests cover happy path, error cases, edge cases
- [x] Documentation updated (README.md, README.zh-CN.md)
- [x] No external dependencies added
- [x] Uses path.join() for Windows compatibility

### Breaking changes

None. Purely additive.