### PR TITLE
ci: fix release pipeline — update actions, add GH releases, extend CI triggers

### DIFF
--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -37,7 +37,7 @@ jobs:
       base_tag: ${{ steps.validate.outputs.base_tag }}
       branch: ${{ steps.validate.outputs.branch }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
@@ -73,11 +73,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -124,12 +124,12 @@ jobs:
       id-token: write
     environment: npm-publish
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ needs.validate-version.outputs.branch }}
           fetch-depth: 0
 
-      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
@@ -189,6 +189,16 @@ jobs:
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          gh release create "v${VERSION}" \
+            --title "v${VERSION} (hotfix)" \
+            --generate-notes
 
       - name: Clean up next dist-tag
         if: ${{ !inputs.dry_run }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       branch: ${{ steps.validate.outputs.branch }}
       is_major: ${{ steps.validate.outputs.is_major }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
@@ -69,11 +69,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -123,12 +123,12 @@ jobs:
       id-token: write
     environment: npm-publish
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ needs.validate-version.outputs.branch }}
           fetch-depth: 0
 
-      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
@@ -208,6 +208,17 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Create GitHub pre-release
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PRE_VERSION: ${{ steps.prerelease.outputs.pre_version }}
+        run: |
+          gh release create "v${PRE_VERSION}" \
+            --title "v${PRE_VERSION}" \
+            --generate-notes \
+            --prerelease
+
       - name: Verify publish
         if: ${{ !inputs.dry_run }}
         env:
@@ -251,12 +262,12 @@ jobs:
       id-token: write
     environment: npm-publish
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ needs.validate-version.outputs.branch }}
           fetch-depth: 0
 
-      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
@@ -330,6 +341,17 @@ jobs:
         run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        if: ${{ !inputs.dry_run }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          gh release create "v${VERSION}" \
+            --title "v${VERSION}" \
+            --generate-notes \
+            --latest
 
       - name: Clean up next dist-tag
         if: ${{ !inputs.dry_run }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+      - 'release/**'
+      - 'hotfix/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+      - 'release/**'
+      - 'hotfix/**'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
## Summary

Closes #1955

- Update `actions/checkout` (v4.2.2 → v6.0.2) and `actions/setup-node` (v4.1.0 → v6.3.0) in `release.yml` and `hotfix.yml` — prevents Node.js 20 deprecation breakage after June 2, 2026
- Add `gh release create` steps to release RC, release finalize, and hotfix finalize — populates GitHub Releases page automatically
- Extend `test.yml` push triggers to `release/**` and `hotfix/**` branches
- Extend `security-scan.yml` PR triggers to `release/**` and `hotfix/**` branches

## MAINTAINER MERGE ONLY

This PR requires **manual repo admin steps** before the release pipeline will fully work. These code changes are necessary but not sufficient — the blocker is a repo setting, not code.

### Post-Merge Admin Checklist

After merging this PR, the repo admin must complete these steps:

- [ ] **Settings → Actions → General → Workflow permissions:** Check **"Allow GitHub Actions to create and approve pull requests"** — this is the root cause of all finalize failures (`GraphQL: GitHub Actions is not permitted to create or approve pull requests`)
- [ ] **Settings → Branches (or Rules → Rulesets):** Add main branch protection — require PR, require status checks (`test`, `security`, `check-issue-link`), block force push
- [ ] **Settings → Environments → npm-publish:** Add required reviewer (trek-e), set deployment branch policy to `release/*`, `hotfix/*`, `main`
- [ ] **Settings → Environments → npm-publish → Secrets:** Add `NPM_TOKEN` as environment secret
- [ ] **Settings → Secrets → Repository secrets:** Delete repo-level `NPM_TOKEN` (after environment secret is confirmed working)
- [ ] **Actions → Release → Run workflow:** Re-run `finalize` for version `1.34.0` (never published due to PR permission blocker)
- [ ] **Actions → Hotfix Release → Run workflow:** Re-run `finalize` for version `1.33.1` (never published due to PR permission blocker)
- [ ] Delete stale remote branches: `release/1.34.0`, `hotfix/1.33.1`

Full analysis: `CI-CD-PIPELINE-REPORT.md` in repo root (not committed — local reference only).

## Test plan

- [x] Full test suite passes locally (`npm run test:coverage` — 2700+ tests, all green)
- [ ] CI passes on this PR (test matrix, security scan, PR gate)
- [ ] After admin checklist: dry-run release finalize with `dry_run: true`
- [ ] After admin checklist: dry-run hotfix finalize with `dry_run: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)