### PR TITLE
perf(workflow): default to inline execution for 1-2 task plans

### DIFF
--- a/get-shit-done/bin/lib/config.cjs
+++ b/get-shit-done/bin/lib/config.cjs
@@ -28,6 +28,7 @@ const VALID_CONFIG_KEYS = new Set([
   'git.branching_strategy', 'git.base_branch', 'git.phase_branch_template', 'git.milestone_branch_template', 'git.quick_branch_template',
   'planning.commit_docs', 'planning.search_gitignored',
   'workflow.subagent_timeout',
+  'workflow.inline_plan_threshold',
   'hooks.context_warnings',
   'features.thinking_partner',
   'context',

--- a/get-shit-done/references/planning-config.md
+++ b/get-shit-done/references/planning-config.md
@@ -35,6 +35,7 @@ Configuration options for `.planning/` directory behavior.
 | `git.quick_branch_template` | `null` | Optional branch template for quick-task runs |
 | `workflow.use_worktrees` | `true` | Whether executor agents run in isolated git worktrees. Set to `false` to disable worktrees — agents execute sequentially on the main working tree instead. Recommended for solo developers or when worktree merges cause issues. |
 | `workflow.subagent_timeout` | `300000` | Timeout in milliseconds for parallel subagent tasks (e.g. codebase mapping). Increase for large codebases or slower models. Default: 300000 (5 minutes). |
+| `workflow.inline_plan_threshold` | `2` | Plans with this many tasks or fewer execute inline (Pattern C) instead of spawning a subagent. Avoids ~14K token spawn overhead for small plans. Set to `0` to always spawn subagents. |
 | `manager.flags.discuss` | `""` | Flags passed to `/gsd-discuss-phase` when dispatched from manager (e.g. `"--auto --analyze"`) |
 | `manager.flags.plan` | `""` | Flags passed to plan workflow when dispatched from manager |
 | `manager.flags.execute` | `""` | Flags passed to execute workflow when dispatched from manager |
@@ -259,6 +260,7 @@ Set via `workflow.*` namespace in config.json (e.g., `"workflow": { "research": 
 | `workflow.skip_discuss` | boolean | `false` | `true`, `false` | Skip discuss phase entirely |
 | `workflow.use_worktrees` | boolean | `true` | `true`, `false` | Run executor agents in isolated git worktrees |
 | `workflow.subagent_timeout` | number | `300000` | Any positive integer (ms) | Timeout for parallel subagent tasks (default: 5 minutes) |
+| `workflow.inline_plan_threshold` | number | `2` | `0`–`10` | Plans with ≤N tasks execute inline instead of spawning a subagent |
 | `workflow.code_review` | boolean | `true` | `true`, `false` | Enable built-in code review step in the ship workflow |
 | `workflow.code_review_depth` | string | `"standard"` | `"light"`, `"standard"`, `"deep"` | Depth level for code review analysis in the ship workflow |
 | `workflow._auto_chain_active` | boolean | `false` | `true`, `false` | Internal: tracks whether autonomous chaining is active |

--- a/get-shit-done/workflows/execute-plan.md
+++ b/get-shit-done/workflows/execute-plan.md
@@ -61,10 +61,18 @@ PLAN_START_EPOCH=$(date +%s)
 
 <step name="parse_segments">
 ```bash
+TASK_COUNT=$(grep -c "^<task" .planning/phases/XX-name/{phase}-{plan}-PLAN.md 2>/dev/null || echo "0")
+INLINE_THRESHOLD=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-get workflow.inline_plan_threshold --default 2 2>/dev/null || echo "2")
 grep -n "type=\"checkpoint" .planning/phases/XX-name/{phase}-{plan}-PLAN.md
 ```
 
-**Routing by checkpoint type:**
+**Primary routing: task count threshold (#1979)**
+
+If `TASK_COUNT <= INLINE_THRESHOLD`: Use Pattern C (inline) regardless of checkpoint type. Small plans execute faster inline — avoids ~14K token subagent spawn overhead and preserves prompt cache. Configure threshold via `workflow.inline_plan_threshold` (default: 2).
+
+If `TASK_COUNT > INLINE_THRESHOLD`: Apply checkpoint-based routing below.
+
+**Checkpoint-based routing (plans with > threshold tasks):**
 
 | Checkpoints | Pattern | Execution |
 |-------------|---------|-----------|

--- a/get-shit-done/workflows/execute-plan.md
+++ b/get-shit-done/workflows/execute-plan.md
@@ -61,16 +61,17 @@ PLAN_START_EPOCH=$(date +%s)
 
 <step name="parse_segments">
 ```bash
-TASK_COUNT=$(grep -c "^<task" .planning/phases/XX-name/{phase}-{plan}-PLAN.md 2>/dev/null || echo "0")
+# Count tasks — match <task tag at any indentation level
+TASK_COUNT=$(grep -cE '^\s*<task[[:space:]>]' .planning/phases/XX-name/{phase}-{plan}-PLAN.md 2>/dev/null || echo "0")
 INLINE_THRESHOLD=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" config-get workflow.inline_plan_threshold --default 2 2>/dev/null || echo "2")
 grep -n "type=\"checkpoint" .planning/phases/XX-name/{phase}-{plan}-PLAN.md
 ```
 
 **Primary routing: task count threshold (#1979)**
 
-If `TASK_COUNT <= INLINE_THRESHOLD`: Use Pattern C (inline) regardless of checkpoint type. Small plans execute faster inline — avoids ~14K token subagent spawn overhead and preserves prompt cache. Configure threshold via `workflow.inline_plan_threshold` (default: 2).
+If `INLINE_THRESHOLD > 0` AND `TASK_COUNT <= INLINE_THRESHOLD`: Use Pattern C (inline) regardless of checkpoint type. Small plans execute faster inline — avoids ~14K token subagent spawn overhead and preserves prompt cache. Configure threshold via `workflow.inline_plan_threshold` (default: 2, set to `0` to always spawn subagents).
 
-If `TASK_COUNT > INLINE_THRESHOLD`: Apply checkpoint-based routing below.
+Otherwise: Apply checkpoint-based routing below.
 
 **Checkpoint-based routing (plans with > threshold tasks):**
 

--- a/tests/inline-plan-threshold.test.cjs
+++ b/tests/inline-plan-threshold.test.cjs
@@ -1,0 +1,131 @@
+/**
+ * Tests for workflow.inline_plan_threshold config key and routing logic (#1979).
+ *
+ * Verifies:
+ * 1. The config key is accepted by config-set (VALID_CONFIG_KEYS contains it)
+ * 2. The key is documented in planning-config.md
+ * 3. The execute-plan.md routing instruction uses the correct grep pattern
+ *    (matches <task at any indentation, since PLAN.md templates differ)
+ * 4. The workflow guards threshold=0 to disable inline routing
+ */
+
+'use strict';
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
+
+const repoRoot = path.resolve(__dirname, '..');
+const executePlanPath = path.join(repoRoot, 'get-shit-done', 'workflows', 'execute-plan.md');
+const planningConfigPath = path.join(repoRoot, 'get-shit-done', 'references', 'planning-config.md');
+const configCjsPath = path.join(repoRoot, 'get-shit-done', 'bin', 'lib', 'config.cjs');
+
+describe('inline_plan_threshold config key (#1979)', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('config-set accepts workflow.inline_plan_threshold', () => {
+    const result = runGsdTools('config-set workflow.inline_plan_threshold 3', tmpDir);
+    assert.ok(result.success, `config-set should accept workflow.inline_plan_threshold: ${result.error}`);
+  });
+
+  test('config-set accepts threshold=0 to disable inline routing', () => {
+    const result = runGsdTools('config-set workflow.inline_plan_threshold 0', tmpDir);
+    assert.ok(result.success, `config-set should accept 0: ${result.error}`);
+  });
+
+  test('VALID_CONFIG_KEYS in config.cjs contains workflow.inline_plan_threshold', () => {
+    const content = fs.readFileSync(configCjsPath, 'utf-8');
+    assert.match(
+      content,
+      /['"]workflow\.inline_plan_threshold['"]/,
+      'workflow.inline_plan_threshold must be in VALID_CONFIG_KEYS'
+    );
+  });
+
+  test('planning-config.md documents workflow.inline_plan_threshold', () => {
+    const content = fs.readFileSync(planningConfigPath, 'utf-8');
+    assert.match(
+      content,
+      /workflow\.inline_plan_threshold/,
+      'planning-config.md must document workflow.inline_plan_threshold'
+    );
+  });
+});
+
+describe('execute-plan.md routing instruction (#1979)', () => {
+  test('grep pattern matches <task at any indentation level', () => {
+    const content = fs.readFileSync(executePlanPath, 'utf-8');
+
+    // The new pattern should use \s* for leading whitespace, not ^ anchor alone
+    // Must match both "<task type=" (unindented) and "  <task type=" (indented)
+    assert.match(
+      content,
+      /TASK_COUNT=\$\(grep -cE '\^\\s\*<task/,
+      'grep pattern must allow any leading whitespace before <task'
+    );
+  });
+
+  test('inline routing is guarded by INLINE_THRESHOLD > 0', () => {
+    const content = fs.readFileSync(executePlanPath, 'utf-8');
+    assert.match(
+      content,
+      /INLINE_THRESHOLD\s*>\s*0.*TASK_COUNT\s*<=\s*INLINE_THRESHOLD/s,
+      'inline routing must be guarded by INLINE_THRESHOLD > 0 so threshold=0 disables it'
+    );
+  });
+
+  test('grep pattern does NOT use ^<task alone (would miss indented tasks)', () => {
+    const content = fs.readFileSync(executePlanPath, 'utf-8');
+    // The old buggy pattern: grep -c "^<task" with no whitespace allowance
+    const buggyPattern = /grep -c "\^<task"/;
+    assert.doesNotMatch(
+      content,
+      buggyPattern,
+      'must not use the buggy "^<task" pattern which misses indented tasks'
+    );
+  });
+
+  test('grep pattern matches real-world indented task formats', () => {
+    // Simulate how the grep pattern would behave against sample PLAN.md content
+    // Extract the pattern from execute-plan.md
+    const content = fs.readFileSync(executePlanPath, 'utf-8');
+    const patternMatch = content.match(/TASK_COUNT=\$\(grep -cE '([^']+)'/);
+    assert.ok(patternMatch, 'must find TASK_COUNT grep pattern');
+
+    const regexSource = patternMatch[1].replace(/\\s/g, '\\s').replace(/\[\[:space:\]>\]/, '[\\s>]');
+    const re = new RegExp(regexSource, 'gm');
+
+    // Test cases: should match all of these as single tasks
+    const samples = [
+      '<task type="auto">',
+      '  <task type="auto">',
+      '    <task type="checkpoint:decision">',
+      '\t<task type="auto">',
+    ];
+    for (const sample of samples) {
+      const matches = sample.match(re);
+      assert.ok(matches && matches.length > 0, `Pattern must match: ${JSON.stringify(sample)}`);
+    }
+
+    // Non-task lines should not match
+    const nonMatches = [
+      '<tasks>',
+      '</task>',
+      '// <task comment',
+    ];
+    for (const sample of nonMatches) {
+      const matches = sample.match(re);
+      assert.ok(!matches || matches.length === 0, `Pattern must NOT match: ${JSON.stringify(sample)}`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Plans with 1-2 tasks now execute inline (Pattern C) instead of spawning a subagent (Pattern A)
- Avoids ~14K token subagent spawn overhead and preserves the orchestrator's prompt cache
- Configurable via \`workflow.inline_plan_threshold\` (default: 2, set to 0 to disable)
- Plans above the threshold continue using checkpoint-based routing as before

### Why

Small plans (gap closure, cleanup, single-task phases) pay the full subagent spawn cost for minimal work. Pattern C already exists and produces identical results — this just makes it the default for small plans.

### Changes

| File | Change |
|------|--------|
| \`execute-plan.md\` | Add task count check before checkpoint routing |
| \`planning-config.md\` | Document \`workflow.inline_plan_threshold\` in both tables |
| \`config.cjs\` | Add to VALID_CONFIG_KEYS |

Closes #1979

## Test plan

- [x] Full test suite passes (2918/2919, 1 pre-existing)
- [x] Pattern C already exists and is well-tested — this just routes more plans to it
- [ ] Manual: run \`/gsd-execute-phase\` on a 1-task plan, verify inline execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)