### PR TITLE
fix(ui-phase): suggest discuss-phase when CONTEXT.md is missing

### DIFF
--- a/get-shit-done/workflows/ui-phase.md
+++ b/get-shit-done/workflows/ui-phase.md
@@ -261,11 +261,17 @@ Dimensions: 6/6 passed
 
 ## ▶ Next Up
 
+{If CONTEXT.md exists for this phase:}
 **Plan Phase {N}** — planner will use UI-SPEC.md as design context
 
-`/clear` then:
+`/clear` then: `/gsd-plan-phase {N}`
 
-`/gsd-plan-phase {N}`
+{If CONTEXT.md does NOT exist:}
+**Discuss Phase {N}** — gather implementation context before planning
+
+`/clear` then: `/gsd-discuss-phase {N}`
+
+(or `/gsd-plan-phase {N}` to skip discussion)
 
 ───────────────────────────────────────────────────────────────
 ```


### PR DESCRIPTION
Fixes #1952

## Summary

- Conditionally suggest `/gsd-discuss-phase` or `/gsd-plan-phase` in the Next Up block based on CONTEXT.md existence
- Matches the logic already used in `progress.md` Route B

## Context

After `/gsd-ui-phase` completes, the Next Up block always suggested `/gsd-plan-phase`. But plan-phase redirects to discuss-phase when CONTEXT.md doesn't exist, causing a confusing two-step redirect ~90% of the time since ui-phase doesn't create CONTEXT.md.

## Test plan

- [x] Workflow template validated
- [ ] Manual: run ui-phase without CONTEXT.md, verify discuss-phase suggested

🤖 Generated with [Claude Code](https://claude.com/claude-code)