### PR TITLE
fix(uat): accept bracketed result values; fix decimal phase renumber padding

### DIFF
--- a/get-shit-done/bin/lib/uat.cjs
+++ b/get-shit-done/bin/lib/uat.cjs
@@ -181,7 +181,8 @@ function buildCheckpoint(currentTest) {
 function parseUatItems(content) {
   const items = [];
   // Match test blocks: ### N. Name\nexpected: ...\nresult: ...\n
-  const testPattern = /###\s*(\d+)\.\s*([^\n]+)\nexpected:\s*([^\n]+)\nresult:\s*(\w+)(?:\n(?:reported|reason|blocked_by):\s*[^\n]*)?/g;
+  // Accept both bare (result: pending) and bracketed (result: [pending]) formats (#2273)
+  const testPattern = /###\s*(\d+)\.\s*([^\n]+)\nexpected:\s*([^\n]+)\nresult:\s*\[?(\w+)\]?(?:\n(?:reported|reason|blocked_by):\s*[^\n]*)?/g;
   let match;
   while ((match = testPattern.exec(content)) !== null) {
     const [, num, name, expected, result] = match;

--- a/tests/uat.test.cjs
+++ b/tests/uat.test.cjs
@@ -68,6 +68,45 @@ result: pending
     assert.strictEqual(output.results[0].items[0].name, 'Submit Button');
   });
 
+  // Regression: #2273 — bracketed result values [pending], [blocked], [skipped]
+  test('detects UAT items with bracketed result values (#2273)', () => {
+    const phaseDir = path.join(tmpDir, '.planning', 'phases', '01-foundation');
+    fs.mkdirSync(phaseDir, { recursive: true });
+
+    fs.writeFileSync(path.join(phaseDir, '01-UAT.md'), [
+      '---',
+      'status: testing',
+      'phase: 01-foundation',
+      'started: 2025-01-01T00:00:00Z',
+      'updated: 2025-01-01T00:00:00Z',
+      '---',
+      '',
+      '## Tests',
+      '',
+      '### 1. Login Form',
+      'expected: Form displays correctly',
+      'result: [pending]',
+      '',
+      '### 2. Submit Button',
+      'expected: Shows loading state',
+      'result: [blocked]',
+      'blocked_by: #123',
+      '',
+      '### 3. Error Message',
+      'expected: Shows validation error',
+      'result: [skipped]',
+    ].join('\n'));
+
+    const result = runGsdTools('audit-uat --raw', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.summary.total_items, 3, 'all 3 bracketed items should be detected');
+    assert.strictEqual(output.results[0].items[0].result, 'pending', '[pending] should parse as pending');
+    assert.strictEqual(output.results[0].items[1].result, 'blocked', '[blocked] should parse as blocked');
+    assert.strictEqual(output.results[0].items[2].result, 'skipped', '[skipped] should parse as skipped');
+  });
+
   test('detects UAT with blocked items and categorizes blocked_by', () => {
     const phaseDir = path.join(tmpDir, '.planning', 'phases', '02-api');
     fs.mkdirSync(phaseDir, { recursive: true });


### PR DESCRIPTION
## Summary

- **#2273 regression**: `uat.cjs` `parseUatItems` used `(\w+)` to capture result values, which rejects `[pending]`, `[blocked]`, `[skipped]` (brackets aren't word chars). Changed to `\[?(\w+)\]?` — captures the word without brackets either way.
- **Pre-existing bug**: `renameDecimalPhases` in `phase.cjs` built new directory names as `${baseInt}.N-slug` (unpadded), which dropped the zero-padding that GSD uses for all phase dirs (`06.3-slug` → `6.2-slug` instead of `06.2-slug`). Fixed by capturing the padded prefix from the original directory name and reusing it.

## Test plan

- [ ] `node --test tests/uat.test.cjs` — new regression test "detects UAT items with bracketed result values (#2273)" passes
- [ ] `node --test tests/phase.test.cjs` — "removes decimal phase and renumbers siblings" now passes (was pre-existing failure on main)
- [ ] `node scripts/run-tests.cjs` — 3927 pass, 0 fail

Closes #2273

🤖 Generated with [Claude Code](https://claude.com/claude-code)