### PR TITLE
fix(executor): enforce acceptance_criteria as hard gate, not advisory text

### DIFF
--- a/get-shit-done/workflows/execute-plan.md
+++ b/get-shit-done/workflows/execute-plan.md
@@ -110,6 +110,8 @@ Pattern B only (verify-only checkpoints). Skip for A/C.
 3. After ALL segments: aggregate files/deviations/decisions → create SUMMARY.md → commit → self-check:
    - Verify key-files.created exist on disk with `[ -f ]`
    - Check `git log --oneline --all --grep="{phase}-{plan}"` returns ≥1 commit
+   - Re-run ALL `<acceptance_criteria>` from every task — if any fail, fix before finalizing SUMMARY
+   - Re-run the plan-level `<verification>` commands — log results in SUMMARY
    - Append `## Self-Check: PASSED` or `## Self-Check: FAILED` to SUMMARY
 
    **Known Claude Code bug (classifyHandoffIfNeeded):** If any segment agent reports "failed" with `classifyHandoffIfNeeded is not defined`, this is a Claude Code runtime bug — not a real failure. Run spot-checks; if they pass, treat as successful.
@@ -145,7 +147,13 @@ Deviations are normal — handle via rules below.
    - **MANDATORY read_first gate:** If the task has a `<read_first>` field, you MUST read every listed file BEFORE making any edits. This is not optional. Do not skip files because you "already know" what's in them — read them. The read_first files establish ground truth for the task.
    - `type="auto"`: if `tdd="true"` → TDD execution. Implement with deviation rules + auth gates. Verify done criteria. Commit (see task_commit). Track hash for Summary.
    - `type="checkpoint:*"`: STOP → checkpoint_protocol → wait for user → continue only after confirmation.
-   - **MANDATORY acceptance_criteria check:** After completing each task, if it has `<acceptance_criteria>`, verify EVERY criterion before moving to the next task. Use grep, file reads, or CLI commands to confirm each criterion. If any criterion fails, fix the implementation before proceeding. Do not skip criteria or mark them as "will verify later".
+   - **HARD GATE — acceptance_criteria verification:** After completing each task, if it has `<acceptance_criteria>`, you MUST run a verification loop before proceeding:
+     1. For each criterion: execute the grep, file check, or CLI command that proves it passes
+     2. Log each result as PASS or FAIL with the command output
+     3. If ANY criterion fails: fix the implementation immediately, then re-run ALL criteria
+     4. Repeat until all criteria pass — you are BLOCKED from starting the next task until this gate clears
+     5. If a criterion cannot be satisfied after 2 fix attempts, log it as a deviation with reason — do NOT silently skip it
+     This is not advisory. A task with failing acceptance criteria is an incomplete task.
 3. Run `<verification>` checks
 4. Confirm `<success_criteria>` met
 5. Document deviations in Summary


### PR DESCRIPTION
## Summary

- Replace advisory "MANDATORY" text with a structured 5-step verification loop that blocks task progression
- Self-check step now re-runs ALL acceptance criteria and plan-level verification before finalizing SUMMARY

## Problem

The `MANDATORY acceptance_criteria check` instruction on line 148 of `execute-plan.md` is purely advisory. Executor agents read it and silently skip criteria when they run low on context or hit complexity. In a real 5-plan phase execution, 3 agents collectively dropped HLS.js streaming, virtual scrolling (virtua), 4 UI components, and skin-aware rendering — all of which had acceptance criteria that would have caught them.

## Changes

**Per-task gate (line 148):** Replaced single-line advisory with a 5-step verification loop:
1. Execute each criterion via grep/file-check/CLI
2. Log PASS/FAIL with output
3. Fix failures immediately, re-run all criteria
4. BLOCK next task until gate clears
5. After 2 failed fix attempts, log as deviation (not silent skip)

**Self-check (line 110):** Added two verification steps before SUMMARY finalization:
- Re-run ALL `<acceptance_criteria>` from every task
- Re-run plan-level `<verification>` commands

## Test plan

- [ ] Executor agent runs acceptance criteria after each task
- [ ] Failing criteria blocks progression to next task
- [ ] Self-check catches criteria missed during per-task execution
- [ ] Deviations logged when criteria can't be satisfied

Closes #1958

🤖 Generated with [Claude Code](https://claude.com/claude-code)