### PR TITLE
fix(debug): read tdd_mode via workflow.tdd_mode key

### DIFF
--- a/commands/gsd/debug.md
+++ b/commands/gsd/debug.md
@@ -63,7 +63,7 @@ debugger_model=$(gsd-sdk query resolve-model gsd-debugger 2>/dev/null | jq -r '.
 
 Read TDD mode from config:
 ```bash
-TDD_MODE=$(gsd-sdk query config-get tdd_mode 2>/dev/null | jq -r 'if type == "boolean" then tostring else . end' 2>/dev/null || echo "false")
+TDD_MODE=$(gsd-sdk query config-get workflow.tdd_mode 2>/dev/null | jq -r 'if type == "boolean" then tostring else . end' 2>/dev/null || echo "false")
 ```
 
 ## 1a. LIST subcommand

--- a/tests/debug-session-management.test.cjs
+++ b/tests/debug-session-management.test.cjs
@@ -66,6 +66,21 @@ describe('debug session management implementation', () => {
     );
   });
 
+  test('debug.md reads tdd_mode via workflow.tdd_mode key (not bare tdd_mode)', () => {
+    const content = fs.readFileSync(
+      path.join(process.cwd(), 'commands/gsd/debug.md'),
+      'utf8'
+    );
+    assert.ok(
+      !content.includes('config-get tdd_mode'),
+      'debug.md must not use bare "tdd_mode" key — use "workflow.tdd_mode" to match every other consumer'
+    );
+    assert.ok(
+      content.includes('config-get workflow.tdd_mode'),
+      'debug.md must read tdd_mode via the "workflow.tdd_mode" key'
+    );
+  });
+
   test('debug command contains security hardening', () => {
     const content = fs.readFileSync(
       path.join(process.cwd(), 'commands/gsd/debug.md'),


### PR DESCRIPTION
Closes #2398

## Root cause
debug.md:66 called config-get tdd_mode (bare key) while all other consumers use workflow.tdd_mode. /gsd-debug silently ignored tdd_mode setting.

## Fix
Changed config-get call from tdd_mode to workflow.tdd_mode.

## Test
Added regression test in debug-session-management.test.cjs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed TDD mode configuration retrieval to use the correct configuration location. Mode initialization functionality remains unchanged, including boolean value conversion, fallback mechanisms, and default settings.

* **Tests**
  * Added test coverage to validate TDD mode configuration is retrieved from the correct source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->