### PR TITLE
fix(config): allow intel.enabled in config-set whitelist

### DIFF
--- a/get-shit-done/bin/lib/config.cjs
+++ b/get-shit-done/bin/lib/config.cjs
@@ -36,6 +36,7 @@ const VALID_CONFIG_KEYS = new Set([
   'project_code', 'phase_naming',
   'manager.flags.discuss', 'manager.flags.plan', 'manager.flags.execute',
   'response_language',
+  'intel.enabled',
 ]);
 
 /**

--- a/get-shit-done/references/planning-config.md
+++ b/get-shit-done/references/planning-config.md
@@ -308,6 +308,14 @@ Set via `learnings.*` namespace (e.g., `"learnings": { "max_inject": 5 }`). Used
 |-----|------|---------|----------------|-------------|
 | `learnings.max_inject` | number | `10` | Any positive integer | Maximum number of global learning entries to inject into agent prompts per session |
 
+### Intel Fields
+
+Set via `intel.*` namespace (e.g., `"intel": { "enabled": true }`). Controls the queryable codebase intelligence system consumed by `/gsd-intel`.
+
+| Key | Type | Default | Allowed Values | Description |
+|-----|------|---------|----------------|-------------|
+| `intel.enabled` | boolean | `false` | `true`, `false` | Enable queryable codebase intelligence system. When `true`, `/gsd-intel` commands build and query a JSON index in `.planning/intel/`. |
+
 ### Manager Fields
 
 Set via `manager.*` namespace (e.g., `"manager": { "flags": { "discuss": "--auto" } }`).

--- a/tests/config.test.cjs
+++ b/tests/config.test.cjs
@@ -252,6 +252,16 @@ describe('config-set command', () => {
     assert.strictEqual(config.git.base_branch, 'master');
   });
 
+  test('sets intel.enabled to opt into the intel subsystem', () => {
+    writeConfig(tmpDir, {});
+
+    const result = runGsdTools('config-set intel.enabled true', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const config = readConfig(tmpDir);
+    assert.strictEqual(config.intel.enabled, true);
+  });
+
   test('errors when no key path provided', () => {
     const result = runGsdTools('config-set', tmpDir);
     assert.strictEqual(result.success, false);


### PR DESCRIPTION
Fixes #2047

## Summary

- `intel.enabled` is the documented opt-in for the intel subsystem (`commands/gsd/intel.md`, `docs/CONFIGURATION.md`, `docs/FEATURES.md`) but it was missing from `VALID_CONFIG_KEYS` in `get-shit-done/bin/lib/config.cjs`, so the canonical enablement command failed:

  ```
  $ node $HOME/.claude/get-shit-done/bin/gsd-tools.cjs config-set intel.enabled true
  Error: Unknown config key: "intel.enabled"
  ```

- Adds `intel.enabled` to the whitelist, documents it under a new "Intel Fields" section in `references/planning-config.md` (matching the pattern from #1947), and covers it with a `config-set` test.

- `loadConfig` in `core.cjs` derives `KNOWN_TOP_LEVEL` from `VALID_CONFIG_KEYS`, so the new `intel` top-level namespace is accepted automatically with no additional changes.

## Test plan

- [x] `node --test tests/config.test.cjs` — all 65 tests pass, including new `sets intel.enabled to opt into the intel subsystem` case
- [x] `node --test tests/config-field-docs.test.cjs tests/intel.test.cjs` — passes
- [x] Manual smoke test in a scratch project:
  ```
  $ node .../gsd-tools.cjs config-set intel.enabled true
  {"updated": true, "key": "intel.enabled", "value": true}
  $ cat .planning/config.json
  { "intel": { "enabled": true } }
  ```