### PR TITLE
fix(workflow): carve out Other+empty exception from answer_validation retry loop

### DIFF
--- a/get-shit-done/workflows/discuss-phase.md
+++ b/get-shit-done/workflows/discuss-phase.md
@@ -113,6 +113,15 @@ Phase: "API documentation"
 
 <answer_validation>
 **IMPORTANT: Answer validation** — After every AskUserQuestion call, check if the response is empty or whitespace-only. If so:
+
+**Exception — "Other" with empty text:** If the user selected "Other" (or "Chat more") and the response body is empty or whitespace-only, this is NOT an empty answer — it is a signal that the user wants to type freeform input. In this case:
+1. Output a single plain-text line: "What would you like to discuss?"
+2. STOP generating. Do not call any tools. Do not output any further text.
+3. Wait for the user's next message.
+4. After receiving their message, reflect it back and continue.
+Do NOT retry the AskUserQuestion or generate more questions when "Other" is selected with empty text.
+
+**All other empty responses:** If the response is empty or whitespace-only (and the user did NOT select "Other"):
 1. Retry the question once with the same parameters
 2. If still empty, present the options as a plain-text numbered list and ask the user to type their choice number
 Never proceed with an empty answer.


### PR DESCRIPTION
## What

When a user selects "Other" (displayed as "Chat more") in a discuss-phase AskUserQuestion prompt with no accompanying text, the response body is empty. The existing answer_validation block at line 115 classified this as a generic empty response and retried the AskUserQuestion — causing 2-3 cascading rounds of unwanted questions before the user could type anything.

The intended behavior on line 795 (ask follow-up as plain text, wait for the user to type) was never reached because the retry path ran first.

## Why

"Other" + empty text is a distinct signal: the user wants to type freeform input. It is not an unanswered question. The answer_validation block needs an explicit exception for this case so it hands control back to the user instead of retrying.

## How

Added an "Other + empty text" exception at the top of the answer_validation block. When "Other" is selected with an empty body, the workflow outputs one plain-text prompt line and stops — it does not retry the AskUserQuestion or generate more questions. All other empty responses continue through the existing retry path unchanged.

The fix applies once, in the answer_validation block, so all three locations where "Other" appears in discuss-phase (gray-area picker, 4-question batch flow, loop-control menu) inherit the exception without redundant wording.

All 3015 tests pass.

Fixes #2085