### PR TITLE
fix(worktree): add pre-merge deletion guard to quick.md; fix backup handling on conflict

### DIFF
--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -614,11 +614,13 @@ Execute each selected wave in sequence. Within a wave: parallel if `PARALLELIZAT
          continue
        fi
 
-       # Merge the worktree branch into the current branch
-       git merge "$WT_BRANCH" --no-edit -m "chore: merge executor worktree ($WT_BRANCH)" 2>&1 || {
+       # Merge the worktree branch into the current branch (--no-ff ensures a merge commit so HEAD~1 is reliable)
+       git merge "$WT_BRANCH" --no-ff --no-edit -m "chore: merge executor worktree ($WT_BRANCH)" 2>&1 || {
          echo "⚠ Merge conflict from worktree $WT_BRANCH — resolve manually"
-         rm -f "$STATE_BACKUP" "$ROADMAP_BACKUP"
-         continue
+         echo "  STATE.md backup:   $STATE_BACKUP"
+         echo "  ROADMAP.md backup: $ROADMAP_BACKUP"
+         echo "  Restore with: cp \$STATE_BACKUP .planning/STATE.md && cp \$ROADMAP_BACKUP .planning/ROADMAP.md"
+         break
        }
 
        # Restore orchestrator-owned files (main always wins)

--- a/get-shit-done/workflows/quick.md
+++ b/get-shit-done/workflows/quick.md
@@ -628,10 +628,21 @@ After executor returns:
        # Snapshot files on main to detect resurrections
        PRE_MERGE_FILES=$(git ls-files .planning/)
 
-       git merge "$WT_BRANCH" --no-edit -m "chore: merge quick task worktree ($WT_BRANCH)" 2>&1 || {
-         echo "⚠ Merge conflict — resolve manually"
+       # Pre-merge deletion guard: block merges that delete tracked .planning/ files
+       DELETIONS=$(git diff --diff-filter=D --name-only HEAD..."$WT_BRANCH" 2>/dev/null || true)
+       if [ -n "$DELETIONS" ]; then
+         echo "BLOCKED: Worktree branch $WT_BRANCH contains file deletions: $DELETIONS"
+         echo "Review these deletions before merging. If intentional, remove this guard and re-run."
          rm -f "$STATE_BACKUP" "$ROADMAP_BACKUP"
          continue
+       fi
+
+       git merge "$WT_BRANCH" --no-ff --no-edit -m "chore: merge quick task worktree ($WT_BRANCH)" 2>&1 || {
+         echo "⚠ Merge conflict from worktree $WT_BRANCH — resolve manually"
+         echo "  STATE.md backup:   $STATE_BACKUP"
+         echo "  ROADMAP.md backup: $ROADMAP_BACKUP"
+         echo "  Restore with: cp \$STATE_BACKUP .planning/STATE.md && cp \$ROADMAP_BACKUP .planning/ROADMAP.md"
+         break
        }
 
        # Restore orchestrator-owned files
@@ -639,7 +650,7 @@ After executor returns:
        if [ -s "$ROADMAP_BACKUP" ]; then cp "$ROADMAP_BACKUP" .planning/ROADMAP.md; fi
        rm -f "$STATE_BACKUP" "$ROADMAP_BACKUP"
 
-       # Remove files deleted on main but re-added by worktree
+       # Remove files deleted on main but re-added by worktree (--no-ff guarantees a merge commit so HEAD~1 is reliable)
        DELETED_FILES=$(git diff --diff-filter=A --name-only HEAD~1 -- .planning/ 2>/dev/null || true)
        for RESURRECTED in $DELETED_FILES; do
          if ! echo "$PRE_MERGE_FILES" | grep -qxF "$RESURRECTED"; then


### PR DESCRIPTION
## Summary

Three gaps in the orchestrator file-protection block introduced by #1756 and partially fixed by #2040:

### Gap 1 — `quick.md` missing pre-merge deletion guard
`execute-phase.md` received a pre-merge deletion check in #2040 that blocks merges when the worktree branch has deleted any tracked `.planning/` files. `quick.md` never got the same guard. Added the identical `DELETIONS` check before the merge.

### Gap 2 — Both workflows delete backups on merge conflict
`STATE_BACKUP` and `ROADMAP_BACKUP` were deleted with `rm -f` inside the conflict handler — destroying the recovery files at the exact moment they're needed. Additionally, `continue` silently advanced to the next worktree instead of stopping.

**Fix:** On conflict, preserve both backup temp files, print their paths with restore instructions, and `break` to halt so the operator can resolve before continuing.

### Gap 3 — Neither workflow uses `--no-ff`
Without `--no-ff`, a fast-forward merge produces no merge commit. The resurrection check (`git diff --diff-filter=A --name-only HEAD~1 -- .planning/`) relies on `HEAD~1` being main's pre-merge state — but on a fast-forward `HEAD~1` is the worktree's parent commit, making the check a no-op.

**Fix:** Added `--no-ff` to both `git merge` calls so a merge commit is always created and `HEAD~1` is always reliable.

## Test plan

- [x] Full test suite passes: `node --test tests/*.test.cjs` (3896 pass, 0 fail)

Closes #2208

🤖 Generated with [Claude Code](https://claude.com/claude-code)