### PR TITLE
fix(set-profile): guard gsd-sdk invocation with command -v pre-flight (#2439)

### DIFF
--- a/commands/gsd/set-profile.md
+++ b/commands/gsd/set-profile.md
@@ -9,4 +9,4 @@ allowed-tools:
 
 Show the following output to the user verbatim, with no extra commentary:
 
-!`gsd-sdk query config-set-model-profile $ARGUMENTS --raw`
+!`if ! command -v gsd-sdk >/dev/null 2>&1; then printf '⚠ gsd-sdk not found in PATH — /gsd:set-profile requires it.\n\nInstall the GSD SDK:\n  npm install -g @gsd-build/sdk\n\nOr update GSD to get the latest packages:\n  /gsd-update\n'; exit 1; fi; gsd-sdk query config-set-model-profile $ARGUMENTS --raw`

--- a/commands/gsd/set-profile.md
+++ b/commands/gsd/set-profile.md
@@ -9,4 +9,4 @@ allowed-tools:
 
 Show the following output to the user verbatim, with no extra commentary:
 
-!`if ! command -v gsd-sdk >/dev/null 2>&1; then printf '⚠ gsd-sdk not found in PATH — /gsd:set-profile requires it.\n\nInstall the GSD SDK:\n  npm install -g @gsd-build/sdk\n\nOr update GSD to get the latest packages:\n  /gsd-update\n'; exit 1; fi; gsd-sdk query config-set-model-profile $ARGUMENTS --raw`
+!`if ! command -v gsd-sdk >/dev/null 2>&1; then printf '⚠ gsd-sdk not found in PATH — /gsd-set-profile requires it.\n\nInstall the GSD SDK:\n  npm install -g @gsd-build/sdk\n\nOr update GSD to get the latest packages:\n  /gsd-update\n'; exit 1; fi; gsd-sdk query config-set-model-profile $ARGUMENTS --raw`

--- a/tests/bug-2439-set-profile-gsd-sdk-preflight.test.cjs
+++ b/tests/bug-2439-set-profile-gsd-sdk-preflight.test.cjs
@@ -1,7 +1,7 @@
 /**
  * Regression test for bug #2439
  *
- * /gsd:set-profile crashed with `command not found: gsd-sdk` when the
+ * /gsd-set-profile crashed with `command not found: gsd-sdk` when the
  * gsd-sdk binary was not installed or not in PATH. The command body
  * invoked `gsd-sdk query config-set-model-profile` directly with no
  * pre-flight check, so missing gsd-sdk produced an opaque shell error.
@@ -19,7 +19,7 @@ const path = require('path');
 
 const COMMAND_PATH = path.join(__dirname, '..', 'commands', 'gsd', 'set-profile.md');
 
-describe('bug #2439: /gsd:set-profile gsd-sdk pre-flight check', () => {
+describe('bug #2439: /gsd-set-profile gsd-sdk pre-flight check', () => {
   const content = fs.readFileSync(COMMAND_PATH, 'utf-8');
 
   test('command file exists', () => {

--- a/tests/bug-2439-set-profile-gsd-sdk-preflight.test.cjs
+++ b/tests/bug-2439-set-profile-gsd-sdk-preflight.test.cjs
@@ -1,0 +1,54 @@
+/**
+ * Regression test for bug #2439
+ *
+ * /gsd:set-profile crashed with `command not found: gsd-sdk` when the
+ * gsd-sdk binary was not installed or not in PATH. The command body
+ * invoked `gsd-sdk query config-set-model-profile` directly with no
+ * pre-flight check, so missing gsd-sdk produced an opaque shell error.
+ *
+ * Fix mirrors bug #2334: guard the invocation with `command -v gsd-sdk`
+ * and emit an install hint when absent.
+ */
+
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const COMMAND_PATH = path.join(__dirname, '..', 'commands', 'gsd', 'set-profile.md');
+
+describe('bug #2439: /gsd:set-profile gsd-sdk pre-flight check', () => {
+  const content = fs.readFileSync(COMMAND_PATH, 'utf-8');
+
+  test('command file exists', () => {
+    assert.ok(fs.existsSync(COMMAND_PATH), 'commands/gsd/set-profile.md should exist');
+  });
+
+  test('guards gsd-sdk invocation with command -v check', () => {
+    const sdkCall = content.indexOf('gsd-sdk query config-set-model-profile');
+    assert.ok(sdkCall !== -1, 'gsd-sdk query config-set-model-profile must be present');
+
+    const preamble = content.slice(0, sdkCall);
+    assert.ok(
+      preamble.includes('command -v gsd-sdk') || preamble.includes('which gsd-sdk'),
+      'set-profile must check for gsd-sdk in PATH before invoking it. ' +
+      'Without this guard the command crashes with exit 127 when gsd-sdk ' +
+      'is not installed (root cause of #2439).'
+    );
+  });
+
+  test('pre-flight error message references install/update path', () => {
+    const sdkCall = content.indexOf('gsd-sdk query config-set-model-profile');
+    const preamble = content.slice(0, sdkCall);
+    const hasInstallHint =
+      preamble.includes('@gsd-build/sdk') ||
+      preamble.includes('gsd-update') ||
+      preamble.includes('/gsd-update');
+    assert.ok(
+      hasInstallHint,
+      'Pre-flight error must point users at `npm install -g @gsd-build/sdk` or `/gsd-update`.'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- `/gsd:set-profile` crashed with `command not found: gsd-sdk` (exit 127) when `gsd-sdk` was not on PATH (#2439).
- Adds a `command -v gsd-sdk` pre-flight guard that prints the install/update hint and exits 1 if absent — mirrors the #2334 fix on `/gsd-quick`.
- Adds regression test `tests/bug-2439-set-profile-gsd-sdk-preflight.test.cjs`.

## Why this is still needed after #2386
#2386 auto-installs `@gsd-build/sdk` from the in-repo `sdk/` source during `bin/install.js`. That catches the common case. But `installSdkIfNeeded()` ([install.js:6720](https://github.com/gsd-build/get-shit-done/blob/main/bin/install.js#L6720)) only **warns** (non-fatal) when `which gsd-sdk` comes back empty after `npm install -g .` — a common scenario on macOS when npm's global bin is not on the user's PATH. Users can miss that warning, then hit the same opaque error on every `/gsd-*` command.

`/gsd-quick` already carries the pre-flight from #2334 for exactly this reason; this PR brings `/gsd:set-profile` to parity. A follow-up will investigate whether the installer should escalate the off-PATH case (fatal, or louder remediation).

## Test plan
- [x] `node --test tests/bug-2439-set-profile-gsd-sdk-preflight.test.cjs` → 3/3 pass
- [x] Manual smoke with `gsd-sdk` absent from PATH → guard prints install hint and exits 1
- [ ] Manual smoke with `gsd-sdk` present → command executes `config-set-model-profile` as before

Closes #2439

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The set-profile command now performs a preflight check to ensure the required CLI tool is available; if missing, it shows installation/update guidance and exits gracefully.

* **Tests**
  * Added a regression test that verifies the set-profile command includes the preflight guard and appropriate install/update hint when the CLI tool is not on PATH.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->