### PR TITLE
fix(milestone): replace test()+replace() with replace()+comparison in cmdRequirementsMarkComplete

### DIFF
--- a/get-shit-done/bin/lib/milestone.cjs
+++ b/get-shit-done/bin/lib/milestone.cjs
@@ -42,19 +42,17 @@ function cmdRequirementsMarkComplete(cwd, reqIdsRaw, raw) {
 
     // Update checkbox: - [ ] **REQ-ID** → - [x] **REQ-ID**
     const checkboxPattern = new RegExp(`(-\\s*\\[)[ ](\\]\\s*\\*\\*${reqEscaped}\\*\\*)`, 'gi');
-    if (checkboxPattern.test(reqContent)) {
-      reqContent = reqContent.replace(checkboxPattern, '$1x$2');
+    const afterCheckbox = reqContent.replace(checkboxPattern, '$1x$2');
+    if (afterCheckbox !== reqContent) {
+      reqContent = afterCheckbox;
       found = true;
     }
 
     // Update traceability table: | REQ-ID | Phase N | Pending | → | REQ-ID | Phase N | Complete |
     const tablePattern = new RegExp(`(\\|\\s*${reqEscaped}\\s*\\|[^|]+\\|)\\s*Pending\\s*(\\|)`, 'gi');
-    if (tablePattern.test(reqContent)) {
-      // Re-read since test() advances lastIndex for global regex
-      reqContent = reqContent.replace(
-        new RegExp(`(\\|\\s*${reqEscaped}\\s*\\|[^|]+\\|)\\s*Pending\\s*(\\|)`, 'gi'),
-        '$1 Complete $2'
-      );
+    const afterTable = reqContent.replace(tablePattern, '$1 Complete $2');
+    if (afterTable !== reqContent) {
+      reqContent = afterTable;
       found = true;
     }
 
@@ -62,8 +60,8 @@ function cmdRequirementsMarkComplete(cwd, reqIdsRaw, raw) {
       updated.push(reqId);
     } else {
       // Check if already complete before declaring not_found
-      const doneCheckbox = new RegExp(`-\\s*\\[x\\]\\s*\\*\\*${reqEscaped}\\*\\*`, 'gi');
-      const doneTable = new RegExp(`\\|\\s*${reqEscaped}\\s*\\|[^|]+\\|\\s*Complete\\s*\\|`, 'gi');
+      const doneCheckbox = new RegExp(`-\\s*\\[x\\]\\s*\\*\\*${reqEscaped}\\*\\*`, 'i');
+      const doneTable = new RegExp(`\\|\\s*${reqEscaped}\\s*\\|[^|]+\\|\\s*Complete\\s*\\|`, 'i');
       if (doneCheckbox.test(reqContent) || doneTable.test(reqContent)) {
         alreadyComplete.push(reqId);
       } else {

--- a/tests/milestone.test.cjs
+++ b/tests/milestone.test.cjs
@@ -773,6 +773,46 @@ describe('requirements mark-complete command', () => {
     assert.strictEqual(output.updated, false, 'updated should be false');
     assert.strictEqual(output.reason, 'REQUIREMENTS.md not found', 'should report file not found');
   });
+
+  test('regression #1922: checkbox and table both updated when only those two lines exist (no surrounding content)', () => {
+    // Exercises the fix for #1922: the function must use replace()+comparison instead
+    // of test()+replace() on the same /gi regex, and must not create the table regex
+    // twice.  With only a checkbox line and a table row, both transforms must succeed.
+    const content = [
+      '- [ ] **REQ-01**: requirement with no surrounding text',
+      '',
+      '| REQ-01 | Phase 1 | Pending |',
+    ].join('\n');
+    writeRequirements(tmpDir, content);
+
+    const result = runGsdTools('requirements mark-complete REQ-01', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.ok(output.marked_complete.includes('REQ-01'), 'REQ-01 must be in marked_complete');
+    assert.deepStrictEqual(output.not_found, [], 'REQ-01 must not be reported as not_found');
+
+    const updated = readRequirements(tmpDir);
+    assert.ok(updated.includes('- [x] **REQ-01**'), 'checkbox must be checked');
+    assert.ok(updated.includes('| REQ-01 | Phase 1 | Complete |'), 'table row must be Complete');
+  });
+
+  test('regression #1922: marks complete when requirement is at position 0 of file (no leading content)', () => {
+    // Only a single line with no preceding characters — exercises the start-of-string
+    // match path to guard against any future regression where lastIndex from test()
+    // could affect replace().
+    writeRequirements(tmpDir, '- [ ] **START-01**: very first line');
+
+    const result = runGsdTools('requirements mark-complete START-01', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.ok(output.marked_complete.includes('START-01'), 'START-01 must be in marked_complete');
+    assert.deepStrictEqual(output.not_found, [], 'must not be reported as not_found');
+
+    const updated = readRequirements(tmpDir);
+    assert.ok(updated.includes('- [x] **START-01**'), 'checkbox at position 0 must be checked');
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Fix

Closes #1922

## What changed

`cmdRequirementsMarkComplete` in `get-shit-done/bin/lib/milestone.cjs` used `test()` + `replace()` on the same `/gi` regex for the checkbox pattern, and created the table pattern regex twice (once for `test()`, once for `replace()`) as a workaround for the same issue.

The fix applies the pattern the issue recommends throughout:

```js
// Before
const pattern = new RegExp(`...`, 'gi');
if (pattern.test(content)) {
  content = content.replace(pattern, '...');
}

// After
const pattern = new RegExp(`...`, 'gi');
const after = content.replace(pattern, '...');
if (after !== content) {
  content = after;
}
```

This eliminates:
- The fragile `test()`+`replace()` pattern on the checkbox regex
- The double regex construction in the table path (the old workaround)
- The unnecessary `g` flag on the done-check patterns (`doneCheckbox`, `doneTable`) that are only used once with `test()`

## Tests added

Two regression tests in `tests/milestone.test.cjs` under the `requirements mark-complete command` suite:

1. Checkbox + table row both update correctly when only those two lines exist (no surrounding content)
2. Checkbox updates correctly when the requirement is the very first character of the file (position 0)

Full suite: 2658 tests, 0 failures.