### PR TITLE
fix: stabilize Windows config and install regressions

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -13,6 +13,36 @@ const yellow = '\x1b[33m';
 const dim = '\x1b[2m';
 const reset = '\x1b[0m';
 
+function isTransientFsReadError(err) {
+  return err && ['EBUSY', 'EPERM', 'EACCES'].includes(err.code);
+}
+
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function withFsRetry(fn, attempts = 6) {
+  let lastError;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return fn();
+    } catch (err) {
+      lastError = err;
+      if (!isTransientFsReadError(err) || i === attempts - 1) throw err;
+      sleepSync(25 * (i + 1));
+    }
+  }
+  throw lastError;
+}
+
+function readFileUtf8WithRetry(filePath) {
+  return withFsRetry(() => fs.readFileSync(filePath, 'utf8'));
+}
+
+function copyFileWithRetry(srcPath, destPath) {
+  return withFsRetry(() => fs.copyFileSync(srcPath, destPath));
+}
+
 // Codex config.toml constants
 const GSD_CODEX_MARKER = '# GSD Agent Configuration \u2014 managed by get-shit-done installer';
 const GSD_CODEX_HOOKS_OWNERSHIP_PREFIX = '# GSD codex_hooks ownership: ';
@@ -5815,7 +5845,7 @@ function install(isGlobal, runtime = 'claude') {
           // Template .js files to replace '.claude' with runtime-specific config dir
           // and stamp the current GSD version into the hook version header
           if (entry.endsWith('.js')) {
-            let content = fs.readFileSync(srcFile, 'utf8');
+            let content = readFileUtf8WithRetry(srcFile);
             content = content.replace(/'\.claude'/g, configDirReplacement);
             content = content.replace(/\/\.claude\//g, `/${getDirName(runtime)}/`);
             if (isQwen) {
@@ -5830,12 +5860,12 @@ function install(isGlobal, runtime = 'claude') {
             // .sh hooks carry a gsd-hook-version header so gsd-check-update.js can
             // detect staleness after updates — stamp the version just like .js hooks.
             if (entry.endsWith('.sh')) {
-              let content = fs.readFileSync(srcFile, 'utf8');
+              let content = readFileUtf8WithRetry(srcFile);
               content = content.replace(/\{\{GSD_VERSION\}\}/g, pkg.version);
               fs.writeFileSync(destFile, content);
               try { fs.chmodSync(destFile, 0o755); } catch (e) { /* Windows doesn't support chmod */ }
             } else {
-              fs.copyFileSync(srcFile, destFile);
+              copyFileWithRetry(srcFile, destFile);
             }
           }
         }
@@ -5940,7 +5970,7 @@ function install(isGlobal, runtime = 'claude') {
         if (!fs.statSync(srcFile).isFile()) continue;
         const destFile = path.join(codexHooksDest, entry);
         if (entry.endsWith('.js')) {
-          let content = fs.readFileSync(srcFile, 'utf8');
+          let content = readFileUtf8WithRetry(srcFile);
           content = content.replace(/'\.claude'/g, configDirReplacement);
           content = content.replace(/\/\.claude\//g, `/${getDirName(runtime)}/`);
           content = content.replace(/\{\{GSD_VERSION\}\}/g, pkg.version);
@@ -5948,12 +5978,12 @@ function install(isGlobal, runtime = 'claude') {
           try { fs.chmodSync(destFile, 0o755); } catch (e) { /* Windows */ }
         } else {
           if (entry.endsWith('.sh')) {
-            let content = fs.readFileSync(srcFile, 'utf8');
+            let content = readFileUtf8WithRetry(srcFile);
             content = content.replace(/\{\{GSD_VERSION\}\}/g, pkg.version);
             fs.writeFileSync(destFile, content);
             try { fs.chmodSync(destFile, 0o755); } catch (e) { /* Windows */ }
           } else {
-            fs.copyFileSync(srcFile, destFile);
+            copyFileWithRetry(srcFile, destFile);
           }
         }
       }

--- a/get-shit-done/bin/lib/config.cjs
+++ b/get-shit-done/bin/lib/config.cjs
@@ -4,7 +4,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { output, error, planningDir, withPlanningLock, CONFIG_DEFAULTS, atomicWriteFileSync } = require('./core.cjs');
+const { output, error, planningDir, withPlanningLock, CONFIG_DEFAULTS, atomicWriteFileSync, resolveHomeDir, toPosixPath } = require('./core.cjs');
 const {
   VALID_PROFILES,
   getAgentToModelMapForProfile,
@@ -106,7 +106,7 @@ function validateKnownConfigKeyPath(keyPath) {
  */
 function buildNewProjectConfig(userChoices) {
   const choices = userChoices || {};
-  const homedir = require('os').homedir();
+  const homedir = resolveHomeDir();
 
   // Detect API key availability
   const braveKeyFile = path.join(homedir, '.gsd', 'brave_api_key');
@@ -185,7 +185,7 @@ function buildNewProjectConfig(userChoices) {
   };
 
   // Three-level deep merge: hardcoded <- userDefaults <- choices
-  return {
+  const config = {
     ...hardcoded,
     ...userDefaults,
     ...choices,
@@ -210,6 +210,16 @@ function buildNewProjectConfig(userChoices) {
       ...(choices.agent_skills || {}),
     },
   };
+
+  if (typeof config.parallelization !== 'boolean') {
+    if (config.parallelization && typeof config.parallelization === 'object' && 'enabled' in config.parallelization) {
+      config.parallelization = !!config.parallelization.enabled;
+    } else {
+      config.parallelization = hardcoded.parallelization;
+    }
+  }
+
+  return config;
 }
 
 /**
@@ -502,7 +512,7 @@ function getCmdConfigSetModelProfileResultMessage(
 function cmdConfigPath(cwd) {
   // Always emit as plain text — a file path is used via shell substitution,
   // never consumed as JSON. Passing raw=true forces plain-text output.
-  const configPath = path.join(planningDir(cwd), 'config.json');
+  const configPath = toPosixPath(path.join(planningDir(cwd), 'config.json'));
   output(configPath, true, configPath);
 }
 

--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -44,6 +44,17 @@ function toPosixPath(p) {
   return p.split(path.sep).join('/');
 }
 
+/** Resolve the effective home directory, honoring test/sandbox overrides first. */
+function resolveHomeDir() {
+  return process.env.GSD_HOME || process.env.HOME || process.env.USERPROFILE || os.homedir();
+}
+
+/** Normalize filesystem paths for stable cross-platform comparisons. */
+function normalizeComparablePath(p) {
+  const normalized = path.normalize(path.resolve(p)).replace(/[\\/]+$/, '');
+  return process.platform === 'win32' ? normalized.toLowerCase() : normalized;
+}
+
 /**
  * Scan immediate child directories for separate git repos.
  * Returns a sorted array of directory names that have their own `.git`.
@@ -86,7 +97,7 @@ function detectSubRepos(cwd) {
 function findProjectRoot(startDir) {
   const resolved = path.resolve(startDir);
   const root = path.parse(resolved).root;
-  const homedir = require('os').homedir();
+  const homedir = resolveHomeDir();
 
   // If startDir already contains .planning/, it IS the project root.
   // Do not walk up to a parent workspace that also has .planning/ (#1362).
@@ -399,7 +410,7 @@ function loadConfig(cwd) {
       return defaults;
     }
     try {
-      const home = process.env.GSD_HOME || os.homedir();
+      const home = resolveHomeDir();
       const globalDefaultsPath = path.join(home, '.gsd', 'defaults.json');
       const raw = fs.readFileSync(globalDefaultsPath, 'utf-8');
       const globalDefaults = JSON.parse(raw);
@@ -653,6 +664,7 @@ function parseWorktreePorcelain(porcelain) {
 function pruneOrphanedWorktrees(repoRoot) {
   const pruned = [];
   const cwd = process.cwd();
+  const normalizedCwd = normalizeComparablePath(cwd);
 
   try {
     // 1. Get all worktrees in porcelain format
@@ -665,15 +677,14 @@ function pruneOrphanedWorktrees(repoRoot) {
       return pruned;
     }
 
-    // 2. First entry is the main worktree — never touch it
-    const mainWorktreePath = worktrees[0].path;
-
     // 3. Check each non-main worktree
     for (let i = 1; i < worktrees.length; i++) {
       const { path: wtPath, branch } = worktrees[i];
+      const normalizedWorktreePath = normalizeComparablePath(wtPath);
+      const worktreePrefix = normalizedWorktreePath + path.sep;
 
       // Never remove the worktree for the current process directory
-      if (wtPath === cwd || cwd.startsWith(wtPath + path.sep)) continue;
+      if (normalizedWorktreePath === normalizedCwd || normalizedCwd.startsWith(worktreePrefix)) continue;
 
       // Check if the branch is fully merged into HEAD (main)
       // git merge-base --is-ancestor <branch> HEAD exits 0 when merged
@@ -1685,6 +1696,7 @@ module.exports = {
   output,
   error,
   safeReadFile,
+  resolveHomeDir,
   loadConfig,
   isGitIgnored,
   execGit,

--- a/get-shit-done/bin/lib/init.cjs
+++ b/get-shit-done/bin/lib/init.cjs
@@ -5,7 +5,7 @@
 const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
-const { loadConfig, resolveModelInternal, findPhaseInternal, getRoadmapPhaseInternal, pathExistsInternal, generateSlugInternal, getMilestoneInfo, getMilestonePhaseFilter, stripShippedMilestones, extractCurrentMilestone, normalizePhaseName, planningPaths, planningDir, planningRoot, toPosixPath, output, error, checkAgentsInstalled, phaseTokenMatches } = require('./core.cjs');
+const { loadConfig, resolveModelInternal, findPhaseInternal, getRoadmapPhaseInternal, pathExistsInternal, generateSlugInternal, getMilestoneInfo, getMilestonePhaseFilter, stripShippedMilestones, extractCurrentMilestone, normalizePhaseName, planningPaths, planningDir, planningRoot, toPosixPath, output, error, checkAgentsInstalled, phaseTokenMatches, resolveHomeDir } = require('./core.cjs');
 
 function getLatestCompletedMilestone(cwd) {
   const milestonesPath = path.join(planningRoot(cwd), 'MILESTONES.md');
@@ -1534,8 +1534,7 @@ function cmdInitRemoveWorkspace(cwd, name, raw) {
  */
 function buildAgentSkillsBlock(config, agentType, projectRoot) {
   const { validatePath } = require('./security.cjs');
-  const os = require('os');
-  const globalSkillsBase = path.join(os.homedir(), '.claude', 'skills');
+  const globalSkillsBase = path.join(resolveHomeDir(), '.claude', 'skills');
 
   if (!config || !config.agent_skills || !agentType) return '';
 
@@ -1643,7 +1642,7 @@ function cmdAgentSkills(cwd, agentType, raw) {
  */
 function buildSkillManifest(cwd, skillsDir = null) {
   const { extractFrontmatter } = require('./frontmatter.cjs');
-  const os = require('os');
+  const homeDir = resolveHomeDir();
 
   const canonicalRoots = skillsDir ? [{
     root: path.resolve(skillsDir),
@@ -1684,26 +1683,26 @@ function buildSkillManifest(cwd, skillsDir = null) {
     },
     {
       root: '~/.claude/skills',
-      path: path.join(os.homedir(), '.claude', 'skills'),
+      path: path.join(homeDir, '.claude', 'skills'),
       scope: 'global',
       kind: 'skills',
     },
     {
       root: '~/.codex/skills',
-      path: path.join(os.homedir(), '.codex', 'skills'),
+      path: path.join(homeDir, '.codex', 'skills'),
       scope: 'global',
       kind: 'skills',
     },
     {
       root: '.claude/get-shit-done/skills',
-      path: path.join(os.homedir(), '.claude', 'get-shit-done', 'skills'),
+      path: path.join(homeDir, '.claude', 'get-shit-done', 'skills'),
       scope: 'import-only',
       kind: 'skills',
       deprecated: true,
     },
     {
       root: '.claude/commands/gsd',
-      path: path.join(os.homedir(), '.claude', 'commands', 'gsd'),
+      path: path.join(homeDir, '.claude', 'commands', 'gsd'),
       scope: 'legacy-commands',
       kind: 'commands',
       deprecated: true,
@@ -1712,6 +1711,7 @@ function buildSkillManifest(cwd, skillsDir = null) {
 
   const skills = [];
   const roots = [];
+  const seenSkillNames = new Set();
   let legacyClaudeCommandsInstalled = false;
   for (const rootInfo of canonicalRoots) {
     const rootPath = rootInfo.path;
@@ -1769,6 +1769,8 @@ function buildSkillManifest(cwd, skillsDir = null) {
       const frontmatter = extractFrontmatter(content);
       const name = frontmatter.name || entry.name;
       const description = frontmatter.description || '';
+      if (seenSkillNames.has(name)) continue;
+      seenSkillNames.add(name);
 
       // Extract trigger lines from body text (after frontmatter)
       const triggers = [];

--- a/tests/bug-1736-local-install-commands.test.cjs
+++ b/tests/bug-1736-local-install-commands.test.cjs
@@ -22,6 +22,7 @@ const { execFileSync } = require('child_process');
 const INSTALL_SRC = path.join(__dirname, '..', 'bin', 'install.js');
 const BUILD_SCRIPT = path.join(__dirname, '..', 'scripts', 'build-hooks.js');
 const { install, copyCommandsAsClaudeSkills } = require(INSTALL_SRC);
+const SUITE_CWD = process.cwd();
 
 // ─── Ensure hooks/dist/ is populated before install tests ────────────────────
 // With --test-concurrency=4, other install tests (bug-1834, bug-1924) run
@@ -46,6 +47,7 @@ describe('#1736: local Claude install populates .claude/commands/gsd/', () => {
   });
 
   afterEach(() => {
+    process.chdir(SUITE_CWD);
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 

--- a/tests/bug-2136-sh-hook-version.test.cjs
+++ b/tests/bug-2136-sh-hook-version.test.cjs
@@ -67,6 +67,10 @@ function cleanup(dir) {
   try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
 }
 
+function readUtf8Normalized(filePath) {
+  return fs.readFileSync(filePath, 'utf8').replace(/\r\n/g, '\n');
+}
+
 function runInstaller(configDir) {
   execFileSync(process.execPath, [INSTALL_SCRIPT, '--claude', '--global', '--yes'], {
     encoding: 'utf-8',
@@ -96,7 +100,7 @@ describe('bug #2136 part 1: bash hook sources carry gsd-hook-version placeholder
     // Placing the header immediately after #!/bin/bash ensures it is always
     // found regardless of how much of the file is read.
     for (const sh of SH_HOOKS) {
-      const lines = fs.readFileSync(path.join(HOOKS_DIR, sh), 'utf8').split('\n');
+      const lines = readUtf8Normalized(path.join(HOOKS_DIR, sh)).split('\n');
       assert.strictEqual(lines[0], '#!/bin/bash', `${sh} line 1 must be #!/bin/bash`);
       assert.ok(
         lines[1].startsWith('# gsd-hook-version:'),

--- a/tests/bug-2248-local-install-statusline.test.cjs
+++ b/tests/bug-2248-local-install-statusline.test.cjs
@@ -28,6 +28,7 @@ const { execFileSync } = require('child_process');
 const INSTALL_SRC = path.join(__dirname, '..', 'bin', 'install.js');
 const BUILD_SCRIPT = path.join(__dirname, '..', 'scripts', 'build-hooks.js');
 const { install, finishInstall } = require(INSTALL_SRC);
+const SUITE_CWD = process.cwd();
 
 // ─── Ensure hooks/dist/ is populated before install tests ────────────────────
 before(() => {
@@ -47,6 +48,7 @@ describe('#2248: local Claude install does not clobber profile-level statusLine'
   });
 
   afterEach(() => {
+    process.chdir(SUITE_CWD);
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 

--- a/tests/few-shot-calibration.test.cjs
+++ b/tests/few-shot-calibration.test.cjs
@@ -8,7 +8,7 @@ const AGENTS_DIR = path.join(__dirname, '..', 'agents');
 
 // ── Helpers ────────────────────────────────────────────────────────
 function readFile(filePath) {
-  return fs.readFileSync(filePath, 'utf-8');
+  return fs.readFileSync(filePath, 'utf-8').replace(/\r\n/g, '\n');
 }
 
 function countPattern(content, pattern) {

--- a/tests/prompt-injection-scan.test.cjs
+++ b/tests/prompt-injection-scan.test.cjs
@@ -60,6 +60,10 @@ const ALLOWLIST = new Set([
   'tests/prompt-injection-scan.test.cjs',       // This file
 ]);
 
+function toAllowlistPath(file) {
+  return path.relative(PROJECT_ROOT, file).split(path.sep).join('/');
+}
+
 // ─── Scanner ────────────────────────────────────────────────────────────────
 
 function collectFiles(dir) {
@@ -100,7 +104,7 @@ describe('codebase prompt injection scan', () => {
     const findings = [];
 
     for (const file of agentFiles) {
-      const relPath = path.relative(PROJECT_ROOT, file);
+      const relPath = toAllowlistPath(file);
       if (ALLOWLIST.has(relPath)) continue;
 
       const content = fs.readFileSync(file, 'utf-8');
@@ -130,7 +134,7 @@ describe('codebase prompt injection scan', () => {
     const oversized = [];
 
     for (const file of agentFiles) {
-      const relPath = path.relative(PROJECT_ROOT, file);
+      const relPath = toAllowlistPath(file);
       if (ALLOWLIST.has(relPath)) continue;
 
       const content = fs.readFileSync(file, 'utf-8');
@@ -151,7 +155,7 @@ describe('codebase prompt injection scan', () => {
     const findings = [];
 
     for (const file of workflowFiles) {
-      const relPath = path.relative(PROJECT_ROOT, file);
+      const relPath = toAllowlistPath(file);
       if (ALLOWLIST.has(relPath)) continue;
 
       const content = fs.readFileSync(file, 'utf-8');
@@ -174,7 +178,7 @@ describe('codebase prompt injection scan', () => {
     const findings = [];
 
     for (const file of commandFiles) {
-      const relPath = path.relative(PROJECT_ROOT, file);
+      const relPath = toAllowlistPath(file);
       if (ALLOWLIST.has(relPath)) continue;
 
       const content = fs.readFileSync(file, 'utf-8');
@@ -197,7 +201,7 @@ describe('codebase prompt injection scan', () => {
     const findings = [];
 
     for (const file of hookFiles) {
-      const relPath = path.relative(PROJECT_ROOT, file);
+      const relPath = toAllowlistPath(file);
       if (ALLOWLIST.has(relPath)) continue;
 
       const content = fs.readFileSync(file, 'utf-8');
@@ -220,7 +224,7 @@ describe('codebase prompt injection scan', () => {
     const findings = [];
 
     for (const file of libFiles) {
-      const relPath = path.relative(PROJECT_ROOT, file);
+      const relPath = toAllowlistPath(file);
       if (ALLOWLIST.has(relPath)) continue;
 
       const content = fs.readFileSync(file, 'utf-8');
@@ -243,7 +247,7 @@ describe('codebase prompt injection scan', () => {
     const invisiblePattern = /[\u200B-\u200F\u2028-\u202F\uFEFF\u00AD]/;
 
     for (const file of allFiles) {
-      const relPath = path.relative(PROJECT_ROOT, file);
+      const relPath = toAllowlistPath(file);
       if (ALLOWLIST.has(relPath)) continue;
 
       const content = fs.readFileSync(file, 'utf-8');
@@ -272,7 +276,7 @@ describe('codebase prompt injection scan', () => {
     const boundaryPattern = /<\/?(?:system|assistant|human)>/i;
 
     for (const file of allFiles) {
-      const relPath = path.relative(PROJECT_ROOT, file);
+      const relPath = toAllowlistPath(file);
       if (ALLOWLIST.has(relPath)) continue;
       // Allow .md files to use common tags in examples/docs
       // But flag .js/.cjs files that embed these

--- a/tests/prune-orphaned-worktrees.test.cjs
+++ b/tests/prune-orphaned-worktrees.test.cjs
@@ -149,6 +149,7 @@ describe('pruneOrphanedWorktrees', () => {
   test('runs git worktree prune to clear stale references', () => {
     const repoDir = path.join(tmpBase, 'repo4');
     const worktreeDir = path.join(tmpBase, 'wt-stale');
+    const normalizedWorktreeDir = worktreeDir.replace(/\\/g, '/');
 
     createGitRepo(repoDir);
 
@@ -157,8 +158,8 @@ describe('pruneOrphanedWorktrees', () => {
     assert.ok(fs.existsSync(worktreeDir), 'worktree dir should exist before manual deletion');
 
     // Verify it appears in git worktree list
-    const beforeList = execSync('git worktree list --porcelain', { cwd: repoDir, encoding: 'utf8' });
-    assert.ok(beforeList.includes(worktreeDir), 'worktree should appear in list before deletion');
+    const beforeList = execSync('git worktree list --porcelain', { cwd: repoDir, encoding: 'utf8' }).replace(/\\/g, '/');
+    assert.ok(beforeList.includes(normalizedWorktreeDir), 'worktree should appear in list before deletion');
 
     // Manually delete the worktree directory (simulate orphan)
     fs.rmSync(worktreeDir, { recursive: true, force: true });
@@ -168,9 +169,9 @@ describe('pruneOrphanedWorktrees', () => {
     pruneOrphanedWorktrees(repoDir);
 
     // Assert: git worktree list no longer shows the stale entry
-    const afterList = execSync('git worktree list --porcelain', { cwd: repoDir, encoding: 'utf8' });
+    const afterList = execSync('git worktree list --porcelain', { cwd: repoDir, encoding: 'utf8' }).replace(/\\/g, '/');
     assert.ok(
-      !afterList.includes(worktreeDir),
+      !afterList.includes(normalizedWorktreeDir),
       'git worktree list still shows stale entry after prune:\n' + afterList
     );
   });


### PR DESCRIPTION
## Summary
- honor HOME/GSD_HOME/USERPROFILE for config and skill-manifest resolution
- normalize Windows path handling for config-path, prompt-injection allowlists, and worktree pruning
- harden installer hook reads/copies against transient Windows file locks and fix Windows-local install test teardown
- normalize CRLF-sensitive tests so the suite is stable on Windows clones

## Verification
- `node --test tests/config.test.cjs`
- `node --test tests/skill-manifest.test.cjs`
- `node --test tests/prompt-injection-scan.test.cjs`
- `node --test tests/prune-orphaned-worktrees.test.cjs`
- `node --test tests/few-shot-calibration.test.cjs`
- `node --test tests/bug-1736-local-install-commands.test.cjs`
- `node --test tests/bug-2248-local-install-statusline.test.cjs`
- `node --test tests/bug-2136-sh-hook-version.test.cjs`
- `npm test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hook and template installation now automatically retries on transient filesystem read/copy errors, improving installation robustness
  * Enhanced cross-platform support with normalized path handling and consistent line ending management
  * Strengthened test suite stability through improved working directory cleanup and restoration between test runs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->