### PR TITLE
fix(sdk): extractCurrentMilestone Backlog leak + state.begin-phase flag parsing

### DIFF
--- a/sdk/src/query/roadmap.test.ts
+++ b/sdk/src/query/roadmap.test.ts
@@ -144,6 +144,57 @@ describe('extractCurrentMilestone', () => {
     const result = await extractCurrentMilestone(content, tmpDir);
     expect(result).toBe('current content');
   });
+
+  // ─── Bug #2422: preamble Backlog leak ─────────────────────────────────
+  it('bug-2422: does not include ## Backlog section before the current milestone', async () => {
+    const roadmapWithBacklog = `# ROADMAP
+
+## Backlog
+### Phase 999.1: Parking lot item A
+### Phase 999.2: Parking lot item B
+
+### 🚧 v2.0 My Milestone (In Progress)
+- [ ] **Phase 100: Real work**
+
+## v2.0 Phase Details
+### Phase 100: Real work
+**Goal**: Do stuff.
+`;
+    const state = `---\nmilestone: v2.0\n---\n# State\n`;
+    await writeFile(join(tmpDir, '.planning', 'STATE.md'), state);
+    await writeFile(join(tmpDir, '.planning', 'ROADMAP.md'), roadmapWithBacklog);
+
+    const result = await extractCurrentMilestone(roadmapWithBacklog, tmpDir);
+
+    // Must NOT include backlog phases
+    expect(result).not.toContain('Phase 999.1');
+    expect(result).not.toContain('Phase 999.2');
+    expect(result).not.toContain('Parking lot');
+    // Must include the actual v2.0 content
+    expect(result).toContain('Phase 100');
+  });
+
+  // ─── Bug #2422: same-version sub-heading truncation ───────────────────
+  it('bug-2422: does not truncate at same-version sub-heading (## v2.0 Phase Details)', async () => {
+    const roadmapWithDetails = `# ROADMAP
+
+### 🚧 v2.0 My Milestone (In Progress)
+- [ ] **Phase 100: Real work**
+
+## v2.0 Phase Details
+### Phase 100: Real work
+**Goal**: Do stuff.
+`;
+    const state = `---\nmilestone: v2.0\n---\n# State\n`;
+    await writeFile(join(tmpDir, '.planning', 'STATE.md'), state);
+    await writeFile(join(tmpDir, '.planning', 'ROADMAP.md'), roadmapWithDetails);
+
+    const result = await extractCurrentMilestone(roadmapWithDetails, tmpDir);
+
+    // The detail section must survive — not be cut off
+    expect(result).toContain('Phase 100');
+    expect(result).toContain('Phase Details');
+  });
 });
 
 // ─── roadmapGetPhase ──────────────────────────────────────────────────────

