### PR TITLE
docs(references): use $GSD_TOOLS variable in workstream-flag.md CLI examples

### DIFF
--- a/get-shit-done/references/workstream-flag.md
+++ b/get-shit-done/references/workstream-flag.md
@@ -93,19 +93,23 @@ This ensures workstream scope chains automatically through the workflow:
 ## CLI Usage
 
 ```bash
+# GSD_TOOLS resolves to the installed bin path, e.g.:
+#   $HOME/.claude/get-shit-done/bin/gsd-tools.cjs  (global install)
+#   .claude/get-shit-done/bin/gsd-tools.cjs         (local install)
+
 # All gsd-tools commands accept --ws
-node gsd-tools.cjs state json --ws feature-a
-node gsd-tools.cjs find-phase 3 --ws feature-b
+node "$GSD_TOOLS" state json --ws feature-a
+node "$GSD_TOOLS" find-phase 3 --ws feature-b
 
 # Session-local switching without --ws on every command
-GSD_SESSION_KEY=my-terminal-a node gsd-tools.cjs workstream set feature-a
-GSD_SESSION_KEY=my-terminal-a node gsd-tools.cjs state json
-GSD_SESSION_KEY=my-terminal-b node gsd-tools.cjs workstream set feature-b
-GSD_SESSION_KEY=my-terminal-b node gsd-tools.cjs state json
+GSD_SESSION_KEY=my-terminal-a node "$GSD_TOOLS" workstream set feature-a
+GSD_SESSION_KEY=my-terminal-a node "$GSD_TOOLS" state json
+GSD_SESSION_KEY=my-terminal-b node "$GSD_TOOLS" workstream set feature-b
+GSD_SESSION_KEY=my-terminal-b node "$GSD_TOOLS" state json
 
 # Workstream CRUD
-node gsd-tools.cjs workstream create <name>
-node gsd-tools.cjs workstream list
-node gsd-tools.cjs workstream status <name>
-node gsd-tools.cjs workstream complete <name>
+node "$GSD_TOOLS" workstream create <name>
+node "$GSD_TOOLS" workstream list
+node "$GSD_TOOLS" workstream status <name>
+node "$GSD_TOOLS" workstream complete <name>
 ```


### PR DESCRIPTION
## Summary

- Replace bare `node gsd-tools.cjs` with `node "$GSD_TOOLS"` throughout the CLI Usage section of `workstream-flag.md`
- Add a comment block explaining that `$GSD_TOOLS` resolves to the full installed bin path (`$HOME/.claude/get-shit-done/bin/gsd-tools.cjs` for global installs, `.claude/get-shit-done/bin/gsd-tools.cjs` for local installs)
- Bare relative paths only work when the shell's cwd happens to be the install directory — they silently fail (module-not-found) when run from a project root, which is the typical usage context

## Test plan

- [ ] Doc-only change; all 3886 existing tests pass (`npm test`)
- [ ] Verify examples in `workstream-flag.md` now match the `$GSD_TOOLS` convention used in other references and the CLI-TOOLS.md docs

Closes #2245

🤖 Generated with [Claude Code](https://claude.com/claude-code)