### PR TITLE
fix(install): guard writeSettings against null settingsPath for cline runtime

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -6124,6 +6124,7 @@ function finishInstall(settingsPath, settings, statuslineCommand, shouldInstallS
   const isCursor = runtime === 'cursor';
   const isWindsurf = runtime === 'windsurf';
   const isTrae = runtime === 'trae';
+  const isCline = runtime === 'cline';
 
   if (shouldInstallStatusline && !isOpencode && !isKilo && !isCodex && !isCopilot && !isCursor && !isWindsurf && !isTrae) {
     settings.statusLine = {
@@ -6134,7 +6135,7 @@ function finishInstall(settingsPath, settings, statuslineCommand, shouldInstallS
   }
 
   // Write settings when runtime supports settings.json
-  if (!isCodex && !isCopilot && !isKilo && !isCursor && !isWindsurf && !isTrae) {
+  if (!isCodex && !isCopilot && !isKilo && !isCursor && !isWindsurf && !isTrae && !isCline) {
     writeSettings(settingsPath, settings);
   }
 

--- a/bin/install.js
+++ b/bin/install.js
@@ -6484,6 +6484,7 @@ if (process.env.GSD_TEST_MODE) {
     validateHookFields,
     preserveUserArtifacts,
     restoreUserArtifacts,
+    finishInstall,
   };
 } else {
 

--- a/tests/cline-install.test.cjs
+++ b/tests/cline-install.test.cjs
@@ -154,6 +154,18 @@ describe('Cline install (local)', () => {
     assert.ok(fs.existsSync(engineDir), 'get-shit-done directory must exist after install');
   });
 
+  test('does not crash with ERR_INVALID_ARG_TYPE (regression: null settingsPath guard)', () => {
+    // Before fix: finishInstall() called writeSettings(null, ...) because isCline guard was missing
+    // After fix:  !isCline is in the writeSettings guard, matching codex/copilot/cursor/windsurf/trae
+    assert.doesNotThrow(() => install(false, 'cline'), /ERR_INVALID_ARG_TYPE/);
+  });
+
+  test('settings.json is not written for cline runtime', () => {
+    install(false, 'cline');
+    const settingsJson = path.join(tmpDir, '.cline', 'settings.json');
+    assert.ok(!fs.existsSync(settingsJson), 'settings.json must not be written for cline runtime');
+  });
+
   test('installed engine files have no leaked .claude paths', () => {
     install(false, 'cline');
     const engineDir = path.join(tmpDir, 'get-shit-done');

--- a/tests/cline-install.test.cjs
+++ b/tests/cline-install.test.cjs
@@ -29,6 +29,7 @@ const {
   getConfigDirFromHome,
   convertClaudeToCliineMarkdown,
   install,
+  finishInstall,
 } = require('../bin/install.js');
 
 describe('Cline runtime directory mapping', () => {
@@ -154,15 +155,20 @@ describe('Cline install (local)', () => {
     assert.ok(fs.existsSync(engineDir), 'get-shit-done directory must exist after install');
   });
 
-  test('does not crash with ERR_INVALID_ARG_TYPE (regression: null settingsPath guard)', () => {
-    // Before fix: finishInstall() called writeSettings(null, ...) because isCline guard was missing
-    // After fix:  !isCline is in the writeSettings guard, matching codex/copilot/cursor/windsurf/trae
-    assert.doesNotThrow(() => install(false, 'cline'), /ERR_INVALID_ARG_TYPE/);
+  test('finishInstall does not throw ERR_INVALID_ARG_TYPE for cline runtime (regression: null settingsPath guard)', () => {
+    // install() returns settingsPath: null for cline — finishInstall() must not call
+    // writeSettings(null, ...) or it crashes with ERR_INVALID_ARG_TYPE.
+    // Before fix: isCline was missing from the writeSettings guard in finishInstall().
+    // After fix:  !isCline is in the guard, matching codex/copilot/cursor/windsurf/trae.
+    assert.doesNotThrow(
+      () => finishInstall(null, null, null, false, 'cline', false, tmpDir),
+      'finishInstall must not throw when called with null settingsPath for cline runtime'
+    );
   });
 
   test('settings.json is not written for cline runtime', () => {
-    install(false, 'cline');
-    const settingsJson = path.join(tmpDir, '.cline', 'settings.json');
+    finishInstall(null, null, null, false, 'cline', false, tmpDir);
+    const settingsJson = path.join(tmpDir, 'settings.json');
     assert.ok(!fs.existsSync(settingsJson), 'settings.json must not be written for cline runtime');
   });
 


### PR DESCRIPTION
Closes #2044

## Summary

- When installing GSD with the `cline` runtime, the installer crashed with `ERR_INVALID_ARG_TYPE` because `fs.writeFileSync` received `null` as the path argument.

- `install()` returns `settingsPath: null` for `cline` (it uses `.clinerules` instead of `settings.json`), but `finishInstall()` was missing `!isCline` in the guard that prevents calling `writeSettings` for null-path runtimes — unlike `codex`, `copilot`, `cursor`, `windsurf`, and `trae` which were all guarded.

- Fix: add `const isCline = runtime === 'cline'` to `finishInstall()` and include `!isCline` in the `writeSettings` guard condition.

## Test plan

- [x] Run installer with `cline` runtime — completes without error
- [x] `.clinerules` is written to the target directory
- [x] `settings.json` is not written for `cline` runtime
- [x] Regression test added to `tests/cline-install.test.cjs`:
  - `finishInstall does not throw ERR_INVALID_ARG_TYPE for cline runtime` — asserts no crash with null settingsPath
  - `settings.json is not written for cline runtime` — asserts writeSettings is not invoked for cline