### PR TITLE
Add Envision brand standards and GSD configuration template

### DIFF
--- a/ENVISION_DEFAULTS.md
+++ b/ENVISION_DEFAULTS.md
@@ -1,0 +1,24 @@
+# Envision GSD Defaults
+
+This fork ships with Envision Inc. brand and engineering standards pre-loaded.
+
+## Voice and Copy Rules
+
+- Never use em dashes.
+- Never use "Envision Dallas" as a standalone term, use "Envision" or "Envision, Dallas Campus."
+- Always write "Envision's Dallas Foundation" with the apostrophe.
+- Avoid "inclusion," "DEI," and "accessible" as standalone buzzwords.
+- Lead with business credibility, mission language is secondary.
+- No AI-sounding phrasing, no passive voice, no softened language.
+
+## Visual Standards
+
+- Primary navy #1B365D, secondary blue #4A90A4, accent green #7CB342.
+- Typography: Montserrat.
+- Reference aesthetics: Palantir, Linear, Vercel.
+
+## Required Workflow
+
+- Always run /gsd-discuss-phase before planning.
+- Always inject Envision skills via agent_skills.
+- Always commit per task.

--- a/envision-config-template.json
+++ b/envision-config-template.json
@@ -1,0 +1,40 @@
+{
+  "mode": "interactive",
+  "granularity": "standard",
+  "project_code": "ENV",
+  "model_profile": "balanced",
+  "workflow": {
+    "research": true,
+    "plan_check": true,
+    "verifier": true,
+    "auto_advance": false,
+    "discuss_mode": "discuss",
+    "skip_discuss": false,
+    "use_worktrees": true
+  },
+  "parallelization": {
+    "enabled": true
+  },
+  "planning": {
+    "commit_docs": true
+  },
+  "hooks": {
+    "context_warnings": true
+  },
+  "git": {
+    "branching_strategy": "phase",
+    "phase_branch_template": "envision/phase-{phase}-{slug}",
+    "milestone_branch_template": "envision/{milestone}-{slug}"
+  },
+  "agent_skills": {
+    "planner": [
+      "/home/user/envision-marketing-brandhub/skills/ai-brand-directive"
+    ],
+    "executor": [
+      "/home/user/envision-marketing-brandhub/skills/ai-brand-directive"
+    ],
+    "verifier": [
+      "/home/user/envision-marketing-brandhub/skills/ai-brand-directive"
+    ]
+  }
+}


### PR DESCRIPTION
## Description

This PR adds foundational configuration and documentation for Envision Inc.'s customized GSD fork, establishing brand voice, visual standards, and workflow defaults.

### Changes

- **envision-config-template.json**: Configuration template defining the standard GSD workflow for Envision projects, including:
  - Interactive mode with standard granularity
  - Enabled research, plan checking, and verification phases
  - Git branching strategy using phase-based branch naming
  - Agent skills pointing to Envision's AI brand directive module
  - Parallelization and worktree support

- **ENVISION_DEFAULTS.md**: Documentation of Envision's brand and engineering standards covering:
  - Voice and copy rules (em dash avoidance, proper terminology, tone guidelines)
  - Visual standards (color palette, typography, design references)
  - Required workflow practices (discussion phase, skill injection, commit discipline)

### Why

These files establish the baseline standards and configuration that all Envision GSD projects should inherit, ensuring consistency across brand voice, visual identity, and development workflow.

### Test Plan

N/A — Configuration and documentation files with no executable code or automated tests.

https://claude.ai/code/session_019CHppSbJSB1nPHEDCocAt5