### PR TITLE
perf(roadmap): hoist readdirSync out of phase loop in analyze command

### DIFF
--- a/get-shit-done/bin/lib/roadmap.cjs
+++ b/get-shit-done/bin/lib/roadmap.cjs
@@ -129,6 +129,15 @@ function cmdRoadmapAnalyze(cwd, raw) {
   const phases = [];
   let match;
 
+  // Build phase directory lookup once (O(1) readdir instead of O(N) per phase)
+  const _phaseDirNames = (() => {
+    try {
+      return fs.readdirSync(phasesDir, { withFileTypes: true })
+        .filter(e => e.isDirectory())
+        .map(e => e.name);
+    } catch { return []; }
+  })();
+
   while ((match = phasePattern.exec(content)) !== null) {
     const phaseNum = match[1];
     const phaseName = match[2].replace(/\(INSERTED\)/i, '').trim();
@@ -155,9 +164,7 @@ function cmdRoadmapAnalyze(cwd, raw) {
     let hasResearch = false;
 
     try {
-      const entries = fs.readdirSync(phasesDir, { withFileTypes: true });
-      const dirs = entries.filter(e => e.isDirectory()).map(e => e.name);
-      const dirMatch = dirs.find(d => phaseTokenMatches(d, normalized));
+      const dirMatch = _phaseDirNames.find(d => phaseTokenMatches(d, normalized));
 
       if (dirMatch) {
         const phaseFiles = fs.readdirSync(path.join(phasesDir, dirMatch));


### PR DESCRIPTION
Fixes #1911

## Summary

- Move `fs.readdirSync(phasesDir)` from inside the per-phase while loop to a single pre-computation before the loop
- Reduces directory I/O from O(N²) to O(N) for N phases in `cmdRoadmapAnalyze`
- At 50 phases: eliminates ~49 redundant `readdirSync` syscalls per invocation

## Context

`cmdRoadmapAnalyze` (`roadmap.cjs:158`) called `fs.readdirSync(phasesDir, { withFileTypes: true })` inside the per-phase while loop — re-reading the same directory listing on every iteration. For a project with N phases, this produced N redundant directory scans (the first scan discovers the same data as all subsequent scans).

The fix builds a `_phaseDirNames` array once before the loop, then uses `.find()` inside the loop for O(1) lookups per phase. The existing 50-phase stress test in `concurrency-safety.test.cjs:782` validates this path.

Found during a performance deep-dive analyzing directory I/O patterns at scale. The same pattern was also fixed in `cmdInitManager` in a companion PR.

## Test plan

- [x] All existing roadmap tests pass (analyze command, disk status, milestone extraction, 50-phase benchmark)
- [ ] Verify performance improvement on large projects (existing stress test should run faster)

🤖 Generated with [Claude Code](https://claude.com/claude-code)