### PR TITLE
ci: upgrade GitHub Actions to Node 22+ runtimes

### DIFF
--- a/.github/workflows/auto-branch.yml
+++ b/.github/workflows/auto-branch.yml
@@ -16,10 +16,10 @@ jobs:
       contains(fromJSON('["bug", "enhancement", "priority: critical", "type: chore", "area: docs"]'),
       github.event.label.name)
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Create branch
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const label = context.payload.label.name;

--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/github-script@v8
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             await github.rest.issues.addLabels({

--- a/.github/workflows/branch-cleanup.yml
+++ b/.github/workflows/branch-cleanup.yml
@@ -22,7 +22,7 @@ jobs:
     if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
     steps:
       - name: Delete head branch
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const branch = context.payload.pull_request.head.ref;
@@ -56,7 +56,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Delete branches from merged PRs
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const protectedBranches = new Set(['main', 'develop', 'release']);

--- a/.github/workflows/branch-naming.yml
+++ b/.github/workflows/branch-naming.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 1
     steps:
       - name: Validate branch naming convention
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const branch = context.payload.pull_request.head.ref;

--- a/.github/workflows/close-draft-prs.yml
+++ b/.github/workflows/close-draft-prs.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Comment and close draft PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -13,12 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Check PR size
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const files = await github.paginate(github.rest.pulls.listFiles, {

--- a/.github/workflows/require-issue-link.yml
+++ b/.github/workflows/require-issue-link.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Comment and fail if no issue link
         if: steps.check.outputs.found == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           # Uses GitHub API SDK — no shell string interpolation of untrusted input
           script: |

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
           days-before-stale: 28
           days-before-close: 14


### PR DESCRIPTION
## Summary

- Upgrades `actions/checkout` v4.2.2 → v6.0.2 (pr-gate, auto-branch)
- Upgrades `actions/github-script` v7/v8 → v9.0.0 (8 workflows)
- Upgrades `actions/stale` v9.0.0 → v10.2.0

Eliminates Node.js 20 deprecation annotations. Node 20 will be forced off June 2, 2026 and removed Sept 16, 2026.

Closes #2127

## Test plan

- [x] All 3606 tests pass locally
- [ ] CI workflows run without Node 20 deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)