### PR TITLE
fix(2095): use cp instead of git-show for worktree STATE.md backup

### DIFF
--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -590,8 +590,8 @@ Execute each selected wave in sequence. Within a wave: parallel if `PARALLELIZAT
        # and ROADMAP.md are stale. Main always wins for these files.
        STATE_BACKUP=$(mktemp)
        ROADMAP_BACKUP=$(mktemp)
-       git show HEAD:.planning/STATE.md > "$STATE_BACKUP" 2>/dev/null || true
-       git show HEAD:.planning/ROADMAP.md > "$ROADMAP_BACKUP" 2>/dev/null || true
+       [ -f .planning/STATE.md ] && cp .planning/STATE.md "$STATE_BACKUP" || true
+       [ -f .planning/ROADMAP.md ] && cp .planning/ROADMAP.md "$ROADMAP_BACKUP" || true
 
        # Snapshot list of files on main BEFORE merge to detect resurrections
        PRE_MERGE_FILES=$(git ls-files .planning/)

--- a/get-shit-done/workflows/quick.md
+++ b/get-shit-done/workflows/quick.md
@@ -613,8 +613,8 @@ After executor returns:
        # Backup STATE.md and ROADMAP.md before merge (main always wins)
        STATE_BACKUP=$(mktemp)
        ROADMAP_BACKUP=$(mktemp)
-       git show HEAD:.planning/STATE.md > "$STATE_BACKUP" 2>/dev/null || true
-       git show HEAD:.planning/ROADMAP.md > "$ROADMAP_BACKUP" 2>/dev/null || true
+       [ -f .planning/STATE.md ] && cp .planning/STATE.md "$STATE_BACKUP" || true
+       [ -f .planning/ROADMAP.md ] && cp .planning/ROADMAP.md "$ROADMAP_BACKUP" || true
 
        # Snapshot files on main to detect resurrections
        PRE_MERGE_FILES=$(git ls-files .planning/)


### PR DESCRIPTION
## Summary

- Replaces `git show HEAD:.planning/STATE.md` with `[ -f .planning/STATE.md ] && cp .planning/STATE.md "$STATE_BACKUP"` in `execute-phase.md` and `quick.md`
- Replaces the equivalent `ROADMAP.md` line in both files
- The `git show HEAD:` approach exits 128 when the file has uncommitted changes or is not yet in HEAD's committed tree; the `|| true` suppresses the error but leaves an empty backup, so the `[ -s "$STATE_BACKUP" ]` restore guard silently skips — leaving STATE.md zeroed or stale after a worktree merge-back

## Test plan

- [ ] `npm run test:coverage` passes (no test changes needed — workflow markdown is not covered by the `.cjs` test suite)
- [ ] Verify that worktree merge-back correctly restores STATE.md and ROADMAP.md when the files have uncommitted orchestrator updates on main

Closes #2095