### PR TITLE
fix(statusline): read CLAUDE_CODE_AUTO_COMPACT_WINDOW for context meter

### DIFF
--- a/hooks/gsd-statusline.js
+++ b/hooks/gsd-statusline.js
@@ -123,10 +123,15 @@ function runStatusline() {
     const session = data.session_id || '';
     const remaining = data.context_window?.remaining_percentage;
 
-    // Context window display (shows USED percentage scaled to usable context)
-    // Claude Code reserves ~16.5% for autocompact buffer, so usable context
-    // is 83.5% of the total window. We normalize to show 100% at that point.
-    const AUTO_COMPACT_BUFFER_PCT = 16.5;
+    // Context window display (shows USED percentage scaled to usable context).
+    // Claude Code reserves CLAUDE_CODE_AUTO_COMPACT_WINDOW tokens for the
+    // autocompact buffer; default ~165k of 1M = 16.5%. When users tune the
+    // env var, the meter tracks the actual threshold instead of the default.
+    const totalCtx = data.context_window?.context_window_size || 1_000_000;
+    const acw = parseInt(process.env.CLAUDE_CODE_AUTO_COMPACT_WINDOW || '0', 10);
+    const AUTO_COMPACT_BUFFER_PCT = acw > 0
+      ? Math.min(100, (acw / totalCtx) * 100)
+      : 16.5;
     let ctx = '';
     if (remaining != null) {
       // Normalize: subtract buffer from remaining, scale to usable range


### PR DESCRIPTION
## Summary
- Context meter hardcoded 16.5% autocompact buffer, which is wrong when users set `CLAUDE_CODE_AUTO_COMPACT_WINDOW` to a non-default value
- Now reads the env var (passed through to hooks by Claude Code) and computes buffer % dynamically against `context_window_size`
- Falls back to 16.5% when unset, preserving current behavior

## Test plan
- [ ] Verify default behavior unchanged: unset env, `remaining_percentage=50` → `used=60%`
- [ ] Verify custom window: `CLAUDE_CODE_AUTO_COMPACT_WINDOW=400000`, `remaining_percentage=50` → `used=83%`
- [ ] Verify bridge file `used_pct` matches displayed percentage (context-monitor reads this)

Fixes #2219

🤖 Generated with [Claude Code](https://claude.com/claude-code)