### PR TITLE
fix: pipe review prompts via stdin to prevent shell expansion

### DIFF
--- a/get-shit-done/workflows/review.md
+++ b/get-shit-done/workflows/review.md
@@ -162,27 +162,27 @@ For each selected CLI, invoke in sequence (not parallel — avoid rate limits):
 **Gemini:**
 ```bash
 if [ -n "$GEMINI_MODEL" ] && [ "$GEMINI_MODEL" != "null" ]; then
-  gemini -m "$GEMINI_MODEL" -p "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-review-gemini-{phase}.md
+  cat /tmp/gsd-review-prompt-{phase}.md | gemini -m "$GEMINI_MODEL" -p - 2>/dev/null > /tmp/gsd-review-gemini-{phase}.md
 else
-  gemini -p "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-review-gemini-{phase}.md
+  cat /tmp/gsd-review-prompt-{phase}.md | gemini -p - 2>/dev/null > /tmp/gsd-review-gemini-{phase}.md
 fi
 ```
 
 **Claude (separate session):**
 ```bash
 if [ -n "$CLAUDE_MODEL" ] && [ "$CLAUDE_MODEL" != "null" ]; then
-  claude --model "$CLAUDE_MODEL" -p "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-review-claude-{phase}.md
+  cat /tmp/gsd-review-prompt-{phase}.md | claude --model "$CLAUDE_MODEL" -p - 2>/dev/null > /tmp/gsd-review-claude-{phase}.md
 else
-  claude -p "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-review-claude-{phase}.md
+  cat /tmp/gsd-review-prompt-{phase}.md | claude -p - 2>/dev/null > /tmp/gsd-review-claude-{phase}.md
 fi
 ```
 
 **Codex:**
 ```bash
 if [ -n "$CODEX_MODEL" ] && [ "$CODEX_MODEL" != "null" ]; then
-  codex exec --model "$CODEX_MODEL" --skip-git-repo-check "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-review-codex-{phase}.md
+  cat /tmp/gsd-review-prompt-{phase}.md | codex exec --model "$CODEX_MODEL" --skip-git-repo-check - 2>/dev/null > /tmp/gsd-review-codex-{phase}.md
 else
-  codex exec --skip-git-repo-check "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-review-codex-{phase}.md
+  cat /tmp/gsd-review-prompt-{phase}.md | codex exec --skip-git-repo-check - 2>/dev/null > /tmp/gsd-review-codex-{phase}.md
 fi
 ```
 
@@ -208,7 +208,7 @@ fi
 
 **Qwen Code:**
 ```bash
-qwen "$(cat /tmp/gsd-review-prompt-{phase}.md)" 2>/dev/null > /tmp/gsd-review-qwen-{phase}.md
+cat /tmp/gsd-review-prompt-{phase}.md | qwen - 2>/dev/null > /tmp/gsd-review-qwen-{phase}.md
 if [ ! -s /tmp/gsd-review-qwen-{phase}.md ]; then
   echo "Qwen review failed or returned empty output." > /tmp/gsd-review-qwen-{phase}.md
 fi


### PR DESCRIPTION
## What

`/gsd-review` invocations of gemini, claude, codex, and qwen passed the review prompt as a shell argument using `"$(cat file)"`. When prompt files contain shell metacharacters — `$VAR`, backticks, `$(...)` — the shell expands them before the CLI tool receives the text, silently corrupting the prompt.

## Why

Prompt files are built from user-authored PLAN.md content and can contain arbitrary text. Double-quoting `$(cat ...)` protects against word splitting and globbing, but not against variable and command substitution. The shell evaluates `$(...)` inside double quotes.

## How

Replace all `-p "$(cat /tmp/gsd-review-prompt-{phase}.md)"` patterns with `cat /tmp/gsd-review-prompt-{phase}.md | cli -p -` so the prompt bytes are delivered verbatim via stdin, bypassing the shell entirely.

Affected CLIs: `gemini`, `claude`, `codex`, `qwen`. `opencode` and `cursor` already used the pipe-to-stdin pattern and are unchanged.

Closes #2200