### PR TITLE
feat(discuss-phase): add --all flag to auto-select all gray areas

### DIFF
--- a/commands/gsd/discuss-phase.md
+++ b/commands/gsd/discuss-phase.md
@@ -1,7 +1,7 @@
 ---
 name: gsd:discuss-phase
-description: Gather phase context through adaptive questioning before planning. Use --auto to skip interactive questions (Claude picks recommended defaults). Use --chain for interactive discuss followed by automatic plan+execute. Use --power for bulk question generation into a file-based UI (answer at your own pace).
-argument-hint: "<phase> [--auto] [--chain] [--batch] [--analyze] [--text] [--power]"
+description: Gather phase context through adaptive questioning before planning. Use --all to skip area selection and discuss all gray areas interactively. Use --auto to skip interactive questions (Claude picks recommended defaults). Use --chain for interactive discuss followed by automatic plan+execute. Use --power for bulk question generation into a file-based UI (answer at your own pace).
+argument-hint: "<phase> [--all] [--auto] [--chain] [--batch] [--analyze] [--text] [--power]"
 allowed-tools:
   - Read
   - Write

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -98,6 +98,7 @@ Capture implementation decisions before planning.
 
 | Flag | Description |
 |------|-------------|
+| `--all` | Skip area selection — discuss all gray areas interactively (no auto-advance) |
 | `--auto` | Auto-select recommended defaults for all questions |
 | `--batch` | Group questions for batch intake instead of one-by-one |
 | `--analyze` | Add trade-off analysis during discussion |
@@ -108,6 +109,7 @@ Capture implementation decisions before planning.
 
 ```bash
 /gsd-discuss-phase 1                # Interactive discussion for phase 1
+/gsd-discuss-phase 1 --all          # Discuss all gray areas without selection step
 /gsd-discuss-phase 3 --auto         # Auto-select defaults for phase 3
 /gsd-discuss-phase --batch          # Batch mode for current phase
 /gsd-discuss-phase 2 --analyze      # Discussion with trade-off analysis

--- a/get-shit-done/workflows/discuss-phase.md
+++ b/get-shit-done/workflows/discuss-phase.md
@@ -171,6 +171,13 @@ Exit workflow.
 - Read and execute @~/.claude/get-shit-done/workflows/discuss-phase-power.md end-to-end
 - Do not continue with the steps below
 
+**All mode** — If `--all` is present in ARGUMENTS:
+- In `present_gray_areas`: auto-select ALL gray areas without asking the user (skips the AskUserQuestion selection step)
+- Discussion for each area proceeds fully interactively (user drives the conversation for every area)
+- Does NOT auto-advance to plan-phase afterward — use `--chain` or `--auto` if you want auto-advance
+- Log: `[--all] Auto-selected all gray areas: [list area names].`
+- This is the "discuss everything" shortcut: skip the selection friction, keep full interactive control
+
 **Auto mode** — If `--auto` is present in ARGUMENTS:
 - In `check_existing`: auto-select "Skip" (if context exists) or continue without prompting (if no context/plans)
 - In `present_gray_areas`: auto-select ALL gray areas without asking the user
@@ -522,7 +529,7 @@ We'll clarify HOW to implement this.
 - [Decision from Phase M that applies here]
 ```
 
-**If `--auto`:** Auto-select ALL gray areas. Log: `[auto] Selected all gray areas: [list area names].` Skip the AskUserQuestion below and continue directly to discuss_areas with all areas selected.
+**If `--auto` or `--all`:** Auto-select ALL gray areas. Log: `[--auto/--all] Selected all gray areas: [list area names].` Skip the AskUserQuestion below and continue directly to discuss_areas with all areas selected.
 
 **Otherwise, use AskUserQuestion (multiSelect: true):**
 - header: "Discuss"
@@ -1130,7 +1137,7 @@ node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" commit "docs(state): record
 <step name="auto_advance">
 Check for auto-advance trigger:
 
