### PR TITLE
feat: add flow diagram directive to phase researcher agent (#2139)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - **`@gsd-build/sdk` — Phase 1 typed query foundation** — Registry-based `gsd-sdk query` command, classified errors (`GSDQueryError`), and unit-tested handlers under `sdk/src/query/` (state, roadmap, phase lifecycle, init, config, validation, and related domains). Implements incremental SDK-first migration scope approved in #2083; builds on validated work from #2007 / `feat/sdk-foundation` without migrating workflows or removing `gsd-tools.cjs` in this phase.
+- **Flow diagram directive for phase researcher** — `gsd-phase-researcher` now enforces data-flow architecture diagrams instead of file-listing diagrams. Language-agnostic directive added to agent prompt and research template. (#2139)
 
 ## [1.35.0] - 2026-04-10
 

--- a/agents/gsd-phase-researcher.md
+++ b/agents/gsd-phase-researcher.md
@@ -312,6 +312,20 @@ Document the verified version and publish date. Training data versions may be mo
 
 ## Architecture Patterns
 
+### System Architecture Diagram
+
+Architecture diagrams MUST show data flow through conceptual components, not file listings.
+
+Requirements:
+- Show entry points (how data/requests enter the system)
+- Show processing stages (what transformations happen, in what order)
+- Show decision points and branching paths
+- Show external dependencies and service boundaries
+- Use arrows to indicate data flow direction
+- A reader should be able to trace the primary use case from input to output by following the arrows
+
+File-to-implementation mapping belongs in the Component Responsibilities table, not in the diagram.
+
 ### Recommended Project Structure
 \`\`\`
 src/

--- a/get-shit-done/templates/research.md
+++ b/get-shit-done/templates/research.md
@@ -94,6 +94,20 @@ yarn add [packages]
 <architecture_patterns>
 ## Architecture Patterns
 
+### System Architecture Diagram
+
+Architecture diagrams MUST show data flow through conceptual components, not file listings.
+
+Requirements:
+- Show entry points (how data/requests enter the system)
+- Show processing stages (what transformations happen, in what order)
+- Show decision points and branching paths
+- Show external dependencies and service boundaries
+- Use arrows to indicate data flow direction
+- A reader should be able to trace the primary use case from input to output by following the arrows
+
+File-to-implementation mapping belongs in the Component Responsibilities table, not in the diagram.
+
 ### Recommended Project Structure
 ```
 src/
@@ -311,6 +325,20 @@ npm install three @react-three/fiber @react-three/drei @react-three/rapier zusta
 
 <architecture_patterns>
 ## Architecture Patterns
+
+### System Architecture Diagram
+
+Architecture diagrams MUST show data flow through conceptual components, not file listings.
+
+Requirements:
+- Show entry points (how data/requests enter the system)
+- Show processing stages (what transformations happen, in what order)
+- Show decision points and branching paths
+- Show external dependencies and service boundaries
+- Use arrows to indicate data flow direction
+- A reader should be able to trace the primary use case from input to output by following the arrows
+
+File-to-implementation mapping belongs in the Component Responsibilities table, not in the diagram.
 
 ### Recommended Project Structure
 ```

--- a/tests/phase-researcher-flow-diagram.test.cjs
+++ b/tests/phase-researcher-flow-diagram.test.cjs
@@ -1,0 +1,104 @@
+/**
+ * Phase Researcher Flow Diagram Tests (#2139)
+ *
+ * Validates that gsd-phase-researcher enforces data-flow architecture
+ * diagrams instead of file-listing diagrams. Also validates that the
+ * research template includes the matching directive.
+ */
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const AGENTS_DIR = path.join(__dirname, '..', 'agents');
+const TEMPLATES_DIR = path.join(__dirname, '..', 'get-shit-done', 'templates');
+
+// ─── Phase Researcher: System Architecture Diagram Directive ─────────────────
+
+describe('phase-researcher: System Architecture Diagram directive', () => {
+  const researcherPath = path.join(AGENTS_DIR, 'gsd-phase-researcher.md');
+  const content = fs.readFileSync(researcherPath, 'utf-8');
+
+  test('contains System Architecture Diagram section', () => {
+    assert.ok(
+      content.includes('### System Architecture Diagram'),
+      'gsd-phase-researcher.md must contain "### System Architecture Diagram"'
+    );
+  });
+
+  test('requires data flow through conceptual components', () => {
+    assert.ok(
+      content.includes('data flow through conceptual components'),
+      'Directive must require "data flow through conceptual components"'
+    );
+  });
+
+  test('explicitly prohibits file listings in diagrams', () => {
+    assert.ok(
+      content.includes('not file listings'),
+      'Directive must explicitly state "not file listings"'
+    );
+  });
+
+  test('includes key requirements for flow diagrams', () => {
+    const requirements = [
+      'entry points',
+      'processing stages',
+      'decision points',
+      'external dependencies',
+      'arrows',
+    ];
+
+    for (const req of requirements) {
+      assert.ok(
+        content.toLowerCase().includes(req),
+        `Directive must mention "${req}"`
+      );
+    }
+  });
+
+  test('directs file-to-implementation mapping to Component Responsibilities table', () => {
+    assert.ok(
+      content.includes('Component Responsibilities table'),
+      'Directive must redirect file mapping to Component Responsibilities table'
+    );
+  });
+
+  test('diagram section comes before Recommended Project Structure', () => {
+    const diagramPos = content.indexOf('### System Architecture Diagram');
+    const structurePos = content.indexOf('### Recommended Project Structure');
+
+    assert.ok(diagramPos !== -1, 'System Architecture Diagram section must exist');
+    assert.ok(structurePos !== -1, 'Recommended Project Structure section must exist');
+    assert.ok(
+      diagramPos < structurePos,
+      'System Architecture Diagram must come before Recommended Project Structure'
+    );
+  });
+});
+
+// ─── Research Template: System Architecture Diagram Section ───────────────────
+
+describe('research template: System Architecture Diagram section', () => {
+  const templatePath = path.join(TEMPLATES_DIR, 'research.md');
+  const content = fs.readFileSync(templatePath, 'utf-8');
+
+  test('contains System Architecture Diagram section', () => {
+    assert.ok(
+      content.includes('### System Architecture Diagram'),
+      'Research template must contain "### System Architecture Diagram"'
+    );
+  });
+
+  test('includes flow diagram requirements', () => {
+    assert.ok(
+      content.includes('data flow through conceptual components'),
+      'Research template must include flow diagram directive'
+    );
+    assert.ok(
+      content.includes('not file listings'),
+      'Research template must prohibit file listings in diagrams'
+    );
+  });
+});


### PR DESCRIPTION
## Enhancement PR

---

## Linked Issue

Closes #2139

---

## What this enhancement improves

The `gsd-phase-researcher` agent's Architecture Patterns output section. Previously, the agent had no guidance on diagram style, resulting in inconsistent output — sometimes file listings, sometimes flow diagrams, depending on the domain.

## Before / After

**Before:**
The Architecture Patterns template only specified `### Recommended Project Structure` (a directory tree). No guidance on system-level diagrams. The agent would often produce file-listing diagrams:

```
┌──────────────────────────────────┐
│  app/                            │
│    main.py                       │
│    slack_app.py                  │
│    formatter.py                  │
└──────────────┬───────────────────┘
               │ imports
┌──────────────▼───────────────────┐
│  core/                           │
│    pipeline.py                   │
│    retriever.py                  │
└──────────────────────────────────┘
```

**After:**
A `### System Architecture Diagram` subsection is added before `### Recommended Project Structure` with a clear directive enforcing flow-style diagrams:

```
┌──────────────────────────────────────────────┐
│              Event Handler                    │
│  Routes events → appropriate handler          │
└──────────┬───────────────────┬───────────────┘
           │ ack immediately    │ background task
           ▼                    ▼
┌──────────────────┐  ┌────────────────────────┐
│  ACK Response    │  │  Pipeline Runner        │
└──────────────────┘  │  step1() → step2()      │
                      └────────────┬───────────┘
                                   ▼
                      ┌────────────────────────┐
                      │  Response Formatter     │
                      └────────────────────────┘
```

## How it was implemented

Added a `### System Architecture Diagram` subsection with a language-agnostic directive to three locations:

1. `agents/gsd-phase-researcher.md` — in the `<output_format>` section's Architecture Patterns template
2. `get-shit-done/templates/research.md` — in both `<architecture_patterns>` sections (blank template and filled example)
3. `tests/phase-researcher-flow-diagram.test.cjs` — 8 new tests validating directive presence, content, ordering, and template consistency

The directive requires: entry points, processing stages, decision points, external dependencies, arrows for flow direction. It explicitly prohibits file listings in diagrams and redirects file-to-implementation mapping to the Component Responsibilities table.

## Testing

### How I verified the enhancement works

```bash
node --test tests/phase-researcher-flow-diagram.test.cjs  # 8/8 pass
npm test  # 3621/3621 pass, 0 fail
```

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

This is a prompt-only change — no code execution paths differ across platforms or runtimes.

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

---

## Checklist

- [x] Issue linked above with `Closes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `approved-enhancement` label — **PR will be closed if missing**
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass (`npm test`)
- [x] New or updated tests cover the enhanced behavior
- [ ] CHANGELOG.md updated
- [ ] Documentation updated if behavior or output changed
- [x] No unnecessary dependencies added

## Breaking changes

None — this adds a new directive subsection to the researcher agent prompt. Existing behavior is unchanged; the agent now has additional guidance for diagram generation.