### PR TITLE
fix: remove head 5 UAT for larger number of phases

### DIFF
--- a/get-shit-done/workflows/verify-work.md
+++ b/get-shit-done/workflows/verify-work.md
@@ -43,7 +43,7 @@ Parse JSON for: `planner_model`, `checker_model`, `commit_docs`, `phase_found`, 
 **First: Check for active UAT sessions**
 
 ```bash
-(find .planning/phases -name "*-UAT.md" -type f 2>/dev/null || true) | head -5
+(find .planning/phases -name "*-UAT.md" -type f 2>/dev/null || true)
 ```
 
 **If active sessions exist AND no $ARGUMENTS provided:**


### PR DESCRIPTION
**What's broken:**
The verify-work.md workflow pipes UAT file search through head -5, silently truncating results when a project has more than 5 phases. Active UAT sessions beyond the first 5 are never shown to the user.

**Root cause:**
Hard-coded | head -5 in the find command for *-UAT.md files at line 46 of get-shit-done/workflows/verify-work.md.

**What this PR does:**
Removes | head -5 so all active UAT session files are listed regardless of the number of phases.

**How to verify:**
1. Create a project with more than 5 phases that have UAT sessions
2. Run /gsd:verify-work
3. Confirm all UAT files are listed, not just the first 5