### PR TITLE
ci: update action versions to v6 in release/hotfix pipelines

### DIFF
--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -37,7 +37,7 @@ jobs:
       base_tag: ${{ steps.validate.outputs.base_tag }}
       branch: ${{ steps.validate.outputs.branch }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
@@ -73,11 +73,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -124,12 +124,12 @@ jobs:
       id-token: write
     environment: npm-publish
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ needs.validate-version.outputs.branch }}
           fetch-depth: 0
 
-      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       branch: ${{ steps.validate.outputs.branch }}
       is_major: ${{ steps.validate.outputs.is_major }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
@@ -69,11 +69,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -123,12 +123,12 @@ jobs:
       id-token: write
     environment: npm-publish
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ needs.validate-version.outputs.branch }}
           fetch-depth: 0
 
-      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'
@@ -251,12 +251,12 @@ jobs:
       id-token: write
     environment: npm-publish
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ needs.validate-version.outputs.branch }}
           fetch-depth: 0
 
-      - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+      - 'release/**'
+      - 'hotfix/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+      - 'release/**'
+      - 'hotfix/**'
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Fixes #1955

## Summary

- Update `actions/checkout` from v4.2.2 to v6.0.2 in `release.yml` and `hotfix.yml`
- Update `actions/setup-node` from v4.1.0 to v6.3.0 in both workflows
- Add `release/**` and `hotfix/**` push triggers to `test.yml`
- Add `release/**` and `hotfix/**` PR triggers to `security-scan.yml`

## Context

The release and hotfix pipelines pinned actions at v4 (Node.js 20 runtime). GitHub will force Node.js 24 on June 2, 2026 and remove Node.js 20 on September 16, 2026. `test.yml` already uses v6 pins — this aligns the release pipelines.

The CI coverage gap is also addressed: release/hotfix branches now trigger the full test suite and security scans, not just the internal test step in the release workflow.

## Changes

| File | Change |
|------|--------|
| `release.yml` | 4x checkout + 3x setup-node pins updated to v6 |
| `hotfix.yml` | 4x checkout + 2x setup-node pins updated to v6 |
| `test.yml` | Added `release/**`, `hotfix/**` to push triggers |
| `security-scan.yml` | Added `release/**`, `hotfix/**` to PR triggers |

No JS changes. Pure workflow YAML.

## Test plan

- [x] Pin hashes match `test.yml` v6 pins exactly
- [x] YAML syntax validated (no structural changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)