### PR TITLE
fix(cli): audit-open crashes with ReferenceError: output is not defined

### DIFF
--- a/get-shit-done/bin/gsd-tools.cjs
+++ b/get-shit-done/bin/gsd-tools.cjs
@@ -781,9 +781,9 @@ async function runCommand(command, args, cwd, raw, defaultValue) {
       const includeRaw = args.includes('--json');
       const result = auditOpenArtifacts(cwd);
       if (includeRaw) {
-        output(JSON.stringify(result, null, 2), raw);
+        core.output(result, raw);
       } else {
-        output(formatAuditReport(result), raw);
+        core.output(formatAuditReport(result), raw);
       }
       break;
     }

--- a/tests/milestone-audit.test.cjs
+++ b/tests/milestone-audit.test.cjs
@@ -3,7 +3,7 @@ const { describe, test, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
-const { createTempProject, cleanup } = require('./helpers.cjs');
+const { createTempProject, cleanup, runGsdTools } = require('./helpers.cjs');
 
 describe('audit.cjs module (#2158)', () => {
   let tmpDir;
@@ -141,5 +141,45 @@ describe('state.md template has Deferred Items section (#2158)', () => {
   test('state.md template includes Deferred Items section', () => {
     assert.ok(stateTemplate.includes('Deferred Items'),
       'state.md template missing Deferred Items section');
+  });
+});
+
+describe('audit-open CLI command — ReferenceError regression (#2236)', () => {
+  // The audit-open case in gsd-tools.cjs called bare output() instead of
+  // core.output(), crashing with ReferenceError: output is not defined
+  // on every invocation. These tests exercise the CLI dispatch directly so
+  // a regression at the call site is caught even if the lib tests all pass.
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject('audit-open-cli-test');
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('audit-open exits without error on an empty project', () => {
+    const result = runGsdTools(['audit-open'], tmpDir);
+    assert.ok(result.success, `audit-open crashed: ${result.error}`);
+  });
+
+  test('audit-open --json exits without error and returns valid JSON', () => {
+    const result = runGsdTools(['audit-open', '--json'], tmpDir);
+    assert.ok(result.success, `audit-open --json crashed: ${result.error}`);
+    let parsed;
+    assert.doesNotThrow(() => { parsed = JSON.parse(result.output); }, 'output must be valid JSON');
+    assert.ok(typeof parsed === 'object', 'parsed output must be an object');
+    assert.ok(typeof parsed.counts === 'object', 'JSON output must include counts');
+  });
+
+  test('audit-open error is not ReferenceError: output is not defined', () => {
+    // Even if the command fails for some other reason, it must not throw the
+    // specific ReferenceError that was the bug in #2236.
+    const result = runGsdTools(['audit-open'], tmpDir);
+    assert.ok(
+      !String(result.error).includes('output is not defined'),
+      `ReferenceError regression: ${result.error}`
+    );
   });
 });


### PR DESCRIPTION
Closes #2236

## Root cause

\`audit-open\` in \`gsd-tools.cjs\` called bare \`output()\` on both branches. \`output\` is never in scope at that call site — the entire \`core\` module is imported as \`const core\`, so every other command in the file uses \`core.output()\`. This is the only case block that got it wrong.

There was a second bug on the \`--json\` path: it passed \`JSON.stringify(result, null, 2)\` (a pre-serialised string) to \`core.output\`. \`core.output\` always calls \`JSON.stringify\` internally, so this double-encoded the payload — agents received a JSON string value instead of an object.

## Fix

- Lines 784/786: \`output(\` → \`core.output(\`
- Line 784 (\`--json\` path): pass raw \`result\` object, not \`JSON.stringify(result)\`
- Line 786 (text path): \`formatAuditReport(result)\` is correct — \`core.output\` JSON-wraps it for agent consumption, consistent with every other text-output command

## Tests

Three CLI-level regression tests added to \`milestone-audit.test.cjs\` via \`runGsdTools\` (the same subprocess path an agent uses):

- \`audit-open\` exits without error on an empty project
- \`audit-open --json\` exits without error and returns a parseable object with \`counts\`
- Error message must not contain \`output is not defined\`

All 3 were red before the fix, all 3 green after. Full suite: 3889/3889 pass.