### PR TITLE
fix(codex): convert /gsd- workflow commands to $gsd- during installation

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -1477,16 +1477,29 @@ function convertClaudeAgentToTraeAgent(content) {
 }
 
 function convertSlashCommandsToCodexSkillMentions(content) {
+  // Convert colon-style skill invocations to Codex $ prefix
   let converted = content.replace(/\/gsd:([a-z0-9-]+)/gi, (_, commandName) => {
     return `$gsd-${String(commandName).toLowerCase()}`;
   });
-  converted = converted.replace(/\/gsd-help\b/g, '$gsd-help');
+  // Convert hyphen-style command references (workflow output) to Codex $ prefix.
+  // Negative lookbehind excludes file paths like bin/gsd-tools.cjs where
+  // the slash is preceded by a word char, dot, or another slash.
+  converted = converted.replace(/(?<![a-zA-Z0-9./])\/gsd-([a-z0-9-]+)/gi, (_, commandName) => {
+    return `$gsd-${String(commandName).toLowerCase()}`;
+  });
   return converted;
 }
 
 function convertClaudeToCodexMarkdown(content) {
   let converted = convertSlashCommandsToCodexSkillMentions(content);
   converted = converted.replace(/\$ARGUMENTS\b/g, '{{GSD_ARGS}}');
+  // Remove /clear references — Codex has no equivalent command
+  // Handle backtick-wrapped: `\/clear` then: → (removed)
+  converted = converted.replace(/`\/clear`\s*,?\s*then:?\s*\n?/gi, '');
+  // Handle bare: /clear then: → (removed)
+  converted = converted.replace(/\/clear\s*,?\s*then:?\s*\n?/gi, '');
+  // Handle standalone /clear on its own line
+  converted = converted.replace(/^\s*`?\/clear`?\s*$/gm, '');
   // Path replacement: .claude → .codex (#1430)
   converted = converted.replace(/\$HOME\/\.claude\//g, '$HOME/.codex/');
   converted = converted.replace(/~\/\.claude\//g, '~/.codex/');

--- a/tests/codex-config.test.cjs
+++ b/tests/codex-config.test.cjs
@@ -17,6 +17,7 @@ const os = require('os');
 const {
   getCodexSkillAdapterHeader,
   convertClaudeAgentToCodexAgent,
+  convertClaudeCommandToCodexSkill,
   generateCodexAgentToml,
   generateCodexConfigBlock,
   stripGsdFromCodexConfig,
@@ -183,6 +184,86 @@ node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" commit "docs: resolve"`;
     const result = convertClaudeAgentToCodexAgent(input);
     assert.ok(result.includes('$HOME/.codex/get-shit-done/bin/gsd-tools.cjs'), 'replaces $HOME/.claude/ with $HOME/.codex/');
     assert.ok(!result.includes('$HOME/.claude/'), 'no .claude paths remain');
+  });
+});
+
+// ─── Codex command prefix conversion ────────────────────────────────────────────
+
+describe('Codex hyphen-style command prefix conversion', () => {
+  test('converts /gsd-command in workflow output to $gsd-command', () => {
+    const input = `---
+name: gsd-test
+description: Test
+tools: Read
+---
+
+/gsd-discuss-phase 1 — gather context
+/gsd-plan-phase 2 — create plan
+/gsd-execute-phase 3 — run it`;
+
+    const result = convertClaudeCommandToCodexSkill(input, 'gsd-test');
+    assert.ok(result.includes('$gsd-discuss-phase'), 'converts /gsd-discuss-phase');
+    assert.ok(result.includes('$gsd-plan-phase'), 'converts /gsd-plan-phase');
+    assert.ok(result.includes('$gsd-execute-phase'), 'converts /gsd-execute-phase');
+    assert.ok(!result.includes('/gsd-discuss-phase'), 'no /gsd-discuss-phase remains');
+  });
+
+  test('converts backtick-wrapped /gsd- commands', () => {
+    const input = `---
+name: gsd-test
+description: Test
+tools: Read
+---
+
+Run \`/gsd-plan-phase 1\` to plan.`;
+
+    const result = convertClaudeCommandToCodexSkill(input, 'gsd-test');
+    assert.ok(result.includes('$gsd-plan-phase'), 'converts backtick-wrapped command');
+  });
+
+  test('does not convert /gsd- in file paths', () => {
+    const input = `---
+name: gsd-test
+description: Test
+tools: Read
+---
+
+node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" init`;
+
+    const result = convertClaudeCommandToCodexSkill(input, 'gsd-test');
+    assert.ok(result.includes('gsd-tools.cjs'), 'gsd-tools.cjs preserved in path');
+    assert.ok(!result.includes('$gsd-tools'), 'no $gsd-tools in file path');
+  });
+
+  test('removes /clear then: for Codex', () => {
+    const input = `---
+name: gsd-test
+description: Test
+tools: Read
+---
+
+\`/clear\` then:
+
+\`$gsd-plan-phase 1\``;
+
+    const result = convertClaudeCommandToCodexSkill(input, 'gsd-test');
+    assert.ok(!result.includes('/clear'), 'no /clear remains');
+    assert.ok(result.includes('$gsd-plan-phase'), 'command preserved after /clear removal');
+  });
+
+  test('removes bare /clear then: for Codex', () => {
+    const input = `---
+name: gsd-test
+description: Test
+tools: Read
+---
+
+/clear then:
+/gsd-execute-phase 2`;
+
+    const result = convertClaudeCommandToCodexSkill(input, 'gsd-test');
+    assert.ok(!result.includes('/clear'), 'no /clear remains');
+    assert.ok(result.includes('$gsd-execute-phase'), 'command converted');
   });
 });
 


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #1993

---

## What was broken

When running GSD inside Codex, workflow chat output (Next Up blocks, phase completion messages) displayed `/gsd-` prefixed commands instead of the correct `$gsd-` prefix. Users could not copy-paste suggested commands directly.

## What this fix does

Extends the Codex installation-time conversion to also handle hyphen-style command references (`/gsd-command` → `$gsd-command`) and strips `/clear` references that have no Codex equivalent.

## Root cause

`convertSlashCommandsToCodexSkillMentions()` in `bin/install.js` only converted colon-style skill invocations (`/gsd:command` → `$gsd-command`) but not hyphen-style references (`/gsd-command`) used throughout all workflow output templates. The `/clear` command was also left unconverted.

## Testing

### How I verified the fix

- All 2,741 existing tests pass
- 5 new regression tests added covering: hyphen-style conversion, backtick-wrapped commands, file path exclusion, and `/clear` removal (both backtick-wrapped and bare)

### Regression test added?

- [x] Yes — added 5 tests that would have caught this bug

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: Codex (the affected runtime)

---

## Checklist

- [x] Issue linked above with `Fixes #1993`
- [ ] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [ ] CHANGELOG.md updated if this is a user-facing fix
- [x] No unnecessary dependencies added

## Breaking changes

None