### PR TITLE
feat: add gsd:plan-review-convergence command

### DIFF
--- a/commands/gsd/plan-review-convergence.md
+++ b/commands/gsd/plan-review-convergence.md
@@ -1,0 +1,52 @@
+---
+name: gsd:plan-review-convergence
+description: "Cross-AI plan convergence loop — replan with review feedback until no HIGH concerns remain (max 3 cycles)"
+argument-hint: "<phase> [--codex] [--gemini] [--all] [--max-cycles N]"
+allowed-tools:
+  - Read
+  - Write
+  - Bash
+  - Glob
+  - Grep
+  - Agent
+  - AskUserQuestion
+---
+
+<objective>
+Cross-AI plan convergence loop — an outer revision gate around gsd-review and gsd-planner.
+Repeatedly: review plans with external AI CLIs → if HIGH concerns found → replan with --reviews feedback → re-review. Stops when no HIGH concerns remain or max cycles reached.
+
+**Flow:** Agent→Skill("gsd-plan-phase") → Agent→Skill("gsd-review") → check HIGHs → Agent→Skill("gsd-plan-phase --reviews") → Agent→Skill("gsd-review") → ... → Converge or escalate
+
+Replaces gsd-plan-phase's internal gsd-plan-checker with external AI reviewers (codex, gemini, etc.). Each step runs inside an isolated Agent that calls the corresponding existing Skill — orchestrator only does loop control.
+
+**Orchestrator role:** Parse arguments, validate phase, spawn Agents for existing Skills, check HIGHs, stall detection, escalation gate.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/plan-review-convergence.md
+@$HOME/.claude/get-shit-done/references/revision-loop.md
+@$HOME/.claude/get-shit-done/references/gates.md
+@$HOME/.claude/get-shit-done/references/agent-contracts.md
+</execution_context>
+
+<runtime_note>
+**Copilot (VS Code):** Use `vscode_askquestions` wherever this workflow calls `AskUserQuestion`. They are equivalent — `vscode_askquestions` is the VS Code Copilot implementation of the same interactive question API. Do not skip questioning steps because `AskUserQuestion` appears unavailable; use `vscode_askquestions` instead.
+</runtime_note>
+
+<context>
+Phase number: extracted from $ARGUMENTS (required)
+
+**Flags:**
+- `--codex` — Use Codex CLI as reviewer (default if no reviewer specified)
+- `--gemini` — Use Gemini CLI as reviewer
+- `--claude` — Use Claude CLI as reviewer (separate session)
+- `--opencode` — Use OpenCode as reviewer
+- `--all` — Use all available CLIs
+- `--max-cycles N` — Maximum replan→review cycles (default: 3)
+</context>
+
+<process>
+Execute the plan-review-convergence workflow from @$HOME/.claude/get-shit-done/workflows/plan-review-convergence.md end-to-end.
+Preserve all workflow gates (pre-flight, revision loop, stall detection, escalation).
+</process>

