### PR TITLE
feat(install): add Cline as a first-class runtime

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -71,6 +71,7 @@ const hasWindsurf = args.includes('--windsurf');
 const hasAugment = args.includes('--augment');
 const hasTrae = args.includes('--trae');
 const hasCodebuddy = args.includes('--codebuddy');
+const hasCline = args.includes('--cline');
 const hasBoth = args.includes('--both'); // Legacy flag, keeps working
 const hasAll = args.includes('--all');
 const hasUninstall = args.includes('--uninstall') || args.includes('-u');
@@ -78,7 +79,7 @@ const hasUninstall = args.includes('--uninstall') || args.includes('-u');
 // Runtime selection - can be set by flags or interactive prompt
 let selectedRuntimes = [];
 if (hasAll) {
-  selectedRuntimes = ['claude', 'kilo', 'opencode', 'gemini', 'codex', 'copilot', 'antigravity', 'cursor', 'windsurf', 'augment', 'trae', 'codebuddy'];
+  selectedRuntimes = ['claude', 'kilo', 'opencode', 'gemini', 'codex', 'copilot', 'antigravity', 'cursor', 'windsurf', 'augment', 'trae', 'codebuddy', 'cline'];
 } else if (hasBoth) {
   selectedRuntimes = ['claude', 'opencode'];
 } else {
@@ -94,6 +95,7 @@ if (hasAll) {
   if (hasAugment) selectedRuntimes.push('augment');
   if (hasTrae) selectedRuntimes.push('trae');
   if (hasCodebuddy) selectedRuntimes.push('codebuddy');
+  if (hasCline) selectedRuntimes.push('cline');
 }
 
 // WSL + Windows Node.js detection
@@ -143,6 +145,7 @@ function getDirName(runtime) {
   if (runtime === 'augment') return '.augment';
   if (runtime === 'trae') return '.trae';
   if (runtime === 'codebuddy') return '.codebuddy';
+  if (runtime === 'cline') return '.cline';
   return '.claude';
 }
 
@@ -176,6 +179,7 @@ function getConfigDirFromHome(runtime, isGlobal) {
   if (runtime === 'augment') return "'.augment'";
   if (runtime === 'trae') return "'.trae'";
   if (runtime === 'codebuddy') return "'.codebuddy'";
+  if (runtime === 'cline') return "'.cline'";
   return "'.claude'";
 }
 
@@ -349,6 +353,16 @@ function getGlobalDir(runtime, explicitDir = null) {
     return path.join(os.homedir(), '.codebuddy');
   }
 
+  if (runtime === 'cline') {
+    // Cline: --config-dir > CLINE_CONFIG_DIR > ~/.cline
+    if (explicitDir) {
+      return expandTilde(explicitDir);
+    }
+    if (process.env.CLINE_CONFIG_DIR) {
+      return expandTilde(process.env.CLINE_CONFIG_DIR);
+    }
+    return path.join(os.homedir(), '.cline');
+  }
 
   // Claude Code: --config-dir > CLAUDE_CONFIG_DIR > ~/.claude
   if (explicitDir) {
@@ -370,7 +384,7 @@ const banner = '\n' +
   '\n' +
   '  Get Shit Done ' + dim + 'v' + pkg.version + reset + '\n' +
   '  A meta-prompting, context engineering and spec-driven\n' +
-  '  development system for Claude Code, OpenCode, Gemini, Kilo, Codex, Copilot, Antigravity, Cursor, Windsurf, Augment, Trae and CodeBuddy by TÂCHES.\n';
+  '  development system for Claude Code, OpenCode, Gemini, Kilo, Codex, Copilot, Antigravity, Cursor, Windsurf, Augment, Trae, Cline and CodeBuddy by TÂCHES.\n';
 
 // Parse --config-dir argument
 function parseConfigDirArg() {
@@ -408,7 +422,7 @@ if (hasUninstall) {
 
 // Show help if requested
 if (hasHelp) {
-  console.log(`  ${yellow}Usage:${reset} npx get-shit-done-cc [options]\n\n  ${yellow}Options:${reset}\n    ${cyan}-g, --global${reset}              Install globally (to config directory)\n    ${cyan}-l, --local${reset}               Install locally (to current directory)\n    ${cyan}--claude${reset}                  Install for Claude Code only\n    ${cyan}--opencode${reset}                Install for OpenCode only\n    ${cyan}--gemini${reset}                  Install for Gemini only\n    ${cyan}--kilo${reset}                    Install for Kilo only\n    ${cyan}--codex${reset}                   Install for Codex only\n    ${cyan}--copilot${reset}                 Install for Copilot only\n    ${cyan}--antigravity${reset}             Install for Antigravity only\n    ${cyan}--cursor${reset}                  Install for Cursor only\n    ${cyan}--windsurf${reset}                Install for Windsurf only\n    ${cyan}--augment${reset}                 Install for Augment only\n    ${cyan}--trae${reset}                    Install for Trae only\n    ${cyan}--codebuddy${reset}              Install for CodeBuddy only\n    ${cyan}--all${reset}                     Install for all runtimes\n    ${cyan}-u, --uninstall${reset}           Uninstall GSD (remove all GSD files)\n    ${cyan}-c, --config-dir <path>${reset}   Specify custom config directory\n    ${cyan}-h, --help${reset}                Show this help message\n    ${cyan}--force-statusline${reset}        Replace existing statusline config\n\n  ${yellow}Examples:${reset}\n    ${dim}# Interactive install (prompts for runtime and location)${reset}\n    npx get-shit-done-cc\n\n    ${dim}# Install for Claude Code globally${reset}\n    npx get-shit-done-cc --claude --global\n\n    ${dim}# Install for Gemini globally${reset}\n    npx get-shit-done-cc --gemini --global\n\n    ${dim}# Install for Kilo globally${reset}\n    npx get-shit-done-cc --kilo --global\n\n    ${dim}# Install for Codex globally${reset}\n    npx get-shit-done-cc --codex --global\n\n    ${dim}# Install for Copilot globally${reset}\n    npx get-shit-done-cc --copilot --global\n\n    ${dim}# Install for Copilot locally${reset}\n    npx get-shit-done-cc --copilot --local\n\n    ${dim}# Install for Antigravity globally${reset}\n    npx get-shit-done-cc --antigravity --global\n\n    ${dim}# Install for Antigravity locally${reset}\n    npx get-shit-done-cc --antigravity --local\n\n    ${dim}# Install for Cursor globally${reset}\n    npx get-shit-done-cc --cursor --global\n\n    ${dim}# Install for Cursor locally${reset}\n    npx get-shit-done-cc --cursor --local\n\n    ${dim}# Install for Windsurf globally${reset}\n    npx get-shit-done-cc --windsurf --global\n\n    ${dim}# Install for Windsurf locally${reset}\n    npx get-shit-done-cc --windsurf --local\n\n    ${dim}# Install for Augment globally${reset}\n    npx get-shit-done-cc --augment --global\n\n    ${dim}# Install for Augment locally${reset}\n    npx get-shit-done-cc --augment --local\n\n    ${dim}# Install for Trae globally${reset}\n    npx get-shit-done-cc --trae --global\n\n    ${dim}# Install for Trae locally${reset}\n    npx get-shit-done-cc --trae --local\n\n    ${dim}# Install for CodeBuddy globally${reset}\n    npx get-shit-done-cc --codebuddy --global\n\n    ${dim}# Install for CodeBuddy locally${reset}\n    npx get-shit-done-cc --codebuddy --local\n\n    ${dim}# Install for all runtimes globally${reset}\n    npx get-shit-done-cc --all --global\n\n    ${dim}# Install to custom config directory${reset}\n    npx get-shit-done-cc --kilo --global --config-dir ~/.kilo-work\n\n    ${dim}# Install to current project only${reset}\n    npx get-shit-done-cc --claude --local\n\n    ${dim}# Uninstall GSD from Cursor globally${reset}\n    npx get-shit-done-cc --cursor --global --uninstall\n\n  ${yellow}Notes:${reset}\n    The --config-dir option is useful when you have multiple configurations.\n    It takes priority over CLAUDE_CONFIG_DIR / OPENCODE_CONFIG_DIR / GEMINI_CONFIG_DIR / KILO_CONFIG_DIR / CODEX_HOME / COPILOT_CONFIG_DIR / ANTIGRAVITY_CONFIG_DIR / CURSOR_CONFIG_DIR / WINDSURF_CONFIG_DIR / AUGMENT_CONFIG_DIR / TRAE_CONFIG_DIR / CODEBUDDY_CONFIG_DIR environment variables.\n`);
+  console.log(`  ${yellow}Usage:${reset} npx get-shit-done-cc [options]\n\n  ${yellow}Options:${reset}\n    ${cyan}-g, --global${reset}              Install globally (to config directory)\n    ${cyan}-l, --local${reset}               Install locally (to current directory)\n    ${cyan}--claude${reset}                  Install for Claude Code only\n    ${cyan}--opencode${reset}                Install for OpenCode only\n    ${cyan}--gemini${reset}                  Install for Gemini only\n    ${cyan}--kilo${reset}                    Install for Kilo only\n    ${cyan}--codex${reset}                   Install for Codex only\n    ${cyan}--copilot${reset}                 Install for Copilot only\n    ${cyan}--antigravity${reset}             Install for Antigravity only\n    ${cyan}--cursor${reset}                  Install for Cursor only\n    ${cyan}--windsurf${reset}                Install for Windsurf only\n    ${cyan}--augment${reset}                 Install for Augment only\n    ${cyan}--trae${reset}                    Install for Trae only\n    ${cyan}--cline${reset}                   Install for Cline only\n    ${cyan}--codebuddy${reset}              Install for CodeBuddy only\n    ${cyan}--all${reset}                     Install for all runtimes\n    ${cyan}-u, --uninstall${reset}           Uninstall GSD (remove all GSD files)\n    ${cyan}-c, --config-dir <path>${reset}   Specify custom config directory\n    ${cyan}-h, --help${reset}                Show this help message\n    ${cyan}--force-statusline${reset}        Replace existing statusline config\n\n  ${yellow}Examples:${reset}\n    ${dim}# Interactive install (prompts for runtime and location)${reset}\n    npx get-shit-done-cc\n\n    ${dim}# Install for Claude Code globally${reset}\n    npx get-shit-done-cc --claude --global\n\n    ${dim}# Install for Gemini globally${reset}\n    npx get-shit-done-cc --gemini --global\n\n    ${dim}# Install for Kilo globally${reset}\n    npx get-shit-done-cc --kilo --global\n\n    ${dim}# Install for Codex globally${reset}\n    npx get-shit-done-cc --codex --global\n\n    ${dim}# Install for Copilot globally${reset}\n    npx get-shit-done-cc --copilot --global\n\n    ${dim}# Install for Copilot locally${reset}\n    npx get-shit-done-cc --copilot --local\n\n    ${dim}# Install for Antigravity globally${reset}\n    npx get-shit-done-cc --antigravity --global\n\n    ${dim}# Install for Antigravity locally${reset}\n    npx get-shit-done-cc --antigravity --local\n\n    ${dim}# Install for Cursor globally${reset}\n    npx get-shit-done-cc --cursor --global\n\n    ${dim}# Install for Cursor locally${reset}\n    npx get-shit-done-cc --cursor --local\n\n    ${dim}# Install for Windsurf globally${reset}\n    npx get-shit-done-cc --windsurf --global\n\n    ${dim}# Install for Windsurf locally${reset}\n    npx get-shit-done-cc --windsurf --local\n\n    ${dim}# Install for Augment globally${reset}\n    npx get-shit-done-cc --augment --global\n\n    ${dim}# Install for Augment locally${reset}\n    npx get-shit-done-cc --augment --local\n\n    ${dim}# Install for Trae globally${reset}\n    npx get-shit-done-cc --trae --global\n\n    ${dim}# Install for Trae locally${reset}\n    npx get-shit-done-cc --trae --local\n\n    ${dim}# Install for Cline locally${reset}\n    npx get-shit-done-cc --cline --local\n\n    ${dim}# Install for CodeBuddy globally${reset}\n    npx get-shit-done-cc --codebuddy --global\n\n    ${dim}# Install for CodeBuddy locally${reset}\n    npx get-shit-done-cc --codebuddy --local\n\n    ${dim}# Install for all runtimes globally${reset}\n    npx get-shit-done-cc --all --global\n\n    ${dim}# Install to custom config directory${reset}\n    npx get-shit-done-cc --kilo --global --config-dir ~/.kilo-work\n\n    ${dim}# Install to current project only${reset}\n    npx get-shit-done-cc --claude --local\n\n    ${dim}# Uninstall GSD from Cursor globally${reset}\n    npx get-shit-done-cc --cursor --global --uninstall\n\n  ${yellow}Notes:${reset}\n    The --config-dir option is useful when you have multiple configurations.\n    It takes priority over CLAUDE_CONFIG_DIR / OPENCODE_CONFIG_DIR / GEMINI_CONFIG_DIR / KILO_CONFIG_DIR / CODEX_HOME / COPILOT_CONFIG_DIR / ANTIGRAVITY_CONFIG_DIR / CURSOR_CONFIG_DIR / WINDSURF_CONFIG_DIR / AUGMENT_CONFIG_DIR / TRAE_CONFIG_DIR / CLINE_CONFIG_DIR / CODEBUDDY_CONFIG_DIR environment variables.\n`);
   process.exit(0);
 }
 
@@ -1543,6 +1557,36 @@ function convertClaudeAgentToCodebuddyAgent(content) {
 
   return `${cleanFrontmatter}\n${body}`;
 }
+
+// ── Cline converters ────────────────────────────────────────────────────────
+
+function convertClaudeToCliineMarkdown(content) {
+  let converted = content;
+  // Cline uses the same tool names as Claude Code — no tool name conversion needed
+  converted = converted.replace(/`\.\/CLAUDE\.md`/g, '`.clinerules`');
+  converted = converted.replace(/\.\/CLAUDE\.md/g, '.clinerules');
+  converted = converted.replace(/`CLAUDE\.md`/g, '`.clinerules`');
+  converted = converted.replace(/\bCLAUDE\.md\b/g, '.clinerules');
+  converted = converted.replace(/\.claude\/skills\//g, '.cline/skills/');
+  converted = converted.replace(/\.\/\.claude\//g, './.cline/');
+  converted = converted.replace(/\.claude\//g, '.cline/');
+  converted = converted.replace(/\*\*Known Claude Code bug \(classifyHandoffIfNeeded\):\*\*[^\n]*\n/g, '');
+  converted = converted.replace(/- \*\*classifyHandoffIfNeeded false failure:\*\*[^\n]*\n/g, '');
+  converted = converted.replace(/\bClaude Code\b/g, 'Cline');
+  return converted;
+}
+
+function convertClaudeAgentToClineAgent(content) {
+  let converted = convertClaudeToCliineMarkdown(content);
+  const { frontmatter, body } = extractFrontmatterAndBody(converted);
+  if (!frontmatter) return converted;
+  const name = extractFrontmatterField(frontmatter, 'name') || 'unknown';
+  const description = extractFrontmatterField(frontmatter, 'description') || '';
+  const cleanFrontmatter = `---\nname: ${yamlIdentifier(name)}\ndescription: ${yamlQuote(toSingleLine(description))}\n---`;
+  return `${cleanFrontmatter}\n${body}`;
+}
+
+// ── End Cline converters ─────────────────────────────────────────────────────
 
 function convertSlashCommandsToCodexSkillMentions(content) {
   // Convert colon-style skill invocations to Codex $ prefix
@@ -4007,6 +4051,7 @@ function copyWithPathReplacement(srcDir, destDir, pathPrefix, runtime, isCommand
   const isWindsurf = runtime === 'windsurf';
   const isAugment = runtime === 'augment';
   const isTrae = runtime === 'trae';
+  const isCline = runtime === 'cline';
   const dirName = getDirName(runtime);
 
   // Clean install: remove existing destination to prevent orphaned files
@@ -4074,6 +4119,9 @@ function copyWithPathReplacement(srcDir, destDir, pathPrefix, runtime, isCommand
       } else if (isTrae) {
         content = convertClaudeToTraeMarkdown(content);
         fs.writeFileSync(destPath, content);
+      } else if (isCline) {
+        content = convertClaudeToCliineMarkdown(content);
+        fs.writeFileSync(destPath, content);
       } else {
         fs.writeFileSync(destPath, content);
       }
@@ -4111,6 +4159,12 @@ function copyWithPathReplacement(srcDir, destDir, pathPrefix, runtime, isCommand
       jsContent = jsContent.replace(/\.claude\/skills\//g, '.trae/skills/');
       jsContent = jsContent.replace(/CLAUDE\.md/g, '.trae/rules/');
       jsContent = jsContent.replace(/\bClaude Code\b/g, 'Trae');
+      fs.writeFileSync(destPath, jsContent);
+    } else if (isCline && (entry.name.endsWith('.cjs') || entry.name.endsWith('.js'))) {
+      let jsContent = fs.readFileSync(srcPath, 'utf8');
+      jsContent = jsContent.replace(/\.claude\/skills\//g, '.cline/skills/');
+      jsContent = jsContent.replace(/CLAUDE\.md/g, '.clinerules');
+      jsContent = jsContent.replace(/\bClaude Code\b/g, 'Cline');
       fs.writeFileSync(destPath, jsContent);
     } else {
       fs.copyFileSync(srcPath, destPath);
@@ -5067,6 +5121,7 @@ function writeManifest(configDir, runtime = 'claude') {
   const isCursor = runtime === 'cursor';
   const isWindsurf = runtime === 'windsurf';
   const isTrae = runtime === 'trae';
+  const isCline = runtime === 'cline';
   const gsdDir = path.join(configDir, 'get-shit-done');
   const commandsDir = path.join(configDir, 'commands', 'gsd');
   const opencodeCommandDir = path.join(configDir, 'command');
@@ -5107,9 +5162,17 @@ function writeManifest(configDir, runtime = 'claude') {
       }
     }
   }
+  // Track .clinerules file in manifest for Cline installs
+  if (isCline) {
+    const clinerulesDest = path.join(configDir, '.clinerules');
+    if (fs.existsSync(clinerulesDest)) {
+      manifest.files['.clinerules'] = fileHash(clinerulesDest);
+    }
+  }
+
   // Track hook files so saveLocalPatches() can detect user modifications
-  // Hooks are only installed for runtimes that use settings.json (not Codex/Copilot)
-  if (!isCodex && !isCopilot) {
+  // Hooks are only installed for runtimes that use settings.json (not Codex/Copilot/Cline)
+  if (!isCodex && !isCopilot && !isCline) {
     const hooksDir = path.join(configDir, 'hooks');
     if (fs.existsSync(hooksDir)) {
       for (const file of fs.readdirSync(hooksDir)) {
@@ -5230,13 +5293,18 @@ function install(isGlobal, runtime = 'claude') {
   const isAugment = runtime === 'augment';
   const isTrae = runtime === 'trae';
   const isCodebuddy = runtime === 'codebuddy';
+  const isCline = runtime === 'cline';
   const dirName = getDirName(runtime);
   const src = path.join(__dirname, '..');
 
-  // Get the target directory based on runtime and install type
+  // Get the target directory based on runtime and install type.
+  // Cline local installs write to the project root (like Claude Code) — .clinerules
+  // lives at the root, not inside a .cline/ subdirectory.
   const targetDir = isGlobal
     ? getGlobalDir(runtime, explicitConfigDir)
-    : path.join(process.cwd(), dirName);
+    : isCline
+      ? process.cwd()
+      : path.join(process.cwd(), dirName);
 
   const locationLabel = isGlobal
     ? targetDir.replace(os.homedir(), '~')
@@ -5265,6 +5333,7 @@ function install(isGlobal, runtime = 'claude') {
   if (isAugment) runtimeLabel = 'Augment';
   if (isTrae) runtimeLabel = 'Trae';
   if (isCodebuddy) runtimeLabel = 'CodeBuddy';
+  if (isCline) runtimeLabel = 'Cline';
 
   console.log(`  Installing for ${cyan}${runtimeLabel}${reset} to ${cyan}${locationLabel}${reset}\n`);
 
@@ -5382,6 +5451,10 @@ function install(isGlobal, runtime = 'claude') {
     } else {
       failures.push('skills/gsd-*');
     }
+  } else if (isCline) {
+    // Cline is rules-based — commands are embedded in .clinerules (generated below).
+    // No skills/commands directory needed. Engine is installed via copyWithPathReplacement.
+    console.log(`  ${green}✓${reset} Cline: commands will be available via .clinerules`);
   } else if (isGemini) {
     const commandsDir = path.join(targetDir, 'commands');
     fs.mkdirSync(commandsDir, { recursive: true });
@@ -5517,6 +5590,8 @@ function install(isGlobal, runtime = 'claude') {
           content = convertClaudeAgentToTraeAgent(content);
         } else if (isCodebuddy) {
           content = convertClaudeAgentToCodebuddyAgent(content);
+        } else if (isCline) {
+          content = convertClaudeAgentToClineAgent(content);
         }
         const destName = isCopilot ? entry.name.replace('.md', '.agent.md') : entry.name;
         fs.writeFileSync(path.join(agentsDest, destName), content);
@@ -5550,7 +5625,7 @@ function install(isGlobal, runtime = 'claude') {
     failures.push('VERSION');
   }
 
-  if (!isCodex && !isCopilot && !isCursor && !isWindsurf && !isTrae) {
+  if (!isCodex && !isCopilot && !isCursor && !isWindsurf && !isTrae && !isCline) {
     // Write package.json to force CommonJS mode for GSD scripts
     // Prevents "require is not defined" errors when project has "type": "module"
     // Node.js walks up looking for package.json - this stops inheritance from project
@@ -5736,6 +5811,26 @@ function install(isGlobal, runtime = 'claude') {
 
   if (isTrae) {
     // Trae uses skills — no settings.json hooks needed
+    return { settingsPath: null, settings: null, statuslineCommand: null, runtime, configDir: targetDir };
+  }
+
+  if (isCline) {
+    // Cline uses .clinerules — generate a rules file with GSD system instructions
+    const clinerulesDest = path.join(targetDir, '.clinerules');
+    const clinerules = [
+      '# GSD — Get Shit Done',
+      '',
+      '- GSD workflows live in `get-shit-done/workflows/`. Load the relevant workflow when',
+      '  the user runs a `/gsd-*` command.',
+      '- GSD agents live in `agents/`. Use the matching agent when spawning subagents.',
+      '- GSD tools are at `get-shit-done/bin/gsd-tools.cjs`. Run with `node`.',
+      '- Planning artifacts live in `.planning/`. Never edit them outside a GSD workflow.',
+      '- Do not apply GSD workflows unless the user explicitly asks for them.',
+      '- When a GSD command triggers a deliverable (feature, fix, docs), offer the next',
+      '  step to the user using Cline\'s ask_user tool after completing it.',
+    ].join('\n') + '\n';
+    fs.writeFileSync(clinerulesDest, clinerules);
+    console.log(`  ${green}✓${reset} Wrote .clinerules`);
     return { settingsPath: null, settings: null, statuslineCommand: null, runtime, configDir: targetDir };
   }
 
@@ -6085,6 +6180,7 @@ function finishInstall(settingsPath, settings, statuslineCommand, shouldInstallS
   if (runtime === 'windsurf') program = 'Windsurf';
   if (runtime === 'augment') program = 'Augment';
   if (runtime === 'trae') program = 'Trae';
+  if (runtime === 'cline') program = 'Cline';
 
   let command = '/gsd-new-project';
   if (runtime === 'opencode') command = '/gsd-new-project';
@@ -6096,6 +6192,7 @@ function finishInstall(settingsPath, settings, statuslineCommand, shouldInstallS
   if (runtime === 'windsurf') command = '/gsd-new-project';
   if (runtime === 'augment') command = '/gsd-new-project';
   if (runtime === 'trae') command = '/gsd-new-project';
+  if (runtime === 'cline') command = '/gsd-new-project';
   console.log(`
   ${green}Done!${reset} Open a blank directory in ${program} and run ${cyan}${command}${reset}.
 
@@ -6177,31 +6274,33 @@ function promptRuntime(callback) {
     '1': 'claude',
     '2': 'antigravity',
     '3': 'augment',
-    '4': 'codebuddy',
-    '5': 'codex',
-    '6': 'copilot',
-    '7': 'cursor',
-    '8': 'gemini',
-    '9': 'kilo',
-    '10': 'opencode',
-    '11': 'trae',
-    '12': 'windsurf'
+    '4': 'cline',
+    '5': 'codebuddy',
+    '6': 'codex',
+    '7': 'copilot',
+    '8': 'cursor',
+    '9': 'gemini',
+    '10': 'kilo',
+    '11': 'opencode',
+    '12': 'trae',
+    '13': 'windsurf'
   };
-  const allRuntimes = ['claude', 'antigravity', 'augment', 'codebuddy', 'codex', 'copilot', 'cursor', 'gemini', 'kilo', 'opencode', 'trae', 'windsurf'];
+  const allRuntimes = ['claude', 'antigravity', 'augment', 'cline', 'codebuddy', 'codex', 'copilot', 'cursor', 'gemini', 'kilo', 'opencode', 'trae', 'windsurf'];
 
   console.log(`  ${yellow}Which runtime(s) would you like to install for?${reset}\n\n  ${cyan}1${reset}) Claude Code  ${dim}(~/.claude)${reset}
   ${cyan}2${reset}) Antigravity  ${dim}(~/.gemini/antigravity)${reset}
   ${cyan}3${reset}) Augment      ${dim}(~/.augment)${reset}
-  ${cyan}4${reset}) CodeBuddy    ${dim}(~/.codebuddy)${reset}
-  ${cyan}5${reset}) Codex        ${dim}(~/.codex)${reset}
-  ${cyan}6${reset}) Copilot      ${dim}(~/.copilot)${reset}
-  ${cyan}7${reset}) Cursor       ${dim}(~/.cursor)${reset}
-  ${cyan}8${reset}) Gemini       ${dim}(~/.gemini)${reset}
-  ${cyan}9${reset}) Kilo         ${dim}(~/.config/kilo)${reset}
-  ${cyan}10${reset}) OpenCode     ${dim}(~/.config/opencode)${reset}
-  ${cyan}11${reset}) Trae         ${dim}(~/.trae)${reset}
-  ${cyan}12${reset}) Windsurf     ${dim}(~/.codeium/windsurf)${reset}
-  ${cyan}13${reset}) All
+  ${cyan}4${reset}) Cline        ${dim}(.clinerules)${reset}
+  ${cyan}5${reset}) CodeBuddy    ${dim}(~/.codebuddy)${reset}
+  ${cyan}6${reset}) Codex        ${dim}(~/.codex)${reset}
+  ${cyan}7${reset}) Copilot      ${dim}(~/.copilot)${reset}
+  ${cyan}8${reset}) Cursor       ${dim}(~/.cursor)${reset}
+  ${cyan}9${reset}) Gemini       ${dim}(~/.gemini)${reset}
+  ${cyan}10${reset}) Kilo         ${dim}(~/.config/kilo)${reset}
+  ${cyan}11${reset}) OpenCode     ${dim}(~/.config/opencode)${reset}
+  ${cyan}12${reset}) Trae         ${dim}(~/.trae)${reset}
+  ${cyan}13${reset}) Windsurf     ${dim}(~/.codeium/windsurf)${reset}
+  ${cyan}14${reset}) All
 
   ${dim}Select multiple: 1,2,6 or 1 2 6${reset}
 `);
@@ -6212,7 +6311,7 @@ function promptRuntime(callback) {
     const input = answer.trim() || '1';
 
     // "All" shortcut
-    if (input === '13') {
+    if (input === '14') {
       callback(allRuntimes);
       return;
     }
@@ -6377,6 +6476,8 @@ if (process.env.GSD_TEST_MODE) {
     convertClaudeCommandToCodebuddySkill,
     convertClaudeAgentToCodebuddyAgent,
     copyCommandsAsCodebuddySkills,
+    convertClaudeToCliineMarkdown,
+    convertClaudeAgentToClineAgent,
     writeManifest,
     reportLocalPatches,
     validateHookFields,

--- a/tests/cline-install.test.cjs
+++ b/tests/cline-install.test.cjs
@@ -1,0 +1,182 @@
+/**
+ * Regression tests for bug #1991
+ *
+ * Cline is listed in GSD documentation as a supported runtime but was
+ * completely absent from bin/install.js. Running `npx get-shit-done-cc`
+ * did not show Cline as an option in the interactive menu.
+ *
+ * Fixed: Cline is now a first-class runtime that:
+ * - Appears in the interactive menu and --all flag
+ * - Supports the --cline CLI flag
+ * - Writes .clinerules to the install directory
+ * - Installs get-shit-done/ engine with path replacement
+ */
+
+'use strict';
+
+process.env.GSD_TEST_MODE = '1';
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { createTempDir, cleanup } = require('./helpers.cjs');
+
+const {
+  getDirName,
+  getGlobalDir,
+  getConfigDirFromHome,
+  convertClaudeToCliineMarkdown,
+  install,
+} = require('../bin/install.js');
+
+describe('Cline runtime directory mapping', () => {
+  test('getDirName returns .cline for local installs', () => {
+    assert.strictEqual(getDirName('cline'), '.cline');
+  });
+
+  test('getGlobalDir returns ~/.cline for global installs', () => {
+    assert.strictEqual(getGlobalDir('cline'), path.join(os.homedir(), '.cline'));
+  });
+
+  test('getConfigDirFromHome returns .cline fragment', () => {
+    assert.strictEqual(getConfigDirFromHome('cline', false), "'.cline'");
+    assert.strictEqual(getConfigDirFromHome('cline', true), "'.cline'");
+  });
+});
+
+describe('getGlobalDir (Cline)', () => {
+  let originalClineConfigDir;
+
+  beforeEach(() => {
+    originalClineConfigDir = process.env.CLINE_CONFIG_DIR;
+  });
+
+  afterEach(() => {
+    if (originalClineConfigDir !== undefined) {
+      process.env.CLINE_CONFIG_DIR = originalClineConfigDir;
+    } else {
+      delete process.env.CLINE_CONFIG_DIR;
+    }
+  });
+
+  test('returns ~/.cline with no env var or explicit dir', () => {
+    delete process.env.CLINE_CONFIG_DIR;
+    const result = getGlobalDir('cline');
+    assert.strictEqual(result, path.join(os.homedir(), '.cline'));
+  });
+
+  test('returns explicit dir when provided', () => {
+    const result = getGlobalDir('cline', '/custom/cline-path');
+    assert.strictEqual(result, '/custom/cline-path');
+  });
+
+  test('respects CLINE_CONFIG_DIR env var', () => {
+    process.env.CLINE_CONFIG_DIR = '~/custom-cline';
+    const result = getGlobalDir('cline');
+    assert.strictEqual(result, path.join(os.homedir(), 'custom-cline'));
+  });
+
+  test('explicit dir takes priority over CLINE_CONFIG_DIR', () => {
+    process.env.CLINE_CONFIG_DIR = '~/from-env';
+    const result = getGlobalDir('cline', '/explicit/path');
+    assert.strictEqual(result, '/explicit/path');
+  });
+
+  test('does not break other runtimes', () => {
+    assert.strictEqual(getGlobalDir('claude'), path.join(os.homedir(), '.claude'));
+    assert.strictEqual(getGlobalDir('codex'), path.join(os.homedir(), '.codex'));
+  });
+});
+
+describe('Cline markdown conversion', () => {
+  test('convertClaudeToCliineMarkdown exists and is a function', () => {
+    assert.strictEqual(typeof convertClaudeToCliineMarkdown, 'function');
+  });
+
+  test('replaces Claude Code brand with Cline', () => {
+    const result = convertClaudeToCliineMarkdown('Use Claude Code to run');
+    assert.ok(!result.includes('Claude Code'));
+    assert.ok(result.includes('Cline'));
+  });
+
+  test('replaces .claude/ paths with .cline/', () => {
+    const result = convertClaudeToCliineMarkdown('See ~/.claude/get-shit-done/');
+    assert.ok(!result.includes('.claude/'), `Expected no .claude/ in: ${result}`);
+    assert.ok(result.includes('.cline/'));
+  });
+
+  test('replaces CLAUDE.md references', () => {
+    const result = convertClaudeToCliineMarkdown('See CLAUDE.md for config');
+    assert.ok(!result.includes('CLAUDE.md'));
+    assert.ok(result.includes('.clinerules'));
+  });
+
+  test('replaces .claude/skills/ with .cline/skills/', () => {
+    const result = convertClaudeToCliineMarkdown('skills at .claude/skills/gsd-executor');
+    assert.ok(!result.includes('.claude/skills/'));
+    assert.ok(result.includes('.cline/skills/'));
+  });
+});
+
+describe('Cline install (local)', () => {
+  let tmpDir;
+  let previousCwd;
+
+  beforeEach(() => {
+    tmpDir = createTempDir('gsd-cline-test-');
+    previousCwd = process.cwd();
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(previousCwd);
+    cleanup(tmpDir);
+  });
+
+  test('install creates .clinerules file', () => {
+    install(false, 'cline');
+    const clinerules = path.join(tmpDir, '.clinerules');
+    assert.ok(fs.existsSync(clinerules), '.clinerules must exist after cline install');
+  });
+
+  test('.clinerules contains GSD instructions', () => {
+    install(false, 'cline');
+    const clinerules = path.join(tmpDir, '.clinerules');
+    const content = fs.readFileSync(clinerules, 'utf8');
+    assert.ok(content.includes('GSD') || content.includes('gsd'), '.clinerules must reference GSD');
+  });
+
+  test('install creates get-shit-done engine directory', () => {
+    install(false, 'cline');
+    const engineDir = path.join(tmpDir, 'get-shit-done');
+    assert.ok(fs.existsSync(engineDir), 'get-shit-done directory must exist after install');
+  });
+
+  test('installed engine files have no leaked .claude paths', () => {
+    install(false, 'cline');
+    const engineDir = path.join(tmpDir, 'get-shit-done');
+    if (!fs.existsSync(engineDir)) return; // skip if engine not installed
+
+    function scanDir(dir) {
+      const entries = fs.readdirSync(dir, { withFileTypes: true });
+      for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          scanDir(fullPath);
+        } else if (entry.name.endsWith('.md') || entry.name.endsWith('.cjs') || entry.name.endsWith('.js')) {
+          // CHANGELOG.md is a historical record and is not path-converted — skip it
+          if (entry.name === 'CHANGELOG.md') continue;
+          const content = fs.readFileSync(fullPath, 'utf8');
+          // Check for GSD install paths that should have been substituted.
+          // profile-pipeline.cjs intentionally references ~/.claude/projects (Claude Code
+          // session data) as a runtime feature — that is not a leaked install path.
+          const hasLeaked = /~\/\.claude\/(?:get-shit-done|commands|agents|hooks)|HOME\/\.claude\/(?:get-shit-done|commands|agents|hooks)/.test(content);
+          assert.ok(!hasLeaked, `Found leaked GSD .claude install path in ${fullPath}`);
+        }
+      }
+    }
+    scanDir(engineDir);
+  });
+});

--- a/tests/copilot-install.test.cjs
+++ b/tests/copilot-install.test.cjs
@@ -139,8 +139,8 @@ describe('Source code integration (Copilot)', () => {
     assert.ok(src.includes('--copilot'), 'help text has --copilot option');
   });
 
-  test('CLI-02: promptRuntime runtimeMap has Copilot as option 6', () => {
-    assert.ok(src.includes("'6': 'copilot'"), 'runtimeMap has 6 -> copilot');
+  test('CLI-02: promptRuntime runtimeMap has Copilot as option 7', () => {
+    assert.ok(src.includes("'7': 'copilot'"), 'runtimeMap has 7 -> copilot');
   });
 
   test('CLI-02: promptRuntime allRuntimes array includes copilot', () => {

--- a/tests/kilo-install.test.cjs
+++ b/tests/kilo-install.test.cjs
@@ -221,12 +221,12 @@ describe('Source code integration (Kilo)', () => {
     assert.ok(src.includes("'kilo'"), '--all includes kilo runtime');
   });
 
-  test('promptRuntime runtimeMap has Kilo as option 9', () => {
-    assert.ok(src.includes("'9': 'kilo'"), 'runtimeMap has 9 -> kilo');
+  test('promptRuntime runtimeMap has Kilo as option 10', () => {
+    assert.ok(src.includes("'10': 'kilo'"), 'runtimeMap has 10 -> kilo');
   });
 
   test('prompt text shows Kilo above OpenCode without marketing copy', () => {
-    assert.ok(src.includes('9${reset}) Kilo'), 'prompt lists Kilo as option 9');
+    assert.ok(src.includes('10${reset}) Kilo'), 'prompt lists Kilo as option 10');
     assert.ok(!src.includes('the #1 AI coding platform on OpenRouter'), 'prompt does not include marketing tagline');
   });
 

--- a/tests/multi-runtime-select.test.cjs
+++ b/tests/multi-runtime-select.test.cjs
@@ -21,17 +21,18 @@ const runtimeMap = {
   '1': 'claude',
   '2': 'antigravity',
   '3': 'augment',
-  '4': 'codebuddy',
-  '5': 'codex',
-  '6': 'copilot',
-  '7': 'cursor',
-  '8': 'gemini',
-  '9': 'kilo',
-  '10': 'opencode',
-  '11': 'trae',
-  '12': 'windsurf'
+  '4': 'cline',
+  '5': 'codebuddy',
+  '6': 'codex',
+  '7': 'copilot',
+  '8': 'cursor',
+  '9': 'gemini',
+  '10': 'kilo',
+  '11': 'opencode',
+  '12': 'trae',
+  '13': 'windsurf'
 };
-const allRuntimes = ['claude', 'antigravity', 'augment', 'codebuddy', 'codex', 'copilot', 'cursor', 'gemini', 'kilo', 'opencode', 'trae', 'windsurf'];
+const allRuntimes = ['claude', 'antigravity', 'augment', 'cline', 'codebuddy', 'codex', 'copilot', 'cursor', 'gemini', 'kilo', 'opencode', 'trae', 'windsurf'];
 
 /**
  * Simulate the parsing logic from promptRuntime without requiring readline.
@@ -40,7 +41,7 @@ const allRuntimes = ['claude', 'antigravity', 'augment', 'codebuddy', 'codex', '
 function parseRuntimeInput(input) {
   input = input.trim() || '1';
 
-  if (input === '13') {
+  if (input === '14') {
     return allRuntimes;
   }
 
@@ -61,42 +62,43 @@ describe('multi-runtime selection parsing', () => {
     assert.deepStrictEqual(parseRuntimeInput('1'), ['claude']);
     assert.deepStrictEqual(parseRuntimeInput('2'), ['antigravity']);
     assert.deepStrictEqual(parseRuntimeInput('3'), ['augment']);
-    assert.deepStrictEqual(parseRuntimeInput('4'), ['codebuddy']);
-    assert.deepStrictEqual(parseRuntimeInput('5'), ['codex']);
-    assert.deepStrictEqual(parseRuntimeInput('6'), ['copilot']);
-    assert.deepStrictEqual(parseRuntimeInput('7'), ['cursor']);
+    assert.deepStrictEqual(parseRuntimeInput('4'), ['cline']);
+    assert.deepStrictEqual(parseRuntimeInput('5'), ['codebuddy']);
+    assert.deepStrictEqual(parseRuntimeInput('6'), ['codex']);
+    assert.deepStrictEqual(parseRuntimeInput('7'), ['copilot']);
+    assert.deepStrictEqual(parseRuntimeInput('8'), ['cursor']);
   });
 
   test('comma-separated choices return multiple runtimes', () => {
-    assert.deepStrictEqual(parseRuntimeInput('1,6,8'), ['claude', 'copilot', 'gemini']);
+    assert.deepStrictEqual(parseRuntimeInput('1,7,9'), ['claude', 'copilot', 'gemini']);
     assert.deepStrictEqual(parseRuntimeInput('2,3'), ['antigravity', 'augment']);
-    assert.deepStrictEqual(parseRuntimeInput('3,5'), ['augment', 'codex']);
+    assert.deepStrictEqual(parseRuntimeInput('3,6'), ['augment', 'codex']);
   });
 
   test('space-separated choices return multiple runtimes', () => {
-    assert.deepStrictEqual(parseRuntimeInput('1 6 8'), ['claude', 'copilot', 'gemini']);
-    assert.deepStrictEqual(parseRuntimeInput('7 9'), ['cursor', 'kilo']);
+    assert.deepStrictEqual(parseRuntimeInput('1 7 9'), ['claude', 'copilot', 'gemini']);
+    assert.deepStrictEqual(parseRuntimeInput('8 10'), ['cursor', 'kilo']);
   });
 
   test('mixed comma and space separators work', () => {
-    assert.deepStrictEqual(parseRuntimeInput('1, 6, 8'), ['claude', 'copilot', 'gemini']);
-    assert.deepStrictEqual(parseRuntimeInput('2 , 7'), ['antigravity', 'cursor']);
+    assert.deepStrictEqual(parseRuntimeInput('1, 7, 9'), ['claude', 'copilot', 'gemini']);
+    assert.deepStrictEqual(parseRuntimeInput('2 , 8'), ['antigravity', 'cursor']);
   });
 
   test('single choice for opencode', () => {
-    assert.deepStrictEqual(parseRuntimeInput('10'), ['opencode']);
+    assert.deepStrictEqual(parseRuntimeInput('11'), ['opencode']);
   });
 
   test('single choice for trae', () => {
-    assert.deepStrictEqual(parseRuntimeInput('11'), ['trae']);
+    assert.deepStrictEqual(parseRuntimeInput('12'), ['trae']);
   });
 
   test('single choice for windsurf', () => {
-    assert.deepStrictEqual(parseRuntimeInput('12'), ['windsurf']);
+    assert.deepStrictEqual(parseRuntimeInput('13'), ['windsurf']);
   });
 
-  test('choice 13 returns all runtimes', () => {
-    assert.deepStrictEqual(parseRuntimeInput('13'), allRuntimes);
+  test('choice 14 returns all runtimes', () => {
+    assert.deepStrictEqual(parseRuntimeInput('14'), allRuntimes);
   });
 
   test('empty input defaults to claude', () => {
@@ -105,29 +107,29 @@ describe('multi-runtime selection parsing', () => {
   });
 
   test('invalid choices are ignored, falls back to claude if all invalid', () => {
-    assert.deepStrictEqual(parseRuntimeInput('14'), ['claude']);
+    assert.deepStrictEqual(parseRuntimeInput('15'), ['claude']);
     assert.deepStrictEqual(parseRuntimeInput('0'), ['claude']);
     assert.deepStrictEqual(parseRuntimeInput('abc'), ['claude']);
   });
 
   test('invalid choices mixed with valid are filtered out', () => {
-    assert.deepStrictEqual(parseRuntimeInput('1,14,6'), ['claude', 'copilot']);
+    assert.deepStrictEqual(parseRuntimeInput('1,15,7'), ['claude', 'copilot']);
     assert.deepStrictEqual(parseRuntimeInput('abc 3 xyz'), ['augment']);
   });
 
   test('duplicate choices are deduplicated', () => {
     assert.deepStrictEqual(parseRuntimeInput('1,1,1'), ['claude']);
-    assert.deepStrictEqual(parseRuntimeInput('6,6,8,8'), ['copilot', 'gemini']);
+    assert.deepStrictEqual(parseRuntimeInput('7,7,9,9'), ['copilot', 'gemini']);
   });
 
   test('preserves selection order', () => {
-    assert.deepStrictEqual(parseRuntimeInput('8,1,6'), ['gemini', 'claude', 'copilot']);
-    assert.deepStrictEqual(parseRuntimeInput('9,2,7'), ['kilo', 'antigravity', 'cursor']);
+    assert.deepStrictEqual(parseRuntimeInput('9,1,7'), ['gemini', 'claude', 'copilot']);
+    assert.deepStrictEqual(parseRuntimeInput('10,2,8'), ['kilo', 'antigravity', 'cursor']);
   });
 });
 
 describe('install.js source contains multi-select support', () => {
-  test('runtimeMap is defined with all 12 runtimes', () => {
+  test('runtimeMap is defined with all 13 runtimes', () => {
     for (const [key, name] of Object.entries(runtimeMap)) {
       assert.ok(
         installSrc.includes(`'${key}': '${name}'`),
@@ -144,21 +146,21 @@ describe('install.js source contains multi-select support', () => {
     }
   });
 
-  test('all shortcut uses option 13', () => {
+  test('all shortcut uses option 14', () => {
     assert.ok(
-      installSrc.includes("if (input === '13')"),
-      'all shortcut uses option 13'
+      installSrc.includes("if (input === '14')"),
+      'all shortcut uses option 14'
     );
   });
 
-  test('prompt lists Trae as option 11 and All as option 13', () => {
+  test('prompt lists Trae as option 12 and All as option 14', () => {
     assert.ok(
-      installSrc.includes('11${reset}) Trae'),
-      'prompt lists Trae as option 11'
+      installSrc.includes('12${reset}) Trae'),
+      'prompt lists Trae as option 12'
     );
     assert.ok(
-      installSrc.includes('13${reset}) All'),
-      'prompt lists All as option 13'
+      installSrc.includes('14${reset}) All'),
+      'prompt lists All as option 14'
     );
   });
 


### PR DESCRIPTION
## What

Adds Cline as a fully supported runtime in `bin/install.js`. Previously, Cline was listed in GSD documentation as a supported runtime but was entirely absent from the installer — `npx get-shit-done-cc` had no `--cline` flag and no interactive menu entry for it.

## Why

Closes #1991

## How

- Registers `--cline` CLI flag; adds `'cline'` to the `--all` runtime list
- Adds `getDirName('cline')` → `'.cline'`, `getConfigDirFromHome`, and `getGlobalDir` with `CLINE_CONFIG_DIR` env var support
- Adds `convertClaudeToCliineMarkdown()` — replaces `.claude/` paths, `CLAUDE.md` references, and `Claude Code` brand with `.cline/`, `.clinerules`, and `Cline`
- Adds `convertClaudeAgentToClineAgent()` for agent frontmatter stripping
- Wires Cline into `copyWithPathReplacement()`, `install()`, `writeManifest()`, and `finishInstall()`
- Local install writes to the project root (like Claude Code), not into a `.cline/` subdirectory — `.clinerules` must be at the project root per Cline's convention
- Generates a `.clinerules` file at install root with GSD integration rules
- Installs the `get-shit-done/` engine and `agents/` with path and brand replacement
- Adds Cline as option 4 in the interactive menu (13-runtime menu; All = option 14)
- Updates the banner description to include Cline
- Exports `convertClaudeToCliineMarkdown` and `convertClaudeAgentToClineAgent` in the `GSD_TEST_MODE` block
- Adds `tests/cline-install.test.cjs` with 17 regression tests covering directory resolution, `CLINE_CONFIG_DIR` env var, markdown conversion, and local install behavior
- Updates `multi-runtime-select.test.cjs`, `copilot-install.test.cjs`, and `kilo-install.test.cjs` to reflect the new option numbering