### PR TITLE
fix: normalize phase numbers in stats to prevent duplicate rows

### DIFF
--- a/get-shit-done/bin/lib/commands.cjs
+++ b/get-shit-done/bin/lib/commands.cjs
@@ -831,8 +831,9 @@ function cmdStats(cwd, format, raw) {
     const headingPattern = /#{2,4}\s*Phase\s+(\d+[A-Z]?(?:\.\d+)*)\s*:\s*([^\n]+)/gi;
     let match;
     while ((match = headingPattern.exec(roadmapContent)) !== null) {
-      phasesByNumber.set(match[1], {
-        number: match[1],
+      const key = normalizePhaseName(match[1]);
+      phasesByNumber.set(key, {
+        number: key,
         name: match[2].replace(/\(INSERTED\)/i, '').trim(),
         plans: 0,
         summaries: 0,
@@ -862,9 +863,10 @@ function cmdStats(cwd, format, raw) {
 
       const status = determinePhaseStatus(plans, summaries, path.join(phasesDir, dir), 'Not Started');
 
-      const existing = phasesByNumber.get(phaseNum);
-      phasesByNumber.set(phaseNum, {
-        number: phaseNum,
+      const normalizedNum = normalizePhaseName(phaseNum);
+      const existing = phasesByNumber.get(normalizedNum);
+      phasesByNumber.set(normalizedNum, {
+        number: normalizedNum,
         name: existing?.name || phaseName,
         plans: (existing?.plans || 0) + plans,
         summaries: (existing?.summaries || 0) + summaries,

--- a/tests/commands.test.cjs
+++ b/tests/commands.test.cjs
@@ -1693,6 +1693,36 @@ describe('stats command', () => {
     const output = JSON.parse(result.output);
     assert.strictEqual(output.phases[0].status, 'Executed', 'progress should show Executed without verification');
   });
+
+  test('does not duplicate phases when ROADMAP uses unpadded numbers and dirs use padded numbers', () => {
+    // ROADMAP.md uses "Phase 1:" (unpadded) but directory is "01-auth" (padded).
+    // Without normalization, the Map holds two entries: "1" and "01", doubling phases_total.
+    const p1 = path.join(tmpDir, '.planning', 'phases', '01-auth');
+    fs.mkdirSync(p1, { recursive: true });
+    fs.writeFileSync(path.join(p1, '01-01-PLAN.md'), '# Plan');
+    fs.writeFileSync(path.join(p1, '01-01-SUMMARY.md'), '# Summary');
+    fs.writeFileSync(path.join(p1, 'VERIFICATION.md'), '---\nstatus: passed\n---\n# Verified');
+
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      [
+        '# Roadmap',
+        '',
+        '## Milestone v1',
+        '',
+        '### Phase 1: Auth',
+        '**Goal:** Authentication',
+      ].join('\n')
+    );
+
+    const result = runGsdTools('stats', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const stats = JSON.parse(result.output);
+    assert.strictEqual(stats.phases_total, 1, 'unpadded ROADMAP heading and padded dir should merge into one phase');
+    assert.strictEqual(stats.phases_completed, 1);
+    assert.strictEqual(stats.phases.length, 1);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What

`/gsd-stats` reported doubled `phases_total` when ROADMAP.md used unpadded phase numbers (e.g. `### Phase 1: Auth`) while the `phases/` directory used zero-padded names (e.g. `01-auth`).

## Why

The `phasesByNumber` Map was keyed with the raw string captured from each source — `"1"` from the ROADMAP heading regex and `"01"` from the directory name regex. Because these never compared equal, every phase appeared twice: once with name-from-ROADMAP and zero plan/summary counts, and once with counts-from-disk but no name.

## How

Apply `normalizePhaseName()` to all Map key writes and reads in the stats phase-collection logic:

- ROADMAP heading scan: `phasesByNumber.set(normalizePhaseName(match[1]), ...)`
- Directory scan: normalize `phaseNum` before the `get()` and `set()` calls

The `normalizePhaseName` helper was already imported at the top of `commands.cjs`; this fix simply applies it consistently to Map keys.

A regression test is included that creates a project with an unpadded ROADMAP heading and a padded directory, then asserts `phases_total === 1`.

Closes #2195