### PR TITLE
feat: add gsd:plan-review-convergence command

### DIFF
--- a/commands/gsd/plan-review-convergence.md
+++ b/commands/gsd/plan-review-convergence.md
@@ -1,7 +1,7 @@
 ---
 name: gsd:plan-review-convergence
 description: "Cross-AI plan convergence loop — replan with review feedback until no HIGH concerns remain (max 3 cycles)"
-argument-hint: "<phase> [--codex] [--gemini] [--claude] [--opencode] [--text] [--ws <name>] [--all] [--max-cycles N]"
+argument-hint: "<phase> [--codex] [--gemini] [--all] [--max-cycles N]"
 allowed-tools:
   - Read
   - Write

--- a/commands/gsd/plan-review-convergence.md
+++ b/commands/gsd/plan-review-convergence.md
@@ -1,7 +1,7 @@
 ---
 name: gsd:plan-review-convergence
 description: "Cross-AI plan convergence loop — replan with review feedback until no HIGH concerns remain (max 3 cycles)"
-argument-hint: "<phase> [--codex] [--gemini] [--all] [--max-cycles N]"
+argument-hint: "<phase> [--codex] [--gemini] [--claude] [--opencode] [--text] [--ws <name>] [--all] [--max-cycles N]"
 allowed-tools:
   - Read
   - Write

--- a/get-shit-done/workflows/plan-review-convergence.md
+++ b/get-shit-done/workflows/plan-review-convergence.md
@@ -15,7 +15,18 @@ Read all files referenced by the invoking prompt's execution_context before star
 
 <process>
 
-## 1. Parse and Normalize Arguments
+## 1. Initialize
+
+```bash
+INIT=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" init plan-phase "$PHASE")
+if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
+```
+
+Parse JSON for: `phase_dir`, `phase_number`, `padded_phase`, `phase_name`, `has_plans`, `plan_count`, `commit_docs`, `text_mode`, `response_language`.
+
+**If `response_language` is set:** All user-facing output should be in `{response_language}`.
+
+## 2. Parse and Normalize Arguments
 
 Extract from $ARGUMENTS: phase number, reviewer flags (`--codex`, `--gemini`, `--claude`, `--opencode`, `--all`), `--max-cycles N`, `--text`, `--ws`.
 
@@ -37,17 +48,6 @@ GSD_WS=""
 echo "$ARGUMENTS" | grep -qE '\-\-ws\s+\S+' && GSD_WS=$(echo "$ARGUMENTS" | grep -oE '\-\-ws\s+\S+')
 ```
 
-## 2. Initialize
-
-```bash
-INIT=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" init plan-phase "$PHASE")
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
-```
-
-Parse JSON for: `phase_dir`, `phase_number`, `padded_phase`, `phase_name`, `has_plans`, `plan_count`, `commit_docs`, `text_mode`, `response_language`.
-
-**If `response_language` is set:** All user-facing output should be in `{response_language}`.
-
 Set `TEXT_MODE=true` if `--text` is present in $ARGUMENTS OR `text_mode` from init JSON is `true`. When `TEXT_MODE` is active, replace every `AskUserQuestion` call with a plain-text numbered list and ask the user to type their choice number.
 
 ## 3. Validate Phase + Pre-flight Gate
@@ -60,7 +60,7 @@ PHASE_INFO=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" roadmap get-ph
 
 Display startup banner:
 
-```text
+```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  GSD ► PLAN CONVERGENCE — Phase {phase_number}
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -77,10 +77,10 @@ Display startup banner:
 
 Display: `◆ No plans found — spawning initial planning agent...`
 
-```text
+```
 Agent(
   description="Initial planning Phase {PHASE}",
-  prompt="Run /gsd:plan-phase for Phase {PHASE}.
+  prompt="Run /gsd-plan-phase for Phase {PHASE}.
 
 Execute: Skill(skill='gsd-plan-phase', args='{PHASE} {GSD_WS}')
 
@@ -102,7 +102,7 @@ Display: `Initial planning complete: ${PLAN_COUNT} PLAN.md files created.`
 
 Initialize loop variables:
 
-```text
+```
 cycle = 0
 prev_high_count = Infinity
 ```
@@ -113,12 +113,12 @@ Increment `cycle`.
 
 Display: `◆ Cycle {cycle}/{MAX_CYCLES} — spawning review agent...`
 
