### PR TITLE
fix(ci): update ARCHITECTURE.md counts and add TEXT_MODE fallback to sketch workflow

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -409,7 +409,7 @@ UI-SPEC.md (per phase) ───────────────────
 
 ```
 ~/.claude/                          # Claude Code (global install)
-├── commands/gsd/*.md               # 75 slash commands
+├── commands/gsd/*.md               # 79 slash commands
 ├── get-shit-done/
 │   ├── bin/gsd-tools.cjs           # CLI utility
 │   ├── bin/lib/*.cjs               # 19 domain modules

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -113,7 +113,7 @@ User-facing entry points. Each file contains YAML frontmatter (name, description
 - **Copilot:** Slash commands (`/gsd-command-name`)
 - **Antigravity:** Skills
 
-**Total commands:** 75
+**Total commands:** 79
 
 ### Workflows (`get-shit-done/workflows/*.md`)
 
@@ -124,7 +124,7 @@ Orchestration logic that commands reference. Contains the step-by-step process i
 - State update patterns
 - Error handling and recovery
 
-**Total workflows:** 72
+**Total workflows:** 76
 
 ### Agents (`agents/*.md`)
 

--- a/get-shit-done/workflows/sketch.md
+++ b/get-shit-done/workflows/sketch.md
@@ -24,7 +24,10 @@ Read all files referenced by the invoking prompt's execution_context before star
 
 Parse `$ARGUMENTS` for:
 - `--quick` flag → set `QUICK_MODE=true`
+- `--text` flag → set `TEXT_MODE=true`
 - Remaining text → the design idea to sketch
+
+**Text mode (`workflow.text_mode: true` in config or `--text` flag):** Set `TEXT_MODE=true` if `--text` is present in `$ARGUMENTS` OR `text_mode` from init JSON is `true`. When TEXT_MODE is active, replace every `AskUserQuestion` call with a plain-text numbered list and ask the user to type their choice number. This is required for non-Claude runtimes (OpenAI Codex, Gemini CLI, etc.) where `AskUserQuestion` is not available.
 </step>
 
 <step name="setup_directory">

--- a/tests/read-guard.test.cjs
+++ b/tests/read-guard.test.cjs
@@ -29,7 +29,7 @@ const HOOK_PATH = path.join(__dirname, '..', 'hooks', 'gsd-read-guard.js');
 function runHook(payload, envOverrides = {}) {
   const input = JSON.stringify(payload);
   // Sanitize CLAUDE_SESSION_ID so positive-path tests work inside Claude Code sessions
-  const env = { ...process.env, CLAUDE_SESSION_ID: '', ...envOverrides };
+  const env = { ...process.env, CLAUDE_SESSION_ID: '', CLAUDECODE: '', ...envOverrides };
   try {
     const stdout = execFileSync(process.execPath, [HOOK_PATH], {
       input,


### PR DESCRIPTION
## Summary
- Updates `docs/ARCHITECTURE.md` component counts: 75→79 commands, 72→76 workflows (4 new spike/sketch files added in 1.37.0 were not reflected)
- Adds required `TEXT_MODE` fallback to `get-shit-done/workflows/sketch.md` — it uses `AskUserQuestion` but was missing the non-Claude runtime fallback required by #2012

## Test plan
- [x] `architecture-counts` tests pass locally
- [x] `ask-user-questions-fallback` tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added text mode to workflows, offering a plain-text numbered-choice interaction as an alternative to standard prompts for non-standard runtimes.

* **Documentation**
  * Updated architecture docs to reflect new totals for commands and workflows.

* **Tests**
  * Adjusted test environment setup for hook tests to explicitly set an additional runtime variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->