--- a/get-shit-done/workflows/plan-review-convergence.md
+++ b/get-shit-done/workflows/plan-review-convergence.md
@@ -1,0 +1,253 @@
+<purpose>
+Cross-AI plan convergence loop — automates the manual chain:
+gsd-plan-phase N → gsd-review N --codex → gsd-plan-phase N --reviews → gsd-review N --codex → ...
+Each step runs inside an isolated Agent that calls the corresponding Skill.
+Orchestrator only does: init, loop control, HIGH count check, stall detection, escalation.
+</purpose>
+
+<required_reading>
+Read all files referenced by the invoking prompt's execution_context before starting.
+
+@$HOME/.claude/get-shit-done/references/revision-loop.md
+@$HOME/.claude/get-shit-done/references/gates.md
+@$HOME/.claude/get-shit-done/references/agent-contracts.md
+</required_reading>
+
+<process>
+
+## 1. Initialize
+
+```bash
+INIT=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" init plan-phase "$PHASE")
+if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
+```
+
+Parse JSON for: `phase_dir`, `phase_number`, `padded_phase`, `phase_name`, `has_plans`, `plan_count`, `commit_docs`, `text_mode`, `response_language`.
+
+**If `response_language` is set:** All user-facing output should be in `{response_language}`.
+
+## 2. Parse and Normalize Arguments
+
+Extract from $ARGUMENTS: phase number, reviewer flags (`--codex`, `--gemini`, `--claude`, `--opencode`, `--all`), `--max-cycles N`, `--text`, `--ws`.
+
+```bash
+PHASE=$(echo "$ARGUMENTS" | grep -oE '[0-9]+\.?[0-9]*' | head -1)
+
+REVIEWER_FLAGS=""
+echo "$ARGUMENTS" | grep -q '\-\-codex' && REVIEWER_FLAGS="$REVIEWER_FLAGS --codex"
+echo "$ARGUMENTS" | grep -q '\-\-gemini' && REVIEWER_FLAGS="$REVIEWER_FLAGS --gemini"
+echo "$ARGUMENTS" | grep -q '\-\-claude' && REVIEWER_FLAGS="$REVIEWER_FLAGS --claude"
+echo "$ARGUMENTS" | grep -q '\-\-opencode' && REVIEWER_FLAGS="$REVIEWER_FLAGS --opencode"
+echo "$ARGUMENTS" | grep -q '\-\-all' && REVIEWER_FLAGS="$REVIEWER_FLAGS --all"
+if [ -z "$REVIEWER_FLAGS" ]; then REVIEWER_FLAGS="--codex"; fi
+
+MAX_CYCLES=$(echo "$ARGUMENTS" | grep -oE '\-\-max-cycles\s+[0-9]+' | awk '{print $2}')
+if [ -z "$MAX_CYCLES" ]; then MAX_CYCLES=3; fi
+
+GSD_WS=""
+echo "$ARGUMENTS" | grep -qE '\-\-ws\s+\S+' && GSD_WS=$(echo "$ARGUMENTS" | grep -oE '\-\-ws\s+\S+')
+```
+
+Set `TEXT_MODE=true` if `--text` is present in $ARGUMENTS OR `text_mode` from init JSON is `true`. When `TEXT_MODE` is active, replace every `AskUserQuestion` call with a plain-text numbered list and ask the user to type their choice number.
+
+## 3. Validate Phase + Pre-flight Gate
+
+```bash
+PHASE_INFO=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" roadmap get-phase "${PHASE}")
+```
+
+**If `found` is false:** Error with available phases. Exit.
+
+Display startup banner:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ GSD ► PLAN CONVERGENCE — Phase {phase_number}
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+ Reviewers: {REVIEWER_FLAGS}
+ Max cycles: {MAX_CYCLES}
+```
+
+## 4. Initial Planning (if no plans exist)
+
+**If `has_plans` is true:** Skip to step 5. Display: `Plans found: {plan_count} PLAN.md files — skipping initial planning.`
+
+**If `has_plans` is false:**
+
+Display: `◆ No plans found — spawning initial planning agent...`
+
+```
+Agent(
+  description="Initial planning Phase {PHASE}",
+  prompt="Run /gsd-plan-phase for Phase {PHASE}.
+
+Execute: Skill(skill='gsd-plan-phase', args='{PHASE} {GSD_WS}')
+
+Complete the full planning workflow. Do NOT return until planning is complete and PLAN.md files are committed.",
+  mode="auto"
+)
+```
+
+After agent returns, verify plans were created:
+```bash
+PLAN_COUNT=$(ls ${phase_dir}/${padded_phase}-*-PLAN.md 2>/dev/null | wc -l)
+```
+
+If PLAN_COUNT == 0: Error — initial planning failed. Exit.
+
+Display: `Initial planning complete: ${PLAN_COUNT} PLAN.md files created.`
+
+## 5. Convergence Loop
+
+Initialize loop variables:
+
+```
+cycle = 0
+prev_high_count = Infinity
+```
+
+### 5a. Review (Spawn Agent)
+
+Increment `cycle`.
+
+Display: `◆ Cycle {cycle}/{MAX_CYCLES} — spawning review agent...`
+
+```
+Agent(
+  description="Cross-AI review Phase {PHASE} cycle {cycle}",
+  prompt="Run /gsd-review for Phase {PHASE}.
+
+Execute: Skill(skill='gsd-review', args='--phase {PHASE} {REVIEWER_FLAGS}')
+
+Complete the full review workflow. Do NOT return until REVIEWS.md is committed.",
+  mode="auto"
+)
+```
+
+After agent returns, verify REVIEWS.md exists:
+```bash
+REVIEWS_FILE=$(ls ${phase_dir}/${padded_phase}-REVIEWS.md 2>/dev/null)
+```
+
+If REVIEWS_FILE is empty: Error — review agent did not produce REVIEWS.md. Exit.
+
+### 5b. Check for HIGH Concerns
+
+```bash
+HIGH_COUNT=$(grep -c '\*\*HIGH' "${REVIEWS_FILE}" 2>/dev/null || echo "0")
+HIGH_LINES=$(grep -B0 -A1 '\*\*HIGH' "${REVIEWS_FILE}" 2>/dev/null)
+```
+
+**If HIGH_COUNT == 0 (converged):**
+
+```bash
+node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" state planned-phase --phase "${PHASE}" --name "${phase_name}" --plans "${PLAN_COUNT}"
+```
+
+Display:
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+ GSD ► CONVERGENCE COMPLETE ✓
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+ Phase {phase_number} converged in {cycle} cycle(s).
+ No HIGH concerns remaining.
+
+ REVIEWS.md: {REVIEWS_FILE}
+ Next: /gsd-execute-phase {PHASE}
+```
+
+Exit — convergence achieved.
+
+**If HIGH_COUNT > 0:** Continue to 5c.
+
+### 5c. Stall Detection + Escalation Check
+
+Display: `◆ Cycle {cycle}/{MAX_CYCLES} — {HIGH_COUNT} HIGH concerns found`
+
+**Stall detection:** If `HIGH_COUNT >= prev_high_count`:
+```
+⚠ Convergence stalled — HIGH concern count not decreasing
+  ({HIGH_COUNT} HIGH concerns, previous cycle had {prev_high_count})
+```
+
+**Max cycles check:** If `cycle >= MAX_CYCLES`:
+
+If `TEXT_MODE` is true, present as plain-text numbered list:
+```
+Plan convergence did not complete after {MAX_CYCLES} cycles.
+{HIGH_COUNT} HIGH concerns remain:
+
+{HIGH_LINES}
+
+How would you like to proceed?
+
+1. Proceed anyway — Accept plans with remaining HIGH concerns and move to execution
+2. Manual review — Stop here, review REVIEWS.md and address concerns manually
+
+Enter number:
+```
+
+Otherwise use AskUserQuestion:
+```
+AskUserQuestion([
+  {
+    question: "Plan convergence did not complete after {MAX_CYCLES} cycles. {HIGH_COUNT} HIGH concerns remain:\n\n{HIGH_LINES}\n\nHow would you like to proceed?",
+    header: "Convergence",
+    multiSelect: false,
+    options: [
+      { label: "Proceed anyway", description: "Accept plans with remaining HIGH concerns and move to execution" },
+      { label: "Manual review", description: "Stop here — review REVIEWS.md and address concerns manually" }
+    ]
+  }
+])
+```
+
+If "Proceed anyway": Display final status and exit.
+If "Manual review":
+```
+Review the concerns in: {REVIEWS_FILE}
+
+To replan manually:  /gsd-plan-phase {PHASE} --reviews
+To restart loop:     /gsd-plan-review-convergence {PHASE} {REVIEWER_FLAGS}
+```
+Exit workflow.
+
+### 5d. Replan (Spawn Agent)
+
+**If under max cycles:**
+
+Update `prev_high_count = HIGH_COUNT`.
+
+Display: `◆ Spawning replan agent with review feedback...`
+
+```
+Agent(
+  description="Replan Phase {PHASE} with review feedback cycle {cycle}",
+  prompt="Run /gsd-plan-phase with --reviews for Phase {PHASE}.
+
+Execute: Skill(skill='gsd-plan-phase', args='{PHASE} --reviews --skip-research {GSD_WS}')
+
+This will replan incorporating cross-AI review feedback from REVIEWS.md.
+Do NOT return until replanning is complete and updated PLAN.md files are committed.
+
+IMPORTANT: When gsd-plan-phase outputs '## PLANNING COMPLETE', that means replanning is done. Return at that point.",
+  mode="auto"
+)
+```
+
+After agent returns → go back to **step 5a** (review again).
+
+</process>
+
+<success_criteria>
+- [ ] Initial planning via Agent → Skill("gsd-plan-phase") if no plans exist
+- [ ] Review via Agent → Skill("gsd-review") — isolated, not inline
+- [ ] Replan via Agent → Skill("gsd-plan-phase --reviews") — isolated, not inline
+- [ ] Orchestrator only does: init, loop control, grep HIGHs, stall detection, escalation
+- [ ] Each Agent fully completes its Skill before returning
+- [ ] Loop exits on: no HIGH concerns (converged) OR max cycles (escalation)
+- [ ] Stall detection reported when HIGH count not decreasing
+- [ ] STATE.md updated on convergence completion
+</success_criteria>