-```text
+```
 Agent(
   description="Cross-AI review Phase {PHASE} cycle {cycle}",
-  prompt="Run /gsd:review for Phase {PHASE}.
+  prompt="Run /gsd-review for Phase {PHASE}.
 
-Execute: Skill(skill='gsd-review', args='--phase {PHASE} {REVIEWER_FLAGS} {GSD_WS}')
+Execute: Skill(skill='gsd-review', args='--phase {PHASE} {REVIEWER_FLAGS}')
 
 Complete the full review workflow. Do NOT return until REVIEWS.md is committed.",
   mode="auto"
@@ -135,8 +135,7 @@ If REVIEWS_FILE is empty: Error — review agent did not produce REVIEWS.md. Exi
 ### 5b. Check for HIGH Concerns
 
 ```bash
-HIGH_COUNT=$(grep -c '\*\*HIGH' "${REVIEWS_FILE}" 2>/dev/null || true)
-HIGH_COUNT=${HIGH_COUNT:-0}
+HIGH_COUNT=$(grep -c '\*\*HIGH' "${REVIEWS_FILE}" 2>/dev/null || echo "0")
 HIGH_LINES=$(grep -B0 -A1 '\*\*HIGH' "${REVIEWS_FILE}" 2>/dev/null)
 ```
 
@@ -147,7 +146,7 @@ node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" state planned-phase --phase
 ```
 
 Display:
-```text
+```
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  GSD ► CONVERGENCE COMPLETE ✓
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -156,7 +155,7 @@ Display:
  No HIGH concerns remaining.
 
  REVIEWS.md: {REVIEWS_FILE}
- Next: /gsd:execute-phase {PHASE}
+ Next: /gsd-execute-phase {PHASE}
 ```
 
 Exit — convergence achieved.
@@ -168,7 +167,7 @@ Exit — convergence achieved.
 Display: `◆ Cycle {cycle}/{MAX_CYCLES} — {HIGH_COUNT} HIGH concerns found`
 
 **Stall detection:** If `HIGH_COUNT >= prev_high_count`:
-```text
+```
 ⚠ Convergence stalled — HIGH concern count not decreasing
   ({HIGH_COUNT} HIGH concerns, previous cycle had {prev_high_count})
 ```
@@ -176,7 +175,7 @@ Display: `◆ Cycle {cycle}/{MAX_CYCLES} — {HIGH_COUNT} HIGH concerns found`
 **Max cycles check:** If `cycle >= MAX_CYCLES`:
 
 If `TEXT_MODE` is true, present as plain-text numbered list:
-```text
+```
 Plan convergence did not complete after {MAX_CYCLES} cycles.
 {HIGH_COUNT} HIGH concerns remain:
 
@@ -191,7 +190,7 @@ Enter number:
 ```
 
 Otherwise use AskUserQuestion:
-```js
+```
 AskUserQuestion([
   {
     question: "Plan convergence did not complete after {MAX_CYCLES} cycles. {HIGH_COUNT} HIGH concerns remain:\n\n{HIGH_LINES}\n\nHow would you like to proceed?",
@@ -207,11 +206,11 @@ AskUserQuestion([
 
 If "Proceed anyway": Display final status and exit.
 If "Manual review":
-```text
+```
 Review the concerns in: {REVIEWS_FILE}
 
-To replan manually:  /gsd:plan-phase {PHASE} --reviews
-To restart loop:     /gsd:plan-review-convergence {PHASE} {REVIEWER_FLAGS}
+To replan manually:  /gsd-plan-phase {PHASE} --reviews
+To restart loop:     /gsd-plan-review-convergence {PHASE} {REVIEWER_FLAGS}
 ```
 Exit workflow.
 
@@ -223,10 +222,10 @@ Update `prev_high_count = HIGH_COUNT`.
 
 Display: `◆ Spawning replan agent with review feedback...`
 
-```text
+```
 Agent(
   description="Replan Phase {PHASE} with review feedback cycle {cycle}",
-  prompt="Run /gsd:plan-phase with --reviews for Phase {PHASE}.
+  prompt="Run /gsd-plan-phase with --reviews for Phase {PHASE}.
 
 Execute: Skill(skill='gsd-plan-phase', args='{PHASE} --reviews --skip-research {GSD_WS}')
 

--- a/get-shit-done/workflows/plan-review-convergence.md
+++ b/get-shit-done/workflows/plan-review-convergence.md
@@ -80,7 +80,7 @@ Display: `◆ No plans found — spawning initial planning agent...`
 ```text
 Agent(
   description="Initial planning Phase {PHASE}",
-  prompt="Run /gsd-plan-phase for Phase {PHASE}.
+  prompt="Run /gsd:plan-phase for Phase {PHASE}.
 
 Execute: Skill(skill='gsd-plan-phase', args='{PHASE} {GSD_WS}')
 
@@ -116,7 +116,7 @@ Display: `◆ Cycle {cycle}/{MAX_CYCLES} — spawning review agent...`
 ```text
 Agent(
   description="Cross-AI review Phase {PHASE} cycle {cycle}",
-  prompt="Run /gsd-review for Phase {PHASE}.
+  prompt="Run /gsd:review for Phase {PHASE}.
 
 Execute: Skill(skill='gsd-review', args='--phase {PHASE} {REVIEWER_FLAGS} {GSD_WS}')
 
@@ -181,7 +181,7 @@ Display:
  No HIGH concerns remaining.
 
  REVIEWS.md: {REVIEWS_FILE}
- Next: /gsd-execute-phase {PHASE}
+ Next: /gsd:execute-phase {PHASE}
 ```
 
 Exit — convergence achieved.
@@ -235,8 +235,8 @@ If "Manual review":
 ```text
 Review the concerns in: {REVIEWS_FILE}
 
-To replan manually:  /gsd-plan-phase {PHASE} --reviews
-To restart loop:     /gsd-plan-review-convergence {PHASE} {REVIEWER_FLAGS}
+To replan manually:  /gsd:plan-phase {PHASE} --reviews
+To restart loop:     /gsd:plan-review-convergence {PHASE} {REVIEWER_FLAGS}
 ```
 Exit workflow.
 
@@ -251,7 +251,7 @@ Display: `◆ Spawning replan agent with review feedback...`
 ```text
 Agent(
   description="Replan Phase {PHASE} with review feedback cycle {cycle}",
-  prompt="Run /gsd-plan-phase with --reviews for Phase {PHASE}.
+  prompt="Run /gsd:plan-phase with --reviews for Phase {PHASE}.
 
 Execute: Skill(skill='gsd-plan-phase', args='{PHASE} --reviews --skip-research {GSD_WS}')
 

--- a/get-shit-done/workflows/plan-review-convergence.md
+++ b/get-shit-done/workflows/plan-review-convergence.md
@@ -158,8 +158,6 @@ If REVIEWS_FILE is empty: Error — review agent did not produce REVIEWS.md. Exi
 
 **Do NOT grep REVIEWS.md.** REVIEWS.md accumulates historical content across cycles; raw text counts are unreliable (a cycle 2 review that re-lists resolved HIGHs for audit would inflate the count and falsely trigger stall detection). Instead, extract the count from the review agent's RETURN MESSAGE using the CYCLE_SUMMARY contract.
 
-**Parsing layer:** this step is performed by the orchestrator LLM on the Agent's final return message (text returned from `Agent(...)`), not by a bash pipeline. There is no `$AGENT_RETURN` variable to feed `grep`/`sed`; the return message is in-context for the orchestrator. The contract below is therefore expressed as extraction rules, not shell code — the same shape `gsd-plan-phase` uses when parsing `gsd-plan-checker`'s return.
-
 Parse the agent's final return message:
 
 - `HIGH_COUNT`: the integer matched by regex `CYCLE_SUMMARY:\s+current_high=(\d+)`. If no match, abort with: `Review agent did not honor the CYCLE_SUMMARY contract — cannot determine HIGH count. Retry or switch reviewer.`

--- a/get-shit-done/workflows/plan-review-convergence.md
+++ b/get-shit-done/workflows/plan-review-convergence.md
@@ -158,6 +158,8 @@ If REVIEWS_FILE is empty: Error — review agent did not produce REVIEWS.md. Exi
 
 **Do NOT grep REVIEWS.md.** REVIEWS.md accumulates historical content across cycles; raw text counts are unreliable (a cycle 2 review that re-lists resolved HIGHs for audit would inflate the count and falsely trigger stall detection). Instead, extract the count from the review agent's RETURN MESSAGE using the CYCLE_SUMMARY contract.
 
+**Parsing layer:** this step is performed by the orchestrator LLM on the Agent's final return message (text returned from `Agent(...)`), not by a bash pipeline. There is no `$AGENT_RETURN` variable to feed `grep`/`sed`; the return message is in-context for the orchestrator. The contract below is therefore expressed as extraction rules, not shell code — the same shape `gsd-plan-phase` uses when parsing `gsd-plan-checker`'s return.
+
 Parse the agent's final return message:
 
 - `HIGH_COUNT`: the integer matched by regex `CYCLE_SUMMARY:\s+current_high=(\d+)`. If no match, abort with: `Review agent did not honor the CYCLE_SUMMARY contract — cannot determine HIGH count. Retry or switch reviewer.`
@@ -271,7 +273,7 @@ After agent returns → go back to **step 5a** (review again).
 - [ ] Initial planning via Agent → Skill("gsd-plan-phase") if no plans exist
 - [ ] Review via Agent → Skill("gsd-review") — isolated, not inline
 - [ ] Replan via Agent → Skill("gsd-plan-phase --reviews") — isolated, not inline
-- [ ] Orchestrator only does: init, loop control, grep HIGHs, stall detection, escalation
+- [ ] Orchestrator only does: init, loop control, parse CYCLE_SUMMARY for HIGH count, stall detection, escalation
 - [ ] Each Agent fully completes its Skill before returning
 - [ ] Loop exits on: no HIGH concerns (converged) OR max cycles (escalation)
 - [ ] Stall detection reported when HIGH count not decreasing

--- a/get-shit-done/workflows/plan-review-convergence.md
+++ b/get-shit-done/workflows/plan-review-convergence.md
@@ -118,9 +118,31 @@ Agent(
   description="Cross-AI review Phase {PHASE} cycle {cycle}",
   prompt="Run /gsd-review for Phase {PHASE}.
 
-Execute: Skill(skill='gsd-review', args='--phase {PHASE} {REVIEWER_FLAGS}')
+Execute: Skill(skill='gsd-review', args='--phase {PHASE} {REVIEWER_FLAGS} {GSD_WS}')
 
-Complete the full review workflow. Do NOT return until REVIEWS.md is committed.",
+Complete the full review workflow. Do NOT return until REVIEWS.md is committed.
+
+--- RETURN CONTRACT (REQUIRED) ---
+
+Your final return message MUST end with these two sections, exactly as specified.
+This is the contract the orchestrator relies on — do NOT skip or reformat.
+
+Section 1 — Machine-readable summary line (exact format, single line):
+
+CYCLE_SUMMARY: current_high=<N> current_medium=<M>
+
+Where <N> counts HIGH-severity concerns that REMAIN UNRESOLVED in this cycle's findings:
+  - INCLUDE: newly raised HIGHs; PARTIALLY RESOLVED HIGHs; previously raised and still unresolved HIGHs
+  - EXCLUDE: explicitly RESOLVED/FULLY RESOLVED HIGHs; HIGH mentions in retrospective/summary tables comparing cycles; quoted excerpts from prior reviews
+<M> follows the same definition for MEDIUM severity.
+
+Section 2 — Current HIGH Concerns (for display on escalation):
+
+## Current HIGH Concerns
+- <one bullet per currently unresolved HIGH, one sentence each>
+(If <N> is 0, write exactly: None.)
+
+--- END RETURN CONTRACT ---",
   mode="auto"
 )
 ```
@@ -132,13 +154,16 @@ REVIEWS_FILE=$(ls ${phase_dir}/${padded_phase}-REVIEWS.md 2>/dev/null)
 
 If REVIEWS_FILE is empty: Error — review agent did not produce REVIEWS.md. Exit.
 
-### 5b. Check for HIGH Concerns
+### 5b. Extract HIGH Count from Agent Return
 
-```bash
-HIGH_COUNT=$(grep -c '\*\*HIGH' "${REVIEWS_FILE}" 2>/dev/null || true)
-HIGH_COUNT=${HIGH_COUNT:-0}
-HIGH_LINES=$(grep -B0 -A1 '\*\*HIGH' "${REVIEWS_FILE}" 2>/dev/null)
-```
+**Do NOT grep REVIEWS.md.** REVIEWS.md accumulates historical content across cycles; raw text counts are unreliable (a cycle 2 review that re-lists resolved HIGHs for audit would inflate the count and falsely trigger stall detection). Instead, extract the count from the review agent's RETURN MESSAGE using the CYCLE_SUMMARY contract.
+
+Parse the agent's final return message:
+
+- `HIGH_COUNT`: the integer matched by regex `CYCLE_SUMMARY:\s+current_high=(\d+)`. If no match, abort with: `Review agent did not honor the CYCLE_SUMMARY contract — cannot determine HIGH count. Retry or switch reviewer.`
+- `HIGH_LINES`: the bullets under the `## Current HIGH Concerns` section of the return message (up to the next `##` heading or end of message). If the section contains only `None.`, set `HIGH_LINES=""`.
+
+Rationale: `gsd-plan-phase` uses the same data-flow pattern — it parses `gsd-plan-checker`'s structured return rather than re-reading PLAN.md. This keeps the count source-of-truth aligned with what the reviewer actually judged (current cycle only), avoiding false stalls from historical accumulation.
 
 **If HIGH_COUNT == 0 (converged):**
 

--- a/get-shit-done/workflows/plan-review-convergence.md
+++ b/get-shit-done/workflows/plan-review-convergence.md
@@ -15,18 +15,7 @@ Read all files referenced by the invoking prompt's execution_context before star
 
 <process>
 
-## 1. Initialize
-
-```bash
-INIT=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" init plan-phase "$PHASE")
-if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
-```
-
-Parse JSON for: `phase_dir`, `phase_number`, `padded_phase`, `phase_name`, `has_plans`, `plan_count`, `commit_docs`, `text_mode`, `response_language`.
-
-**If `response_language` is set:** All user-facing output should be in `{response_language}`.
-
-## 2. Parse and Normalize Arguments
+## 1. Parse and Normalize Arguments
 
 Extract from $ARGUMENTS: phase number, reviewer flags (`--codex`, `--gemini`, `--claude`, `--opencode`, `--all`), `--max-cycles N`, `--text`, `--ws`.
 
@@ -48,6 +37,17 @@ GSD_WS=""
 echo "$ARGUMENTS" | grep -qE '\-\-ws\s+\S+' && GSD_WS=$(echo "$ARGUMENTS" | grep -oE '\-\-ws\s+\S+')
 ```
 
+## 2. Initialize
+
+```bash
+INIT=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" init plan-phase "$PHASE")
+if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
+```
+
+Parse JSON for: `phase_dir`, `phase_number`, `padded_phase`, `phase_name`, `has_plans`, `plan_count`, `commit_docs`, `text_mode`, `response_language`.
+
+**If `response_language` is set:** All user-facing output should be in `{response_language}`.
+
 Set `TEXT_MODE=true` if `--text` is present in $ARGUMENTS OR `text_mode` from init JSON is `true`. When `TEXT_MODE` is active, replace every `AskUserQuestion` call with a plain-text numbered list and ask the user to type their choice number.
 
 ## 3. Validate Phase + Pre-flight Gate
@@ -60,7 +60,7 @@ PHASE_INFO=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" roadmap get-ph
 
 Display startup banner:
 
-```
+```text
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  GSD ► PLAN CONVERGENCE — Phase {phase_number}
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -77,7 +77,7 @@ Display startup banner:
 
 Display: `◆ No plans found — spawning initial planning agent...`
 
-```
+```text
 Agent(
   description="Initial planning Phase {PHASE}",
   prompt="Run /gsd-plan-phase for Phase {PHASE}.
@@ -102,7 +102,7 @@ Display: `Initial planning complete: ${PLAN_COUNT} PLAN.md files created.`
 
 Initialize loop variables:
 
-```
+```text
 cycle = 0
 prev_high_count = Infinity
 ```
@@ -113,7 +113,7 @@ Increment `cycle`.
 
 Display: `◆ Cycle {cycle}/{MAX_CYCLES} — spawning review agent...`
 
-```
+```text
 Agent(
   description="Cross-AI review Phase {PHASE} cycle {cycle}",
   prompt="Run /gsd-review for Phase {PHASE}.
@@ -135,7 +135,8 @@ If REVIEWS_FILE is empty: Error — review agent did not produce REVIEWS.md. Exi
 ### 5b. Check for HIGH Concerns
 
 ```bash
-HIGH_COUNT=$(grep -c '\*\*HIGH' "${REVIEWS_FILE}" 2>/dev/null || echo "0")
+HIGH_COUNT=$(grep -c '\*\*HIGH' "${REVIEWS_FILE}" 2>/dev/null || true)
+HIGH_COUNT=${HIGH_COUNT:-0}
 HIGH_LINES=$(grep -B0 -A1 '\*\*HIGH' "${REVIEWS_FILE}" 2>/dev/null)
 ```
 
@@ -146,7 +147,7 @@ node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" state planned-phase --phase
 ```
 
 Display:
-```
+```text
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
  GSD ► CONVERGENCE COMPLETE ✓
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -167,7 +168,7 @@ Exit — convergence achieved.
 Display: `◆ Cycle {cycle}/{MAX_CYCLES} — {HIGH_COUNT} HIGH concerns found`
 
 **Stall detection:** If `HIGH_COUNT >= prev_high_count`:
-```
+```text
 ⚠ Convergence stalled — HIGH concern count not decreasing
   ({HIGH_COUNT} HIGH concerns, previous cycle had {prev_high_count})
 ```
@@ -175,7 +176,7 @@ Display: `◆ Cycle {cycle}/{MAX_CYCLES} — {HIGH_COUNT} HIGH concerns found`
 **Max cycles check:** If `cycle >= MAX_CYCLES`:
 
 If `TEXT_MODE` is true, present as plain-text numbered list:
-```
+```text
 Plan convergence did not complete after {MAX_CYCLES} cycles.
 {HIGH_COUNT} HIGH concerns remain:
 
@@ -190,7 +191,7 @@ Enter number:
 ```
 
 Otherwise use AskUserQuestion:
-```
+```js
 AskUserQuestion([
   {
     question: "Plan convergence did not complete after {MAX_CYCLES} cycles. {HIGH_COUNT} HIGH concerns remain:\n\n{HIGH_LINES}\n\nHow would you like to proceed?",
@@ -206,7 +207,7 @@ AskUserQuestion([
 
 If "Proceed anyway": Display final status and exit.
 If "Manual review":
-```
+```text
 Review the concerns in: {REVIEWS_FILE}
 
 To replan manually:  /gsd-plan-phase {PHASE} --reviews
@@ -222,7 +223,7 @@ Update `prev_high_count = HIGH_COUNT`.
 
 Display: `◆ Spawning replan agent with review feedback...`
 
-```
+```text
 Agent(
   description="Replan Phase {PHASE} with review feedback cycle {cycle}",
   prompt="Run /gsd-plan-phase with --reviews for Phase {PHASE}.

--- a/tests/plan-review-convergence.test.cjs
+++ b/tests/plan-review-convergence.test.cjs
@@ -3,8 +3,9 @@
  *
  * Validates that the command source and workflow contain the key structural
  * elements required for correct cross-AI plan convergence loop behavior:
- * initial planning gate, review agent spawning, HIGH count detection,
- * stall detection, escalation gate, and STATE.md update on convergence.
+ * initial planning gate, review agent spawning, HIGH count extraction via
+ * CYCLE_SUMMARY contract, stall detection (behavioral), escalation gate
+ * (including --max-cycles 1 edge case), and STATE.md update on convergence.
  */
 
 const { test, describe } = require('node:test');
@@ -107,6 +108,18 @@ describe('plan-review-convergence workflow: initialization (#2306)', () => {
       'workflow must display a startup banner'
     );
   });
+
+  test('workflow parses ARGUMENTS before calling gsd-tools init (PHASE must be known)', () => {
+    const workflow = fs.readFileSync(WORKFLOW_PATH, 'utf8');
+    const parseIdx = workflow.search(/Parse (and Normalize )?Arguments/i);
+    const initIdx = workflow.search(/node\s+"?\$HOME[^"]*gsd-tools\.cjs"?\s+init\s+plan-phase/);
+    assert.ok(parseIdx > -1, 'workflow must have an ARGUMENTS parsing section');
+    assert.ok(initIdx > -1, 'workflow must call gsd-tools.cjs init plan-phase');
+    assert.ok(
+      parseIdx < initIdx,
+      'Arguments parsing must come BEFORE init plan-phase so $PHASE is populated'
+    );
+  });
 });
 
 // ─── Workflow: initial planning gate ──────────────────────────────────────
@@ -148,10 +161,49 @@ describe('plan-review-convergence workflow: convergence loop (#2306)', () => {
     );
   });
 
-  test('workflow detects HIGH concerns by grepping REVIEWS.md', () => {
+  test('review agent spawn forwards --ws via {GSD_WS} (symmetric with replan agent)', () => {
+    // Extract the review agent spawn block (between "Cross-AI review" description and its closing mode="auto")
+    const reviewMatch = workflow.match(/description="Cross-AI review[\s\S]*?mode="auto"/);
+    assert.ok(reviewMatch, 'review agent spawn block must exist');
     assert.ok(
-      workflow.includes('HIGH_COUNT') || workflow.includes('grep'),
-      'workflow must grep REVIEWS.md for HIGH concerns to determine convergence'
+      reviewMatch[0].includes('{GSD_WS}'),
+      'review agent spawn must include {GSD_WS} in the skill args — asymmetry with replan agent is a correctness bug when user passes --ws'
+    );
+  });
+
+  test('replan agent spawn forwards --ws via {GSD_WS}', () => {
+    const replanMatch = workflow.match(/description="Replan[\s\S]*?mode="auto"/);
+    assert.ok(replanMatch, 'replan agent spawn block must exist');
+    assert.ok(
+      replanMatch[0].includes('{GSD_WS}'),
+      'replan agent must include {GSD_WS} in the skill args'
+    );
+  });
+
+  test('workflow extracts HIGH_COUNT via CYCLE_SUMMARY contract (not raw grep of REVIEWS.md)', () => {
+    assert.ok(
+      workflow.includes('CYCLE_SUMMARY'),
+      'workflow must use CYCLE_SUMMARY contract — raw grep of REVIEWS.md double-counts historical references across cycles'
+    );
+    assert.ok(
+      workflow.includes('current_high='),
+      'CYCLE_SUMMARY contract must use current_high=<N> format'
+    );
+    assert.ok(
+      workflow.match(/CYCLE_SUMMARY:\s*\\s\+\s*current_high=\(\\d\+\)/) ||
+      workflow.match(/CYCLE_SUMMARY:\\s\+current_high=\(\\d\+\)/),
+      'workflow must extract HIGH_COUNT via regex matching CYCLE_SUMMARY: current_high=<N>'
+    );
+  });
+
+  test('workflow instructs reviewer to exclude resolved/historical HIGH from count', () => {
+    assert.ok(
+      workflow.includes('EXCLUDE') && workflow.includes('RESOLVED'),
+      'CYCLE_SUMMARY contract must exclude resolved HIGHs from the count'
+    );
+    assert.ok(
+      workflow.match(/retrospective|summary tables/i),
+      'contract must exclude HIGH mentions in retrospective/summary tables (cycle-comparison artifacts)'
     );
   });
 
@@ -186,9 +238,9 @@ describe('plan-review-convergence workflow: convergence loop (#2306)', () => {
   });
 });
 
-// ─── Workflow: stall detection ─────────────────────────────────────────────
+// ─── Workflow: stall detection (behavioral) ───────────────────────────────
 
-describe('plan-review-convergence workflow: stall detection (#2306)', () => {
+describe('plan-review-convergence workflow: stall detection — behavioral (#2306)', () => {
   const workflow = fs.readFileSync(WORKFLOW_PATH, 'utf8');
 
   test('workflow tracks previous HIGH count to detect stalls', () => {
@@ -198,15 +250,50 @@ describe('plan-review-convergence workflow: stall detection (#2306)', () => {
     );
   });
 
-  test('workflow warns when HIGH count is not decreasing', () => {
+  test('stall condition uses >= (covers both "stable" AND "increasing" cases)', () => {
+    // The exact spec: "If HIGH_COUNT >= prev_high_count"
+    // A bug would be using > alone (misses the stable-count case) or <= (inverted logic)
     assert.ok(
-      workflow.includes('stall') || workflow.includes('Stall') || workflow.includes('not decreasing'),
-      'workflow must warn user when HIGH count is not decreasing between cycles'
+      workflow.match(/HIGH_COUNT\s*>=\s*prev_high_count/),
+      'stall condition must be HIGH_COUNT >= prev_high_count — using > alone would miss the "count stable across cycles" case (real stall)'
+    );
+    assert.ok(
+      !workflow.match(/HIGH_COUNT\s*<=\s*prev_high_count/),
+      'stall condition must NOT be <= (that would be inverted logic — decreasing counts would falsely trigger stall)'
+    );
+  });
+
+  // Behavioral simulation: verify the condition `HIGH_COUNT >= prev_high_count`
+  // produces correct stall/no-stall decisions across the three cycle transitions.
+  const stallCondition = (current, previous) => current >= previous;
+
+  test('BEHAVIORAL: decreasing HIGH count (progress) does NOT trigger stall', () => {
+    // 5 → 3: real progress, cycle should continue to replan
+    assert.strictEqual(stallCondition(3, 5), false, 'decreasing 5→3 must NOT be stall');
+    assert.strictEqual(stallCondition(1, 10), false, 'decreasing 10→1 must NOT be stall');
+  });
+
+  test('BEHAVIORAL: stable HIGH count (no progress) DOES trigger stall', () => {
+    // 5 → 5: the original stall case from revision-loop.md
+    assert.strictEqual(stallCondition(5, 5), true, 'stable 5→5 MUST be stall (revision not converging)');
+    assert.strictEqual(stallCondition(0, 0), true, 'stable 0→0 is stall but HIGH_COUNT==0 exits loop first — trap prevents false alarm');
+  });
+
+  test('BEHAVIORAL: increasing HIGH count (regression) DOES trigger stall', () => {
+    // Regression case: replan made things worse
+    assert.strictEqual(stallCondition(7, 5), true, 'increasing 5→7 MUST be stall (regression)');
+    assert.strictEqual(stallCondition(13, 3), true, 'increasing 3→13 MUST be stall');
+  });
+
+  test('workflow emits stall warning text when condition triggers', () => {
+    assert.ok(
+      workflow.match(/stalled|Stall|not decreasing/),
+      'workflow must emit a stall warning message when condition triggers (for user visibility)'
     );
   });
 });
 
-// ─── Workflow: escalation gate ────────────────────────────────────────────
+// ─── Workflow: escalation gate (including --max-cycles 1 edge) ────────────
 
 describe('plan-review-convergence workflow: escalation gate (#2306)', () => {
   const workflow = fs.readFileSync(WORKFLOW_PATH, 'utf8');
@@ -217,6 +304,28 @@ describe('plan-review-convergence workflow: escalation gate (#2306)', () => {
       (workflow.includes('AskUserQuestion') || workflow.includes('vscode_askquestions')),
       'workflow must escalate to user via AskUserQuestion when max cycles reached'
     );
+  });
+
+  test('max-cycles condition uses >= (so --max-cycles 1 triggers after cycle 1)', () => {
+    assert.ok(
+      workflow.match(/cycle\s*>=\s*MAX_CYCLES/),
+      'max-cycles check must use cycle >= MAX_CYCLES — using > alone would require cycle=MAX_CYCLES+1 before escalation'
+    );
+  });
+
+  // Behavioral simulation: --max-cycles 1 corner case
+  const shouldEscalate = (cycle, maxCycles, highCount) => highCount > 0 && cycle >= maxCycles;
+
+  test('BEHAVIORAL: --max-cycles 1 with HIGHs in cycle 1 immediately escalates (no replan)', () => {
+    // User sets --max-cycles 1 as "review-only / dry-run" mode
+    assert.strictEqual(shouldEscalate(1, 1, 3), true, 'cycle=1, max=1, HIGHs=3 MUST escalate immediately');
+    assert.strictEqual(shouldEscalate(1, 1, 0), false, 'cycle=1, max=1, HIGHs=0 converges instead (HIGH_COUNT==0 branch exits earlier)');
+  });
+
+  test('BEHAVIORAL: --max-cycles 3 (default) only escalates after 3 cycles', () => {
+    assert.strictEqual(shouldEscalate(1, 3, 5), false, 'cycle=1 of 3: must NOT escalate yet — replan next');
+    assert.strictEqual(shouldEscalate(2, 3, 5), false, 'cycle=2 of 3: must NOT escalate yet — replan next');
+    assert.strictEqual(shouldEscalate(3, 3, 5), true, 'cycle=3 of 3: MUST escalate (max reached)');
   });
 
   test('escalation offers "Proceed anyway" option', () => {
@@ -257,6 +366,13 @@ describe('plan-review-convergence workflow: artifact verification (#2306)', () =
     assert.ok(
       workflow.includes('REVIEWS_FILE') || workflow.includes('review agent did not produce'),
       'workflow must error if the review agent fails to produce REVIEWS.md'
+    );
+  });
+
+  test('workflow aborts if review agent omits CYCLE_SUMMARY contract', () => {
+    assert.ok(
+      workflow.match(/did not honor the CYCLE_SUMMARY contract/i),
+      'workflow must fail-loud (not silently default) if review agent omits the CYCLE_SUMMARY summary line'
     );
   });
 });

--- a/tests/plan-review-convergence.test.cjs
+++ b/tests/plan-review-convergence.test.cjs
@@ -241,59 +241,6 @@ describe('plan-review-convergence workflow: escalation gate (#2306)', () => {
   });
 });
 
-// ─── Workflow: stall detection — behavioral ───────────────────────────────
-
-describe('plan-review-convergence workflow: stall detection behavioral (#2306)', () => {
-  const workflow = fs.readFileSync(WORKFLOW_PATH, 'utf8');
-
-  test('workflow surfaces stall warning when prev_high_count equals current HIGH_COUNT', () => {
-    // Behavioral test: two consecutive cycles with the same HIGH count must trigger
-    // the stall warning. The workflow must compare HIGH_COUNT >= prev_high_count and
-    // emit a warning string that would appear in output.
-    assert.ok(
-      workflow.includes('prev_high_count') || workflow.includes('prev_HIGH'),
-      'workflow must track prev_high_count across cycles'
-    );
-    // The comparison that detects the stall
-    assert.ok(
-      workflow.includes('HIGH_COUNT >= prev_high_count') ||
-      workflow.includes('HIGH_COUNT >= prev_HIGH') ||
-      workflow.includes('not decreasing'),
-      'workflow must compare current HIGH count against previous to detect stall'
-    );
-    // The stall warning text that appears in output
-    assert.ok(
-      workflow.includes('stall') || workflow.includes('Stall') || workflow.includes('not decreasing'),
-      'workflow must emit a stall warning when HIGH count is not decreasing'
-    );
-  });
-});
-
-// ─── Workflow: --max-cycles 1 immediate escalation — behavioral ────────────
-
-describe('plan-review-convergence workflow: --max-cycles 1 immediate escalation behavioral (#2306)', () => {
-  const workflow = fs.readFileSync(WORKFLOW_PATH, 'utf8');
-
-  test('workflow escalates immediately after cycle 1 when --max-cycles 1 and HIGH > 0', () => {
-    // Behavioral test: when max_cycles=1, after the first review cycle, if HIGH_COUNT > 0
-    // the workflow must trigger the escalation gate (cycle >= MAX_CYCLES check fires on
-    // cycle 1 itself). Verify the workflow contains the logic for this edge case.
-    assert.ok(
-      workflow.includes('cycle >= MAX_CYCLES') ||
-      workflow.includes('cycle >= max_cycles') ||
-      (workflow.includes('MAX_CYCLES') && workflow.includes('AskUserQuestion')),
-      'workflow must check cycle >= MAX_CYCLES so --max-cycles 1 triggers escalation after first cycle'
-    );
-    // Escalation gate must fire when HIGH > 0 (not just at exactly max_cycles)
-    assert.ok(
-      workflow.includes('HIGH_COUNT > 0') ||
-      workflow.includes('HIGH concerns remain') ||
-      workflow.includes('Proceed anyway'),
-      'escalation gate must be reachable when HIGH_COUNT > 0 after a single cycle'
-    );
-  });
-});
-
 // ─── Workflow: REVIEWS.md verification ────────────────────────────────────
 
 describe('plan-review-convergence workflow: artifact verification (#2306)', () => {


### PR DESCRIPTION
## Linked Issue

Closes #2306

---

## Feature summary

Adds `gsd:plan-review-convergence` — a cross-AI plan convergence loop that automates the manual `plan-phase → review → replan → re-review` chain. The orchestrator spawns isolated Agents for existing `gsd-plan-phase` and `gsd-review` Skills, then loops until no HIGH concerns remain in REVIEWS.md or max cycles (default 3) are reached.

## What changed

### New files

| File | Purpose |
|------|---------|
| `commands/gsd/plan-review-convergence.md` | Command source — installs as `gsd-plan-review-convergence` skill |
| `get-shit-done/workflows/plan-review-convergence.md` | Workflow logic: init, convergence loop, stall detection, escalation gate |
| `tests/plan-review-convergence.test.cjs` | 27 tests covering command structure, loop behavior, stall detection, escalation |

### Modified files

| File | What changed |
|------|-------------|
| `CHANGELOG.md` | Added `[Unreleased] → Added` entry for the new command |

## Implementation notes

Implementation matches the approved spec exactly. The only discretionary decisions:
- Test file name follows existing `<command-name>.test.cjs` convention
- Tests use content assertion pattern (same as `chain-flag-plan-phase.test.cjs`, `code-review-command.test.cjs`) — verifies workflow contains key instruction strings the LLM will read at runtime
- CHANGELOG entry placed under `### Added` in `[Unreleased]` section

## Spec compliance

- [x] New command `gsd:plan-review-convergence` with all documented flags (`--codex`, `--gemini`, `--claude`, `--opencode`, `--all`, `--max-cycles N`)
- [x] `--codex` is the default reviewer when no flag specified
- [x] Orchestrator-only loop control — planning and reviewing happen in isolated Agents calling existing Skills
- [x] Initial planning gate: skips if plans exist, spawns `gsd-plan-phase` if not, errors if no PLAN.md produced
- [x] Review agent spawned each cycle via `gsd-review`
- [x] HIGH concern detection by grepping REVIEWS.md
- [x] Loop exits when HIGH_COUNT == 0, STATE.md updated
- [x] Stall detection: warns when HIGH count not decreasing
- [x] Escalation gate at max cycles: `AskUserQuestion` with "Proceed anyway" / "Manual review" options
- [x] TEXT_MODE fallback for plain-text escalation
- [x] Copilot `vscode_askquestions` runtime note

## Testing

### Test coverage

`tests/plan-review-convergence.test.cjs` — 27 tests across 7 suites:
- Command source structure (name prefix, flags, allowed-tools, execution_context references)
- Workflow initialization (gsd-tools.cjs init, --max-cycles parsing, banner)
- Initial planning gate (has_plans check, agent spawn, error on empty output)
- Convergence loop (review agent, HIGH grep, loop exit, STATE.md update, --reviews, --skip-research)
- Stall detection (prev_high_count tracking, warning text)
- Escalation gate (AskUserQuestion, "Proceed anyway", "Manual review", TEXT_MODE)
- Artifact verification (REVIEWS.md existence check, error on missing)

All 27 tests pass: `node --test tests/plan-review-convergence.test.cjs`

### Platforms tested

- [x] macOS
- [ ] Windows (backslash paths — workflow uses bash string ops; no path construction in the new files)
- [ ] Linux

### Runtimes tested

- [x] Claude Code (validated on real phase, 2 cycles, 13 HIGH → 0 HIGH)
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Codex (used as reviewer in real-world validation)
- [ ] Copilot
- [ ] Other

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue exactly
- [x] No additional features, commands, or behaviors were added beyond what was approved
- [x] Scope did not change during implementation

---

## Checklist

- [x] Issue linked above with `Closes #2306`
- [x] Linked issue has the `approved-feature` label
- [x] All acceptance criteria from the issue are met (listed above)
- [x] Implementation scope matches the approved spec exactly
- [x] All existing tests pass (`npm test`)
- [x] New tests cover the happy path, error cases, and edge cases (27 tests)
- [x] CHANGELOG.md updated with a user-facing description of the feature
- [ ] Documentation updated — no existing docs reference this command; workflow self-documents via `<objective>` and `<context>` tags
- [x] No unnecessary external dependencies added
- [x] Works on Windows — no path construction in new files; workflow uses bash variable substitution only

## Breaking changes

None

## Screenshots / recordings

Real-world validation on Phase 04.1 (COMET Evaluation Metrics, 4 PLAN.md files):

| Cycle | HIGH count | Action |
|-------|-----------|--------|
| 1 | 13 | Stall check passed (13 < ∞) → replan with review feedback |
| 2 | 0 | Converged — STATE.md updated |

Concerns caught: verdict math not switched to new metric, missing INCONCLUSIVE outcome paths, silent COMET model failure modes. All resolved in one replan cycle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced validation and escalation logic for high-priority concerns in the plan review process to ensure strict format compliance and reliable issue tracking.

* **Tests**
  * Added comprehensive test coverage for plan review convergence workflow, including initialization, convergence loops, stall detection, and escalation gates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->