### PR TITLE
perf(config): cache isGitIgnored result per process lifetime

### DIFF
--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -400,7 +400,11 @@ function loadConfig(cwd) {
 
 // ─── Git utilities ────────────────────────────────────────────────────────────
 
+const _gitIgnoredCache = new Map();
+
 function isGitIgnored(cwd, targetPath) {
+  const key = cwd + '::' + targetPath;
+  if (_gitIgnoredCache.has(key)) return _gitIgnoredCache.get(key);
   try {
     // --no-index checks .gitignore rules regardless of whether the file is tracked.
     // Without it, git check-ignore returns "not ignored" for tracked files even when
@@ -412,8 +416,10 @@ function isGitIgnored(cwd, targetPath) {
       cwd,
       stdio: 'pipe',
     });
+    _gitIgnoredCache.set(key, true);
     return true;
   } catch {
+    _gitIgnoredCache.set(key, false);
     return false;
   }
 }


### PR DESCRIPTION
Fixes #1910

## Summary

- Add module-level Map cache for `isGitIgnored()` results keyed on `(cwd, targetPath)`
- The `git check-ignore` subprocess now fires at most once per unique pair per process lifetime
- Eliminates redundant subprocess spawns across the 28+ `loadConfig` call sites

## Context

`loadConfig()` calls `isGitIgnored()` which spawns a synchronous `git check-ignore` subprocess on every invocation when `commit_docs` is not explicitly set. The result is stable for the entire process lifetime (GSD tools are short-lived single-command processes), but was being recomputed on every call. With 28+ `loadConfig` call sites across lib modules, complex commands could spawn multiple redundant git subprocesses at ~20-60ms each.

Found during a performance deep-dive analyzing I/O patterns at scale.

## Test plan

- [x] All existing config and core tests pass unchanged
- [ ] Verify `isGitIgnored` returns consistent results across repeated calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)