### PR TITLE
perf(init): hoist readdirSync and regex out of phase loop in manager

### DIFF
--- a/get-shit-done/bin/lib/init.cjs
+++ b/get-shit-done/bin/lib/init.cjs
@@ -870,6 +870,23 @@ function cmdInitManager(cwd, raw) {
   const phasesDir = paths.phases;
   const isDirInMilestone = getMilestonePhaseFilter(cwd);
 
+  // Pre-compute directory listing once (avoids O(N) readdirSync per phase)
+  const _phaseDirEntries = (() => {
+    try {
+      return fs.readdirSync(phasesDir, { withFileTypes: true })
+        .filter(e => e.isDirectory())
+        .map(e => e.name);
+    } catch { return []; }
+  })();
+
+  // Pre-extract all checkbox states in a single pass (avoids O(N) regex per phase)
+  const _checkboxStates = new Map();
+  const _cbPattern = /-\s*\[(x| )\]\s*.*Phase\s+(\d+[A-Z]?(?:\.\d+)*)[:\s]/gi;
+  let _cbMatch;
+  while ((_cbMatch = _cbPattern.exec(content)) !== null) {
+    _checkboxStates.set(_cbMatch[2], _cbMatch[1].toLowerCase() === 'x');
+  }
+
   const phasePattern = /#{2,4}\s*Phase\s+(\d+[A-Z]?(?:\.\d+)*)\s*:\s*([^\n]+)/gi;
   const phases = [];
   let match;
@@ -900,8 +917,7 @@ function cmdInitManager(cwd, raw) {
     let isActive = false;
 
     try {
-      const entries = fs.readdirSync(phasesDir, { withFileTypes: true });
-      const dirs = entries.filter(e => e.isDirectory()).map(e => e.name).filter(isDirInMilestone);
+      const dirs = _phaseDirEntries.filter(isDirInMilestone);
       const dirMatch = dirs.find(d => phaseTokenMatches(d, normalized));
 
       if (dirMatch) {
@@ -935,10 +951,8 @@ function cmdInitManager(cwd, raw) {
       }
     } catch { /* intentionally empty */ }
 
-    // Check ROADMAP checkbox status
-    const checkboxPattern = new RegExp(`-\\s*\\[(x| )\\]\\s*.*Phase\\s+${phaseNum.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}[:\\s]`, 'i');
-    const checkboxMatch = content.match(checkboxPattern);
-    const roadmapComplete = checkboxMatch ? checkboxMatch[1] === 'x' : false;
+    // Check ROADMAP checkbox status (pre-extracted above the loop)
+    const roadmapComplete = _checkboxStates.get(phaseNum) || false;
     if (roadmapComplete && diskStatus !== 'complete') {
       diskStatus = 'complete';
     }


### PR DESCRIPTION
Fixes #1912

## Summary

- Move `fs.readdirSync(phasesDir)` from inside the per-phase while loop to a single pre-computation before the loop
- Pre-extract all ROADMAP checkbox states in a single `matchAll` pass, replacing per-phase `new RegExp()` + full-content scan
- Reduces both patterns from O(N²) to O(N) for N phases in `cmdInitManager`
- At 50 phases: eliminates ~49 redundant directory scans and ~50 regex compilations

## Context

`cmdInitManager` (the dashboard command) had two O(N²) patterns:

1. `fs.readdirSync(phasesDir)` called inside the per-phase loop (`init.cjs:903`) — same directory re-read on every iteration
2. `new RegExp(...)` compiled per phase (`init.cjs:939`) with a full ROADMAP content scan each time to check checkbox status

The fix pre-computes both: a `_phaseDirEntries` array for directory lookups, and a `_checkboxStates` Map from a single regex pass over the ROADMAP content. Inside the loop, these become O(1) lookups.

This is the dashboard command — called frequently when checking project status — so the performance improvement has high visibility. Found during a performance deep-dive alongside the companion roadmap analyze fix.

## Test plan

- [x] All existing init and manager tests pass (2650 passing)
- [ ] Verify dashboard responsiveness on projects with 20+ phases

🤖 Generated with [Claude Code](https://claude.com/claude-code)