### PR TITLE
fix(hooks): stamp gsd-hook-version into shell hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+- **Shell hooks falsely flagged as stale** — `gsd-phase-boundary.sh`, `gsd-session-state.sh`, and `gsd-validate-commit.sh` now ship with a `gsd-hook-version` header, and the installer substitutes `{{GSD_VERSION}}` in `.sh` hooks the same way it does for `.js` hooks. Resolves the "⚠ stale hooks — run /gsd-update" warning on fresh installs (#2136, #2206, #2209, #2210, #2212)
+
 ## [1.36.0] - 2026-04-14
 
 ### Added

--- a/bin/install.js
+++ b/bin/install.js
@@ -5761,10 +5761,16 @@ function install(isGlobal, runtime = 'claude') {
             // Ensure hook files are executable (fixes #1162 — missing +x permission)
             try { fs.chmodSync(destFile, 0o755); } catch (e) { /* Windows doesn't support chmod */ }
           } else {
-            fs.copyFileSync(srcFile, destFile);
-            // Ensure .sh hook files are executable (mirrors chmod in build-hooks.js)
+            // Non-.js hooks: .sh hooks also carry a gsd-hook-version header so
+            // gsd-check-update.js can detect staleness after updates — stamp the
+            // version in the same way we do for .js hooks.
             if (entry.endsWith('.sh')) {
+              let content = fs.readFileSync(srcFile, 'utf8');
+              content = content.replace(/\{\{GSD_VERSION\}\}/g, pkg.version);
+              fs.writeFileSync(destFile, content);
               try { fs.chmodSync(destFile, 0o755); } catch (e) { /* Windows doesn't support chmod */ }
+            } else {
+              fs.copyFileSync(srcFile, destFile);
             }
           }
         }
@@ -5876,9 +5882,13 @@ function install(isGlobal, runtime = 'claude') {
           fs.writeFileSync(destFile, content);
           try { fs.chmodSync(destFile, 0o755); } catch (e) { /* Windows */ }
         } else {
-          fs.copyFileSync(srcFile, destFile);
           if (entry.endsWith('.sh')) {
+            let content = fs.readFileSync(srcFile, 'utf8');
+            content = content.replace(/\{\{GSD_VERSION\}\}/g, pkg.version);
+            fs.writeFileSync(destFile, content);
             try { fs.chmodSync(destFile, 0o755); } catch (e) { /* Windows */ }
+          } else {
+            fs.copyFileSync(srcFile, destFile);
           }
         }
       }

--- a/hooks/gsd-phase-boundary.sh
+++ b/hooks/gsd-phase-boundary.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# gsd-hook-version: {{GSD_VERSION}}
 # gsd-phase-boundary.sh — PostToolUse hook: detect .planning/ file writes
 # Outputs a reminder when planning files are modified outside normal workflow.
 # Uses Node.js for JSON parsing (always available in GSD projects, no jq dependency).

--- a/hooks/gsd-session-state.sh
+++ b/hooks/gsd-session-state.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# gsd-hook-version: {{GSD_VERSION}}
 # gsd-session-state.sh — SessionStart hook: inject project state reminder
 # Outputs STATE.md head on every session start for orientation.
 #

--- a/hooks/gsd-validate-commit.sh
+++ b/hooks/gsd-validate-commit.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# gsd-hook-version: {{GSD_VERSION}}
 # gsd-validate-commit.sh — PreToolUse hook: enforce Conventional Commits format
 # Blocks git commit commands with non-conforming messages (exit 2).
 # Allows conforming messages and all non-commit commands (exit 0).

--- a/tests/install-hooks-copy.test.cjs
+++ b/tests/install-hooks-copy.test.cjs
@@ -254,6 +254,30 @@ describe('install.js source correctness', () => {
       'install should warn about missing .sh hooks after verification'
     );
   });
