### PR TITLE
fix(sdk): drop Node 20 engines requirement — EOL April 30 2026

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -30,7 +30,7 @@
   "author": "TÂCHES",
   "license": "MIT",
   "engines": {
-    "node": ">=20"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## Summary

- Bumps `sdk/package.json` `engines.node` from `>=20` to `>=22.0.0`
- Aligns the SDK with the root package (`>=22.0.0`) and CI matrix (Node 22, 24)
- Eliminates silent Node 20 install that breaks at runtime once EOL lands

## Why

Node 20 EOL is **April 30, 2026**. After that date GitHub Actions will emit deprecation warnings for workflows/actions running on Node 20, and npm will flag installs on unsupported engines. The root package already declared `>=22.0.0`; `sdk/package.json` was simply missed.

## Test plan

- [x] No code changes — engines field only
- [x] `node --test tests/gsd-sdk-query-registry-integration.test.cjs` passes

Closes #2464

🤖 Generated with [Claude Code](https://claude.com/claude-code)