### PR TITLE
fix(tests): clear CLAUDECODE env var in read-guard test runner

### DIFF
--- a/tests/read-guard.test.cjs
+++ b/tests/read-guard.test.cjs
@@ -29,7 +29,7 @@ const HOOK_PATH = path.join(__dirname, '..', 'hooks', 'gsd-read-guard.js');
 function runHook(payload, envOverrides = {}) {
   const input = JSON.stringify(payload);
   // Sanitize CLAUDE_SESSION_ID so positive-path tests work inside Claude Code sessions
-  const env = { ...process.env, CLAUDE_SESSION_ID: '', ...envOverrides };
+  const env = { ...process.env, CLAUDE_SESSION_ID: '', CLAUDECODE: '', ...envOverrides };
   try {
     const stdout = execFileSync(process.execPath, [HOOK_PATH], {
       input,


### PR DESCRIPTION
## Summary
- Fixes 4 failing tests in `tests/read-guard.test.cjs` that caused CI to fail on the 1.37.0 commit
- The `gsd-read-guard.js` hook skips on two env vars: `CLAUDE_SESSION_ID` **and** `CLAUDECODE`. The test helper cleared `CLAUDE_SESSION_ID` but not `CLAUDECODE`, so when tests ran inside a Claude Code session the hook silently no-oped and produced no stdout — causing `JSON.parse('')` to throw downstream

## Test plan
- [x] All 13 `gsd-read-guard` tests pass locally
- [x] `CLAUDECODE` is now cleared alongside `CLAUDE_SESSION_ID` in `runHook()`

Closes #(none — CI fix for 1.37.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test execution environment by updating the test helper to inject additional environment-specific variables during subprocess operations. This modification improves test coverage for runtime behavior scenarios and session-related code paths, enabling more comprehensive validation across different execution contexts while maintaining full compatibility with existing test flows and assertion logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->