### PR TITLE
fix(core): preserve letter suffix case in normalizePhaseName

### DIFF
--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -900,7 +900,10 @@ function normalizePhaseName(phase) {
   const match = stripped.match(/^(\d+)([A-Z])?((?:\.\d+)*)/i);
   if (match) {
     const padded = match[1].padStart(2, '0');
-    const letter = match[2] ? match[2].toUpperCase() : '';
+    // Preserve original case of letter suffix (#1962).
+    // Uppercasing causes directory/roadmap mismatches on case-sensitive filesystems
+    // (e.g., "16c" in ROADMAP.md → directory "16C-name" → progress can't match).
+    const letter = match[2] || '';
     const decimal = match[3] || '';
     return padded + letter + decimal;
   }

--- a/tests/bug-1962-phase-suffix-case.test.cjs
+++ b/tests/bug-1962-phase-suffix-case.test.cjs
@@ -1,0 +1,49 @@
+/**
+ * Regression tests for bug #1962
+ *
+ * normalizePhaseName must preserve the original case of letter suffixes.
+ * Uppercasing "16c" to "16C" causes directory/roadmap mismatches on
+ * case-sensitive filesystems — init progress can't match the directory
+ * back to the roadmap phase entry.
+ */
+
+'use strict';
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { normalizePhaseName } = require('../get-shit-done/bin/lib/core.cjs');
+
+describe('bug #1962: normalizePhaseName preserves letter suffix case', () => {
+  test('lowercase suffix preserved: 16c → 16c', () => {
+    assert.equal(normalizePhaseName('16c'), '16c');
+  });
+
+  test('uppercase suffix preserved: 16C → 16C', () => {
+    assert.equal(normalizePhaseName('16C'), '16C');
+  });
+
+  test('single digit padded with lowercase suffix: 1a → 01a', () => {
+    assert.equal(normalizePhaseName('1a'), '01a');
+  });
+
+  test('single digit padded with uppercase suffix: 1A → 01A', () => {
+    assert.equal(normalizePhaseName('1A'), '01A');
+  });
+
+  test('no suffix unchanged: 16 → 16', () => {
+    assert.equal(normalizePhaseName('16'), '16');
+  });
+
+  test('decimal suffix preserved: 16.1 → 16.1', () => {
+    assert.equal(normalizePhaseName('16.1'), '16.1');
+  });
+
+  test('letter + decimal preserved: 16c.2 → 16c.2', () => {
+    assert.equal(normalizePhaseName('16c.2'), '16c.2');
+  });
+
+  test('project code prefix stripped, suffix case preserved: CK-01a → 01a', () => {
+    assert.equal(normalizePhaseName('CK-01a'), '01a');
+  });
+});

--- a/tests/phase.test.cjs
+++ b/tests/phase.test.cjs
@@ -1906,9 +1906,9 @@ describe('normalizePhaseName', () => {
     assert.strictEqual(normalizePhaseName('12A.2'), '12A.2');
   });
 
-  test('uppercases letters', () => {
-    assert.strictEqual(normalizePhaseName('3a'), '03A');
-    assert.strictEqual(normalizePhaseName('12b.1'), '12B.1');
+  test('preserves letter case', () => {
+    assert.strictEqual(normalizePhaseName('3a'), '03a');
+    assert.strictEqual(normalizePhaseName('12b.1'), '12b.1');
   });
 
   test('handles multi-level decimal phases', () => {


### PR DESCRIPTION
Fixes #1962

## Summary

- Remove `.toUpperCase()` from the letter suffix in `normalizePhaseName` — preserve original case
- Prevents directory/roadmap mismatches on case-sensitive filesystems (e.g., "16c" in ROADMAP → directory "16C-name" → progress can't match)

## Context

`normalizePhaseName("16c")` returned `"16C"` because line 903 called `match[2].toUpperCase()`. On case-sensitive filesystems (Linux), this caused `init progress` to report the phase as `not_started` even though plans and summaries existed — the directory name `16C-*` didn't match the expected `16c-*`.

`comparePhaseNum` still uppercases for sorting (correct — comparison should be case-insensitive), but `normalizePhaseName` is used for display and directory creation where case must match the roadmap.

## Test plan

- [x] New test `bug-1962-phase-suffix-case.test.cjs` — 8 assertions covering lowercase, uppercase, padded, decimal, and project-code-prefix cases
- [ ] Manual: create phase 16c, verify directory name preserves lowercase

🤖 Generated with [Claude Code](https://claude.com/claude-code)