### PR TITLE
fix(core): resolve @file: references in gsd-tools stdout

### DIFF
--- a/get-shit-done/bin/gsd-tools.cjs
+++ b/get-shit-done/bin/gsd-tools.cjs
@@ -355,7 +355,27 @@ async function main() {
     return;
   }
 
-  await runCommand(command, args, cwd, raw);
+  // Intercept stdout to transparently resolve @file: references (#1891).
+  // core.cjs output() writes @file:<path> when JSON > 50KB. The --pick path
+  // already resolves this, but the normal path wrote @file: to stdout, forcing
+  // every workflow to have a bash-specific `if [[ "$INIT" == @file:* ]]` check
+  // that breaks on PowerShell and other non-bash shells.
+  const origWriteSync2 = fs.writeSync;
+  const outChunks = [];
+  fs.writeSync = function (fd, data, ...rest) {
+    if (fd === 1) { outChunks.push(String(data)); return; }
+    return origWriteSync2.call(fs, fd, data, ...rest);
+  };
+  try {
+    await runCommand(command, args, cwd, raw);
+  } finally {
+    fs.writeSync = origWriteSync2;
+  }
+  let captured = outChunks.join('');
+  if (captured.startsWith('@file:')) {
+    captured = fs.readFileSync(captured.slice(6), 'utf-8');
+  }
+  origWriteSync2.call(fs, 1, captured);
 }
 
 /**

--- a/tests/bug-1891-file-resolution.test.cjs
+++ b/tests/bug-1891-file-resolution.test.cjs
@@ -1,0 +1,58 @@
+/**
+ * Regression tests for bug #1891
+ *
+ * gsd-tools.cjs must transparently resolve @file: references in stdout
+ * so that workflows never see the @file: prefix. This eliminates the
+ * bash-specific `if [[ "$INIT" == @file:* ]]` check that breaks on
+ * PowerShell and other non-bash shells.
+ */
+
+'use strict';
+
+const { describe, test, before } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const GSD_TOOLS_SRC = path.join(__dirname, '..', 'get-shit-done', 'bin', 'gsd-tools.cjs');
+
+describe('bug #1891: @file: resolution in gsd-tools.cjs', () => {
+  let src;
+
+  before(() => {
+    src = fs.readFileSync(GSD_TOOLS_SRC, 'utf-8');
+  });
+
+  test('main() intercepts stdout and resolves @file: references', () => {
+    // The non-pick path should have @file: resolution, just like the --pick path
+    assert.ok(
+      src.includes("captured.startsWith('@file:')") ||
+      src.includes('captured.startsWith(\'@file:\')'),
+      'main() should check for @file: prefix in captured output'
+    );
+  });
+
+  test('@file: resolution reads file content via readFileSync', () => {
+    // Verify the resolution reads the actual file
+    assert.ok(
+      src.includes("readFileSync(captured.slice(6)") ||
+      src.includes('readFileSync(captured.slice(6)'),
+      '@file: resolution should read file at the path after the prefix'
+    );
+  });
+
+  test('stdout interception wraps runCommand in the non-pick path', () => {
+    // The main function should intercept fs.writeSync for fd=1
+    // in BOTH the pick path AND the normal path
+    const mainFunc = src.slice(src.indexOf('async function main()'));
+    const pickInterception = mainFunc.indexOf('// When --pick is active');
+    const fileResolution = mainFunc.indexOf('@file:');
+
+    // There should be at least two @file: resolution points:
+    // one in the --pick path and one in the normal path
+    const firstAt = mainFunc.indexOf("'@file:'");
+    const secondAt = mainFunc.indexOf("'@file:'", firstAt + 1);
+    assert.ok(secondAt > firstAt,
+      'Both --pick and normal paths should resolve @file: references');
+  });
+});


### PR DESCRIPTION
Fixes #1891

## Summary

- Intercept stdout in `gsd-tools.cjs` to transparently resolve `@file:` references before they reach the calling shell
- Eliminates the need for bash-specific `if [[ "$INIT" == @file:* ]]` checks in 40+ workflow files
- The existing bash checks become harmless no-ops and can be removed in a follow-up cleanup

## Context

When `output()` in `core.cjs` produces JSON larger than 50KB, it writes the content to a temp file and outputs `@file:/path` to stdout. Every workflow file then needed a bash-specific check to detect and resolve this:

```bash
INIT=$(node gsd-tools.cjs state load)
if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
```

This `[[ ... ]]` syntax is bash-specific and breaks on PowerShell (the default shell for OpenCode on Windows), producing `ParserError: Missing '(' after 'if' in if statement`.

The `--pick` code path in `gsd-tools.cjs` already handled `@file:` resolution internally (line 336). This PR extends the same pattern to the normal (non-pick) output path, so `@file:` references are always resolved before reaching stdout.

## How it works

`gsd-tools.cjs` intercepts `fs.writeSync(1, ...)` calls (the same technique the `--pick` path uses), captures the output, checks for the `@file:` prefix, reads the temp file if found, and writes the actual content to stdout. The workflow shell never sees `@file:`.

## Test plan

- [x] New test `bug-1891-file-resolution.test.cjs` — 3 assertions verifying @file: resolution exists in both code paths
- [x] All 170 config + state tests pass (no regressions from stdout interception)
- [ ] Manual: on Windows/PowerShell, verify `state load` output no longer starts with `@file:`

🤖 Generated with [Claude Code](https://claude.com/claude-code)