### PR TITLE
fix(install): remove gsd-file-manifest.json on uninstall

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -4565,6 +4565,14 @@ function uninstall(isGlobal, runtime = 'claude') {
     }
   }
 
+  // 8. Remove gsd-file-manifest.json (#1908)
+  const manifestPath = path.join(targetDir, 'gsd-file-manifest.json');
+  if (fs.existsSync(manifestPath)) {
+    fs.unlinkSync(manifestPath);
+    removedCount++;
+    console.log(`  ${green}✓${reset} Removed gsd-file-manifest.json`);
+  }
+
   if (removedCount === 0) {
     console.log(`  ${yellow}⚠${reset} No GSD files found to remove.`);
   }

--- a/tests/bug-1908-uninstall-manifest.test.cjs
+++ b/tests/bug-1908-uninstall-manifest.test.cjs
@@ -1,0 +1,67 @@
+/**
+ * Regression tests for bug #1908
+ *
+ * The uninstall() function must remove gsd-file-manifest.json from the
+ * target directory. The installer writes this file during install/update
+ * (writeManifest), but uninstall() previously did not clean it up —
+ * leaving stale GSD metadata in the runtime config root.
+ */
+
+'use strict';
+
+const { describe, test, before } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const INSTALL_SRC = path.join(__dirname, '..', 'bin', 'install.js');
+
+describe('bug #1908: uninstall removes gsd-file-manifest.json', () => {
+  let src;
+
+  before(() => {
+    src = fs.readFileSync(INSTALL_SRC, 'utf-8');
+  });
+
+  test('uninstall function references gsd-file-manifest.json for removal', () => {
+    // The uninstall function should contain code to remove the manifest
+    // Find the uninstall function body
+    const uninstallStart = src.indexOf('function uninstall(');
+    assert.ok(uninstallStart !== -1, 'uninstall function must exist');
+
+    // Get the function body (up to the next top-level function)
+    const afterUninstall = src.slice(uninstallStart);
+    const nextFuncMatch = afterUninstall.match(/\n(?:function |const |\/\*\*)\s/);
+    const uninstallBody = nextFuncMatch
+      ? afterUninstall.slice(0, nextFuncMatch.index)
+      : afterUninstall;
+
+    assert.ok(
+      uninstallBody.includes('gsd-file-manifest.json'),
+      'uninstall() must reference gsd-file-manifest.json for cleanup'
+    );
+  });
+
+  test('manifest removal uses unlinkSync (not rmSync recursive)', () => {
+    // The manifest is a single file — should use unlinkSync, not rmSync
+    const uninstallStart = src.indexOf('function uninstall(');
+    const afterUninstall = src.slice(uninstallStart);
+
+    // Find the manifest removal block
+    const manifestBlock = afterUninstall.match(
+      /gsd-file-manifest\.json[\s\S]{0,200}unlinkSync/
+    );
+    assert.ok(manifestBlock, 'manifest should be removed with unlinkSync');
+  });
+
+  test('manifest removal is guarded by existsSync', () => {
+    const uninstallStart = src.indexOf('function uninstall(');
+    const afterUninstall = src.slice(uninstallStart);
+
+    // The pattern should be: existsSync check before unlinkSync
+    const manifestSection = afterUninstall.match(
+      /existsSync\(manifestPath\)[\s\S]{0,100}unlinkSync\(manifestPath\)/
+    );
+    assert.ok(manifestSection, 'manifest removal should be guarded by existsSync');
+  });
+});


### PR DESCRIPTION
Fixes #1908

## Summary

- Add `gsd-file-manifest.json` cleanup to the `uninstall()` function
- Guarded by `existsSync` check, uses `unlinkSync` (single file, not recursive)
- Placed after settings.json cleanup (step 8), before the completion summary

## Context

The installer writes `gsd-file-manifest.json` during install/update via `writeManifest()`, but `uninstall()` never removed it. This left stale GSD metadata in the runtime config root after uninstall, which could confuse post-uninstall state checks and leaves a footprint that contradicts the "clean uninstall" promise.

The fix is minimal — 6 lines following the exact same pattern as the other file cleanup steps in `uninstall()`.

## Test plan

- [x] New test `bug-1908-uninstall-manifest.test.cjs` — 3 assertions verifying the cleanup exists, uses `unlinkSync`, and is guarded by `existsSync`
- [x] Full test suite passes (2681 pass, 7 pre-existing failures unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)