### PR TITLE
feat(health): detect stale and orphan worktrees in validate-health (W017)

### DIFF
--- a/get-shit-done/bin/lib/verify.cjs
+++ b/get-shit-done/bin/lib/verify.cjs
@@ -837,6 +837,40 @@ function cmdValidateHealth(cwd, options, raw) {
     } catch { /* parse error already caught in Check 5 */ }
   }
 
+  // ─── Check 11: Stale / orphan git worktrees (#2167) ────────────────────────
+  try {
+    const worktreeResult = execGit(cwd, ['worktree', 'list', '--porcelain']);
+    if (worktreeResult.exitCode === 0 && worktreeResult.stdout) {
+      const blocks = worktreeResult.stdout.split('\n\n').filter(Boolean);
+      // Skip the first block — it is always the main worktree
+      for (let i = 1; i < blocks.length; i++) {
+        const lines = blocks[i].split('\n');
+        const wtLine = lines.find(l => l.startsWith('worktree '));
+        if (!wtLine) continue;
+        const wtPath = wtLine.slice('worktree '.length);
+
+        if (!fs.existsSync(wtPath)) {
+          // Orphan: path no longer exists on disk
+          addIssue('warning', 'W017',
+            `Orphan git worktree: ${wtPath} (path no longer exists on disk)`,
+            'Run: git worktree prune');
+        } else {
+          // Check if stale (older than 1 hour)
+          try {
+            const stat = fs.statSync(wtPath);
+            const ageMs = Date.now() - stat.mtimeMs;
+            const ONE_HOUR = 60 * 60 * 1000;
+            if (ageMs > ONE_HOUR) {
+              addIssue('warning', 'W017',
+                `Stale git worktree: ${wtPath} (last modified ${Math.round(ageMs / 60000)} minutes ago)`,
+                `Run: git worktree remove ${wtPath} --force`);
+            }
+          } catch { /* stat failed — skip */ }
+        }
+      }
+    }
+  } catch { /* git worktree not available or not a git repo — skip silently */ }
+
   // ─── Perform repairs if requested ─────────────────────────────────────────
   const repairActions = [];
   if (options.repair && repairs.length > 0) {

--- a/tests/orphan-worktree-detection.test.cjs
+++ b/tests/orphan-worktree-detection.test.cjs
@@ -1,0 +1,126 @@
+/**
+ * GSD Tools Tests - Orphan/Stale Worktree Detection (W017)
+ *
+ * Tests for feat/worktree-health-w017-2167:
+ *   - W017 code exists in verify.cjs (structural)
+ *   - No false positives on projects without linked worktrees
+ *   - Adding the check does not regress baseline health status
+ */
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { runGsdTools, createTempGitProject, cleanup } = require('./helpers.cjs');
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function writeMinimalProjectMd(tmpDir) {
+  const sections = ['## What This Is', '## Core Value', '## Requirements'];
+  const content = sections.map(s => `${s}\n\nContent here.\n`).join('\n');
+  fs.writeFileSync(
+    path.join(tmpDir, '.planning', 'PROJECT.md'),
+    `# Project\n\n${content}`
+  );
+}
+
+function writeMinimalRoadmap(tmpDir) {
+  fs.writeFileSync(
+    path.join(tmpDir, '.planning', 'ROADMAP.md'),
+    '# Roadmap\n\n### Phase 1: Setup\n'
+  );
+}
+
+function writeMinimalStateMd(tmpDir) {
+  fs.writeFileSync(
+    path.join(tmpDir, '.planning', 'STATE.md'),
+    '# Session State\n\n## Current Position\n\nPhase: 1\n'
+  );
+}
+
+function writeValidConfigJson(tmpDir) {
+  fs.writeFileSync(
+    path.join(tmpDir, '.planning', 'config.json'),
+    JSON.stringify({
+      model_profile: 'balanced',
+      commit_docs: true,
+      workflow: { nyquist_validation: true, ai_integration_phase: true },
+    }, null, 2)
+  );
+}
+
+function setupHealthyProject(tmpDir) {
+  writeMinimalProjectMd(tmpDir);
+  writeMinimalRoadmap(tmpDir);
+  writeMinimalStateMd(tmpDir);
+  writeValidConfigJson(tmpDir);
+  fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '01-setup'), { recursive: true });
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. Structural: W017 code exists in verify.cjs
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('W017: structural presence', () => {
+  test('verify.cjs contains W017 warning code', () => {
+    const verifyPath = path.join(__dirname, '..', 'get-shit-done', 'bin', 'lib', 'verify.cjs');
+    const source = fs.readFileSync(verifyPath, 'utf-8');
+    assert.ok(source.includes("'W017'"), 'verify.cjs should contain W017 warning code');
+  });
+
+  test('verify.cjs contains worktree list --porcelain invocation', () => {
+    const verifyPath = path.join(__dirname, '..', 'get-shit-done', 'bin', 'lib', 'verify.cjs');
+    const source = fs.readFileSync(verifyPath, 'utf-8');
+    assert.ok(
+      source.includes('worktree') && source.includes('--porcelain'),
+      'verify.cjs should invoke git worktree list --porcelain'
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. No worktrees = no W017
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('W017: no false positives', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempGitProject();
+    setupHealthyProject(tmpDir);
+  });
+
+  afterEach(() => cleanup(tmpDir));
+
+  test('no W017 when project has no linked worktrees', () => {
+    const result = runGsdTools('validate health --raw', tmpDir);
+    assert.ok(result.success, `validate health should succeed: ${result.error || ''}`);
+    const parsed = JSON.parse(result.output);
+
+    // Collect all warning codes
+    const warningCodes = (parsed.warnings || []).map(w => w.code);
+    assert.ok(!warningCodes.includes('W017'), `W017 should not fire when no linked worktrees exist, got warnings: ${JSON.stringify(warningCodes)}`);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. Clean project still reports healthy
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('W017: no regression on healthy projects', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempGitProject();
+    setupHealthyProject(tmpDir);
+  });
+
+  afterEach(() => cleanup(tmpDir));
+
+  test('validate health still reports healthy on a clean project', () => {
+    const result = runGsdTools('validate health --raw', tmpDir);
+    assert.ok(result.success, `validate health should succeed: ${result.error || ''}`);
+    const parsed = JSON.parse(result.output);
+    assert.equal(parsed.status, 'healthy', `Expected healthy status, got ${parsed.status}. Errors: ${JSON.stringify(parsed.errors)}. Warnings: ${JSON.stringify(parsed.warnings)}`);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new W017 warning to `cmdValidateHealth` in `verify.cjs` that detects stale and orphan git worktrees left behind by crashed or interrupted agents.

- Runs `git worktree list --porcelain` to enumerate all linked worktrees
- Flags worktrees older than 1 hour as **stale** (likely from a crashed agent)
- Flags worktrees whose paths no longer exist on disk as **orphaned** (definitely abandoned)
- Skips the main worktree (current repo root) — never flagged
- Gracefully degrades if `git worktree list` fails (old git, not a repo) — silently skips
- Provides actionable fix suggestions: `git worktree remove <path> --force` for stale, `git worktree prune` for orphans

## Linked issue

Closes #2167

Resubmission of #1931 (closed as stale). trek-e confirmed the idea and noted W016 is claimed by #1907 — this uses W017.

## Test plan

- [x] Structural test: verify.cjs source contains `W017` string
- [x] No false positives: clean project with no linked worktrees produces no W017
- [x] No regression: clean project still reports `status: healthy`
- [x] Existing health tests: `health-validation.test.cjs` (14/14), `verify-health.test.cjs` (31/31) still pass

## Files changed

| File | Change |
|------|--------|
| `get-shit-done/bin/lib/verify.cjs` | +34 lines — W017 check block |
| `tests/orphan-worktree-detection.test.cjs` | NEW — 4 tests |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>