### PR TITLE
fix(workflow): quote path variables in workspace next-step examples

### DIFF
--- a/get-shit-done/workflows/new-workspace.md
+++ b/get-shit-done/workflows/new-workspace.md
@@ -202,7 +202,7 @@ Workspace created: $TARGET_PATH
   Branch: $BRANCH_NAME
 
 Next steps:
-  cd $TARGET_PATH
+  cd "$TARGET_PATH"
   /gsd-new-project    # Initialize GSD in the workspace
 ```
 
@@ -215,7 +215,7 @@ Workspace created with $SUCCESS_COUNT of $TOTAL_COUNT repos: $TARGET_PATH
   Failed: repo3 (branch already exists), repo4 (not a git repo)
 
 Next steps:
-  cd $TARGET_PATH
+  cd "$TARGET_PATH"
   /gsd-new-project    # Initialize GSD in the workspace
 ```
 
@@ -225,7 +225,7 @@ Use AskUserQuestion:
 - header: "Initialize GSD"
 - question: "Would you like to initialize a GSD project in the new workspace?"
 - options:
-  - "Yes — run /gsd-new-project" → tell user to `cd $TARGET_PATH` first, then run `/gsd-new-project`
+  - "Yes — run /gsd-new-project" → tell user to `cd "$TARGET_PATH"` first, then run `/gsd-new-project`
   - "No — I'll set it up later" → done
 
 </process>

--- a/get-shit-done/workflows/remove-workspace.md
+++ b/get-shit-done/workflows/remove-workspace.md
@@ -43,7 +43,7 @@ Cannot remove workspace "$WORKSPACE_NAME" — the following repos have uncommitt
   - repo2
 
 Commit or stash changes in these repos before removing the workspace:
-  cd $WORKSPACE_PATH/repo1
+  cd "$WORKSPACE_PATH/repo1"
   git stash   # or git commit
 ```
 


### PR DESCRIPTION
## What

Display examples in `new-workspace.md` and `remove-workspace.md` showed `cd $TARGET_PATH` and `cd $WORKSPACE_PATH/repo1` without quotes. On Windows with paths containing spaces (e.g. `C:\Users\First Last\Documents\...`), copying these examples directly causes the shell to split at the space and fail with `bash: C:/Users/First: No such file or directory`.

## Why

The unquoted examples in user-facing "Next steps" and guidance blocks are what users copy into their terminal. The actual bash execution blocks in the same files (git worktree add, rm -rf, etc.) were already correctly quoted — only the display examples were missing quotes.

## How

Quoted all path variable references in user-facing guidance blocks:
- `new-workspace.md`: `cd $TARGET_PATH` → `cd "$TARGET_PATH"` (2 occurrences, plus the AskUserQuestion option text)
- `remove-workspace.md`: `cd $WORKSPACE_PATH/repo1` → `cd "$WORKSPACE_PATH/repo1"`

No behavior change — these are documentation strings shown to users, not executed code paths. The fix ensures examples shown are safe to copy-paste on paths with spaces.

All 3015 tests pass.

Fixes #2088