--- a/sdk/src/query/roadmap.ts
+++ b/sdk/src/query/roadmap.ts
@@ -110,7 +110,7 @@ export async function extractCurrentMilestone(content: string, projectDir: strin
 
   // Fallback: derive from ROADMAP in-progress marker
   if (!version) {
-    const inProgressMatch = content.match(/🚧\s*\*\*v(\d+\.\d+)\s/);
+    const inProgressMatch = content.match(/🚧\s*\*\*v(\d+(?:\.\d+)+)\s/);
     if (inProgressMatch) {
       version = 'v' + inProgressMatch[1];
     }
@@ -137,11 +137,12 @@ export async function extractCurrentMilestone(content: string, projectDir: strin
   const restContent = content.slice(sectionStart + sectionMatch[0].length);
 
   // Extract current version so same-version sub-headings are not treated as boundaries.
-  const currentVersionMatch = version ? version.match(/v(\d+\.\d+)/) : null;
+  // Capture full semver (major.minor.patch) so v2.0.1 is not collapsed to "2.0".
+  const currentVersionMatch = version ? version.match(/v(\d+(?:\.\d+)+)/i) : null;
   const currentVersionStr = currentVersionMatch ? currentVersionMatch[1] : '';
 
   const nextMilestoneRegex = new RegExp(
-    `^#{1,${headingLevel}}\\s+(?:.*v(\\d+\\.\\d+)[^\\n]*|.*(?:✅|📋|🚧))`,
+    `^#{1,${headingLevel}}\\s+(?:.*v(\\d+(?:\\.\\d+)+)[^\\n]*|.*(?:✅|📋|🚧))`,
     'gm'
   );
 

--- a/sdk/src/query/roadmap.ts
+++ b/sdk/src/query/roadmap.ts
@@ -130,30 +130,34 @@ export async function extractCurrentMilestone(content: string, projectDir: strin
 
   const sectionStart = sectionMatch.index;
 
-  // Find end: next milestone heading at same or higher level, or EOF
+  // Find end: next milestone heading at same or higher level, or EOF.
+  // Skip headings that belong to the SAME version (e.g. "## v2.0 Phase Details").
   const headingLevelMatch = sectionMatch[1].match(/^(#{1,3})\s/);
   const headingLevel = headingLevelMatch ? headingLevelMatch[1].length : 2;
   const restContent = content.slice(sectionStart + sectionMatch[0].length);
-  const nextMilestonePattern = new RegExp(
-    `^#{1,${headingLevel}}\\s+(?:.*v\\d+\\.\\d+|✅|📋|🚧)`,
-    'mi'
-  );
-  const nextMatch = restContent.match(nextMilestonePattern);
 
-  let sectionEnd: number;
-  if (nextMatch && nextMatch.index !== undefined) {
-    sectionEnd = sectionStart + sectionMatch[0].length + nextMatch.index;
-  } else {
-    sectionEnd = content.length;
+  // Extract current version so same-version sub-headings are not treated as boundaries.
+  const currentVersionMatch = version ? version.match(/v(\d+\.\d+)/) : null;
+  const currentVersionStr = currentVersionMatch ? currentVersionMatch[1] : '';
+
+  const nextMilestoneRegex = new RegExp(
+    `^#{1,${headingLevel}}\\s+(?:.*v(\\d+\\.\\d+)[^\\n]*|.*(?:✅|📋|🚧))`,
+    'gm'
+  );
+
+  let sectionEnd = content.length;
+  let m: RegExpExecArray | null;
+  while ((m = nextMilestoneRegex.exec(restContent)) !== null) {
+    const matchedVersion = m[1];
+    // Skip headings that reference the same version (e.g. "## v2.0 Phase Details").
+    if (matchedVersion && currentVersionStr && matchedVersion === currentVersionStr) continue;
+    sectionEnd = sectionStart + sectionMatch[0].length + m.index;
+    break;
   }
 
-  const beforeMilestones = content.slice(0, sectionStart);
-  const currentSection = content.slice(sectionStart, sectionEnd);
-
-  // Strip <details> from preamble
-  const preamble = beforeMilestones.replace(/<details>[\s\S]*?<\/details>/gi, '');
-
-  return preamble + currentSection;
+  // Return only the current milestone section — never include the preamble, which
+  // may contain ## Backlog and other non-current-milestone phases.
+  return content.slice(sectionStart, sectionEnd);
 }
 
 // ─── Internal helpers ─────────────────────────────────────────────────────

--- a/sdk/src/query/state-mutation.test.ts
+++ b/sdk/src/query/state-mutation.test.ts
@@ -339,6 +339,15 @@ describe('stateBeginPhase', () => {
     expect(data.name).toBe('Positional Test');
     expect(data.plan_count).toBe('5');
   });
+
+  it('bug-2420: flag parser throws when a flag value is missing (next token is a flag)', async () => {
+    const { stateBeginPhase } = await import('./state-mutation.js');
+
+    // --phase has no value — next token is --name, which is itself a flag.
+    await expect(
+      stateBeginPhase(['--phase', '--name', 'Title', '--plans', '1'], tmpDir)
+    ).rejects.toThrow('missing value for --phase');
+  });
 });
 
 // ─── stateAdvancePlan ───────────────────────────────────────────────────────

--- a/sdk/src/query/state-mutation.test.ts
+++ b/sdk/src/query/state-mutation.test.ts
@@ -304,6 +304,41 @@ describe('stateBeginPhase', () => {
     expect(content).toContain('Executing Phase 11');
     expect(content).toContain('State Mutations');
   });
+
+  // ─── Bug #2420: flag-form args not parsed ────────────────────────────
+  it('bug-2420: parses --phase/--name/--plans flag-form args correctly', async () => {
+    const { stateBeginPhase } = await import('./state-mutation.js');
+
+    // This is how execute-phase.md calls it: flag form
+    const result = await stateBeginPhase(
+      ['--phase', '99', '--name', 'probe-test', '--plans', '1'],
+      tmpDir
+    );
+    const data = result.data as Record<string, unknown>;
+
+    // Must return the actual values, not the flag names
+    expect(data.phase).toBe('99');
+    expect(data.name).toBe('probe-test');
+    expect(data.plan_count).toBe('1');
+
+    // STATE.md must contain clean output, not literal "--phase"
+    const content = await readFile(join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    expect(content).not.toContain('--phase');
+    expect(content).not.toContain('--name');
+    expect(content).not.toContain('--plans');
+    expect(content).toContain('Executing Phase 99');
+    expect(content).toContain('probe-test');
+  });
+
+  it('bug-2420: positional args still work after flag-parsing fix', async () => {
+    const { stateBeginPhase } = await import('./state-mutation.js');
+
+    const result = await stateBeginPhase(['42', 'Positional Test', '5'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+    expect(data.phase).toBe('42');
+    expect(data.name).toBe('Positional Test');
+    expect(data.plan_count).toBe('5');
+  });
 });
 
 // ─── stateAdvancePlan ───────────────────────────────────────────────────────

--- a/sdk/src/query/state-mutation.ts
+++ b/sdk/src/query/state-mutation.ts
@@ -338,10 +338,16 @@ export const stateBeginPhase: QueryHandler = async (args, projectDir) => {
 
   if (args.length > 0 && typeof args[0] === 'string' && args[0].startsWith('--')) {
     const flags: Record<string, string> = {};
-    for (let i = 0; i < args.length - 1; i += 2) {
-      if (typeof args[i] === 'string' && args[i].startsWith('--')) {
-        flags[args[i].slice(2)] = args[i + 1];
+    for (let i = 0; i < args.length; i++) {
+      const token = args[i];
+      if (typeof token !== 'string' || !token.startsWith('--')) continue;
+      const key = token.slice(2);
+      const value = args[i + 1];
+      if (value === undefined || (typeof value === 'string' && value.startsWith('--'))) {
+        throw new GSDError(`missing value for --${key}`, ErrorClassification.Validation);
       }
+      flags[key] = value as string;
+      i += 1;
     }
     phaseNumber = flags['phase'] ?? '';
     phaseName = flags['name'] ?? '';

--- a/sdk/src/query/state-mutation.ts
+++ b/sdk/src/query/state-mutation.ts
@@ -331,9 +331,26 @@ export const statePatch: QueryHandler = async (args, projectDir) => {
  * @returns QueryResult with { phase, name, plan_count }
  */
 export const stateBeginPhase: QueryHandler = async (args, projectDir) => {
-  const phaseNumber = args[0];
-  const phaseName = args[1] || '';
-  const planCount = args[2] || '?';
+  // Accept both flag form (--phase 04 --name "Title" --plans 3) and positional form (04 "Title" 3).
+  let phaseNumber: string;
+  let phaseName: string;
+  let planCount: string;
+
+  if (args.length > 0 && typeof args[0] === 'string' && args[0].startsWith('--')) {
+    const flags: Record<string, string> = {};
+    for (let i = 0; i < args.length - 1; i += 2) {
+      if (typeof args[i] === 'string' && args[i].startsWith('--')) {
+        flags[args[i].slice(2)] = args[i + 1];
+      }
+    }
+    phaseNumber = flags['phase'] ?? '';
+    phaseName = flags['name'] ?? '';
+    planCount = flags['plans'] ?? flags['plan-count'] ?? '?';
+  } else {
+    phaseNumber = args[0] ?? '';
+    phaseName = args[1] || '';
+    planCount = args[2] || '?';
+  }
 
   if (!phaseNumber) {
     throw new GSDError('phase number required', ErrorClassification.Validation);


### PR DESCRIPTION
Closes #2422
Closes #2420

## Root cause

**#2422 — `extractCurrentMilestone`** had two compounding bugs:
1. **Backlog leak**: the function returned `preamble + currentSection`, where `preamble` is everything before the current milestone heading. Any `## Backlog` / `### Phase 999.x:` lines in that preamble were fed into the phase-pattern scanner, producing 37 backlog phases instead of the real milestone phases.
2. **Same-version truncation**: `nextMilestonePattern` matched `## v2.0 Phase Details` (a sub-heading belonging to the current milestone), cutting off the section before any `### Phase N:` detail headings could be scanned.

**#2420 — `stateBeginPhase`** read `args[0..2]` as positional values with no flag-parsing step. When called as `state.begin-phase --phase 04 --name "Title" --plans 3` (the form used by `execute-phase.md`), `phaseNumber` became `"--phase"`, `phaseName` became `"04"`, and `planCount` became `"--name"`, corrupting STATE.md on every phase start.

## Fix

**#2422** (`sdk/src/query/roadmap.ts` — `extractCurrentMilestone`):
- Removed the `preamble + currentSection` concatenation; returns only `currentSection`.
- Replaced the single-shot `nextMilestonePattern` with a `while` loop using a capturing-group regex that extracts the matched version. Same-version sub-headings (e.g. `## v2.0 Phase Details`) are skipped; only headings with a different version or a milestone emoji stop the scan.

**#2420** (`sdk/src/query/state-mutation.ts` — `stateBeginPhase`):
- Added flag-parsing at the top of the handler: if `args[0]` starts with `--`, iterate pairs and build a `flags` map; then resolve `phaseNumber`, `phaseName`, `planCount` from `flags` with positional fallbacks.
- Positional calls continue to work unchanged.

## Tests

New failing-first tests in `sdk/src/query/`:

- `roadmap.test.ts`: `bug-2422: does not include ## Backlog section before the current milestone`
- `roadmap.test.ts`: `bug-2422: does not truncate at same-version sub-heading (## v2.0 Phase Details)`
- `state-mutation.test.ts`: `bug-2420: parses --phase/--name/--plans flag-form args correctly`
- `state-mutation.test.ts`: `bug-2420: positional args still work after flag-parsing fix`

SDK test result: `PASS (47) FAIL (0)`. Full suite: exit 0, 86.99% line coverage (threshold 70%).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed milestone content extraction to exclude backlog sections and properly handle version-specific subsections
  * Enabled phase initialization to accept both flag-style (`--phase`, `--name`, `--plans`) and traditional positional arguments

* **Tests**
  * Added unit tests for milestone extraction scenarios
  * Added unit tests for phase initialization with multiple argument formats

<!-- end of auto-generated comment: release notes by coderabbit.ai -->