### PR TITLE
fix(cli): audit-open crashes with ReferenceError: output is not defined

### DIFF
--- a/get-shit-done/bin/gsd-tools.cjs
+++ b/get-shit-done/bin/gsd-tools.cjs
@@ -781,9 +781,9 @@ async function runCommand(command, args, cwd, raw, defaultValue) {
       const includeRaw = args.includes('--json');
       const result = auditOpenArtifacts(cwd);
       if (includeRaw) {
-        output(JSON.stringify(result, null, 2), raw);
+        core.output(JSON.stringify(result, null, 2), raw);
       } else {
-        output(formatAuditReport(result), raw);
+        core.output(formatAuditReport(result), raw);
       }
       break;
     }

--- a/tests/milestone-audit.test.cjs
+++ b/tests/milestone-audit.test.cjs
@@ -84,6 +84,32 @@ describe('audit.cjs module (#2158)', () => {
   });
 });
 
+describe('audit-open CLI command (#2236)', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject('audit-cli-');
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('audit-open runs without ReferenceError', () => {
+    const { runGsdTools } = require('./helpers.cjs');
+    const result = runGsdTools(['audit-open'], tmpDir);
+    assert.strictEqual(result.success, true, `audit-open crashed: ${result.error}`);
+    assert.ok(result.output.length > 0, 'audit-open should produce output');
+  });
+
+  test('audit-open --json succeeds without ReferenceError', () => {
+    const { runGsdTools } = require('./helpers.cjs');
+    const result = runGsdTools(['audit-open', '--json'], tmpDir);
+    assert.strictEqual(result.success, true, `audit-open --json crashed: ${result.error}`);
+    assert.ok(result.output.length > 0, 'audit-open --json should produce output');
+  });
+});
+
 describe('complete-milestone workflow has pre-close audit gate (#2158)', () => {
   const completeMilestoneContent = fs.readFileSync(
     path.join(__dirname, '..', 'get-shit-done', 'workflows', 'complete-milestone.md'),


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #2236

---

## What was broken

The `audit-open` CLI command crashes with `ReferenceError: output is not defined` on every invocation — both the formatted report path and the `--json` path.

## What this fix does

Adds the `core.` prefix to both `output()` calls on lines 784 and 786 of `gsd-tools.cjs`, matching every other command handler in the file.

## Root cause

The `audit-open` case (added in the #2158 milestone audit feature) called bare `output()` instead of `core.output()`. The function is a method on the `core` module, not a standalone function in scope.

## Testing

### How I verified the fix

- Ran `gsd-tools.cjs audit-open` before fix → crashes with ReferenceError
- Ran `gsd-tools.cjs audit-open` after fix → produces report successfully
- Ran `gsd-tools.cjs audit-open --json` after fix → produces JSON output successfully
- Full test suite passes (`npm test`)

### Regression test added?

- [x] Yes — added a test that would have caught this bug

Two regression tests added to `tests/milestone-audit.test.cjs`:
1. `audit-open runs without ReferenceError` — exercises the formatted report path
2. `audit-open --json succeeds without ReferenceError` — exercises the JSON path

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [ ] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [ ] CHANGELOG.md updated if this is a user-facing fix
- [x] No unnecessary dependencies added

## Breaking changes

None

🤖 Generated with [Claude Code](https://claude.com/claude-code)