### PR TITLE
docs: fix trust-bug defaults and stale claims (stacked 1/5)

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,6 +1,6 @@
 # GSD Agent Reference
 
-> All 21 specialized agents — roles, tools, spawn patterns, and relationships. For architecture context, see [Architecture](ARCHITECTURE.md).
+> Role cards for 21 specialized agents — roles, tools, spawn patterns, and relationships. The `agents/` directory is the authoritative roster; see [Architecture](ARCHITECTURE.md) for context.
 
 ---
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -95,7 +95,7 @@ GSD stores project settings in `.planning/config.json`. Created during `/gsd-new
   "intel": {
     "enabled": false
   },
-  "claude_md_path": null
+  "claude_md_path": "./CLAUDE.md"
 }
 ```
 
@@ -111,7 +111,7 @@ GSD stores project settings in `.planning/config.json`. Created during `/gsd-new
 | `project_code` | string | any short string | (none) | Prefix for phase directory names (e.g., `"ABC"` produces `ABC-01-setup/`). Added in v1.31 |
 | `response_language` | string | language code | (none) | Language for agent responses (e.g., `"pt"`, `"ko"`, `"ja"`). Propagates to all spawned agents for cross-phase language consistency. Added in v1.32 |
 | `context_profile` | string | `dev`, `research`, `review` | (none) | Execution context preset that applies a pre-configured bundle of mode, model, and workflow settings for the current type of work. Added in v1.34 |
-| `claude_md_path` | string | any file path | (none) | Custom output path for the generated CLAUDE.md file. Useful for monorepos or projects that need CLAUDE.md in a non-root location. When set, GSD writes its CLAUDE.md content to this path instead of the project root. Added in v1.36 |
+| `claude_md_path` | string | any file path | `./CLAUDE.md` | Custom output path for the generated CLAUDE.md file. Useful for monorepos or projects that need CLAUDE.md in a non-root location. Defaults to `./CLAUDE.md` at the project root. Added in v1.36 |
 
 > **Note:** `granularity` was renamed from `depth` in v1.22.3. Existing configs are auto-migrated.
 
@@ -143,7 +143,7 @@ All workflow toggles follow the **absent = enabled** pattern. If a key is missin
 | `workflow.plan_bounce_script` | string | (none) | Path to the external script invoked for plan bounce validation. Receives the PLAN.md path as its first argument. Required when `plan_bounce` is `true`. Added in v1.36 |
 | `workflow.plan_bounce_passes` | number | `2` | Number of sequential bounce passes to run. Each pass feeds the previous pass's output back into the validator. Higher values increase rigor at the cost of latency. Added in v1.36 |
 | `workflow.code_review_command` | string | (none) | Shell command for external code review integration in `/gsd-ship`. Receives changed file paths via stdin. Non-zero exit blocks the ship workflow. Added in v1.36 |
-| `workflow.tdd_mode` | boolean | `false` | Enable TDD pipeline as a first-class execution mode. When `true`, the planner aggressively applies `type: tdd` to eligible tasks (business logic, APIs, validations, algorithms) and the executor enforces RED/GREEN/REFACTOR gate sequence. An end-of-phase collaborative review checkpoint verifies gate compliance. Added in v1.37 |
+| `workflow.tdd_mode` | boolean | `false` | Enable TDD pipeline as a first-class execution mode. When `true`, the planner aggressively applies `type: tdd` to eligible tasks (business logic, APIs, validations, algorithms) and the executor enforces RED/GREEN/REFACTOR gate sequence. An end-of-phase collaborative review checkpoint verifies gate compliance. Added in v1.36 |
 | `workflow.cross_ai_execution` | boolean | `false` | Delegate phase execution to an external AI CLI instead of spawning local executor agents. Useful for leveraging a different model's strengths for specific phases. Added in v1.36 |
 | `workflow.cross_ai_command` | string | (none) | Shell command template for cross-AI execution. Receives the phase prompt via stdin. Must produce SUMMARY.md-compatible output. Required when `cross_ai_execution` is `true`. Added in v1.36 |
 | `workflow.cross_ai_timeout` | number | `300` | Timeout in seconds for cross-AI execution commands. Prevents runaway external processes. Added in v1.36 |

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,18 +9,18 @@ Language versions: [English](README.md) · [Português (pt-BR)](pt-BR/README.md)
 | Document | Audience | Description |
 |----------|----------|-------------|
 | [Architecture](ARCHITECTURE.md) | Contributors, advanced users | System architecture, agent model, data flow, and internal design |
-| [Feature Reference](FEATURES.md) | All users | Complete feature and function documentation with requirements |
-| [Command Reference](COMMANDS.md) | All users | Every command with syntax, flags, options, and examples |
+| [Feature Reference](FEATURES.md) | All users | Feature narratives and requirements for released features (see [CHANGELOG](../CHANGELOG.md) for latest additions) |
+| [Command Reference](COMMANDS.md) | All users | Stable commands with syntax, flags, options, and examples |
 | [Configuration Reference](CONFIGURATION.md) | All users | Full config schema, workflow toggles, model profiles, git branching |
 | [CLI Tools Reference](CLI-TOOLS.md) | Contributors, agent authors | `gsd-tools.cjs` programmatic API for workflows and agents |
-| [Agent Reference](AGENTS.md) | Contributors, advanced users | All 18 specialized agents — roles, tools, spawn patterns |
+| [Agent Reference](AGENTS.md) | Contributors, advanced users | Role cards for primary agents — roles, tools, spawn patterns (the `agents/` filesystem is authoritative) |
 | [User Guide](USER-GUIDE.md) | All users | Workflow walkthroughs, troubleshooting, and recovery |
 | [Context Monitor](context-monitor.md) | All users | Context window monitoring hook architecture |
 | [Discuss Mode](workflow-discuss-mode.md) | All users | Assumptions vs interview mode for discuss-phase |
 
 ## Quick Links
 
-- **What's new in v1.32:** STATE.md consistency gates, `--to N` autonomous flag, research gate, verifier scope filtering, read-before-edit guard, 4 new runtimes (Trae, Kilo, Augment, Cline), context reduction, response language config — see [CHANGELOG](../CHANGELOG.md)
+- **What's new:** see [CHANGELOG](../CHANGELOG.md) for current release notes, and upstream [README](../README.md) for release highlights
 - **Getting started:** [README](../README.md) → install → `/gsd-new-project`
 - **Full workflow walkthrough:** [User Guide](USER-GUIDE.md)
 - **All commands at a glance:** [Command Reference](COMMANDS.md)

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -623,7 +623,7 @@ GSD stores project settings in `.planning/config.json`. Configure during `/gsd-n
 | `workflow.ui_phase` | `true`, `false` | `true` | Generate UI design contracts for frontend phases |
 | `workflow.ui_safety_gate` | `true`, `false` | `true` | plan-phase prompts to run /gsd-ui-phase for frontend phases |
 | `workflow.research_before_questions` | `true`, `false` | `false` | Run research before discussion questions instead of after |
