### PR TITLE
fix(add-backlog): write ROADMAP entry before directory creation (#2280)

### DIFF
--- a/commands/gsd/add-backlog.md
+++ b/commands/gsd/add-backlog.md
@@ -27,14 +27,10 @@ the normal phase sequence and accumulate context over time.
    ```
    If no 999.x phases exist, start at 999.1.
 
-3. **Create the phase directory:**
-   ```bash
-   SLUG=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" generate-slug "$ARGUMENTS" --raw)
-   mkdir -p ".planning/phases/${NEXT}-${SLUG}"
-   touch ".planning/phases/${NEXT}-${SLUG}/.gitkeep"
-   ```
-
-4. **Add to ROADMAP.md** under a `## Backlog` section. If the section doesn't exist, create it at the end:
+3. **Add to ROADMAP.md** under a `## Backlog` section. If the section doesn't exist, create it at the end.
+   Write the ROADMAP entry BEFORE creating the directory — this ensures directory existence is always
+   a reliable indicator that the phase is already registered, which prevents false duplicate detection
+   in any hook that checks for existing 999.x directories (#2280):
 
    ```markdown
    ## Backlog
@@ -47,6 +43,13 @@ the normal phase sequence and accumulate context over time.
 
    Plans:
    - [ ] TBD (promote with /gsd-review-backlog when ready)
+   ```
+
+4. **Create the phase directory:**
+   ```bash
+   SLUG=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" generate-slug "$ARGUMENTS" --raw)
+   mkdir -p ".planning/phases/${NEXT}-${SLUG}"
+   touch ".planning/phases/${NEXT}-${SLUG}/.gitkeep"
    ```
 
 5. **Commit:**

--- a/get-shit-done/bin/lib/phase.cjs
+++ b/get-shit-done/bin/lib/phase.cjs
@@ -585,10 +585,12 @@ function cmdPhaseInsert(cwd, afterPhase, description, raw) {
  */
 function renameDecimalPhases(phasesDir, baseInt, removedDecimal) {
   const renamedDirs = [], renamedFiles = [];
-  const decPattern = new RegExp(`^${baseInt}\\.(\\d+)-(.+)$`);
+  // Capture the zero-padded prefix (e.g. "06" from "06.3-slug") so the renamed
+  // directory preserves the original padding format.
+  const decPattern = new RegExp(`^(0*${baseInt})\\.(\\d+)-(.+)$`);
   const dirs = readSubdirectories(phasesDir, true);
   const toRename = dirs
-    .map(dir => { const m = dir.match(decPattern); return m ? { dir, oldDecimal: parseInt(m[1], 10), slug: m[2] } : null; })
+    .map(dir => { const m = dir.match(decPattern); return m ? { dir, prefix: m[1], oldDecimal: parseInt(m[2], 10), slug: m[3] } : null; })
     .filter(item => item && item.oldDecimal > removedDecimal)
     .sort((a, b) => b.oldDecimal - a.oldDecimal); // descending to avoid conflicts
 
@@ -596,7 +598,7 @@ function renameDecimalPhases(phasesDir, baseInt, removedDecimal) {
     const newDecimal = item.oldDecimal - 1;
     const oldPhaseId = `${baseInt}.${item.oldDecimal}`;
     const newPhaseId = `${baseInt}.${newDecimal}`;
-    const newDirName = `${baseInt}.${newDecimal}-${item.slug}`;
+    const newDirName = `${item.prefix}.${newDecimal}-${item.slug}`;
     fs.renameSync(path.join(phasesDir, item.dir), path.join(phasesDir, newDirName));
     renamedDirs.push({ from: item.dir, to: newDirName });
     for (const f of fs.readdirSync(path.join(phasesDir, newDirName))) {


### PR DESCRIPTION
## Summary

- Swaps steps 3 and 4 in `add-backlog.md` so ROADMAP.md is written **before** the phase directory is created
- Directory existence is now a reliable indicator that a 999.x phase is already registered, preventing false duplicate detection in hooks that scan for existing directories
- Also fixes `renameDecimalPhases` to preserve zero-padded prefixes when renaming sibling decimal phases (e.g. `06.3-slug` → `06.2-slug` instead of `6.2-slug`)

Closes #2280

## Test plan

- [x] All 3926 tests pass (including phase renumber regression)
- [x] `add-backlog.md` step ordering verified: ROADMAP entry written before `mkdir`

🤖 Generated with [Claude Code](https://claude.com/claude-code)