### PR TITLE
fix(hooks): skip read-guard advisory on Claude Code runtime

### DIFF
--- a/hooks/gsd-read-guard.js
+++ b/hooks/gsd-read-guard.js
@@ -36,6 +36,11 @@ process.stdin.on('end', () => {
       process.exit(0);
     }
 
+    // Claude Code natively enforces read-before-edit — skip the advisory (#1984)
+    if (process.env.CLAUDE_SESSION_ID) {
+      process.exit(0);
+    }
+
     const filePath = data.tool_input?.file_path || '';
     if (!filePath) {
       process.exit(0);

--- a/tests/read-guard.test.cjs
+++ b/tests/read-guard.test.cjs
@@ -26,14 +26,17 @@ const HOOK_PATH = path.join(__dirname, '..', 'hooks', 'gsd-read-guard.js');
  * Run the read guard hook with a given tool input payload.
  * Returns { exitCode, stdout, stderr }.
  */
-function runHook(payload) {
+function runHook(payload, envOverrides = {}) {
   const input = JSON.stringify(payload);
+  // Sanitize CLAUDE_SESSION_ID so positive-path tests work inside Claude Code sessions
+  const env = { ...process.env, CLAUDE_SESSION_ID: '', ...envOverrides };
   try {
     const stdout = execFileSync(process.execPath, [HOOK_PATH], {
       input,
       encoding: 'utf-8',
       timeout: 5000,
       stdio: ['pipe', 'pipe', 'pipe'],
+      env,
     });
     return { exitCode: 0, stdout: stdout.trim(), stderr: '' };
   } catch (err) {
@@ -228,23 +231,12 @@ describe('gsd-read-guard hook', () => {
     const filePath = path.join(tmpDir, 'existing.js');
     fs.writeFileSync(filePath, 'const x = 1;\n');
 
-    const input = JSON.stringify({
-      tool_name: 'Edit',
-      tool_input: { file_path: filePath, old_string: 'const x = 1;', new_string: 'const x = 2;' },
-    });
+    const result = runHook(
+      { tool_name: 'Edit', tool_input: { file_path: filePath, old_string: 'const x = 1;', new_string: 'const x = 2;' } },
+      { CLAUDE_SESSION_ID: 'test-session-123' }
+    );
 
-    try {
-      const stdout = execFileSync(process.execPath, [HOOK_PATH], {
-        input,
-        encoding: 'utf-8',
-        timeout: 5000,
-        stdio: ['pipe', 'pipe', 'pipe'],
-        env: { ...process.env, CLAUDE_SESSION_ID: 'test-session-123' },
-      });
-      assert.equal(stdout.trim(), '', 'should produce no output on Claude Code');
-    } catch (err) {
-      assert.equal(err.status, 0, 'should exit 0');
-      assert.equal((err.stdout || '').toString().trim(), '');
-    }
+    assert.equal(result.exitCode, 0);
+    assert.equal(result.stdout, '', 'should produce no output on Claude Code');
   });
 });

--- a/tests/read-guard.test.cjs
+++ b/tests/read-guard.test.cjs
@@ -221,4 +221,30 @@ describe('gsd-read-guard hook', () => {
     assert.equal(result.exitCode, 0);
     assert.equal(result.stdout, '');
   });
+
+  // ─── Claude Code runtime skip (#1984) ─────────────────────────────────
+
+  test('skips advisory on Claude Code runtime (CLAUDE_SESSION_ID set)', () => {
+    const filePath = path.join(tmpDir, 'existing.js');
+    fs.writeFileSync(filePath, 'const x = 1;\n');
+
+    const input = JSON.stringify({
+      tool_name: 'Edit',
+      tool_input: { file_path: filePath, old_string: 'const x = 1;', new_string: 'const x = 2;' },
+    });
+
+    try {
+      const stdout = execFileSync(process.execPath, [HOOK_PATH], {
+        input,
+        encoding: 'utf-8',
+        timeout: 5000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: { ...process.env, CLAUDE_SESSION_ID: 'test-session-123' },
+      });
+      assert.equal(stdout.trim(), '', 'should produce no output on Claude Code');
+    } catch (err) {
+      assert.equal(err.status, 0, 'should exit 0');
+      assert.equal((err.stdout || '').toString().trim(), '');
+    }
+  });
 });


### PR DESCRIPTION
## Summary

- Skip the `gsd-read-guard.js` advisory when running inside Claude Code, which natively enforces read-before-edit at the runtime level
- Detection uses `CLAUDE_SESSION_ID` env var — the established Claude Code detection pattern already used in `core.cjs:15` and `workstream-flag.md`
- Saves ~80 tokens per Write/Edit call and eliminates noisy `<system-reminder>` blocks in Claude Code sessions
- Non-Claude runtimes (OpenCode, Gemini, Cursor, etc.) continue to receive the advisory as before

### Context

The read guard was added for non-Claude models (e.g. MiniMax M2.5 on OpenCode) that don't follow read-before-edit natively and get stuck in infinite retry loops. Claude Code doesn't have this problem — it tracks read state internally. The advisory was harmless but added token waste and noise on every edit.

### Test isolation

The `runHook()` test helper now sanitizes `CLAUDE_SESSION_ID` from the inherited environment so the positive-path tests pass even when the test suite runs inside a Claude Code session.

Closes #1984

## Test plan

- [x] New test: `skips advisory on Claude Code runtime (CLAUDE_SESSION_ID set)` — verifies empty output
- [x] All 13 read-guard tests pass
- [x] `runHook()` helper sanitizes env to prevent test failures inside Claude Code
- [x] Adversarial security review passed (0 critical/high findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)