### PR TITLE
docs(contributing): clarify agents/ source of truth (#2365)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -316,12 +316,24 @@ get-shit-done/
   workflows/            — Workflow definitions (.md)
   references/           — Reference documentation (.md)
   templates/            — File templates
-agents/                 — Agent definitions (.md)
+agents/                 — Agent definitions (.md) — CANONICAL SOURCE
 commands/gsd/           — Slash command definitions (.md)
 tests/                  — Test files (.test.cjs)
   helpers.cjs           — Shared test utilities
 docs/                   — User-facing documentation
 ```
+
+### Source of truth for agents
+
+Only `agents/` at the repo root is tracked by git. The following directories may exist on a developer machine with GSD installed and **must not be edited** — they are install-sync outputs and will be overwritten:
+
+| Path | Gitignored | What it is |
+|------|-----------|------------|
+| `.claude/agents/` | Yes (`.gitignore:9`) | Local Claude Code runtime sync |
+| `.cursor/agents/` | Yes (`.gitignore:12`) | Local Cursor IDE bundle |
+| `.github/agents/gsd-*` | Yes (`.gitignore:37`) | Local CI-surface bundle |
+
+If you find that `.claude/agents/` has drifted from `agents/` (e.g., after a branch change), re-run `bin/install.js` to re-sync from the canonical source. Always edit `agents/` — never the derivative directories.
 
 ## Security
 


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #2365

---

## What this enhancement improves

Documents which `agents/` directory is the canonical source of truth. Without this doc, new contributors (and Claude in `/gsd-quick` sessions) can edit `.claude/agents/`, `.cursor/agents/`, or `.github/agents/` by mistake — those are install-sync outputs and edits are lost on reinstall.

## Before / After

**Before:** `CONTRIBUTING.md § File Structure` listed `agents/  — Agent definitions (.md)` with no indication the other paths are derivative.

**After:** A new **"Source of truth for agents"** subsection explicitly lists the four agent paths, marks only `agents/` as canonical, cites the exact `.gitignore` lines for each install-sync target, and instructs contributors to re-run `bin/install.js` if they notice drift. The entry for `agents/` in the File Structure tree is now marked `CANONICAL SOURCE`.

## How it was implemented

Docs-only change to `CONTRIBUTING.md § File Structure`. No code.

## Testing

### How I verified the enhancement works

- Confirmed each cited `.gitignore` line exists at the stated line number:
  - `.gitignore:9` — `.claude/`
  - `.gitignore:12` — `.cursor/`
  - `.gitignore:37` — `.github/agents/gsd-*`
- Verified `agents/` is git-tracked (`git ls-files agents/ | head`) and `.claude/agents/` is not (`git ls-files .claude/agents/` returns nothing).
- Markdown preview renders cleanly.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (pure docs change)

### Runtimes tested

- [x] N/A (pure docs change)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

---

## Checklist

- [x] Issue linked above with `Closes #NNN`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass (`npm test`) — docs-only change, no tests affected
- [x] New or updated tests cover the enhanced behavior (N/A — docs)
- [x] CHANGELOG.md updated (N/A — docs-only; CONTRIBUTING changes are not typically changelogged)
- [x] Documentation updated if behavior or output changed (this IS the doc change)
- [x] No unnecessary dependencies added

## Breaking changes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributing guidelines to clearly identify the canonical source location for agents in the repository structure.
  * Added detailed guidance on agent directory management, explaining which directories are maintained in git versus automatically synced, along with instructions for keeping developer environments synchronized when drift occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->