### PR TITLE
docs(readme): add /gsd-ingest-docs to Brownfield commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,6 +624,7 @@ You're never locked in. The system adapts.
 | Command | What it does |
 |---------|--------------|
 | `/gsd-map-codebase [area]` | Analyze existing codebase before new-project |
+| `/gsd-ingest-docs [dir]` | Scan a repo of mixed ADRs, PRDs, SPECs, and DOCs and bootstrap or merge the full `.planning/` setup in one pass — parallel classification, synthesis with precedence rules, and a three-bucket conflicts report |
 
 ### Phase Management
 


### PR DESCRIPTION
## Summary
- Adds the new `/gsd-ingest-docs` command to the Brownfield section of the README so it's discoverable alongside `/gsd-map-codebase`.
- Pulled from the `[Unreleased]` CHANGELOG entry describing the command's parallel classification, synthesis precedence, and three-bucket conflicts report.

Closes #2438

## Test plan
- [ ] Visual check: Commands → Brownfield table renders with both rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)