### PR TITLE
fix(core): add atomicWriteFileSync helper for crash-safe file writes

### DIFF
--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -418,6 +418,29 @@ function isGitIgnored(cwd, targetPath) {
   }
 }
 
+// ─── Atomic file writes ─────────────────────────────────────────────────────
+
+/**
+ * Atomic file write: writes to a temp file then renames into place.
+ * Prevents truncated files when the process is killed mid-write.
+ *
+ * The rename(2) syscall is atomic on POSIX — the destination file is
+ * either the old content or the new content, never a partial write.
+ * On Windows, fs.renameSync is not guaranteed atomic but still avoids
+ * the most common truncation scenarios.
+ */
+function atomicWriteFileSync(filePath, content, encoding = 'utf-8') {
+  const tmpPath = filePath + '.tmp.' + process.pid;
+  try {
+    fs.writeFileSync(tmpPath, content, encoding);
+    fs.renameSync(tmpPath, filePath);
+  } catch (err) {
+    // Clean up the temp file on failure (best-effort)
+    try { fs.unlinkSync(tmpPath); } catch { /* already gone or never created */ }
+    throw err;
+  }
+}
+
 // ─── Markdown normalization ─────────────────────────────────────────────────
 
 /**
@@ -1490,6 +1513,7 @@ module.exports = {
   error,
   safeReadFile,
   loadConfig,
+  atomicWriteFileSync,
   isGitIgnored,
   execGit,
   normalizeMd,

--- a/get-shit-done/bin/lib/state.cjs
+++ b/get-shit-done/bin/lib/state.cjs
@@ -4,7 +4,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { escapeRegex, loadConfig, getMilestoneInfo, getMilestonePhaseFilter, normalizeMd, planningDir, planningPaths, output, error } = require('./core.cjs');
+const { atomicWriteFileSync, escapeRegex, loadConfig, getMilestoneInfo, getMilestonePhaseFilter, normalizeMd, planningDir, planningPaths, output, error } = require('./core.cjs');
 const { extractFrontmatter, reconstructFrontmatter } = require('./frontmatter.cjs');
 
 /** Shorthand — every state command needs this path */
@@ -845,7 +845,7 @@ function writeStateMd(statePath, content, cwd) {
   const synced = syncStateFrontmatter(content, cwd);
   const lockPath = acquireStateLock(statePath);
   try {
-    fs.writeFileSync(statePath, normalizeMd(synced), 'utf-8');
+    atomicWriteFileSync(statePath, normalizeMd(synced), 'utf-8');
   } finally {
     releaseStateLock(lockPath);
   }
@@ -863,7 +863,7 @@ function readModifyWriteStateMd(statePath, transformFn, cwd) {
     const content = fs.existsSync(statePath) ? fs.readFileSync(statePath, 'utf-8') : '';
     const modified = transformFn(content);
     const synced = syncStateFrontmatter(modified, cwd);
-    fs.writeFileSync(statePath, normalizeMd(synced), 'utf-8');
+    atomicWriteFileSync(statePath, normalizeMd(synced), 'utf-8');
   } finally {
     releaseStateLock(lockPath);
   }


### PR DESCRIPTION
Fixes #1915

## Summary

- Add `atomicWriteFileSync(filePath, content, encoding)` helper using write-to-temp + `renameSync`
- Apply to STATE.md write paths (`writeStateMd` and `readModifyWriteStateMd`) as the highest-frequency target
- Prevents truncated files when process is killed mid-write

## Context

All file writes in the GSD CLI use direct `fs.writeFileSync()` which is not atomic on POSIX — a process killed mid-write (SIGKILL, power loss, disk full) can produce a truncated file that is unparseable on next read.

The standard durable-write pattern is write-to-temp-then-rename:
```javascript
const tmp = filePath + '.tmp.' + process.pid;
fs.writeFileSync(tmp, content, encoding);
fs.renameSync(tmp, filePath); // atomic on POSIX
```

STATE.md is the highest-frequency write target (every state patch, plan completion, phase transition), so it benefits most from this protection. Other write paths (ROADMAP.md, config.json) can adopt this helper in follow-up PRs.

The helper includes cleanup of the temp file on error to prevent orphaned `.tmp` files.

## Test plan

- [x] All existing state and core tests pass (2650 passing)
- [x] `atomicWriteFileSync` exported and available for other modules
- [ ] Verify crash-safety: write large content, SIGKILL mid-write, confirm file is old or new, never truncated

🤖 Generated with [Claude Code](https://claude.com/claude-code)