-| `workflow.discuss_mode` | `standard`, `assumptions` | `standard` | Discussion style: open-ended questions vs. codebase-driven assumptions |
+| `workflow.discuss_mode` | `discuss`, `assumptions` | `discuss` | Discussion style: open-ended questions vs. codebase-driven assumptions |
 | `workflow.skip_discuss` | `true`, `false` | `false` | Skip discuss-phase entirely in autonomous mode; writes minimal CONTEXT.md from ROADMAP phase goal |
 | `response_language` | language code | (none) | Agent response language for cross-phase consistency (e.g., `"pt"`, `"ko"`, `"ja"`) |
 


### PR DESCRIPTION
## Summary

PR 1 of a stacked 5-PR docs refresh series. Fixes the load-bearing trust-bugs in the v1.36.0 docs corpus that would mislead a reader using the docs as config or release reference.

### Changes

- **`docs/README.md`**: drop three exhaustiveness claims (\"Complete feature and function documentation\", \"Every command\", \"All 18 specialized agents\") and replace the version-pinned \"What's new in v1.32\" bullet with a CHANGELOG pointer.
- **`docs/CONFIGURATION.md`**: correct `claude_md_path` default (`null` / `(none)` → `./CLAUDE.md`) in both the Full Schema and the core settings table to match `templates/config.json:55` and `tests/claude-md-path.test.cjs`; correct `workflow.tdd_mode` provenance from \"Added in v1.37\" → \"Added in v1.36\" to match `CHANGELOG.md` and `bin/lib/config.cjs`.
- **`docs/USER-GUIDE.md`**: fix `workflow.discuss_mode` default (`standard` → `discuss`) and the Options enum cell (`standard, assumptions` → `discuss, assumptions`).
- **`docs/AGENTS.md`**: weaken the \"All 21 specialized agents\" header so it stops asserting exhaustiveness the file does not deliver (the `agents/` filesystem roster is 31).

### Scope

Docs-only. No `CHANGELOG.md` touches. No new files. No runtime changes. Localized docs (`pt-BR/`, `ja-JP/`, `ko-KR/`, `zh-CN/`) are intentionally deferred to a post-series localization pass.

### Stack context

Base: `main`. This is the first in a 5-PR series:

1. **PR 1 (this PR)** — trust-bug hotfixes
2. PR 2 — shipped-surface catchup (graphify, `/gsd-quick`, `/gsd-thread`, `planning.sub_repos`)
3. PR 3 — inventory and model-profile truth (adds `docs/INVENTORY.md`)
4. PR 4 — drift-prevention parity tests and structural moves
5. PR 5 — cleanup (FEATURES TOC, hook-list reconciliation, workflow-discuss-mode invocation syntax)

Each subsequent PR stacks on its predecessor's branch.

## Test plan

- [ ] CI green
- [ ] Render `docs/README.md`, `docs/CONFIGURATION.md`, `docs/USER-GUIDE.md`, `docs/AGENTS.md` and spot-check the corrected cells
- [ ] Cross-check `claude_md_path` default against `templates/config.json` and `tests/claude-md-path.test.cjs`
- [ ] Cross-check `workflow.tdd_mode` provenance against `CHANGELOG.md` v1.36.0 entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation index and descriptions for clarity.
  * Refined agent and command reference documentation.

* **Configuration**
  * Changed `claude_md_path` default to `./CLAUDE.md`.
  * Changed `workflow.discuss_mode` default to `discuss`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->