### PR TITLE
test(hooks): cross-reference issue #2294 in stale-hooks regression test

### DIFF
--- a/tests/bug-2136-sh-hook-version.test.cjs
+++ b/tests/bug-2136-sh-hook-version.test.cjs
@@ -1,10 +1,15 @@
 /**
- * Regression tests for bug #2136 / #2206
+ * Regression tests for bug #2136 / #2206 / #2294
  *
  * Root cause: three bash hooks (gsd-phase-boundary.sh, gsd-session-state.sh,
  * gsd-validate-commit.sh) shipped without a gsd-hook-version header, and the
  * stale-hook detector in gsd-check-update.js only matched JavaScript comment
  * syntax (//) — not bash comment syntax (#).
+ *
+ * Re-reported in #2294 by @raphaelbgr with a detailed root-cause analysis and
+ * the two-part fix: stamp bash hooks with "# gsd-hook-version: {{GSD_VERSION}}"
+ * and widen the detector regex to accept both "//" and "#" comment prefixes via
+ * the alternation (?:\/\/|#).
  *
  * Result: every session showed "⚠ stale hooks — run /gsd-update" immediately
  * after a fresh install, because the detector saw hookVersion: 'unknown' for


### PR DESCRIPTION
## Summary

Formally closes issue #2294 by cross-referencing it in the existing regression test suite for the bash-hook stale-detection false positive.

## Context

Issue #2294 was reported by @raphaelbgr with a thorough root-cause analysis and a two-part fix:

1. **Stamp .sh hooks** — add `# gsd-hook-version: {{GSD_VERSION}}` (line 2, after shebang) to all bash hooks so the installer can stamp a concrete version at install time.
2. **Widen the detector regex** — change the version-match pattern from `/\/\/ gsd-hook-version:\s*(.+)/` (JS-only) to `/(?:\/\/|#) gsd-hook-version:\s*(.+)/` so bash `#` comments are matched alongside JS `//` comments.

Both fixes were already implemented in #2224, but issue #2294 was filed after that merge (reporter was still on 1.36.0, the broken version) and was never linked to a closing PR.

## Change

Updates the docblock of `tests/bug-2136-sh-hook-version.test.cjs` to:
- Add `#2294` to the bug references header
- Credit @raphaelbgr's diagnosis and the two-part solution they described

No logic changes — the fix is already in main via #2224.

Closes #2294