### PR TITLE
perf(hooks): skip config read for non-GSD projects in context monitor

### DIFF
--- a/hooks/gsd-context-monitor.js
+++ b/hooks/gsd-context-monitor.js
@@ -52,17 +52,19 @@ process.stdin.on('end', () => {
       process.exit(0);
     }
 
-    // Check if context warnings are disabled via config
+    // Check if context warnings are disabled via config.
+    // Quick sentinel check: skip config read entirely for non-GSD projects (#P2.5).
     const cwd = data.cwd || process.cwd();
-    const configPath = path.join(cwd, '.planning', 'config.json');
-    if (fs.existsSync(configPath)) {
+    const planningDir = path.join(cwd, '.planning');
+    if (fs.existsSync(planningDir)) {
       try {
+        const configPath = path.join(planningDir, 'config.json');
         const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
         if (config.hooks?.context_warnings === false) {
           process.exit(0);
         }
       } catch (e) {
-        // Ignore config parse errors
+        // Ignore config read/parse errors (config may not exist in .planning/)
       }
     }
 


### PR DESCRIPTION
Fixes #1929

## Summary

- Add `.planning/` directory sentinel check before reading `config.json` in the context monitor hook
- For non-GSD projects, this skips the config read/parse entirely

## Test plan

- [x] Manual: non-GSD project skips config read
- [x] GSD project still reads config and respects `hooks.context_warnings: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)