### PR TITLE
test(docs): add command-count sync test; fix ARCHITECTURE.md drift

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -113,7 +113,7 @@ User-facing entry points. Each file contains YAML frontmatter (name, description
 - **Copilot:** Slash commands (`/gsd-command-name`)
 - **Antigravity:** Skills
 
-**Total commands:** 69
+**Total commands:** 73
 
 ### Workflows (`get-shit-done/workflows/*.md`)
 
@@ -409,7 +409,7 @@ UI-SPEC.md (per phase) ───────────────────
 
 ```
 ~/.claude/                          # Claude Code (global install)
-├── commands/gsd/*.md               # 69 slash commands
+├── commands/gsd/*.md               # 73 slash commands
 ├── get-shit-done/
 │   ├── bin/gsd-tools.cjs           # CLI utility
 │   ├── bin/lib/*.cjs               # 19 domain modules

--- a/tests/command-count-sync.test.cjs
+++ b/tests/command-count-sync.test.cjs
@@ -1,0 +1,93 @@
+/**
+ * Regression test: command count in docs/ARCHITECTURE.md must match
+ * the actual number of .md files in commands/gsd/.
+ *
+ * Counts are extracted from the doc programmatically — never hardcoded
+ * in this test — so any future drift (adding a command without updating
+ * the doc, or vice-versa) is caught immediately.
+ *
+ * Related: issue #2257
+ */
+'use strict';
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..');
+const COMMANDS_DIR = path.join(ROOT, 'commands', 'gsd');
+const ARCH_MD = path.join(ROOT, 'docs', 'ARCHITECTURE.md');
+
+/**
+ * Count .md files that actually live in commands/gsd/.
+ * Does not recurse into subdirectories.
+ */
+function actualCommandCount() {
+  return fs
+    .readdirSync(COMMANDS_DIR)
+    .filter((f) => f.endsWith('.md'))
+    .length;
+}
+
+/**
+ * Extract the integer from the "**Total commands:** N" prose line in
+ * ARCHITECTURE.md.  Returns null if the pattern is not found.
+ */
+function docProseCount(content) {
+  const m = content.match(/\*\*Total commands:\*\*\s+(\d+)/);
+  return m ? parseInt(m[1], 10) : null;
+}
+
+/**
+ * Extract the integer from the directory-tree comment line:
+ *   ├── commands/gsd/*.md               # N slash commands
+ * Returns null if the pattern is not found.
+ */
+function docTreeCount(content) {
+  const m = content.match(/commands\/gsd\/\*\.md[^\n]*#\s*(\d+)\s+slash commands/);
+  return m ? parseInt(m[1], 10) : null;
+}
+
+describe('ARCHITECTURE.md command count sync', () => {
+  const archContent = fs.readFileSync(ARCH_MD, 'utf8');
+  const actual = actualCommandCount();
+
+  test('docs/ARCHITECTURE.md contains a "Total commands:" prose count', () => {
+    const count = docProseCount(archContent);
+    assert.notEqual(count, null, 'Expected "**Total commands:** N" line not found in ARCHITECTURE.md');
+  });
+
+  test('docs/ARCHITECTURE.md contains a directory-tree slash-command count', () => {
+    const count = docTreeCount(archContent);
+    assert.notEqual(count, null, 'Expected "# N slash commands" tree comment not found in ARCHITECTURE.md');
+  });
+
+  test('"Total commands:" prose count matches actual commands/gsd/ file count', () => {
+    const prose = docProseCount(archContent);
+    assert.equal(
+      prose,
+      actual,
+      `ARCHITECTURE.md "Total commands:" says ${prose} but commands/gsd/ has ${actual} .md files — update the doc`,
+    );
+  });
+
+  test('directory-tree slash-command count matches actual commands/gsd/ file count', () => {
+    const tree = docTreeCount(archContent);
+    assert.equal(
+      tree,
+      actual,
+      `ARCHITECTURE.md directory tree says ${tree} slash commands but commands/gsd/ has ${actual} .md files — update the doc`,
+    );
+  });
+
+  test('"Total commands:" prose count and directory-tree count agree with each other', () => {
+    const prose = docProseCount(archContent);
+    const tree = docTreeCount(archContent);
+    assert.equal(
+      prose,
+      tree,
+      `ARCHITECTURE.md has two mismatched counts: "Total commands: ${prose}" vs tree "# ${tree} slash commands"`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add `tests/command-count-sync.test.cjs` — 5 tests that programmatically count `.md` files in `commands/gsd/` and compare against the two documented counts in `docs/ARCHITECTURE.md`
- Fix the current drift: `ARCHITECTURE.md` said **69** commands; the committed filesystem has **73** — both occurrences updated
- Counts are **never hardcoded** in the test — extracted from the doc at runtime via regex, so future drift is caught in CI whether the doc or the filesystem moves

## Rubber duck

The bug here is a documentation drift that's been accumulating silently. `ARCHITECTURE.md` has two count occurrences: a prose line (`**Total commands:** N`) and a directory-tree comment (`# N slash commands`). With no automated check, both fell 4 commands behind as new commands were added. Because there's no canonical source of truth outside the filesystem itself, the correct fix is to make the test parse the doc and compare to `readdirSync` — not to hardcode the number anywhere.

The test also validates that the two in-doc counts agree with each other, catching cases where one gets updated and the other doesn't.

## Red → Green

```
RED:  69 !== 73  (both count tests fail as expected)
GREEN: update ARCHITECTURE.md: 69 → 73 in both locations
```

## Test plan

- [ ] `node --test tests/command-count-sync.test.cjs` → 5/5 pass
- [ ] `npm test` → full suite green (3879 tests)
- [ ] Add a command file to `commands/gsd/` without updating `ARCHITECTURE.md` → tests fail
- [ ] Update only one of the two count locations in `ARCHITECTURE.md` → "counts agree" test fails

Closes #2257

🤖 Generated with [Claude Code](https://claude.com/claude-code)