### PR TITLE
fix(new-project): display saved defaults before prompting to use them

### DIFF
--- a/get-shit-done/workflows/new-project.md
+++ b/get-shit-done/workflows/new-project.md
@@ -410,25 +410,80 @@ gsd-sdk query commit "docs: initialize project" .planning/PROJECT.md
 
 **If auto mode:** Skip — config was collected in Step 2a. Proceed to Step 5.5.
 
-**Check for global defaults** at `~/.gsd/defaults.json`. If the file exists, offer to use saved defaults:
+**Check for global defaults** at `~/.gsd/defaults.json`. If the file exists, read and display its contents before asking:
+
+```bash
+DEFAULTS_RAW=$(cat ~/.gsd/defaults.json 2>/dev/null)
+```
+
+Format the JSON into human-readable bullets using these label mappings:
+- `mode` → "Mode"
+- `granularity` → "Granularity"
+- `parallelization` → "Execution" (`true` → "Parallel", `false` → "Sequential")
+- `commit_docs` → "Git Tracking" (`true` → "Yes", `false` → "No")
+- `model_profile` → "AI Models"
+- `workflow.research` → "Research agent" (`true` → "Yes", `false` → "No")
+- `workflow.plan_check` → "Plan Check agent" (`true` → "Yes", `false` → "No")
+- `workflow.verifier` → "Verifier agent" (`true` → "Yes", `false` → "No")
+
+Display above the prompt:
+
+```
+Your saved defaults (~/.gsd/defaults.json):
+  • Mode: [value]
+  • Granularity: [value]
+  • Execution: [Parallel|Sequential]
+  • Git Tracking: [Yes|No]
+  • AI Models: [value]
+  • Research agent: [Yes|No]
+  • Plan Check agent: [Yes|No]
+  • Verifier agent: [Yes|No]
+```
+
+Then ask:
 
 ```
 AskUserQuestion([
   {
-    question: "Use your saved default settings? (from ~/.gsd/defaults.json)",
+    question: "Use these saved defaults?",
     header: "Defaults",
     multiSelect: false,
     options: [
-      { label: "Yes (Recommended)", description: "Use saved defaults, skip settings questions" },
-      { label: "No", description: "Configure settings manually" }
+      { label: "Use as-is (Recommended)", description: "Proceed with the defaults shown above" },
+      { label: "Modify some settings", description: "Keep defaults, change a few" },
+      { label: "Configure fresh", description: "Walk through all questions from scratch" }
     ]
   }
 ])
 ```
 
-If "Yes": read `~/.gsd/defaults.json`, use those values for config.json, and skip directly to **Commit config.json** below.
+**If "Use as-is":** use the defaults values for config.json and skip directly to **Commit config.json** below.
 
-If "No" or `~/.gsd/defaults.json` doesn't exist: proceed with the questions below.
+**If "Modify some settings":** present a multiSelect listing every setting with its current saved value:
+
+```
+AskUserQuestion([
+  {
+    question: "Which settings do you want to change?",
+    header: "Change Settings",
+    multiSelect: true,
+    options: [
+      { label: "Mode", description: "Currently: [value]" },
+      { label: "Granularity", description: "Currently: [value]" },
+      { label: "Execution", description: "Currently: [Parallel|Sequential]" },
+      { label: "Git Tracking", description: "Currently: [Yes|No]" },
+      { label: "AI Models", description: "Currently: [value]" },
+      { label: "Research agent", description: "Currently: [Yes|No]" },
+      { label: "Plan Check agent", description: "Currently: [Yes|No]" },
+      { label: "Verifier agent", description: "Currently: [Yes|No]" }
+    ]
+  }
+])
+```
+
+For each selected setting, ask only that question using the option set from Round 1 / Round 2 below. Merge user answers over the saved defaults — unchanged settings retain their saved values. Then skip to **Commit config.json**.
+
+**If "Configure fresh" or `~/.gsd/defaults.json` doesn't exist:** proceed with the questions below.
 
 **Round 1 — Core workflow settings (4 questions):**
 

--- a/get-shit-done/workflows/new-project.md
+++ b/get-shit-done/workflows/new-project.md
@@ -422,27 +422,27 @@ Format the JSON into human-readable bullets using these label mappings:
 - `parallelization` → "Execution" (`true` → "Parallel", `false` → "Sequential")
 - `commit_docs` → "Git Tracking" (`true` → "Yes", `false` → "No")
 - `model_profile` → "AI Models"
