### PR TITLE
fix(autonomous): add Agent to allowed-tools in gsd-autonomous skill

### DIFF
--- a/commands/gsd/autonomous.md
+++ b/commands/gsd/autonomous.md
@@ -10,6 +10,7 @@ allowed-tools:
   - Grep
   - AskUserQuestion
   - Task
+  - Agent
 ---
 <objective>
 Execute all remaining milestone phases autonomously. For each phase: discuss → plan → execute. Pauses only for user decisions (grey area acceptance, blockers, validation requests).

--- a/tests/autonomous-allowed-tools.test.cjs
+++ b/tests/autonomous-allowed-tools.test.cjs
@@ -1,0 +1,37 @@
+/**
+ * Regression test for #2043 — autonomous.md must include Agent in allowed-tools.
+ *
+ * The gsd-autonomous skill spawns background agents via Agent(..., run_in_background=true).
+ * Without Agent in allowed-tools the runtime rejects those calls silently.
+ */
+
+'use strict';
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+describe('commands/gsd/autonomous.md allowed-tools', () => {
+  test('includes Agent in allowed-tools list', () => {
+    const filePath = path.join(__dirname, '..', 'commands', 'gsd', 'autonomous.md');
+    const content = fs.readFileSync(filePath, 'utf-8');
+
+    // Extract the YAML frontmatter block between the first pair of --- delimiters
+    const frontmatterMatch = content.match(/^---\n([\s\S]*?)\n---/);
+    assert.ok(frontmatterMatch, 'autonomous.md must have YAML frontmatter');
+
+    const frontmatter = frontmatterMatch[1];
+
+    // Parse the allowed-tools list items (lines starting with "  - ")
+    const toolLines = frontmatter
+      .split('\n')
+      .filter((line) => /^\s+-\s+/.test(line))
+      .map((line) => line.replace(/^\s+-\s+/, '').trim());
+
+    assert.ok(
+      toolLines.includes('Agent'),
+      `allowed-tools must include "Agent" but found: [${toolLines.join(', ')}]`
+    );
+  });
+});


### PR DESCRIPTION
## What

Added `Agent` to the `allowed-tools` list in `commands/gsd/autonomous.md`.

## Why

The `gsd-autonomous` skill spawns background agents via `Agent(..., run_in_background=true)`. Without `Agent` listed in `allowed-tools`, the runtime rejects those calls silently, causing the skill to exit after printing its banner without actually running any phases.

## Changes

- `commands/gsd/autonomous.md` — added `  - Agent` to the `allowed-tools` block
- `tests/autonomous-allowed-tools.test.cjs` — regression test that reads the raw file, parses the frontmatter allowed-tools list, and asserts `Agent` is present

## Test

The regression test was written first (TDD). It failed before the fix and passes after:

```
node --test tests/autonomous-allowed-tools.test.cjs
✔ includes Agent in allowed-tools list
```

Full suite: 2907 pass, 0 fail.

Closes #2043