### PR TITLE
fix: remove legacy .claude roots from manifest metadata

### DIFF
--- a/get-shit-done/bin/lib/init.cjs
+++ b/get-shit-done/bin/lib/init.cjs
@@ -1658,14 +1658,14 @@ function buildSkillManifest(cwd, skillsDir = null) {
       kind: 'skills',
     },
     {
-      root: '~/.claude/get-shit-done/skills',
+      root: '.claude/get-shit-done/skills',
       path: path.join(os.homedir(), '.claude', 'get-shit-done', 'skills'),
       scope: 'import-only',
       kind: 'skills',
       deprecated: true,
     },
     {
-      root: '~/.claude/commands/gsd',
+      root: '.claude/commands/gsd',
       path: path.join(os.homedir(), '.claude', 'commands', 'gsd'),
       scope: 'legacy-commands',
       kind: 'commands',

--- a/tests/skill-manifest.test.cjs
+++ b/tests/skill-manifest.test.cjs
@@ -97,7 +97,7 @@ describe('skill-manifest', () => {
         deprecated: importedSkill.deprecated,
       },
       {
-        root: '~/.claude/get-shit-done/skills',
+        root: '.claude/get-shit-done/skills',
         scope: 'import-only',
         installed: false,
         deprecated: true,


### PR DESCRIPTION
## Summary
- remove two deprecated `~/.claude/...` root labels from manifest metadata on the `release/1.37.0` branch
- align the branch with the already-correct behavior on `main`
- update the manifest expectation so the release branch test matches the shipped metadata

## Why
The `release.yml` run for `1.37.0` failed in the install-and-test step because the release branch still leaked deprecated Claude install roots in `init.cjs`. That triggered the Cline install path-leak regression test and blocked the release.

## Verification
- `node --test tests/cline-install.test.cjs --test-name-pattern="installed engine files have no leaked .claude paths"`
- `node --test tests/skill-manifest.test.cjs`
- `TMP_EMPTY_ROOT=$(mktemp -d)/missing-plugin && GSD_PLUGIN_ROOT="$TMP_EMPTY_ROOT" npm run test:coverage`