### PR TITLE
fix(config): add intel.enabled to VALID_CONFIG_KEYS

### DIFF
--- a/get-shit-done/bin/lib/config.cjs
+++ b/get-shit-done/bin/lib/config.cjs
@@ -33,6 +33,7 @@ const VALID_CONFIG_KEYS = new Set([
   'context',
   'features.global_learnings',
   'learnings.max_inject',
+  'intel.enabled',
   'project_code', 'phase_naming',
   'manager.flags.discuss', 'manager.flags.plan', 'manager.flags.execute',
   'response_language',

--- a/tests/config.test.cjs
+++ b/tests/config.test.cjs
@@ -213,6 +213,16 @@ describe('config-set command', () => {
     assert.strictEqual(typeof config.workflow, 'object');
   });
 
+  test('accepts intel.enabled as a valid config key (#2047)', () => {
+    writeConfig(tmpDir, {});
+
+    const result = runGsdTools('config-set intel.enabled true', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const config = readConfig(tmpDir);
+    assert.strictEqual(config.intel.enabled, true);
+  });
+
   test('rejects unknown config keys', () => {
     const result = runGsdTools('config-set workflow.nyquist_validation_enabled false', tmpDir);
     assert.strictEqual(result.success, false);


### PR DESCRIPTION
## Summary

- Add `intel.enabled` to `VALID_CONFIG_KEYS` in `config.cjs` so `config-set intel.enabled true` works as documented
- `intel.enabled` is referenced in `intel.md`, `CONFIGURATION.md`, `FEATURES.md`, and gated in `intel.cjs:58` — but was never added to the validation set, so the canonical enablement command failed with "Unknown config key"

Closes #2047

## Test plan

- [x] New test: `accepts intel.enabled as a valid config key (#2047)` — verifies config-set succeeds and writes `{ intel: { enabled: true } }`
- [x] All 65 config tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)