-1. Parse `--auto` and `--chain` flags from $ARGUMENTS
+1. Parse `--auto` and `--chain` flags from $ARGUMENTS. Note: --all is NOT an auto-advance trigger — it only affects area selection. A session with `--all` but without `--auto` or `--chain` returns to manual next-steps after discussion completes.
 2. **Sync chain flag with intent** — if user invoked manually (no `--auto` and no `--chain`), clear the ephemeral chain flag from any previous interrupted `--auto` chain. This does NOT touch `workflow.auto_advance` (the user's persistent settings preference):
    ```bash
    if [[ ! "$ARGUMENTS" =~ --auto ]] && [[ ! "$ARGUMENTS" =~ --chain ]]; then

--- a/tests/discuss-all-flag.test.cjs
+++ b/tests/discuss-all-flag.test.cjs
@@ -1,0 +1,94 @@
+/**
+ * Tests for --all flag on /gsd-discuss-phase (#2188)
+ *
+ * The --all flag auto-selects all gray areas, skipping the interactive
+ * AskUserQuestion, but does NOT auto-advance to plan-phase afterward
+ * (unlike --auto which both auto-selects and auto-advances).
+ */
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+describe('#2188: discuss-phase --all flag', () => {
+  test('discuss-phase command argument-hint includes --all', () => {
+    const command = fs.readFileSync(
+      path.join(__dirname, '..', 'commands', 'gsd', 'discuss-phase.md'), 'utf8'
+    );
+    assert.ok(command.includes('--all'), 'argument-hint should include --all');
+  });
+
+  test('discuss-phase command description mentions --all', () => {
+    const command = fs.readFileSync(
+      path.join(__dirname, '..', 'commands', 'gsd', 'discuss-phase.md'), 'utf8'
+    );
+    // The description frontmatter or objective should reference --all
+    assert.ok(command.includes('--all'), 'command description should mention --all flag');
+  });
+
+  test('discuss-phase workflow handles --all flag in present_gray_areas', () => {
+    const workflow = fs.readFileSync(
+      path.join(__dirname, '..', 'get-shit-done', 'workflows', 'discuss-phase.md'), 'utf8'
+    );
+    assert.ok(workflow.includes('--all'), 'workflow should handle --all flag');
+  });
+
+  test('discuss-phase workflow auto-selects all areas when --all is present', () => {
+    const workflow = fs.readFileSync(
+      path.join(__dirname, '..', 'get-shit-done', 'workflows', 'discuss-phase.md'), 'utf8'
+    );
+    // The present_gray_areas step must trigger auto-select when --all is set
+    const grayAreasStep = workflow.slice(
+      workflow.indexOf('<step name="present_gray_areas">'),
+      workflow.indexOf('</step>', workflow.indexOf('<step name="present_gray_areas">'))
+    );
+    assert.ok(grayAreasStep.includes('--all'), 'present_gray_areas step should handle --all');
+    assert.ok(
+      grayAreasStep.includes('Auto-select') || grayAreasStep.includes('auto-select'),
+      'present_gray_areas step should auto-select areas when --all is set'
+    );
+  });
+
+  test('discuss-phase workflow does NOT auto-advance when --all is used without --auto or --chain', () => {
+    const workflow = fs.readFileSync(
+      path.join(__dirname, '..', 'get-shit-done', 'workflows', 'discuss-phase.md'), 'utf8'
+    );
+    // The auto_advance step should NOT treat --all as a trigger for plan-phase auto-launch
+    const autoAdvanceStep = workflow.slice(
+      workflow.indexOf('<step name="auto_advance">'),
+      workflow.indexOf('</step>', workflow.indexOf('<step name="auto_advance">'))
+    );
+    // --all should NOT appear in the auto-advance trigger conditions
+    // (it is not a chain/auto flag — it only affects area selection)
+    assert.ok(
+      !autoAdvanceStep.includes('--all') ||
+      autoAdvanceStep.includes('--all does not trigger auto-advance') ||
+      autoAdvanceStep.includes('--all is NOT an auto-advance trigger'),
+      '--all should not trigger auto-advance in auto_advance step'
+    );
+  });
+
+  test('discuss-phase workflow initialize step documents --all flag behavior', () => {
+    const workflow = fs.readFileSync(
+      path.join(__dirname, '..', 'get-shit-done', 'workflows', 'discuss-phase.md'), 'utf8'
+    );
+    // The initialize step should document --all mode like it documents --auto and --chain
+    const initStep = workflow.slice(
+      workflow.indexOf('<step name="initialize"'),
+      workflow.indexOf('</step>', workflow.indexOf('<step name="initialize"'))
+    );
+    assert.ok(initStep.includes('--all'), 'initialize step should document --all flag');
+  });
+
+  test('COMMANDS.md documents --all flag for discuss-phase', () => {
+    const commands = fs.readFileSync(
+      path.join(__dirname, '..', 'docs', 'COMMANDS.md'), 'utf8'
+    );
+    // Find the discuss-phase section and verify --all is documented
+    const discussSection = commands.slice(
+      commands.indexOf('gsd-discuss-phase') > -1 ? commands.indexOf('gsd-discuss-phase') : commands.indexOf('discuss-phase')
+    );
+    assert.ok(discussSection.includes('--all'), 'COMMANDS.md should document --all for discuss-phase');
+  });
+});


### PR DESCRIPTION
## TL;DR
Adds `--all` to `/gsd-discuss-phase` so users can skip the area-selection AskUserQuestion and jump straight into discussing every gray area interactively — without triggering auto-advance to plan-phase.

## What
- `commands/gsd/discuss-phase.md` — `argument-hint` updated to include `[--all]`; description documents the flag
- `get-shit-done/workflows/discuss-phase.md` — three changes:
  1. `initialize` step: documents `--all` mode (parallel to `--auto` and `--chain` documentation)
  2. `present_gray_areas` step: `--auto or --all` both trigger auto-selection of all areas
  3. `auto_advance` step: explicit note that `--all` is NOT an auto-advance trigger
- `docs/COMMANDS.md` — `--all` entry added to the flag table with example invocation
- `tests/discuss-all-flag.test.cjs` — 7 regression tests covering flag presence in command/workflow files, auto-select behavior, and the non-auto-advance contract

## Why
Manually ticking each area before discussing is friction — especially for users who always want to discuss everything. The `--all` flag eliminates that selection step while keeping full interactive control (unlike `--auto` which both selects and auto-answers). This is the "discuss everything without ceremony" path.

## How
The `present_gray_areas` step already had `**If --auto:** Auto-select ALL gray areas` logic. The change extends that condition to include `--all`, and adds clear documentation in `initialize` that `--all` is an area-selection shortcut only — it does not chain to plan-phase.

Closes #2188