### PR TITLE
fix: add Qwen Code dedicated path replacement branches and finishInstall labels

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -4149,6 +4149,10 @@ function copyWithPathReplacement(srcDir, destDir, pathPrefix, runtime, isCommand
       } else if (isCline) {
         content = convertClaudeToCliineMarkdown(content);
         fs.writeFileSync(destPath, content);
+      } else if (isQwen) {
+        content = content.replace(/CLAUDE\.md/g, 'QWEN.md');
+        content = content.replace(/\bClaude Code\b/g, 'Qwen Code');
+        fs.writeFileSync(destPath, content);
       } else {
         fs.writeFileSync(destPath, content);
       }
@@ -4192,6 +4196,13 @@ function copyWithPathReplacement(srcDir, destDir, pathPrefix, runtime, isCommand
       jsContent = jsContent.replace(/\.claude\/skills\//g, '.cline/skills/');
       jsContent = jsContent.replace(/CLAUDE\.md/g, '.clinerules');
       jsContent = jsContent.replace(/\bClaude Code\b/g, 'Cline');
+      fs.writeFileSync(destPath, jsContent);
+    } else if (isQwen && (entry.name.endsWith('.cjs') || entry.name.endsWith('.js'))) {
+      let jsContent = fs.readFileSync(srcPath, 'utf8');
+      jsContent = jsContent.replace(/\.claude\/skills\//g, '.qwen/skills/');
+      jsContent = jsContent.replace(/\.claude\//g, '.qwen/');
+      jsContent = jsContent.replace(/CLAUDE\.md/g, 'QWEN.md');
+      jsContent = jsContent.replace(/\bClaude Code\b/g, 'Qwen Code');
       fs.writeFileSync(destPath, jsContent);
     } else {
       fs.copyFileSync(srcPath, destPath);
@@ -6261,6 +6272,7 @@ function finishInstall(settingsPath, settings, statuslineCommand, shouldInstallS
   if (runtime === 'augment') program = 'Augment';
   if (runtime === 'trae') program = 'Trae';
   if (runtime === 'cline') program = 'Cline';
+  if (runtime === 'qwen') program = 'Qwen Code';
 
   let command = '/gsd-new-project';
   if (runtime === 'opencode') command = '/gsd-new-project';
@@ -6273,6 +6285,7 @@ function finishInstall(settingsPath, settings, statuslineCommand, shouldInstallS
   if (runtime === 'augment') command = '/gsd-new-project';
   if (runtime === 'trae') command = '/gsd-new-project';
   if (runtime === 'cline') command = '/gsd-new-project';
+  if (runtime === 'qwen') command = '/gsd-new-project';
   console.log(`
   ${green}Done!${reset} Open a blank directory in ${program} and run ${cyan}${command}${reset}.
 


### PR DESCRIPTION
Closes #2081

After #2077 was merged, Qwen Code works as a runtime but the generic 6 regex path replacements only cover directory patterns like `~/.claude/`. The `isQwen` variable falls through to the `else` block in both the `.md` and `.cjs/.js` conversion chains, meaning `CLAUDE.md` references and engine files with `path.join('.claude', ...)` args never get converted.

### Changes

- **`.md` branch in copyWithPathReplacement** — replaces `CLAUDE.md` → `QWEN.md` and `'Claude Code'` → `'Qwen Code'` before the final else, following the same pattern as Cursor/Windsurf/Trae/Cline
- **`.cjs/.js` branch in copyWithPathReplacement** — replaces `.claude/` → `.qwen/`, `CLAUDE.md` → `QWEN.md`, and `'Claude Code'` → `'Qwen Code'` in engine files where path.join args don't match the generic directory-level regex patterns
- **finishInstall() program/command labels** — Qwen was missing from the post-install message labels, causing it to display *"Open a blank directory in Claude Code"* instead of Qwen Code

All 3015 tests pass.