### PR TITLE
fix(installer): prefix local-install hook commands with $CLAUDE_PROJECT_DIR

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -5540,19 +5540,19 @@ function install(isGlobal, runtime = 'claude') {
   const settings = validateHookFields(cleanupOrphanedHooks(rawSettings));
   const statuslineCommand = isGlobal
     ? buildHookCommand(targetDir, 'gsd-statusline.js')
-    : 'node ' + dirName + '/hooks/gsd-statusline.js';
+    : 'node "$CLAUDE_PROJECT_DIR"/' + dirName + '/hooks/gsd-statusline.js';
   const updateCheckCommand = isGlobal
     ? buildHookCommand(targetDir, 'gsd-check-update.js')
-    : 'node ' + dirName + '/hooks/gsd-check-update.js';
+    : 'node "$CLAUDE_PROJECT_DIR"/' + dirName + '/hooks/gsd-check-update.js';
   const contextMonitorCommand = isGlobal
     ? buildHookCommand(targetDir, 'gsd-context-monitor.js')
-    : 'node ' + dirName + '/hooks/gsd-context-monitor.js';
+    : 'node "$CLAUDE_PROJECT_DIR"/' + dirName + '/hooks/gsd-context-monitor.js';
   const promptGuardCommand = isGlobal
     ? buildHookCommand(targetDir, 'gsd-prompt-guard.js')
-    : 'node ' + dirName + '/hooks/gsd-prompt-guard.js';
+    : 'node "$CLAUDE_PROJECT_DIR"/' + dirName + '/hooks/gsd-prompt-guard.js';
   const readGuardCommand = isGlobal
     ? buildHookCommand(targetDir, 'gsd-read-guard.js')
-    : 'node ' + dirName + '/hooks/gsd-read-guard.js';
+    : 'node "$CLAUDE_PROJECT_DIR"/' + dirName + '/hooks/gsd-read-guard.js';
 
   // Enable experimental agents for Gemini CLI (required for custom sub-agents)
   if (isGemini) {
@@ -5689,7 +5689,7 @@ function install(isGlobal, runtime = 'claude') {
     // /gsd-quick or /gsd-fast for state-tracked changes. Advisory only.
     const workflowGuardCommand = isGlobal
       ? buildHookCommand(targetDir, 'gsd-workflow-guard.js')
-      : 'node ' + dirName + '/hooks/gsd-workflow-guard.js';
+      : 'node "$CLAUDE_PROJECT_DIR"/' + dirName + '/hooks/gsd-workflow-guard.js';
     const hasWorkflowGuardHook = settings.hooks[preToolEvent].some(entry =>
       entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-workflow-guard'))
     );
@@ -5711,7 +5711,7 @@ function install(isGlobal, runtime = 'claude') {
     // Configure commit validation hook (Conventional Commits enforcement, opt-in)
     const validateCommitCommand = isGlobal
       ? 'bash ' + targetDir.replace(/\\/g, '/') + '/hooks/gsd-validate-commit.sh'
-      : 'bash ' + dirName + '/hooks/gsd-validate-commit.sh';
+      : 'bash "$CLAUDE_PROJECT_DIR"/' + dirName + '/hooks/gsd-validate-commit.sh';
     const hasValidateCommitHook = settings.hooks[preToolEvent].some(entry =>
       entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-validate-commit'))
     );
@@ -5738,7 +5738,7 @@ function install(isGlobal, runtime = 'claude') {
     // Configure session state orientation hook (opt-in)
     const sessionStateCommand = isGlobal
       ? 'bash ' + targetDir.replace(/\\/g, '/') + '/hooks/gsd-session-state.sh'
-      : 'bash ' + dirName + '/hooks/gsd-session-state.sh';
+      : 'bash "$CLAUDE_PROJECT_DIR"/' + dirName + '/hooks/gsd-session-state.sh';
     const hasSessionStateHook = settings.hooks.SessionStart.some(entry =>
       entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-session-state'))
     );
@@ -5760,7 +5760,7 @@ function install(isGlobal, runtime = 'claude') {
     // Configure phase boundary detection hook (opt-in)
     const phaseBoundaryCommand = isGlobal
       ? 'bash ' + targetDir.replace(/\\/g, '/') + '/hooks/gsd-phase-boundary.sh'
-      : 'bash ' + dirName + '/hooks/gsd-phase-boundary.sh';
+      : 'bash "$CLAUDE_PROJECT_DIR"/' + dirName + '/hooks/gsd-phase-boundary.sh';
     const hasPhaseBoundaryHook = settings.hooks[postToolEvent].some(entry =>
       entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-phase-boundary'))
     );

--- a/tests/local-install-hook-paths.test.cjs
+++ b/tests/local-install-hook-paths.test.cjs
@@ -1,0 +1,99 @@
+/**
+ * Regression test for #1906: local-install hook commands must use
+ * $CLAUDE_PROJECT_DIR so they resolve correctly when Claude Code's
+ * bash cwd drifts to a subdirectory.
+ *
+ * All 9 hook command construction sites in the local-install branch of
+ * install.js must prefix with "$CLAUDE_PROJECT_DIR"/ rather than using
+ * bare relative paths like `node .claude/hooks/...`.
+ */
+
+'use strict';
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const INSTALL_JS = path.join(__dirname, '..', 'bin', 'install.js');
+
+// All 9 hooks that must be registered with $CLAUDE_PROJECT_DIR in local installs
+const HOOKS = [
+  { name: 'gsd-statusline.js',       interpreter: 'node' },
+  { name: 'gsd-check-update.js',     interpreter: 'node' },
+  { name: 'gsd-context-monitor.js',  interpreter: 'node' },
+  { name: 'gsd-prompt-guard.js',     interpreter: 'node' },
+  { name: 'gsd-read-guard.js',       interpreter: 'node' },
+  { name: 'gsd-workflow-guard.js',   interpreter: 'node' },
+  { name: 'gsd-validate-commit.sh',  interpreter: 'bash' },
+  { name: 'gsd-session-state.sh',    interpreter: 'bash' },
+  { name: 'gsd-phase-boundary.sh',   interpreter: 'bash' },
+];
+
+describe('local install hook paths (#1906)', () => {
+  let content;
+
+  // Read once; all tests in this describe share the source.
+  test('setup: install.js is readable', () => {
+    content = fs.readFileSync(INSTALL_JS, 'utf-8');
+    assert.ok(content.length > 0);
+  });
+
+  for (const hook of HOOKS) {
+    test(`local-install branch for ${hook.name} uses $CLAUDE_PROJECT_DIR`, () => {
+      if (!content) {
+        content = fs.readFileSync(INSTALL_JS, 'utf-8');
+      }
+      // The local branch (the `: ...` branch of `isGlobal ? ... : ...`) must
+      // reference "$CLAUDE_PROJECT_DIR" next to the hook filename.
+      // We look for the pattern: `$CLAUDE_PROJECT_DIR` appearing on the same
+      // logical line or expression as the hook name.
+      const lines = content.split('\n');
+      const localBranchLines = lines.filter(line =>
+        line.includes(hook.name) &&
+        !line.includes('buildHookCommand') &&  // exclude global branch
+        !line.includes('gsdHooks') &&           // exclude cleanup array
+        !line.includes('includes(') &&          // exclude dedup checks
+        !line.includes('//') &&                 // exclude comments
+        !line.trim().startsWith('*')            // exclude jsdoc
+      );
+
+      // At least one local-branch line for this hook should include $CLAUDE_PROJECT_DIR
+      const hasProjectDir = localBranchLines.some(line =>
+        line.includes('$CLAUDE_PROJECT_DIR')
+      );
+
+      assert.ok(
+        hasProjectDir,
+        [
+          `install.js local-install command for ${hook.name} must include "$CLAUDE_PROJECT_DIR".`,
+          `Found these lines referencing ${hook.name} (excluding global/dedup/cleanup):`,
+          ...localBranchLines.map(l => '  ' + l.trim()),
+          '',
+          'Fix: change the local branch from:',
+          `  : '${hook.interpreter} ' + dirName + '/hooks/${hook.name}'`,
+          'to:',
+          `  : '${hook.interpreter} "$CLAUDE_PROJECT_DIR"/' + dirName + '/hooks/${hook.name}'`,
+        ].join('\n')
+      );
+    });
+  }
+
+  test('no local hook command string starts with bare "node .claude/hooks"', () => {
+    if (!content) {
+      content = fs.readFileSync(INSTALL_JS, 'utf-8');
+    }
+    // Bare relative path patterns that are wrong
+    const badPatterns = [
+      /['"]node \s*'\s*\+\s*dirName\s*\+\s*'\/hooks\//,
+      /['"]bash \s*'\s*\+\s*dirName\s*\+\s*'\/hooks\//,
+    ];
+    for (const pattern of badPatterns) {
+      const match = content.match(pattern);
+      assert.ok(
+        !match,
+        `install.js still has a bare relative local hook path matching ${pattern}: ${match && match[0]}`
+      );
+    }
+  });
+});


### PR DESCRIPTION
## What

All 9 hook command strings in the local-install branch of `bin/install.js` were bare relative paths (e.g. `node .claude/hooks/gsd-context-monitor.js`). Claude Code persists the bash `cwd` across tool calls, so after any `cd subdir` command, those paths resolve against `<subdir>/.claude/hooks/...` and fail with `MODULE_NOT_FOUND`.

## Fix

Prefix every local-install hook command with `"$CLAUDE_PROJECT_DIR"/` so the path anchors to the project root regardless of cwd drift:

```js
// Before
: 'node ' + dirName + '/hooks/gsd-context-monitor.js'

// After
: 'node "$CLAUDE_PROJECT_DIR"/' + dirName + '/hooks/gsd-context-monitor.js'
```

Global installs already used absolute paths via `buildHookCommand()` and are unchanged.

Hooks fixed:
- `gsd-statusline.js`
- `gsd-check-update.js`
- `gsd-context-monitor.js`
- `gsd-prompt-guard.js`
- `gsd-read-guard.js`
- `gsd-workflow-guard.js`
- `gsd-validate-commit.sh`
- `gsd-session-state.sh`
- `gsd-phase-boundary.sh`

## Test

New regression test `tests/local-install-hook-paths.test.cjs` with 11 cases:
- One test per hook asserting `$CLAUDE_PROJECT_DIR` appears in the local-install branch
- One test asserting no bare `'node ' + dirName` patterns remain

TDD: tests were written first and confirmed failing before the fix was applied.

Closes #1906

🤖 Generated with [Claude Code](https://claude.com/claude-code)