### PR DESCRIPTION
## Summary

- Adds `gsd:plan-review-convergence` — a cross-AI plan convergence loop that automates `plan-phase → review → replan → re-review` cycles
- Orchestrator-only loop control: spawns isolated Agents for existing `gsd-plan-phase` and `gsd-review` Skills
- Bounded iteration with stall detection and escalation gate

## Motivation

`gsd-plan-phase` uses an internal `gsd-plan-checker` (single-AI review). This command enables **external AI reviewers** (Codex, Gemini, Claude, OpenCode) in a closed-loop revision cycle, catching blind spots that single-AI review misses.

## Files

| File | Purpose |
|------|---------|
| `commands/gsd/plan-review-convergence.md` | Command source (installed as `gsd-plan-review-convergence` skill) |
| `get-shit-done/workflows/plan-review-convergence.md` | Workflow logic (init, loop, stall detection, escalation) |

## Design

```
No plans? → Agent(gsd-plan-phase)
         ↓
Review  → Agent(gsd-review --codex/--gemini/--all)
         ↓
grep **HIGH in REVIEWS.md
         ↓
0 HIGH → Converged ✓ (update STATE.md)
N HIGH → Stall check → Replan Agent(gsd-plan-phase --reviews) → Loop
Max cycles → Escalation gate (proceed/manual review)
```