+
+  test('.sh hook sources carry gsd-hook-version template placeholder', () => {
+    // Shell hooks must ship a version header so gsd-check-update.js can
+    // detect staleness after updates (mirrors the .js convention).
+    const hooksSrcDir = path.join(__dirname, '..', 'hooks');
+    for (const sh of EXPECTED_SH_HOOKS) {
+      const content = fs.readFileSync(path.join(hooksSrcDir, sh), 'utf8');
+      assert.ok(
+        content.includes('# gsd-hook-version: {{GSD_VERSION}}'),
+        `${sh} should include the gsd-hook-version template placeholder`
+      );
+    }
+  });
+
+  test('install.js substitutes {{GSD_VERSION}} in .sh hooks', () => {
+    // The .sh install branch must perform template substitution so the
+    // shipped hook files carry a concrete version string, not the literal
+    // placeholder.
+    const shBranchRegex = /entry\.endsWith\(['"]\.sh['"]\)[\s\S]{0,400}?GSD_VERSION/;
+    assert.ok(
+      shBranchRegex.test(src),
+      'install.js .sh branch should substitute {{GSD_VERSION}}'
+    );
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Linked Issue

Fixes #2136

Closes #2206, #2209, #2210, #2212 (duplicates reported independently).

> #2136 carries `bug`, `confirmed`, `fix-pending`, `area: hooks` labels. Its suggested remediation — _"add the bash hooks to MANAGED_HOOKS (they'd need `# gsd-hook-version:` headers)"_ — is exactly what this PR implements.

---

## What was broken

After a fresh install of GSD 1.36.0 (and earlier), every session immediately showed the warning:

```
⚠ stale hooks — run /gsd-update
```

even though the installed version already matched the latest release on npm. Running `/gsd-update` would bail with _"already on the latest version"_ and the warning never cleared.

## What this fix does

1. Adds a `# gsd-hook-version: {{GSD_VERSION}}` header line to the three shipped shell hooks (`gsd-phase-boundary.sh`, `gsd-session-state.sh`, `gsd-validate-commit.sh`), mirroring the convention already used by the six `.js` hooks.
2. Extends `bin/install.js` — both the bundled-hooks branch and the Codex branch — to substitute `{{GSD_VERSION}}` in `.sh` hooks at install time, the same way it already did for `.js` hooks.

## Root cause

`gsd-check-update.js` scans all managed hooks for a `gsd-hook-version` marker and compares against the installed VERSION. The `.js` hooks carried the marker and were substituted by the installer at `bin/install.js:5759`. The `.sh` hooks were simply `copyFileSync`'d — no header, no substitution — so the checker recorded them with `hookVersion: "unknown"` and persistently marked them stale.

## Testing

### How I verified the fix

1. Ran `npm test` — all 3,868 tests pass (including the existing `#1834`/`#1755` regression suite which pins the outer `} else {` structure in the hook copy loop).
2. Built hooks and ran the installer into a temp directory; verified all three `.sh` hooks now contain `# gsd-hook-version: 1.36.0` (concrete version, not the template placeholder).
3. Cleared `~/.cache/gsd/gsd-update-check.json`; on next session the stale warning no longer appears.

### Regression test added

Yes — `tests/install-hooks-copy.test.cjs` now has two new cases:
- Asserts all three `.sh` hook sources carry `# gsd-hook-version: {{GSD_VERSION}}`.
- Asserts `install.js` performs `{{GSD_VERSION}}` substitution in the `.sh` path.

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS
- [ ] Windows — logic is platform-agnostic; `chmod` already guarded with try/catch for Windows as before
- [ ] Linux — logic identical to macOS
- [x] N/A (file copy + string substitution — no platform-specific behavior)

### Runtimes tested

- [x] Claude Code — end-to-end install + verified stamped versions
- [ ] Gemini CLI, OpenCode, Kilo, Codex — same code path (the Codex-specific hook block was updated symmetrically); not manually verified
- [x] N/A for the bug itself — the warning fires on any runtime that installs the shell hooks

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed` + `fix-pending` labels (#2136)
- [x] Fix is scoped to the reported bug — no unrelated changes
- [x] Regression test added
- [x] All existing tests pass (`npm test`) — 3,868/3,868
- [x] CHANGELOG.md updated under `[Unreleased] → Fixed`
- [x] No unnecessary dependencies added

## Breaking changes

None. The substitution is additive: shell hooks previously had no version header, now they have one. Downstream code (`gsd-check-update.js`) already expects and handles this header.