### PR TITLE
fix(map-codebase): pass current date to mapper agents to fix wrong Analysis Date

### DIFF
--- a/agents/gsd-codebase-mapper.md
+++ b/agents/gsd-codebase-mapper.md
@@ -160,7 +160,7 @@ Write document(s) to `.planning/codebase/` using the templates below.
 **Document naming:** UPPERCASE.md (e.g., STACK.md, ARCHITECTURE.md)
 
 **Template filling:**
-1. Replace `[YYYY-MM-DD]` with current date
+1. Replace `[YYYY-MM-DD]` with the date provided in your prompt (the `Today's date:` line). NEVER guess or infer the date — always use the exact date from the prompt.
 2. Replace `[Placeholder text]` with findings from exploration
 3. If something is not found, use "Not detected" or "Not applicable"
 4. Always include file paths with backticks

--- a/get-shit-done/bin/lib/init.cjs
+++ b/get-shit-done/bin/lib/init.cjs
@@ -879,6 +879,7 @@ function cmdInitMilestoneOp(cwd, raw) {
 
 function cmdInitMapCodebase(cwd, raw) {
   const config = loadConfig(cwd);
+  const now = new Date();
 
   // Check for existing codebase maps
   const codebaseDir = path.join(planningRoot(cwd), 'codebase');
@@ -896,6 +897,10 @@ function cmdInitMapCodebase(cwd, raw) {
     search_gitignored: config.search_gitignored,
     parallelization: config.parallelization,
     subagent_timeout: config.subagent_timeout,
+
+    // Timestamps
+    date: now.toISOString().split('T')[0],
+    timestamp: now.toISOString(),
 
     // Paths
     codebase_dir: '.planning/codebase',

--- a/get-shit-done/workflows/map-codebase.md
+++ b/get-shit-done/workflows/map-codebase.md
@@ -36,7 +36,7 @@ if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 AGENT_SKILLS_MAPPER=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" agent-skills gsd-codebase-mapper 2>/dev/null)
 ```
 
-Extract from init JSON: `mapper_model`, `commit_docs`, `codebase_dir`, `existing_maps`, `has_maps`, `codebase_dir_exists`, `subagent_timeout`.
+Extract from init JSON: `mapper_model`, `commit_docs`, `codebase_dir`, `existing_maps`, `has_maps`, `codebase_dir_exists`, `subagent_timeout`, `date`.
 </step>
 
 <step name="check_existing">
@@ -114,12 +114,15 @@ Task(
   run_in_background=true,
   description="Map codebase tech stack",
   prompt="Focus: tech
+Today's date: {date}
 
 Analyze this codebase for technology stack and external integrations.
 
 Write these documents to .planning/codebase/:
 - STACK.md - Languages, runtime, frameworks, dependencies, configuration
 - INTEGRATIONS.md - External APIs, databases, auth providers, webhooks
+
+IMPORTANT: Use {date} for all [YYYY-MM-DD] date placeholders in documents.
 
 Explore thoroughly. Write documents directly using templates. Return confirmation only.
 ${AGENT_SKILLS_MAPPER}"
@@ -135,12 +138,15 @@ Task(
   run_in_background=true,
   description="Map codebase architecture",
   prompt="Focus: arch
+Today's date: {date}
 
 Analyze this codebase architecture and directory structure.
 
 Write these documents to .planning/codebase/:
 - ARCHITECTURE.md - Pattern, layers, data flow, abstractions, entry points
 - STRUCTURE.md - Directory layout, key locations, naming conventions
+
+IMPORTANT: Use {date} for all [YYYY-MM-DD] date placeholders in documents.
 
 Explore thoroughly. Write documents directly using templates. Return confirmation only.
 ${AGENT_SKILLS_MAPPER}"
@@ -156,12 +162,15 @@ Task(
   run_in_background=true,
   description="Map codebase conventions",
   prompt="Focus: quality
+Today's date: {date}
 
 Analyze this codebase for coding conventions and testing patterns.
 
 Write these documents to .planning/codebase/:
 - CONVENTIONS.md - Code style, naming, patterns, error handling
 - TESTING.md - Framework, structure, mocking, coverage
+
+IMPORTANT: Use {date} for all [YYYY-MM-DD] date placeholders in documents.
 
 Explore thoroughly. Write documents directly using templates. Return confirmation only.
 ${AGENT_SKILLS_MAPPER}"
@@ -177,11 +186,14 @@ Task(
   run_in_background=true,
   description="Map codebase concerns",
   prompt="Focus: concerns
+Today's date: {date}
 
 Analyze this codebase for technical debt, known issues, and areas of concern.
 
 Write this document to .planning/codebase/:
 - CONCERNS.md - Tech debt, bugs, security, performance, fragile areas
+
+IMPORTANT: Use {date} for all [YYYY-MM-DD] date placeholders in documents.
 
 Explore thoroughly. Write document directly using template. Return confirmation only.
 ${AGENT_SKILLS_MAPPER}"
@@ -231,6 +243,8 @@ Continue to verify_output.
 When the `Task` tool is unavailable, perform codebase mapping sequentially in the current context. This replaces `spawn_agents` and `collect_confirmations`.
 
 **IMPORTANT:** Do NOT use `browser_subagent`, `Explore`, or any browser-based tool. Use only file system tools (Read, Bash, Write, Grep, Glob, list_dir, view_file, grep_search, or equivalent tools available in your runtime).
+
+**IMPORTANT:** Use `{date}` from init context for all `[YYYY-MM-DD]` date placeholders in documents. NEVER guess the date.
 
 Perform all 4 mapping passes sequentially:
 

--- a/sdk/src/query/init.ts
+++ b/sdk/src/query/init.ts
@@ -747,6 +747,7 @@ export const initMilestoneOp: QueryHandler = async (_args, projectDir) => {
  */
 export const initMapCodebase: QueryHandler = async (_args, projectDir) => {
   const config = await loadConfig(projectDir);
+  const now = new Date();
   const codebaseDir = join(projectDir, '.planning', 'codebase');
   let existingMaps: string[] = [];
   try {
@@ -761,6 +762,8 @@ export const initMapCodebase: QueryHandler = async (_args, projectDir) => {
     search_gitignored: config.search_gitignored,
     parallelization: config.parallelization,
     subagent_timeout: (config as Record<string, unknown>).subagent_timeout ?? undefined,
+    date: now.toISOString().split('T')[0],
+    timestamp: now.toISOString(),
     codebase_dir: '.planning/codebase',
     existing_maps: existingMaps,
     has_maps: existingMaps.length > 0,


### PR DESCRIPTION
## Summary

Fixes #2297

- Add `date` and `timestamp` fields to `cmdInitMapCodebase` (init.cjs) and `initMapCodebase` (init.ts), matching the pattern already used by `init quick` and `init todo`
- Pass `{date}` from init context into each mapper agent prompt in the workflow
- Update `gsd-codebase-mapper` agent definition to use the prompt-provided date instead of guessing
- Cover the `sequential_mapping` fallback path as well

## Root Cause

`cmdInitMapCodebase` did not include `date` or `timestamp` in its JSON output. The mapper agents were instructed to "Replace `[YYYY-MM-DD]` with current date" but had no reliable date source — the AI model could only guess from training data, producing dates like `2025-07-15` instead of the actual current date.

## Test plan

- [x] All 98 existing tests pass (`init.test.cjs` + `subagent-timeout.test.cjs`)
- [x] Verified `gsd-tools.cjs init map-codebase` now returns correct `date` field
- [ ] Run `/gsd-map-codebase` on a project and verify all 7 documents show today's date