### PR TITLE
fix(cli): audit-open crashes with ReferenceError: output is not defined

### DIFF
--- a/get-shit-done/bin/gsd-tools.cjs
+++ b/get-shit-done/bin/gsd-tools.cjs
@@ -781,9 +781,9 @@ async function runCommand(command, args, cwd, raw, defaultValue) {
       const includeRaw = args.includes('--json');
       const result = auditOpenArtifacts(cwd);
       if (includeRaw) {
-        output(JSON.stringify(result, null, 2), raw);
+        core.output(JSON.stringify(result, null, 2), raw);
       } else {
-        output(formatAuditReport(result), raw);
+        core.output(formatAuditReport(result), raw);
       }
       break;
     }


### PR DESCRIPTION
## Problem

`gsd-tools.cjs audit-open` crashes with:

```
ReferenceError: output is not defined
    at runCommand (/home/REDACTED/.claude/get-shit-done/bin/gsd-tools.cjs:786:9)
```

Lines 784 and 786 in the `audit-open` case handler call bare `output()` instead of `core.output()`. Every other command handler in the file uses `core.output()` correctly.

## Fix

Changed both calls from `output(...)` to `core.output(...)`:
- Line 784: `output(JSON.stringify(result, null,2), raw)` → `core.output(...)`
- Line 786: `output(formatAuditReport(result), raw)` → `core.output(...)`

## Verification

After the fix, `audit-open` correctly calls `core.output()` matching the pattern used by all other command handlers in the file (lines 1045, 1056, 1059, 1062, etc.).

Fixes #2236