### PR TITLE
fix: show contextual warning for dev installs with stale hooks

### DIFF
--- a/get-shit-done/workflows/update.md
+++ b/get-shit-done/workflows/update.md
@@ -289,7 +289,16 @@ Exit.
 **Installed:** X.Y.Z
 **Latest:** A.B.C
 
-You're ahead of the latest release (development version?).
+You're ahead of the latest release — this looks like a dev install.
+
+If you see a "⚠ dev install — re-run installer to sync hooks" warning in
+your statusline, your hook files are older than your VERSION file. Fix it
+by re-running the local installer from your dev branch:
+
+    node bin/install.js --global --claude
+
+Running /gsd-update would install the npm release (A.B.C) and downgrade
+your dev version — do NOT use it to resolve this warning.
 ```
 
 Exit.

--- a/hooks/gsd-statusline.js
+++ b/hooks/gsd-statusline.js
@@ -211,7 +211,20 @@ function runStatusline() {
           gsdUpdate = '\x1b[33m⬆ /gsd-update\x1b[0m │ ';
         }
         if (cache.stale_hooks && cache.stale_hooks.length > 0) {
-          gsdUpdate += '\x1b[31m⚠ stale hooks — run /gsd-update\x1b[0m │ ';
+          // If installed version is ahead of npm latest, this is a dev install.
+          // Running /gsd-update would downgrade — show a contextual warning instead.
+          const isDevInstall = (() => {
+            if (!cache.installed || !cache.latest || cache.latest === 'unknown') return false;
+            const parseV = v => v.replace(/^v/, '').split('.').map(Number);
+            const [ai, bi, ci] = parseV(cache.installed);
+            const [an, bn, cn] = parseV(cache.latest);
+            return ai > an || (ai === an && bi > bn) || (ai === an && bi === bn && ci > cn);
+          })();
+          if (isDevInstall) {
+            gsdUpdate += '\x1b[33m⚠ dev install — re-run installer to sync hooks\x1b[0m │ ';
+          } else {
+            gsdUpdate += '\x1b[31m⚠ stale hooks — run /gsd-update\x1b[0m │ ';
+          }
         }
       } catch (e) {}
     }


### PR DESCRIPTION
## Summary

- Detects dev installs (`cache.installed > cache.latest`) in `gsd-statusline.js` and shows an amber **⚠ dev install — re-run installer to sync hooks** instead of the red **/gsd-update** prompt
- Adds inline semver comparison helper (IIFE) — no extra deps, no I/O beyond the cache already being read
- Expands `update.md` `installed > latest` branch with the exact remediation command (`node bin/install.js --global --claude`) and an explicit warning not to run `/gsd-update` in this case

## Test plan

- [ ] Normal stale hooks (installed < latest): still shows red ⚠ stale hooks — run /gsd-update
- [ ] Dev install (installed > latest) with stale hooks: shows amber ⚠ dev install — re-run installer to sync hooks
- [ ] No stale hooks: neither warning shown
- [ ] `latest === 'unknown'` (offline / cache missing field): falls back to red stale-hooks path (safe default)
- [ ] All tests: `npm test` → fail 0 ✓

Closes #2161

🤖 Generated with [Claude Code](https://claude.com/claude-code)