-- `workflow.research` → "Research agent" (`true` → "Yes", `false` → "No")
-- `workflow.plan_check` → "Plan Check agent" (`true` → "Yes", `false` → "No")
-- `workflow.verifier` → "Verifier agent" (`true` → "Yes", `false` → "No")
+- `workflow.research` → "Research" (`true` → "Yes", `false` → "No")
+- `workflow.plan_check` → "Plan Check" (`true` → "Yes", `false` → "No")
+- `workflow.verifier` → "Verifier" (`true` → "Yes", `false` → "No")
 
 Display above the prompt:
 
-```
+```text
 Your saved defaults (~/.gsd/defaults.json):
   • Mode: [value]
   • Granularity: [value]
   • Execution: [Parallel|Sequential]
   • Git Tracking: [Yes|No]
   • AI Models: [value]
-  • Research agent: [Yes|No]
-  • Plan Check agent: [Yes|No]
-  • Verifier agent: [Yes|No]
+  • Research: [Yes|No]
+  • Plan Check: [Yes|No]
+  • Verifier: [Yes|No]
 ```
 
 Then ask:
 
-```
+```text
 AskUserQuestion([
   {
     question: "Use these saved defaults?",
@@ -459,9 +459,26 @@ AskUserQuestion([
 
 **If "Use as-is":** use the defaults values for config.json and skip directly to **Commit config.json** below.
 
-**If "Modify some settings":** present a multiSelect listing every setting with its current saved value:
+**If "Modify some settings":** present a selection of every setting with its current saved value.
 
+**If TEXT_MODE is active** (non-Claude runtimes): display a numbered list and ask the user to type the numbers of settings they want to change (comma-separated). Parse the response and proceed.
+
+```text
+Which settings do you want to change? (enter numbers, comma-separated)
+
+  1. Mode — Currently: [value]
+  2. Granularity — Currently: [value]
+  3. Execution — Currently: [Parallel|Sequential]
+  4. Git Tracking — Currently: [Yes|No]
+  5. AI Models — Currently: [value]
+  6. Research — Currently: [Yes|No]
+  7. Plan Check — Currently: [Yes|No]
+  8. Verifier — Currently: [Yes|No]
 ```
+
+**Otherwise** (Claude runtime with AskUserQuestion): use multiSelect:
+
+```text
 AskUserQuestion([
   {
     question: "Which settings do you want to change?",
@@ -473,9 +490,9 @@ AskUserQuestion([
       { label: "Execution", description: "Currently: [Parallel|Sequential]" },
       { label: "Git Tracking", description: "Currently: [Yes|No]" },
       { label: "AI Models", description: "Currently: [value]" },
-      { label: "Research agent", description: "Currently: [Yes|No]" },
-      { label: "Plan Check agent", description: "Currently: [Yes|No]" },
-      { label: "Verifier agent", description: "Currently: [Yes|No]" }
+      { label: "Research", description: "Currently: [Yes|No]" },
+      { label: "Plan Check", description: "Currently: [Yes|No]" },
+      { label: "Verifier", description: "Currently: [Yes|No]" }
     ]
   }
 ])


### PR DESCRIPTION
## Summary

- Reads `~/.gsd/defaults.json` and displays all saved values in human-readable form **before** asking what to do with them
- Replaces the blind Yes/No gate with three options: **Use as-is**, **Modify some settings**, **Configure fresh**
- "Modify some settings" path shows a multiSelect of setting names with current values, asks only the selected questions, and merges answers over the saved defaults — no full re-walk for a one-setting change

Fixes the "trust me bro" UX described in #2332, where users with saved defaults had to pick Yes and hope, or pick No and re-answer all 8 questions from scratch.

## Test plan

- [ ] User with `~/.gsd/defaults.json`: verify defaults are displayed before the prompt appears
- [ ] "Use as-is": skips all questions, uses saved values
- [ ] "Modify some settings": multiSelect shows current values, only selected settings are asked, others keep their saved values
- [ ] "Configure fresh": full Round 1 + Round 2 question flow runs normally
- [ ] User without `~/.gsd/defaults.json`: full question flow unchanged

Closes #2332

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced default settings workflow with a three-option interface: use saved defaults as-is (recommended), selectively modify specific settings, or configure fresh from scratch
  * Saved defaults are now displayed in a clear, human-readable format before prompting for your selection
  * Selective modification mode lets you pick which settings to update and merges your changes with the saved configuration, preserving untouched values
<!-- end of auto-generated comment: release notes by coderabbit.ai -->