### PR TITLE
fix(hooks): add gsd-hook-version to bash hooks, extend check-update regex for bash syntax

### DIFF
--- a/hooks/gsd-check-update.js
+++ b/hooks/gsd-check-update.js
@@ -103,7 +103,7 @@ const child = spawn(process.execPath, ['-e', `
         for (const hookFile of hookFiles) {
           try {
             const content = fs.readFileSync(path.join(hooksDir, hookFile), 'utf8');
-            const versionMatch = content.match(/\\/\\/ gsd-hook-version:\\s*(.+)/);
+            const versionMatch = content.match(/(?:\/\/|#) gsd-hook-version:\s*(.+)/);
             if (versionMatch) {
               const hookVersion = versionMatch[1].trim();
               if (isNewer(installed, hookVersion) && !hookVersion.includes('{{')) {

--- a/hooks/gsd-phase-boundary.sh
+++ b/hooks/gsd-phase-boundary.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# gsd-hook-version: {{GSD_VERSION}}
 # gsd-phase-boundary.sh — PostToolUse hook: detect .planning/ file writes
 # Outputs a reminder when planning files are modified outside normal workflow.
 # Uses Node.js for JSON parsing (always available in GSD projects, no jq dependency).

--- a/hooks/gsd-session-state.sh
+++ b/hooks/gsd-session-state.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# gsd-hook-version: {{GSD_VERSION}}
 # gsd-session-state.sh — SessionStart hook: inject project state reminder
 # Outputs STATE.md head on every session start for orientation.
 #

--- a/hooks/gsd-validate-commit.sh
+++ b/hooks/gsd-validate-commit.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# gsd-hook-version: {{GSD_VERSION}}
 # gsd-validate-commit.sh — PreToolUse hook: enforce Conventional Commits format
 # Blocks git commit commands with non-conforming messages (exit 2).
 # Allows conforming messages and all non-commit commands (exit 0).


### PR DESCRIPTION
Fixes #2206

## Summary

- Add `# gsd-hook-version: {{GSD_VERSION}}` header to `gsd-phase-boundary.sh`, `gsd-session-state.sh`, and `gsd-validate-commit.sh`
- Extend the version regex in `gsd-check-update.js` from `// gsd-hook-version:` to `(?:\/\/|#) gsd-hook-version:` to handle both JS and bash comment syntax

## Test plan

- [ ] Fresh install: verify `~/.cache/gsd/gsd-update-check.json` has no `stale_hooks` entries for the three bash files
- [ ] Statusline shows no stale hooks warning after install
- [ ] JS hooks still detected correctly (regex change is additive)