### PR TITLE
fix(init): ignore archived phases from prior milestones sharing a phase number

### DIFF
--- a/get-shit-done/bin/lib/init.cjs
+++ b/get-shit-done/bin/lib/init.cjs
@@ -58,6 +58,16 @@ function cmdInitExecutePhase(cwd, phase, raw, options = {}) {
 
   const roadmapPhase = getRoadmapPhaseInternal(cwd, phase);
 
+  // If findPhaseInternal matched an archived phase from a prior milestone, but
+  // the phase exists in the current milestone's ROADMAP.md, ignore the archive
+  // match — we are initializing a new phase in the current milestone that
+  // happens to share a number with an archived one. Without this, phase_dir,
+  // phase_slug and related fields would point at artifacts from a previous
+  // milestone.
+  if (phaseInfo?.archived && roadmapPhase?.found) {
+    phaseInfo = null;
+  }
+
   // Fallback to ROADMAP.md if no phase directory exists yet
   if (!phaseInfo && roadmapPhase?.found) {
     const phaseName = roadmapPhase.phase_name;
@@ -180,6 +190,16 @@ function cmdInitPlanPhase(cwd, phase, raw, options = {}) {
   let phaseInfo = findPhaseInternal(cwd, phase);
 
   const roadmapPhase = getRoadmapPhaseInternal(cwd, phase);
+
+  // If findPhaseInternal matched an archived phase from a prior milestone, but
+  // the phase exists in the current milestone's ROADMAP.md, ignore the archive
+  // match — we are planning a new phase in the current milestone that happens
+  // to share a number with an archived one. Without this, phase_dir,
+  // phase_slug, has_context and has_research would point at artifacts from a
+  // previous milestone.
+  if (phaseInfo?.archived && roadmapPhase?.found) {
+    phaseInfo = null;
+  }
 
   // Fallback to ROADMAP.md if no phase directory exists yet
   if (!phaseInfo && roadmapPhase?.found) {
@@ -551,6 +571,16 @@ function cmdInitVerifyWork(cwd, phase, raw) {
 
   const config = loadConfig(cwd);
   let phaseInfo = findPhaseInternal(cwd, phase);
+
+  // If findPhaseInternal matched an archived phase from a prior milestone, but
+  // the phase exists in the current milestone's ROADMAP.md, ignore the archive
+  // match — same pattern as cmdInitPhaseOp.
+  if (phaseInfo?.archived) {
+    const roadmapPhase = getRoadmapPhaseInternal(cwd, phase);
+    if (roadmapPhase?.found) {
+      phaseInfo = null;
+    }
+  }
 
   // Fallback to ROADMAP.md if no phase directory exists yet
   if (!phaseInfo) {

--- a/tests/init.test.cjs
+++ b/tests/init.test.cjs
@@ -353,6 +353,76 @@ describe('init commands ROADMAP fallback when phase directory does not exist (#1
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// init ignores archived phases from prior milestones that share a phase number
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('init commands ignore archived phases from prior milestones sharing a number', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+    // Current milestone ROADMAP has Phase 2 but no disk directory yet
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      '# v2.0 Roadmap\n\n### Phase 2: New Feature\n**Goal:** New v2.0 feature\n**Requirements**: NEW-01, NEW-02\n**Plans:** TBD\n'
+    );
+    // Prior milestone archive has a shipped Phase 2 with different slug and artifacts
+    const archivedDir = path.join(tmpDir, '.planning', 'milestones', 'v1.0-phases', '02-old-feature');
+    fs.mkdirSync(archivedDir, { recursive: true });
+    fs.writeFileSync(path.join(archivedDir, '2-CONTEXT.md'), '# OLD v1.0 Phase 2 context');
+    fs.writeFileSync(path.join(archivedDir, '2-RESEARCH.md'), '# OLD v1.0 Phase 2 research');
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('init plan-phase prefers current ROADMAP entry over archived v1.0 phase of same number', () => {
+    const result = runGsdTools('init plan-phase 2', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.phase_found, true);
+    assert.strictEqual(output.phase_name, 'New Feature',
+      'phase_name must come from current ROADMAP.md, not archived v1.0');
+    assert.strictEqual(output.phase_slug, 'new-feature');
+    assert.strictEqual(output.phase_dir, null,
+      'phase_dir must be null — current milestone has no directory yet');
+    assert.strictEqual(output.has_context, false,
+      'has_context must not inherit archived v1.0 artifacts');
+    assert.strictEqual(output.has_research, false,
+      'has_research must not inherit archived v1.0 artifacts');
+    assert.ok(!output.context_path,
+      'context_path must not point at archived v1.0 file');
+    assert.ok(!output.research_path,
+      'research_path must not point at archived v1.0 file');
+    assert.strictEqual(output.phase_req_ids, 'NEW-01, NEW-02');
+  });
+
+  test('init execute-phase prefers current ROADMAP entry over archived v1.0 phase of same number', () => {
+    const result = runGsdTools('init execute-phase 2', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.phase_found, true);
+    assert.strictEqual(output.phase_name, 'New Feature');
+    assert.strictEqual(output.phase_slug, 'new-feature');
+    assert.strictEqual(output.phase_dir, null);
+    assert.strictEqual(output.phase_req_ids, 'NEW-01, NEW-02');
+  });
+
+  test('init verify-work prefers current ROADMAP entry over archived v1.0 phase of same number', () => {
+    const result = runGsdTools('init verify-work 2', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.phase_found, true);
+    assert.strictEqual(output.phase_name, 'New Feature');
+    assert.strictEqual(output.phase_dir, null);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // cmdInitTodos (INIT-01)
 // ─────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Linked Issue

Fixes #2185

## What was broken

`init plan-phase`, `init execute-phase`, and `init verify-work` returned the archived phase from a prior milestone when the current milestone's ROADMAP reused the same phase number. `phase_dir`, `phase_slug`, `has_context`, `has_research`, and the `*_path` fields pointed at shipped artifacts from a previous milestone, while `phase_req_ids` correctly came from the current ROADMAP — a silent inconsistency that routed gsd-planner / gsd-phase-researcher at the wrong phase directory.

## What this fix does

In `cmdInitPlanPhase`, `cmdInitExecutePhase`, and `cmdInitVerifyWork` (`get-shit-done/bin/lib/init.cjs`): if `findPhaseInternal` returns an archived match (`phaseInfo.archived` is set) and the current milestone's ROADMAP.md has the phase, discard the archived `phaseInfo` so the existing ROADMAP-fallback path produces clean values (null `phase_dir`, correct `phase_name`/`phase_slug` from ROADMAP, `has_context`/`has_research` = `false`).

This is the same pattern `cmdInitPhaseOp` already implements (current lines 617–642) for the discuss-phase flow — now applied consistently to the other three init entry points.

## Root cause

`findPhaseInternal` searches `.planning/phases/` first, then falls through to `.planning/milestones/v*-phases/` archives. The archived match gets an `archived: version` flag, but three of the four `cmdInit*` call sites never consulted it.

## Testing

### How I verified the fix

- Added 3 regression tests in `tests/init.test.cjs` covering plan-phase, execute-phase, and verify-work under the shared-phase-number scenario.
- All tests pass: `node --test tests/init.test.cjs` → 76 pass, 0 fail.
- Full suite: `npm test` → 3874 pass, 0 fail.

### Regression test added?

- [x] Yes — `init commands ignore archived phases from prior milestones sharing a number` describe block (3 tests).

### Platforms tested

- [x] macOS
- [ ] Windows
- [ ] Linux
- [ ] N/A

### Runtimes tested

- [x] Claude Code
- [ ] N/A

---

## Scope

Touches only `get-shit-done/bin/lib/init.cjs` (+16 LOC) and `tests/init.test.cjs` (+84 LOC of regression tests). No public API surface change; behavior converges three init entry points on the same guard `cmdInitPhaseOp` already uses.