### PR TITLE
Fix graphify 0.4 build contract

### DIFF
--- a/commands/gsd/graphify.md
+++ b/commands/gsd/graphify.md
@@ -153,13 +153,13 @@ gsd-tools path: $HOME/.claude/get-shit-done/bin/gsd-tools.cjs
 1. **Invoke graphify:**
    Run from the project root:
    ```
-   graphify . --update
+   graphify update .
    ```
    This builds the knowledge graph with SHA256 incremental caching.
    Timeout: up to 5 minutes (or as configured via graphify.build_timeout).
 
 2. **Validate output:**
-   Check that graphify-out/graph.json exists and is valid JSON with nodes[] and edges[] arrays.
+   Check that graphify-out/graph.json exists and is valid JSON with nodes[] plus either links[] or edges[].
    If graphify exited non-zero or graph.json is not parseable, output:
    ## GRAPHIFY BUILD FAILED
    Include the stderr output for debugging. Do NOT delete .planning/graphs/ -- prior valid graph remains available.
@@ -167,10 +167,9 @@ gsd-tools path: $HOME/.claude/get-shit-done/bin/gsd-tools.cjs
 3. **Copy artifacts to .planning/graphs/:**
    ```
    cp graphify-out/graph.json .planning/graphs/graph.json
-   cp graphify-out/graph.html .planning/graphs/graph.html
    cp graphify-out/GRAPH_REPORT.md .planning/graphs/GRAPH_REPORT.md
    ```
-   These three files are the build output consumed by query, status, and diff commands.
+   These files are the build output consumed by query, status, and diff commands.
 
 4. **Write diff snapshot:**
    ```

--- a/get-shit-done/bin/lib/graphify.cjs
+++ b/get-shit-done/bin/lib/graphify.cjs
@@ -433,7 +433,7 @@ function graphifyBuild(cwd) {
     timeout_seconds: timeoutSec,
     version: version.version,
     version_warning: version.warning,
-    artifacts: ['graph.json', 'graph.html', 'GRAPH_REPORT.md'],
+    artifacts: ['graph.json', 'GRAPH_REPORT.md'],
   };
 }
 

--- a/tests/graphify.test.cjs
+++ b/tests/graphify.test.cjs
@@ -879,7 +879,7 @@ describe('graphifyBuild', () => {
     assert.strictEqual(result.timeout_seconds, 300);
     assert.strictEqual(result.version, '0.4.3');
     assert.strictEqual(result.version_warning, null);
-    assert.deepStrictEqual(result.artifacts, ['graph.json', 'graph.html', 'GRAPH_REPORT.md']);
+    assert.deepStrictEqual(result.artifacts, ['graph.json', 'GRAPH_REPORT.md']);
   });
 
   test('creates .planning/graphs/ directory if missing', () => {


### PR DESCRIPTION
## Summary
Align the graphify build contract with graphify 0.4.x actual output.

## Problem
Graphify 0.4.x no longer reliably produces `graphify-out/graph.html`, and the current CLI invocation is `graphify update .` rather than `graphify . --update`.
Because the GSD builder prompt and pre-flight artifact list still assume the old contract, `/gsd-graphify build` can report a failed build even when graphify successfully generated `graph.json` and `GRAPH_REPORT.md`.

## Changes
- remove `graph.html` from the graphify build artifact contract
- update the graphify builder prompt to use `graphify update .`
- update the builder prompt to accept `graph.json` files with `nodes[]` plus either `links[]` or `edges[]`
- update the graphify build unit test to match the current artifact contract

## Validation
- `node --test tests/graphify.test.cjs`
- verified locally against a real graphify 0.4.18 build where status/query/snapshot/diff returned non-zero edge counts and stable results after the contract fix
