### PR TITLE
fix(quick): normalize --discuss --research --validate combo to FULL_MODE

### DIFF
--- a/get-shit-done/workflows/quick.md
+++ b/get-shit-done/workflows/quick.md
@@ -36,6 +36,8 @@ Parse `$ARGUMENTS` for:
 - `--research` flag → store `$RESEARCH_MODE=true`
 - Remaining text → use as `$DESCRIPTION` if non-empty
 
+After parsing, normalize: if `$DISCUSS_MODE` and `$RESEARCH_MODE` and `$VALIDATE_MODE` are all true, set `$FULL_MODE=true`. This ensures `--discuss --research --validate` is treated identically to `--full`.
+
 If `$DESCRIPTION` is empty after parsing, prompt user interactively:
 
 
@@ -59,15 +61,6 @@ If `$FULL_MODE` (all phases enabled — `--full` or all granular flags):
 ```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  GSD ► QUICK TASK (FULL)
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-◆ Discussion + research + plan checking + verification enabled
-```
-
-If `$DISCUSS_MODE` and `$RESEARCH_MODE` and `$VALIDATE_MODE` (no `$FULL_MODE` — composed granularly):
-```
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
- GSD ► QUICK TASK (DISCUSS + RESEARCH + VALIDATE)
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
 ◆ Discussion + research + plan checking + verification enabled


### PR DESCRIPTION
## Summary

After #1518 redefined `--full` as the equivalent of all three granular flags combined, passing `--discuss --research --validate` together bypassed `$FULL_MODE` and displayed a "DISCUSS + RESEARCH + VALIDATE" banner — inconsistent with what `--full` shows ("FULL") despite being semantically identical.

**Fix:**
- Add a normalization step in Step 1 flag parsing: if `$DISCUSS_MODE && $RESEARCH_MODE && $VALIDATE_MODE` are all true after parsing, promote to `$FULL_MODE=true`
- Remove the now-unreachable "DISCUSS + RESEARCH + VALIDATE" banner case (it can never fire after normalization)

The `purpose` header already documented this equivalence ("Granular flags are composable: `--discuss --research --validate` gives the same result as `--full`") — the runtime logic now matches the documented contract.

## Test plan

- [x] `--full` → shows FULL banner ✅
- [x] `--discuss --research --validate` → shows FULL banner (previously showed DISCUSS + RESEARCH + VALIDATE) ✅
- [x] All partial combos (`--discuss --validate`, `--research --validate`, etc.) unchanged ✅
- [x] Full test suite passes: `npm run test:coverage`

Closes #2181

🤖 Generated with [Claude Code](https://claude.com/claude-code)