### PR TITLE
fix(core): register held locks for cleanup on process exit

### DIFF
--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -24,6 +24,14 @@ const WORKSTREAM_SESSION_ENV_KEYS = [
   'ZELLIJ_SESSION_NAME',
 ];
 
+// Track held lock files for cleanup on unexpected exit (e.g. process.exit in error())
+const _heldLocks = new Set();
+process.on('exit', () => {
+  for (const lockPath of _heldLocks) {
+    try { fs.unlinkSync(lockPath); } catch { /* ignore */ }
+  }
+});
+
 let cachedControllingTtyToken = null;
 let didProbeControllingTtyToken = false;
 
@@ -598,11 +606,13 @@ function withPlanningLock(cwd, fn) {
         acquired: new Date().toISOString(),
       }), { flag: 'wx' });
 
-      // Lock acquired — run the function
+      // Lock acquired — register for cleanup on unexpected exit
+      _heldLocks.add(lockPath);
       try {
         return fn();
       } finally {
         try { fs.unlinkSync(lockPath); } catch { /* already released */ }
+        _heldLocks.delete(lockPath);
       }
     } catch (err) {
       if (err.code === 'EEXIST') {
@@ -1530,4 +1540,5 @@ module.exports = {
   readSubdirectories,
   getAgentsDir,
   checkAgentsInstalled,
+  _heldLocks,
 };

--- a/get-shit-done/bin/lib/state.cjs
+++ b/get-shit-done/bin/lib/state.cjs
@@ -4,7 +4,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { escapeRegex, loadConfig, getMilestoneInfo, getMilestonePhaseFilter, normalizeMd, planningDir, planningPaths, output, error } = require('./core.cjs');
+const { escapeRegex, loadConfig, getMilestoneInfo, getMilestonePhaseFilter, normalizeMd, planningDir, planningPaths, output, error, _heldLocks } = require('./core.cjs');
 const { extractFrontmatter, reconstructFrontmatter } = require('./frontmatter.cjs');
 
 /** Shorthand — every state command needs this path */
@@ -805,6 +805,7 @@ function acquireStateLock(statePath) {
       const fd = fs.openSync(lockPath, fs.constants.O_CREAT | fs.constants.O_EXCL | fs.constants.O_WRONLY);
       fs.writeSync(fd, String(process.pid));
       fs.closeSync(fd);
+      _heldLocks.add(lockPath);
       return lockPath;
     } catch (err) {
       if (err.code === 'EEXIST') {
@@ -833,6 +834,7 @@ function acquireStateLock(statePath) {
 
 function releaseStateLock(lockPath) {
   try { fs.unlinkSync(lockPath); } catch { /* lock already gone */ }
+  _heldLocks.delete(lockPath);
 }
 
 /**


### PR DESCRIPTION
Fixes #1916

## Summary

- Track held lock files in a module-level Set (`_heldLocks`)
- Register a `process.on('exit')` handler that cleans up any remaining locks
- Applied to both `withPlanningLock` (core.cjs) and `acquireStateLock` (state.cjs)

## Context

When `error()` calls `process.exit(1)` inside a locked region, the `finally` block that releases the lock never executes. This leaves stale lock files on disk until the staleness timeout (10 seconds for state lock, 30 seconds for planning lock). During that window, any other process trying to acquire the lock spin-waits.

The fix registers locks on acquisition and unregisters them on normal release. The `process.on('exit')` handler is the safety net — it fires even on `process.exit(1)` and cleans up any locks that were never normally released.

This complements the existing staleness detection (which recovers from truly orphaned locks after timeout) by providing immediate cleanup on the most common abnormal exit path.

## Test plan

- [x] All existing lock, state, and core tests pass (2650 passing)
- [x] `_heldLocks` exported for cross-module use (state.cjs imports from core.cjs)
- [ ] Verify: trigger `error()` inside locked region, confirm lock file cleaned up immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)