### PR TITLE
fix: parse baseInt to integer in renameDecimalPhases to fix regex mismatch

### DIFF
--- a/get-shit-done/bin/lib/phase.cjs
+++ b/get-shit-done/bin/lib/phase.cjs
@@ -712,7 +712,7 @@ function cmdPhaseRemove(cwd, targetPhase, options, raw) {
   let renamedDirs = [], renamedFiles = [];
   try {
     const renamed = isDecimal
-      ? renameDecimalPhases(phasesDir, normalized.split('.')[0], parseInt(normalized.split('.')[1], 10))
+      ? renameDecimalPhases(phasesDir, parseInt(normalized.split('.')[0], 10), parseInt(normalized.split('.')[1], 10))
       : renameIntegerPhases(phasesDir, parseInt(normalized, 10));
     renamedDirs = renamed.renamedDirs;
     renamedFiles = renamed.renamedFiles;


### PR DESCRIPTION
Closes #2197

## Problem
In `cmdPhaseRemove`, `renameDecimalPhases` was called with `normalized.split('.')[0]` which returns a **string** (e.g. `"06"`). Inside `renameDecimalPhases`, this string was used directly in a regex: `/^06\.(\d+)-(.+)$/`. Phase directories are named without leading zeros (e.g. `6.1-feature`), so the pattern never matched and no decimal siblings were renumbered after a phase removal.

## Fix
Parse the base part to an integer with `parseInt(..., 10)` at the call site:

```js
// Before
renameDecimalPhases(phasesDir, normalized.split('.')[0], ...)
// After  
renameDecimalPhases(phasesDir, parseInt(normalized.split('.')[0], 10), ...)
```

This is a one-character change that ensures the regex matches directory names correctly.