### PR TITLE
fix(tests): add before() hook to bug-1736 to prevent hooks/dist race condition

### DIFF
--- a/tests/bug-1736-local-install-commands.test.cjs
+++ b/tests/bug-1736-local-install-commands.test.cjs
@@ -12,7 +12,7 @@
 
 process.env.GSD_TEST_MODE = '1';
 
-const { describe, test, beforeEach, afterEach } = require('node:test');
+const { describe, test, before, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
@@ -20,7 +20,21 @@ const os = require('os');
 const { execFileSync } = require('child_process');
 
 const INSTALL_SRC = path.join(__dirname, '..', 'bin', 'install.js');
+const BUILD_SCRIPT = path.join(__dirname, '..', 'scripts', 'build-hooks.js');
 const { install, copyCommandsAsClaudeSkills } = require(INSTALL_SRC);
+
+// ─── Ensure hooks/dist/ is populated before install tests ────────────────────
+// With --test-concurrency=4, other install tests (bug-1834, bug-1924) run
+// build-hooks.js concurrently. That script creates hooks/dist/ empty first,
+// then copies files — creating a window where this test sees an empty dir and
+// install() fails with "directory is empty" → process.exit(1).
+
+before(() => {
+  execFileSync(process.execPath, [BUILD_SCRIPT], {
+    encoding: 'utf-8',
+    stdio: 'pipe',
+  });
+});
 
 // ─── #1736: local install deploys commands/gsd/ ─────────────────────────────
 


### PR DESCRIPTION
## Summary

- `bug-1736-local-install-commands.test.cjs` was the only install test without a `before()` hook to ensure `hooks/dist/` is built before calling `install()`
- With `--test-concurrency=4`, concurrent tests (`bug-1834`, `bug-1924`) run `build-hooks.js` which first creates `hooks/dist/` empty then copies files — creating a window where `bug-1736` sees an empty directory and `process.exit(1)` kills the test process
- Added the same `before(() => execFileSync(BUILD_SCRIPT))` guard used by all other install tests

## Test plan

- [x] `node --test tests/bug-1736-local-install-commands.test.cjs` passes (3/3)
- [x] `npm run test:coverage` passes (3015/3015)

Closes #2098

🤖 Generated with [Claude Code](https://claude.com/claude-code)