### PR TITLE
docs: remove duplicate keys in CONFIGURATION.md

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -77,7 +77,6 @@ GSD stores project settings in `.planning/config.json`. Created during `/gsd-new
   "security_block_on": "high",
   "agent_skills": {},
   "response_language": null,
-  "context_profile": null,
   "features": {
     "thinking_partner": false,
     "global_learnings": false
@@ -358,14 +357,6 @@ Settings for the security enforcement feature (v1.31). All follow the **absent =
 | `security_enforcement` | boolean | `true` | Enable threat-model-anchored security verification via `/gsd-secure-phase`. When `false`, security checks are skipped entirely |
 | `security_asvs_level` | number (1-3) | `1` | OWASP ASVS verification level. Level 1 = opportunistic, Level 2 = standard, Level 3 = comprehensive |
 | `security_block_on` | string | `"high"` | Minimum severity that blocks phase advancement. Options: `"high"`, `"medium"`, `"low"` |
-
----
-
-## Hook Settings
-
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `hooks.context_warnings` | boolean | `true` | Show context window usage warnings during sessions |
 
 ---
 


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #1894

---

## What was broken

`docs/CONFIGURATION.md` contained two duplicate entries:
1. `"context_profile": null` appeared twice in the Full Schema JSON block
2. The "## Hook Settings" section appeared twice in the document (the second being a subset of the first)

## What this fix does

Removes the duplicate `context_profile` key (line 80) and the redundant second "Hook Settings" section (lines 362–369), keeping the complete originals.

## Root cause

Likely accumulated from separate documentation updates that each added the same content without checking for existing entries.

## Testing

### How I verified the fix

Grepped `docs/CONFIGURATION.md` after the edit to confirm:
- `context_profile` appears exactly once in the schema block (line 23) and once in the Core Settings table
- `## Hook Settings` appears exactly once (line 156)

### Regression test added?

- [ ] Yes — added a test that would have caught this bug
- [x] No — explain why: doc-only change, no code behavior affected

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #1894` — **PR will be auto-closed if missing**
- [ ] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [ ] CHANGELOG.md updated if this is a user-facing fix
- [x] No unnecessary dependencies added

## Breaking changes

None