### PR TITLE
fix(quick): rescue uncommitted SUMMARY.md before worktree removal (#2296)

### DIFF
--- a/get-shit-done/workflows/quick.md
+++ b/get-shit-done/workflows/quick.md
@@ -660,6 +660,15 @@ After executor returns:
          fi
        fi
 
+       # Safety net: rescue uncommitted SUMMARY.md before worktree removal (#2296, mirrors #2070)
+       UNCOMMITTED_SUMMARY=$(git -C "$WT" ls-files --modified --others --exclude-standard -- "*SUMMARY.md" 2>/dev/null || true)
+       if [ -n "$UNCOMMITTED_SUMMARY" ]; then
+         echo "⚠ SUMMARY.md was not committed by executor — committing now to prevent data loss"
+         git -C "$WT" add -- "*SUMMARY.md" 2>/dev/null || true
+         git -C "$WT" commit --no-verify -m "docs(recovery): rescue uncommitted SUMMARY.md before worktree removal (#2070)" 2>/dev/null || true
+         git merge "$WT_BRANCH" --no-edit -m "chore: merge rescued SUMMARY.md from executor worktree ($WT_BRANCH)" 2>/dev/null || true
+       fi
+
        git worktree remove "$WT" --force 2>/dev/null || true
        git branch -D "$WT_BRANCH" 2>/dev/null || true
      fi


### PR DESCRIPTION
## Summary

- `quick.md` was missing the SUMMARY.md rescue block that `execute-phase.md` has had since #2070
- Before `git worktree remove --force`, the orchestrator now checks for uncommitted `SUMMARY.md` files in the executor worktree, commits them to the branch, and merges the branch — exactly mirroring the execute-phase.md safety net
- Prevents silent data loss when an executor exits without committing its SUMMARY.md

## Test plan

- [ ] Full test suite `npm test` passes (verified in prior session)

Closes #2296

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added automatic preservation of unsaved summary files during cleanup operations, creating a safety recovery mechanism to prevent accidental data loss when removing temporary work environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->