### PR TITLE
feat(review): add Qwen Code and Cursor CLI as peer reviewers

### DIFF
--- a/commands/gsd/review.md
+++ b/commands/gsd/review.md
@@ -1,7 +1,7 @@
 ---
 name: gsd:review
 description: Request cross-AI peer review of phase plans from external AI CLIs
-argument-hint: "--phase N [--gemini] [--claude] [--codex] [--opencode] [--all]"
+argument-hint: "--phase N [--gemini] [--claude] [--codex] [--opencode] [--qwen] [--cursor] [--all]"
 allowed-tools:
   - Read
   - Write
@@ -11,7 +11,7 @@ allowed-tools:
 ---
 
 <objective>
-Invoke external AI CLIs (Gemini, Claude, Codex, OpenCode) to independently review phase plans.
+Invoke external AI CLIs (Gemini, Claude, Codex, OpenCode, Qwen Code, Cursor) to independently review phase plans.
 Produces a structured REVIEWS.md with per-reviewer feedback that can be fed back into
 planning via /gsd-plan-phase --reviews.
 
@@ -30,6 +30,8 @@ Phase number: extracted from $ARGUMENTS (required)
 - `--claude` — Include Claude CLI review (uses separate session)
 - `--codex` — Include Codex CLI review
 - `--opencode` — Include OpenCode review (uses model from user's OpenCode config)
+- `--qwen` — Include Qwen Code review (Alibaba Qwen models)
+- `--cursor` — Include Cursor agent review
 - `--all` — Include all available CLIs
 </context>
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1023,6 +1023,8 @@ Cross-AI peer review of phase plans from external AI CLIs.
 | `--codex` | Include Codex CLI review |
 | `--coderabbit` | Include CodeRabbit review |
 | `--opencode` | Include OpenCode review (via GitHub Copilot) |
+| `--qwen` | Include Qwen Code review (Alibaba Qwen models) |
+| `--cursor` | Include Cursor agent review |
 | `--all` | Include all available CLIs |
 
 **Produces:** `{phase}-REVIEWS.md` — consumable by `/gsd-plan-phase --reviews`

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1068,9 +1068,9 @@ When verification returns `human_needed`, items are persisted as a trackable HUM
 
 ### 42. Cross-AI Peer Review
 
-**Command:** `/gsd-review --phase N [--gemini] [--claude] [--codex] [--coderabbit] [--all]`
+**Command:** `/gsd-review --phase N [--gemini] [--claude] [--codex] [--coderabbit] [--opencode] [--qwen] [--cursor] [--all]`
 
-**Purpose:** Invoke external AI CLIs (Gemini, Claude, Codex, CodeRabbit) to independently review phase plans. Produces structured REVIEWS.md with per-reviewer feedback.
+**Purpose:** Invoke external AI CLIs (Gemini, Claude, Codex, CodeRabbit, OpenCode, Qwen Code, Cursor) to independently review phase plans. Produces structured REVIEWS.md with per-reviewer feedback.
 
 **Requirements:**
 - REQ-REVIEW-01: System MUST detect available AI CLIs on the system

--- a/docs/ja-JP/COMMANDS.md
+++ b/docs/ja-JP/COMMANDS.md
@@ -839,6 +839,9 @@ GSDアップデート後にローカルの変更を復元します。
 | `--claude` | Claude CLIレビューを含める（別セッション） |
 | `--codex` | Codex CLIレビューを含める |
 | `--coderabbit` | CodeRabbitレビューを含める |
+| `--opencode` | OpenCodeレビューを含める（GitHub Copilot経由） |
+| `--qwen` | Qwen Codeレビューを含める（Alibaba Qwenモデル） |
+| `--cursor` | Cursorエージェントレビューを含める |
 | `--all` | 利用可能なすべてのCLIを含める |
 
 **生成物:** `{phase}-REVIEWS.md` — `/gsd-plan-phase --reviews` で利用可能

--- a/docs/ko-KR/COMMANDS.md
+++ b/docs/ko-KR/COMMANDS.md
@@ -839,6 +839,9 @@ GSD 업데이트 후 로컬 수정사항을 복원합니다.
 | `--claude` | Claude CLI 리뷰 포함 (별도 세션) |
 | `--codex` | Codex CLI 리뷰 포함 |
 | `--coderabbit` | CodeRabbit 리뷰 포함 |
+| `--opencode` | OpenCode 리뷰 포함 (GitHub Copilot 경유) |
+| `--qwen` | Qwen Code 리뷰 포함 (Alibaba Qwen 모델) |
+| `--cursor` | Cursor 에이전트 리뷰 포함 |
 | `--all` | 사용 가능한 모든 CLI 포함 |
 
 **생성 파일:** `{phase}-REVIEWS.md` — `/gsd-plan-phase --reviews`에서 사용 가능

--- a/get-shit-done/workflows/help.md
+++ b/get-shit-done/workflows/help.md
@@ -345,7 +345,7 @@ Usage: `/gsd-ship 4` or `/gsd-ship 4 --draft`
 
 ---
 
-**`/gsd-review --phase N [--gemini] [--claude] [--codex] [--coderabbit] [--all]`**
+**`/gsd-review --phase N [--gemini] [--claude] [--codex] [--coderabbit] [--opencode] [--qwen] [--cursor] [--all]`**
 Cross-AI peer review — invoke external AI CLIs to independently review phase plans.
 
 - Detects available CLIs (gemini, claude, codex, coderabbit)

--- a/get-shit-done/workflows/review.md
+++ b/get-shit-done/workflows/review.md
@@ -20,6 +20,8 @@ command -v claude >/dev/null 2>&1 && echo "claude:available" || echo "claude:mis
 command -v codex >/dev/null 2>&1 && echo "codex:available" || echo "codex:missing"
 command -v coderabbit >/dev/null 2>&1 && echo "coderabbit:available" || echo "coderabbit:missing"
 command -v opencode >/dev/null 2>&1 && echo "opencode:available" || echo "opencode:missing"
+command -v qwen >/dev/null 2>&1 && echo "qwen:available" || echo "qwen:missing"
+command -v cursor >/dev/null 2>&1 && echo "cursor:available" || echo "cursor:missing"
 ```
 
 Parse flags from `$ARGUMENTS`:
@@ -28,6 +30,8 @@ Parse flags from `$ARGUMENTS`:
 - `--codex` → include Codex
 - `--coderabbit` → include CodeRabbit
 - `--opencode` → include OpenCode
+- `--qwen` → include Qwen Code
+- `--cursor` → include Cursor
 - `--all` → include all available
 - No flags → include all available
 
@@ -38,6 +42,8 @@ No external AI CLIs found. Install at least one:
 - codex: https://github.com/openai/codex
 - claude: https://github.com/anthropics/claude-code
 - opencode: https://opencode.ai (leverages GitHub Copilot subscription models)
+- qwen: https://github.com/nicepkg/qwen-code (Alibaba Qwen models)
+- cursor: https://cursor.com (Cursor IDE agent mode)
 
 Then run /gsd-review again.
 ```
@@ -197,6 +203,22 @@ if [ ! -s /tmp/gsd-review-opencode-{phase}.md ]; then
 fi
 ```
 
+**Qwen Code:**
+```bash
+qwen -p "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-review-qwen-{phase}.md
+if [ ! -s /tmp/gsd-review-qwen-{phase}.md ]; then
+  echo "Qwen review failed or returned empty output." > /tmp/gsd-review-qwen-{phase}.md
+fi
+```
+
+**Cursor:**
+```bash
+cursor --prompt "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-review-cursor-{phase}.md
+if [ ! -s /tmp/gsd-review-cursor-{phase}.md ]; then
+  echo "Cursor review failed or returned empty output." > /tmp/gsd-review-cursor-{phase}.md
+fi
+```
+
 If a CLI fails, log the error and continue with remaining CLIs.
 
 Display progress:
@@ -216,7 +238,7 @@ Combine all review responses into `{phase_dir}/{padded_phase}-REVIEWS.md`:
 ```markdown
 ---
 phase: {N}
-reviewers: [gemini, claude, codex, coderabbit, opencode]
+reviewers: [gemini, claude, codex, coderabbit, opencode, qwen, cursor]
 reviewed_at: {ISO timestamp}
 plans_reviewed: [{list of PLAN.md files}]
 ---

--- a/get-shit-done/workflows/review.md
+++ b/get-shit-done/workflows/review.md
@@ -205,7 +205,7 @@ fi
 
 **Qwen Code:**
 ```bash
-qwen -p "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-review-qwen-{phase}.md
+qwen "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-review-qwen-{phase}.md
 if [ ! -s /tmp/gsd-review-qwen-{phase}.md ]; then
   echo "Qwen review failed or returned empty output." > /tmp/gsd-review-qwen-{phase}.md
 fi
@@ -213,7 +213,7 @@ fi
 
 **Cursor:**
 ```bash
-cursor --prompt "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-review-cursor-{phase}.md
+cat /tmp/gsd-review-prompt-{phase}.md | cursor agent -p --mode ask --trust 2>/dev/null > /tmp/gsd-review-cursor-{phase}.md
 if [ ! -s /tmp/gsd-review-cursor-{phase}.md ]; then
   echo "Cursor review failed or returned empty output." > /tmp/gsd-review-cursor-{phase}.md
 fi


### PR DESCRIPTION
Fixes #1938

## Summary

- Add `qwen` and `cursor` to the `/gsd-review` peer review pipeline
- CLI detection via `command -v`, `--qwen` and `--cursor` flags, invocation blocks with empty-output fallback, install help URLs
- Follows the established pattern from CodeRabbit (#1519) and OpenCode integrations

Note: Cursor support included alongside Qwen since it follows the identical pattern. If #1960 needs separate approval, happy to split into two PRs.

## Changes to review.md

1. **Detection**: Added `command -v qwen` and `command -v cursor` checks
2. **Flags**: Added `--qwen` and `--cursor` to the flags list
3. **Install help**: Added URLs for qwen-code and Cursor
4. **Invocation**: Added reviewer blocks matching the OpenCode pattern (pipe prompt, check for empty output)
5. **Template**: Added qwen and cursor to the REVIEWS.md frontmatter reviewers list

## Test plan

- [x] Workflow structure validated (follows existing CLI patterns exactly)
- [ ] Manual: with qwen installed, run `/gsd-review --qwen` and verify output

🤖 Generated with [Claude Code](https://claude.com/claude-code)