### PR TITLE
fix: remove head -5 truncation from UAT file listing in verify-work

### DIFF
--- a/get-shit-done/workflows/verify-work.md
+++ b/get-shit-done/workflows/verify-work.md
@@ -43,7 +43,7 @@ Parse JSON for: `planner_model`, `checker_model`, `commit_docs`, `phase_found`, 
 **First: Check for active UAT sessions**
 
 ```bash
-(find .planning/phases -name "*-UAT.md" -type f 2>/dev/null || true) | head -5
+(find .planning/phases -name "*-UAT.md" -type f 2>/dev/null || true)
 ```
 
 **If active sessions exist AND no $ARGUMENTS provided:**


### PR DESCRIPTION
Closes #2171

## Root cause
`verify-work.md` piped the `find .planning/phases -name "*-UAT.md"` command through `| head -5`, silently dropping any UAT files beyond the first five. On projects with more than 5 phases, active UAT sessions were never shown to the user.

## Fix
Remove `| head -5` so the `find` output is passed through in full. The listing display logic already handles any number of entries — the truncation was the only problem.

## Test
This is a workflow `.md` file change (not executable code), so the fix is verified by confirming the line is removed and the test suite still passes (fail 0).

Originally reported and fixed by @Myashka in PR #2163, which was closed due to the issue-first rule. This PR is the properly-linked follow-on.