### PR TITLE
fix(install): replace all ~/.claude/ paths in Codex .toml files (#2320)

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -3016,10 +3016,12 @@ function installCodexConfig(targetDir, agentsSrc) {
     // Replace full .claude/get-shit-done prefix so path resolves to codex GSD install
     content = content.replace(/~\/\.claude\/get-shit-done\//g, codexGsdPath);
     content = content.replace(/\$HOME\/\.claude\/get-shit-done\//g, codexGsdPath);
-    // Replace remaining .claude paths with .codex equivalents (#2320)
-    content = content.replace(/\$HOME\/\.claude\//g, '$HOME/.codex/');
-    content = content.replace(/~\/\.claude\//g, '~/.codex/');
-    content = content.replace(/\.\/\.claude\//g, './.codex/');
+    // Replace remaining .claude paths with .codex equivalents (#2320).
+    // Capture group handles both trailing-slash form (~/.claude/) and
+    // bare end-of-string form (~/.claude) in a single pass.
+    content = content.replace(/\$HOME\/\.claude(\/|$)/g, '$HOME/.codex$1');
+    content = content.replace(/~\/\.claude(\/|$)/g, '~/.codex$1');
+    content = content.replace(/\.\/\.claude(\/|$)/g, './.codex$1');
     const { frontmatter } = extractFrontmatterAndBody(content);
     const name = extractFrontmatterField(frontmatter, 'name') || file.replace('.md', '');
     const description = extractFrontmatterField(frontmatter, 'description') || '';

--- a/bin/install.js
+++ b/bin/install.js
@@ -3016,6 +3016,10 @@ function installCodexConfig(targetDir, agentsSrc) {
     // Replace full .claude/get-shit-done prefix so path resolves to codex GSD install
     content = content.replace(/~\/\.claude\/get-shit-done\//g, codexGsdPath);
     content = content.replace(/\$HOME\/\.claude\/get-shit-done\//g, codexGsdPath);
+    // Replace remaining .claude paths with .codex equivalents (#2320)
+    content = content.replace(/\$HOME\/\.claude\//g, '$HOME/.codex/');
+    content = content.replace(/~\/\.claude\//g, '~/.codex/');
+    content = content.replace(/\.\/\.claude\//g, './.codex/');
     const { frontmatter } = extractFrontmatterAndBody(content);
     const name = extractFrontmatterField(frontmatter, 'name') || file.replace('.md', '');
     const description = extractFrontmatterField(frontmatter, 'description') || '';

--- a/tests/codex-config.test.cjs
+++ b/tests/codex-config.test.cjs
@@ -811,23 +811,32 @@ describe('installCodexConfig (integration)', () => {
     assert.ok(checkerToml.includes('sandbox_mode = "read-only"'), 'plan-checker is read-only');
   });
 
-  // PATHS-01: no ~/.claude/ references should leak into generated .toml files (#2320)
-  (hasAgents ? test : test.skip)('generated .toml files contain no leaked ~/.claude/ paths (PATHS-01)', () => {
+  // PATHS-01: no ~/.claude references should leak into generated .toml files (#2320)
+  // Covers both trailing-slash and bare end-of-string forms, and scans all .toml
+  // files (agents/ subdirectory + top-level config.toml if present).
+  (hasAgents ? test : test.skip)('generated .toml files contain no leaked ~/.claude paths (PATHS-01)', () => {
     const { installCodexConfig } = require('../bin/install.js');
     installCodexConfig(tmpTarget, agentsSrc);
 
+    // Collect all .toml files: per-agent files in agents/ plus top-level config.toml
     const agentsDir = path.join(tmpTarget, 'agents');
-    const tomlFiles = fs.readdirSync(agentsDir).filter(f => f.endsWith('.toml'));
+    const tomlFiles = fs.readdirSync(agentsDir)
+      .filter(f => f.endsWith('.toml'))
+      .map(f => path.join(agentsDir, f));
+    const topLevel = path.join(tmpTarget, 'config.toml');
+    if (fs.existsSync(topLevel)) tomlFiles.push(topLevel);
     assert.ok(tomlFiles.length > 0, 'at least one .toml file generated');
 
+    // Match ~/.claude, $HOME/.claude, or ./.claude with or without trailing slash
+    const leakPattern = /(?:~|\$HOME|\.)\/\.claude(?:\/|$)/;
     const leaks = [];
-    for (const file of tomlFiles) {
-      const content = fs.readFileSync(path.join(agentsDir, file), 'utf8');
-      if (/~\/\.claude\//.test(content) || /\$HOME\/\.claude\//.test(content)) {
-        leaks.push(file);
+    for (const filePath of tomlFiles) {
+      const content = fs.readFileSync(filePath, 'utf8');
+      if (leakPattern.test(content)) {
+        leaks.push(path.relative(tmpTarget, filePath));
       }
     }
-    assert.deepStrictEqual(leaks, [], `No .toml files should contain ~/.claude/ paths; found leaks in: ${leaks.join(', ')}`);
+    assert.deepStrictEqual(leaks, [], `No .toml files should contain .claude paths; found leaks in: ${leaks.join(', ')}`);
   });
 });
 

--- a/tests/codex-config.test.cjs
+++ b/tests/codex-config.test.cjs
@@ -810,6 +810,25 @@ describe('installCodexConfig (integration)', () => {
     assert.ok(checkerToml.includes('name = "gsd-plan-checker"'), 'plan-checker has name');
     assert.ok(checkerToml.includes('sandbox_mode = "read-only"'), 'plan-checker is read-only');
   });
+
+  // PATHS-01: no ~/.claude/ references should leak into generated .toml files (#2320)
+  (hasAgents ? test : test.skip)('generated .toml files contain no leaked ~/.claude/ paths (PATHS-01)', () => {
+    const { installCodexConfig } = require('../bin/install.js');
+    installCodexConfig(tmpTarget, agentsSrc);
+
+    const agentsDir = path.join(tmpTarget, 'agents');
+    const tomlFiles = fs.readdirSync(agentsDir).filter(f => f.endsWith('.toml'));
+    assert.ok(tomlFiles.length > 0, 'at least one .toml file generated');
+
+    const leaks = [];
+    for (const file of tomlFiles) {
+      const content = fs.readFileSync(path.join(agentsDir, file), 'utf8');
+      if (/~\/\.claude\//.test(content) || /\$HOME\/\.claude\//.test(content)) {
+        leaks.push(file);
+      }
+    }
+    assert.deepStrictEqual(leaks, [], `No .toml files should contain ~/.claude/ paths; found leaks in: ${leaks.join(', ')}`);
+  });
 });
 
 // ─── Codex config.toml [features] safety (#1202) ─────────────────────────────


### PR DESCRIPTION
## Summary

- `installCodexConfig()` only rewrote `~/.claude/get-shit-done/`-scoped paths; hooks, skills, and configDir references like `$HOME/.claude/` were copied into generated `.toml` files unchanged
- Adds three additional regex replacements to catch all `$HOME/.claude/`, `~/.claude/`, and `./.claude/` patterns and rewrite them to `.codex` equivalents
- Adds regression test PATHS-01 that asserts no generated `.toml` file contains a leaked `~/.claude/` path

## Test plan

- [ ] `node --test tests/codex-config.test.cjs` — PATHS-01 passes
- [ ] Full suite `npm test` passes

Closes #2320

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration installation process now comprehensively replaces all legacy path references across generated configuration files, ensuring consistent and proper setup.

* **Tests**
  * Added integration test that validates configuration file generation and confirms the absence of any legacy path references in newly created configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->