### PR TITLE
fix(config): add planning lock to setConfigValue

### DIFF
--- a/get-shit-done/bin/lib/config.cjs
+++ b/get-shit-done/bin/lib/config.cjs
@@ -4,7 +4,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { output, error, planningRoot, CONFIG_DEFAULTS } = require('./core.cjs');
+const { output, error, planningRoot, withPlanningLock, CONFIG_DEFAULTS } = require('./core.cjs');
 const {
   VALID_PROFILES,
   getAgentToModelMapForProfile,
@@ -293,36 +293,40 @@ function cmdConfigEnsureSection(cwd, raw) {
 function setConfigValue(cwd, keyPath, parsedValue) {
   const configPath = path.join(planningRoot(cwd), 'config.json');
 
-  // Load existing config or start with empty object
-  let config = {};
-  try {
-    if (fs.existsSync(configPath)) {
-      config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+  // Hold planning lock across read-modify-write to prevent concurrent
+  // config set commands from clobbering each other's changes (#P1.4).
+  return withPlanningLock(cwd, () => {
+    // Load existing config or start with empty object
+    let config = {};
+    try {
+      if (fs.existsSync(configPath)) {
+        config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      }
+    } catch (err) {
+      error('Failed to read config.json: ' + err.message);
     }
-  } catch (err) {
-    error('Failed to read config.json: ' + err.message);
-  }
 
-  // Set nested value using dot notation (e.g., "workflow.research")
-  const keys = keyPath.split('.');
-  let current = config;
-  for (let i = 0; i < keys.length - 1; i++) {
-    const key = keys[i];
-    if (current[key] === undefined || typeof current[key] !== 'object') {
-      current[key] = {};
+    // Set nested value using dot notation (e.g., "workflow.research")
+    const keys = keyPath.split('.');
+    let current = config;
+    for (let i = 0; i < keys.length - 1; i++) {
+      const key = keys[i];
+      if (current[key] === undefined || typeof current[key] !== 'object') {
+        current[key] = {};
+      }
+      current = current[key];
     }
-    current = current[key];
-  }
-  const previousValue = current[keys[keys.length - 1]]; // Capture previous value before overwriting
-  current[keys[keys.length - 1]] = parsedValue;
+    const previousValue = current[keys[keys.length - 1]];
+    current[keys[keys.length - 1]] = parsedValue;
 
-  // Write back
-  try {
-    fs.writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8');
-    return { updated: true, key: keyPath, value: parsedValue, previousValue };
-  } catch (err) {
-    error('Failed to write config.json: ' + err.message);
-  }
+    // Write back
+    try {
+      fs.writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8');
+      return { updated: true, key: keyPath, value: parsedValue, previousValue };
+    } catch (err) {
+      error('Failed to write config.json: ' + err.message);
+    }
+  });
 }
 
 /**

--- a/tests/config-locking.test.cjs
+++ b/tests/config-locking.test.cjs
@@ -1,0 +1,45 @@
+/**
+ * Structural test for P1.4: config.json write locking.
+ *
+ * setConfigValue must hold the planning lock across its read-modify-write
+ * cycle to prevent concurrent config-set commands from clobbering each
+ * other's changes during parallel agent execution.
+ */
+
+'use strict';
+
+const { describe, test, before } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const CONFIG_SRC = path.join(__dirname, '..', 'get-shit-done', 'bin', 'lib', 'config.cjs');
+
+describe('P1.4: config.json write locking', () => {
+  let src;
+
+  before(() => {
+    src = fs.readFileSync(CONFIG_SRC, 'utf-8');
+  });
+
+  test('config.cjs imports withPlanningLock from core.cjs', () => {
+    assert.ok(
+      src.includes('withPlanningLock'),
+      'config.cjs must import withPlanningLock'
+    );
+  });
+
+  test('setConfigValue wraps read-modify-write in withPlanningLock', () => {
+    const funcStart = src.indexOf('function setConfigValue(');
+    assert.ok(funcStart !== -1, 'setConfigValue must exist');
+
+    const afterFunc = src.slice(funcStart);
+    const nextFunc = afterFunc.match(/\n(?:function |const |\/\*\*)\s/);
+    const funcBody = nextFunc ? afterFunc.slice(0, nextFunc.index) : afterFunc.slice(0, 1500);
+
+    assert.ok(
+      funcBody.includes('withPlanningLock(cwd,'),
+      'setConfigValue must wrap its body in withPlanningLock(cwd, ...)'
+    );
+  });
+});


### PR DESCRIPTION
Fixes #1927

## Summary

- Wrap `setConfigValue()` read-modify-write in `withPlanningLock()` to prevent concurrent config-set commands from clobbering each other
- Import `withPlanningLock` from `core.cjs` into `config.cjs`

## Context

`setConfigValue()` does an unlocked read-modify-write on `config.json`. During parallel wave execution, two agents calling `config set` with different keys would lose one agent's changes. The planning lock (`withPlanningLock`) already exists and is used by `roadmap.cjs` for ROADMAP.md writes — this PR extends the same protection to config writes.

Create-only operations (`cmdConfigNewProject`, `ensureConfigFile`) don't need locking since they write fresh configs rather than modifying existing content.

## Test plan

- [x] New test `config-locking.test.cjs` — 2 assertions verifying lock usage
- [x] All 77 existing config tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)