### PR TITLE
fix: copy hook files to Codex install target (#2153)

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -5856,6 +5856,35 @@ function install(isGlobal, runtime = 'claude') {
     console.log(`  ${green}✓${reset} Generated config.toml with ${agentCount} agent roles`);
     console.log(`  ${green}✓${reset} Generated ${agentCount} agent .toml config files`);
 
+    // Copy hook files that are referenced in config.toml (#2153)
+    // The main hook-copy block is gated to non-Codex runtimes, but Codex registers
+    // gsd-check-update.js in config.toml — the file must physically exist.
+    const codexHooksSrc = path.join(src, 'hooks', 'dist');
+    if (fs.existsSync(codexHooksSrc)) {
+      const codexHooksDest = path.join(targetDir, 'hooks');
+      fs.mkdirSync(codexHooksDest, { recursive: true });
+      const configDirReplacement = getConfigDirFromHome(runtime, isGlobal);
+      for (const entry of fs.readdirSync(codexHooksSrc)) {
+        const srcFile = path.join(codexHooksSrc, entry);
+        if (!fs.statSync(srcFile).isFile()) continue;
+        const destFile = path.join(codexHooksDest, entry);
+        if (entry.endsWith('.js')) {
+          let content = fs.readFileSync(srcFile, 'utf8');
+          content = content.replace(/'\.claude'/g, configDirReplacement);
+          content = content.replace(/\/\.claude\//g, `/${getDirName(runtime)}/`);
+          content = content.replace(/\{\{GSD_VERSION\}\}/g, pkg.version);
+          fs.writeFileSync(destFile, content);
+          try { fs.chmodSync(destFile, 0o755); } catch (e) { /* Windows */ }
+        } else {
+          fs.copyFileSync(srcFile, destFile);
+          if (entry.endsWith('.sh')) {
+            try { fs.chmodSync(destFile, 0o755); } catch (e) { /* Windows */ }
+          }
+        }
+      }
+      console.log(`  ${green}✓${reset} Installed hooks`);
+    }
+
     // Add Codex hooks (SessionStart for update checking) — requires codex_hooks feature flag
     const configPath = path.join(targetDir, 'config.toml');
     try {

--- a/tests/codex-config.test.cjs
+++ b/tests/codex-config.test.cjs
@@ -830,6 +830,22 @@ describe('Codex install hook configuration (e2e)', () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
+  test('Codex install copies hook file that is referenced in config.toml (#2153)', () => {
+    // Regression test: Codex install writes gsd-check-update hook reference into
+    // config.toml but must also copy the hook file to ~/$CODEX_HOME/hooks/
+    runCodexInstall(codexHome);
+
+    const configContent = readCodexConfig(codexHome);
+    // config.toml must reference the hook
+    assert.ok(configContent.includes('gsd-check-update.js'), 'config.toml references gsd-check-update.js');
+    // The hook file must physically exist at the referenced path
+    const hookFile = path.join(codexHome, 'hooks', 'gsd-check-update.js');
+    assert.ok(
+      fs.existsSync(hookFile),
+      `gsd-check-update.js must exist at ${hookFile} — config.toml references it but file was not installed`
+    );
+  });
+
   test('fresh CODEX_HOME enables codex_hooks without draft root defaults', () => {
     runCodexInstall(codexHome);
 


### PR DESCRIPTION
## Fix PR

## Linked Issue

Closes #2153

## What was broken

A fresh Codex global install (`npx get-shit-done-cc --codex --global`) wrote a `SessionStart` hook reference into `~/.codex/config.toml` pointing to `~/.codex/hooks/gsd-check-update.js`, but never copied the hook file there. Every fresh Codex install had a broken hook reference.

## Root cause

The hook-copy block in `install()` (lines 5729–5784) is gated by `!isCodex`. Codex was excluded from this block intentionally (it doesn't use `settings.json`), but that exclusion also skipped the file copy — leaving Codex without the hook files it references in `config.toml`.

## What this fix does

Adds a dedicated hook-copy step inside the `if (isCodex)` branch (before the `config.toml` hook-registration step) that mirrors the existing copy logic: template substitution (`'.claude'` → `'.codex'`), `{{GSD_VERSION}}` stamping, and `chmod 755`. All hooks from `hooks/dist/` are installed to `~/.codex/hooks/`.

## Testing

Added a regression test in `tests/codex-config.test.cjs` that:
1. Runs `install(true, 'codex')` against a temp directory
2. Asserts that `config.toml` references `gsd-check-update.js`
3. Asserts that the file physically exists at the referenced path

The test fails on the unfixed code and passes after the fix.

```
node --test tests/codex-config.test.cjs
# pass 86, fail 0
npm test
# pass 3702, fail 0
```