**Key properties:**
- Reuses existing skills — no new planning or review logic
- Default max 3 cycles, configurable via `--max-cycles N`
- Stall detection: warns if HIGH count not decreasing
- References existing `revision-loop.md`, `gates.md`, `agent-contracts.md`

## Validation

Tested on a real phase (COMET Evaluation Metrics, 4 PLAN.md files):

| Cycle | HIGH Count | Action |
|-------|-----------|--------|
| 1 | 13 | Replan with review feedback |
| 2 | 0 | Converged |

13 HIGH concerns (verdict math, missing INCONCLUSIVE paths, silent failure modes) caught and resolved in 2 cycles.

## Test plan

- [ ] Verify `commands/gsd/plan-review-convergence.md` installs correctly via `bin/install.js` → `~/.claude/skills/gsd-plan-review-convergence/SKILL.md`
- [ ] Verify `name: gsd:plan-review-convergence` converts to `name: gsd-plan-review-convergence` after install
- [ ] Run convergence loop on a phase with existing plans — should skip initial planning
- [ ] Run on a phase without plans — should spawn initial planning agent
- [ ] Verify stall detection triggers when HIGH count doesn't decrease
- [ ] Verify max-cycles escalation gate appears after N cycles

Closes #2306

🤖 Generated with [Claude Code](https://claude.com/claude-code)