### PR TITLE
fix(quick): add gsd-sdk pre-flight check with install hint (#2334)

### DIFF
--- a/get-shit-done/workflows/quick.md
+++ b/get-shit-done/workflows/quick.md
@@ -125,6 +125,19 @@ If `$VALIDATE_MODE` only:
 **Step 2: Initialize**
 
 ```bash
+if ! command -v gsd-sdk &>/dev/null; then
+  echo "⚠ gsd-sdk not found in PATH — /gsd-quick requires it."
+  echo ""
+  echo "Install the GSD SDK:"
+  echo "  npm install -g @gsd-build/sdk"
+  echo ""
+  echo "Or update GSD to get the latest packages:"
+  echo "  /gsd-update"
+  exit 1
+fi
+```
+
+```bash
 INIT=$(gsd-sdk query init.quick "$DESCRIPTION")
 if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 AGENT_SKILLS_PLANNER=$(gsd-sdk query agent-skills gsd-planner 2>/dev/null)

--- a/tests/bug-2334-quick-gsd-sdk-preflight.test.cjs
+++ b/tests/bug-2334-quick-gsd-sdk-preflight.test.cjs
@@ -1,0 +1,62 @@
+/**
+ * Regression test for bug #2334
+ *
+ * /gsd-quick crashed with `command not found: gsd-sdk` (exit code 127) when
+ * the gsd-sdk binary was not installed or not in PATH. The workflow's Step 2
+ * called `gsd-sdk query init.quick` directly with no pre-flight check and no
+ * fallback, so missing gsd-sdk caused an immediate abort with no helpful message.
+ *
+ * Fix: Step 2 must check for gsd-sdk in PATH before invoking it. If absent,
+ * emit a human-readable error pointing users to the install command.
+ */
+
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const WORKFLOW_PATH = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'quick.md');
+
+describe('bug #2334: quick workflow gsd-sdk pre-flight check', () => {
+  let content;
+
+  test('workflow file exists', () => {
+    assert.ok(fs.existsSync(WORKFLOW_PATH), 'workflows/quick.md should exist');
+    content = fs.readFileSync(WORKFLOW_PATH, 'utf-8');
+  });
+
+  test('Step 2 checks for gsd-sdk before invoking it', () => {
+    content = content || fs.readFileSync(WORKFLOW_PATH, 'utf-8');
+    // The check must appear before the first gsd-sdk invocation in Step 2
+    const step2Start = content.indexOf('**Step 2:');
+    assert.ok(step2Start !== -1, 'Step 2 must exist in quick workflow');
+
+    const firstSdkCall = content.indexOf('gsd-sdk query init.quick', step2Start);
+    assert.ok(firstSdkCall !== -1, 'gsd-sdk query init.quick must be present in Step 2');
+
+    // Find any gsd-sdk availability check between the Step 2 heading and the first call
+    const step2Section = content.slice(step2Start, firstSdkCall);
+    const hasCommandCheck = step2Section.includes('command -v gsd-sdk') || step2Section.includes('which gsd-sdk');
+    assert.ok(
+      hasCommandCheck,
+      'Step 2 must check for gsd-sdk in PATH (via `command -v gsd-sdk` or `which gsd-sdk`) ' +
+      'before calling `gsd-sdk query init.quick`. Without this guard, the workflow crashes ' +
+      'with exit code 127 when gsd-sdk is not installed (root cause of #2334).'
+    );
+  });
+
+  test('pre-flight error message references the install command', () => {
+    content = content || fs.readFileSync(WORKFLOW_PATH, 'utf-8');
+    const step2Start = content.indexOf('**Step 2:');
+    const firstSdkCall = content.indexOf('gsd-sdk query init.quick', step2Start);
+    const step2Section = content.slice(step2Start, firstSdkCall);
+
+    const hasInstallHint = step2Section.includes('@gsd-build/sdk') || step2Section.includes('gsd-update') || step2Section.includes('/gsd-update');
+    assert.ok(
+      hasInstallHint,
+      'Pre-flight error must include a hint on how to install gsd-sdk (npm install -g @gsd-build/sdk or /gsd-update)'
+    );
+  });
+});


### PR DESCRIPTION
Closes #2334

## Root cause
\`/gsd-quick\` Step 2 called \`gsd-sdk query init.quick\` with no check that \`gsd-sdk\` was available in PATH. Users who install \`get-shit-done-cc\` without also installing \`@gsd-build/sdk\` see an immediate \`command not found: gsd-sdk\` (exit 127) with no guidance.

## Fix
Added a pre-flight check block at the start of Step 2. If \`gsd-sdk\` is not found in PATH, the workflow emits a clear error with the install command before aborting.

## Test
\`tests/bug-2334-quick-gsd-sdk-preflight.test.cjs\` — 3 tests verifying:
1. A \`command -v gsd-sdk\` check exists before the first SDK invocation
2. The error message includes the \`@gsd-build/sdk\` install command
3. Workflow file exists

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added preflight validation to the Quick workflow to verify required tools are available before execution. Users now receive clear installation instructions if tools are missing, preventing silent failures.

* **Tests**
  * Added regression tests to ensure preflight validation functions correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->