### PR TITLE
fix(state): replace busy-wait spin loop with Atomics.wait in state lock

### DIFF
--- a/get-shit-done/bin/lib/state.cjs
+++ b/get-shit-done/bin/lib/state.cjs
@@ -821,8 +821,7 @@ function acquireStateLock(statePath) {
           return lockPath;
         }
         const jitter = Math.floor(Math.random() * 50);
-        const start = Date.now();
-        while (Date.now() - start < retryDelay + jitter) { /* busy wait */ }
+        Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, retryDelay + jitter);
         continue;
       }
       return lockPath; // non-EEXIST error — proceed without lock


### PR DESCRIPTION
Fixes #1909

## Summary

- Replace CPU-burning `while (Date.now() - start < delay) {}` busy-wait in `acquireStateLock` with `Atomics.wait()`, matching the pattern already used by `withPlanningLock` in `core.cjs`
- Eliminates unnecessary CPU consumption during lock contention in parallel agent execution
- One-line change, zero behavioral difference

## Context

The state lock retry mechanism (`state.cjs:823-825`) used a spin loop that pegs a CPU core for the full retry delay. The same codebase already uses the correct `Atomics.wait()` pattern in `withPlanningLock` (`core.cjs:619`), which yields the thread to the OS scheduler. This aligns the two lock implementations.

Found during a performance deep-dive analyzing GSD's behavior in long-running projects with parallel agent execution.

## Test plan

- [x] All existing lock and state tests pass unchanged
- [ ] Verify lock contention behavior under parallel workload (same semantics, lower CPU)

🤖 Generated with [Claude Code](https://claude.com/claude-code)