### PR TITLE
fix(workflow): prevent silent SUMMARY.md loss on worktree force-removal

### DIFF
--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -382,6 +382,12 @@ Execute each selected wave in sequence. Within a wave: parallel if `PARALLELIZAT
        auto-detects worktree mode (`.git` is a file, not a directory) and skips
        shared file updates automatically. The orchestrator updates them centrally
        after merge.
+
+       REQUIRED: SUMMARY.md MUST be committed before you return. In worktree mode the
+       git_commit_metadata step in execute-plan.md commits SUMMARY.md and REQUIREMENTS.md
+       only (STATE.md and ROADMAP.md are excluded automatically). Do NOT skip or defer
+       this commit — the orchestrator force-removes the worktree after you return, and
+       any uncommitted SUMMARY.md will be permanently lost (#2070).
        </parallel_execution>
 
        <execution_context>
@@ -554,6 +560,17 @@ Execute each selected wave in sequence. Within a wave: parallel if `PARALLELIZAT
            git add .planning/STATE.md .planning/ROADMAP.md 2>/dev/null || true
            git commit --amend --no-edit 2>/dev/null || true
          fi
+       fi
+
+       # Safety net: commit any uncommitted SUMMARY.md before force-removing the worktree.
+       # This guards against executors that skipped the git_commit_metadata step (#2070).
+       UNCOMMITTED_SUMMARY=$(git -C "$WT" ls-files --modified --others --exclude-standard -- "*SUMMARY.md" 2>/dev/null || true)
+       if [ -n "$UNCOMMITTED_SUMMARY" ]; then
+         echo "⚠ SUMMARY.md was not committed by executor — committing now to prevent data loss"
+         git -C "$WT" add -- "*SUMMARY.md" 2>/dev/null || true
+         git -C "$WT" commit --no-verify -m "docs(recovery): rescue uncommitted SUMMARY.md before worktree removal (#2070)" 2>/dev/null || true
+         # Re-merge the recovery commit
+         git merge "$WT_BRANCH" --no-edit -m "chore: merge rescued SUMMARY.md from executor worktree ($WT_BRANCH)" 2>/dev/null || true
        fi
 
        # Remove the worktree


### PR DESCRIPTION
## Summary

Fixes the silent data loss bug where executor agents in worktree isolation mode could leave `SUMMARY.md` uncommitted, then have it destroyed by `git worktree remove --force` during post-wave cleanup.

Closes #2070

## What / Why / How

**Root cause:** The `<parallel_execution>` block in `execute-phase.md` correctly instructs executors not to modify `STATE.md` or `ROADMAP.md`, and notes that `execute-plan.md` auto-detects worktree mode. However it did not explicitly state that `SUMMARY.md` MUST be committed before returning. An executor following the "do not modify orchestrator files" instruction could interpret this as skipping the entire commit step to be safe — leaving `SUMMARY.md` as an uncommitted dirty file on the worktree's filesystem. The subsequent `git worktree remove --force` in the orchestrator then destroys it silently.

**Layer 1 — Clarify executor instruction (`execute-phase.md`):**
Added an explicit `REQUIRED:` note to the `<parallel_execution>` block stating that `SUMMARY.md` MUST be committed before the agent returns, and that the `git_commit_metadata` step in `execute-plan.md` handles the `SUMMARY.md`-only commit path automatically in worktree mode.

**Layer 2 — Orchestrator safety net (`execute-phase.md`):**
Before `git worktree remove --force`, check for any uncommitted `SUMMARY.md` files using `git ls-files --modified --others`. If found, commit them on the worktree branch and re-merge into the main branch before removal. This prevents data loss even when an executor skips the commit step.

## Files changed

| File | Change |
|------|--------|
| `get-shit-done/workflows/execute-phase.md` | Added REQUIRED SUMMARY.md commit note to `<parallel_execution>` block; added pre-removal safety net that rescues any uncommitted SUMMARY.md before `git worktree remove --force` |

## Test plan

- [x] `npm run test:coverage` — 2942/2942 pass, 0 fail
- [x] No regressions (workflow-only change, no CJS logic touched)
- [x] Safety net uses `--no-verify` consistent with parallel executor conventions
- [x] Safety net is idempotent: if SUMMARY.md is already committed, `git ls-files` returns empty and the block is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)