### PR TITLE
fix(config+workflows): VALID_CONFIG_KEYS gap and four test failures from bugs #2399 #2418 #2419 #2421

### DIFF
--- a/agents/gsd-planner.md
+++ b/agents/gsd-planner.md
@@ -215,6 +215,17 @@ Every task has four required fields:
 
 **Nyquist Rule:** Every `<verify>` must include an `<automated>` command. If no test exists yet, set `<automated>MISSING — Wave 0 must create {test_file} first</automated>` and create a Wave 0 task that generates the test scaffold.
 
+**Grep gate hygiene:** If `<automated>` is a `grep -c <token> <file>` counting gate, the gate MUST exclude comments — otherwise descriptive prose in the file counts against its own invariant and forces authors to reword legitimate comments to pass. This is the "self-invalidating grep gate" anti-pattern.
+
+**Do:**
+- Strip comments first, then count: `grep -vE '^\s*(//|\*|/\*)' src/foo.ts | grep -c '<token>'`
+- Use an AST-aware tool: `ast-grep --lang typescript --pattern '<token>' src/foo.ts | wc -l`
+- Bound the gate to non-comment regions via ripgrep: `rg --no-line-number --type ts -N '<token>' src/foo.ts | grep -cvE '^\s*(//|\*)'`
+
+**Do NOT:**
+- Write a zero-count gate (`grep -c '<token>' <file> == 0`) on an entire source file. The author cannot document the invariant in comments without tripping the gate.
+- Write a count-exact gate (`== 1`, `== 2`) without comment exclusion — same failure mode.
+
 **<done>:** Acceptance criteria - measurable state of completion.
 - Good: "Valid credentials return 200 + JWT cookie, invalid credentials return 401"
 - Bad: "Authentication is complete"

--- a/bin/install.js
+++ b/bin/install.js
@@ -1004,11 +1004,19 @@ function convertClaudeAgentToCopilotAgent(content, isGlobal = false) {
 function convertClaudeToAntigravityContent(content, isGlobal = false) {
   let c = content;
   if (isGlobal) {
+    // Replace slash-suffixed forms first (most specific)
     c = c.replace(/\$HOME\/\.claude\//g, '$HOME/.gemini/antigravity/');
     c = c.replace(/~\/\.claude\//g, '~/.gemini/antigravity/');
+    // Replace bare forms (no trailing slash) that were not already replaced
+    c = c.replace(/\$HOME\/\.claude(?!\/)/g, '$HOME/.gemini/antigravity');
+    c = c.replace(/~\/\.claude(?!\/)/g, '~/.gemini/antigravity');
   } else {
+    // Replace slash-suffixed forms first (most specific)
     c = c.replace(/\$HOME\/\.claude\//g, '.agent/');
     c = c.replace(/~\/\.claude\//g, '.agent/');
+    // Replace bare forms (no trailing slash) that were not already replaced
+    c = c.replace(/\$HOME\/\.claude(?!\/)/g, '.agent');
+    c = c.replace(/~\/\.claude(?!\/)/g, '.agent');
   }
   c = c.replace(/\.\/\.claude\//g, './.agent/');
   c = c.replace(/\.claude\//g, '.agent/');

--- a/get-shit-done/bin/lib/config.cjs
+++ b/get-shit-done/bin/lib/config.cjs
@@ -48,6 +48,9 @@ const VALID_CONFIG_KEYS = new Set([
   'intel.enabled',
   'graphify.enabled',
   'graphify.build_timeout',
+  'workflow.security_enforcement',
+  'workflow.security_asvs_level',
+  'workflow.security_block_on',
   'claude_md_path',
 ]);
 

--- a/get-shit-done/workflows/new-milestone.md
+++ b/get-shit-done/workflows/new-milestone.md
@@ -208,7 +208,9 @@ AGENT_SKILLS_SYNTHESIZER=$(gsd-sdk query agent-skills gsd-synthesizer 2>/dev/nul
 AGENT_SKILLS_ROADMAPPER=$(gsd-sdk query agent-skills gsd-roadmapper 2>/dev/null)
 ```
 
-Extract from init JSON: `researcher_model`, `synthesizer_model`, `roadmapper_model`, `commit_docs`, `research_enabled`, `current_milestone`, `project_exists`, `roadmap_exists`, `latest_completed_milestone`, `phase_dir_count`, `phase_archive_path`.
+Extract from init JSON: `researcher_model`, `synthesizer_model`, `roadmapper_model`, `commit_docs`, `research_enabled`, `current_milestone`, `project_exists`, `roadmap_exists`, `latest_completed_milestone`, `phase_dir_count`, `phase_archive_path`, `agents_installed`.
+
+**If `agents_installed` is false:** Warn the user that subagents are not installed in this runtime's config directory. Subagent steps (research, synthesis, roadmapping) will fail with "agent type not found" until agents are installed. Prompt the user to run the GSD installer for this runtime, or install agents manually into the runtime's agents directory, then rerun this command.
 
 ## 7.5 Reset-phase safety (only when `--reset-phase-numbers`)
 

--- a/get-shit-done/workflows/new-project.md
+++ b/get-shit-done/workflows/new-project.md
@@ -64,7 +64,9 @@ AGENT_SKILLS_SYNTHESIZER=$(gsd-sdk query agent-skills gsd-synthesizer 2>/dev/nul
 AGENT_SKILLS_ROADMAPPER=$(gsd-sdk query agent-skills gsd-roadmapper 2>/dev/null)
 ```
 
-Parse JSON for: `researcher_model`, `synthesizer_model`, `roadmapper_model`, `commit_docs`, `project_exists`, `has_codebase_map`, `planning_exists`, `has_existing_code`, `has_package_file`, `is_brownfield`, `needs_codebase_map`, `has_git`, `project_path`.
+Parse JSON for: `researcher_model`, `synthesizer_model`, `roadmapper_model`, `commit_docs`, `project_exists`, `has_codebase_map`, `planning_exists`, `has_existing_code`, `has_package_file`, `is_brownfield`, `needs_codebase_map`, `has_git`, `project_path`, `agents_installed`.
+
+**If `agents_installed` is false:** Warn the user that subagents are not installed in this runtime's config directory. Subagent steps (research, synthesis, roadmapping) will fail with "agent type not found" until agents are installed. Prompt the user to run the GSD installer for this runtime, or install agents manually into the runtime's agents directory, then rerun this command.
 
 **Detect runtime and set instruction file name:**
 

--- a/get-shit-done/workflows/plan-phase.md
+++ b/get-shit-done/workflows/plan-phase.md
@@ -1145,6 +1145,20 @@ gsd-sdk query state.planned-phase --phase "${PHASE_NUMBER}" --name "${PHASE_NAME
 
 This updates STATUS to "Ready to execute", sets the correct plan count, and timestamps Last Activity.
 
+## 13c. Commit Plan Artifacts (if commit_docs enabled)
+
+If `commit_docs` is `true`, commit the generated PLAN.md files and updated STATE.md so plan artifacts are tracked in git:
+
+```bash
+if [[ "${COMMIT_DOCS}" == "true" ]]; then
+  gsd-sdk query commit "docs(${padded_phase}): add plan artifacts" \
+    "${phase_dir}/${padded_phase}-01-PLAN.md" \
+    ".planning/STATE.md"
+fi
+```
+
+If multiple PLAN.md files were generated (e.g., wave-split plans), include each one in the commit arguments. Only commit files that exist — skip any that were not produced.
+
 ## 14. Present Final Status
 
 Route to `<offer_next>` OR `auto_advance` depending on flags/config.


### PR DESCRIPTION
## Summary

Five separate defects found during CodeRabbit review audit and pre-PR gate analysis, fixed together in this branch.

### Fix 1: workflow.security_* keys missing from VALID_CONFIG_KEYS (CodeRabbit finding on PR #2390)

Three keys documented in `docs/CONFIGURATION.md` were absent from the `VALID_CONFIG_KEYS` allowlist in `get-shit-done/bin/lib/config.cjs`, causing `gsd-sdk config-set workflow.security_enforcement strict` to fail with "not a valid config key" at runtime.

Added: `workflow.security_enforcement`, `workflow.security_asvs_level`, `workflow.security_block_on`

### Fix 2: Grep gate hygiene rule missing from gsd-planner.md (#2421)

`agents/gsd-planner.md` had no instruction for comment-aware grep counting gates. Agents were generating bare `grep -c <token> <file> == 0` gates that counted prose in file headers, forcing authors to reword documentation to pass the gate (the self-invalidating grep gate anti-pattern). Added the Grep gate hygiene section immediately after the existing Nyquist Rule.

Closes #2421

### Fix 3: Antigravity converter misses bare ~/.claude paths (#2418)

`convertClaudeToAntigravityContent` in `bin/install.js` only replaced `~/.claude/` (with trailing slash). Bare `~/.claude` references (no trailing slash, e.g. `configDir = ~/.claude` or `# e.g. ~/.claude, ...`) were left unreplaced, triggering the installer's leaked-path warning. Added negative-lookahead replacements for the bare forms, applied after the slash-suffixed forms to avoid double-replacement.

Closes #2418

### Fix 4: new-project.md and new-milestone.md do not check agents_installed (#2419)

When subagents are not installed in the runtime's config directory, spawning them fails with "agent type not found" — silently, with no guidance. Added `agents_installed` to the init JSON parse step in both `new-project.md` and `new-milestone.md`, and a guard that warns the user and provides remediation steps when the field is false.

Closes #2419

### Fix 5: plan-phase.md missing step 13c to commit plan artifacts (#2399)

When `commit_docs` is true, plan-phase generated PLAN.md files but never committed them. Added step 13c between steps 13b and 14 that runs `gsd-sdk query commit` on the generated PLAN.md and STATE.md when `commit_docs` is enabled.

Closes #2399

## Test plan

- `node --test tests/config.test.cjs` — 0 failures
- `node --test tests/bug-2421-planner-grep-gate-hygiene.test.cjs` — 6/6 pass
- `node --test tests/bug-2418-antigravity-bare-path.test.cjs` — 15/15 pass
- `node --test tests/bug-2419-project-researcher-agent.test.cjs` — 8/8 pass
- `node --test tests/bug-2399-commit-docs-plan-phase.test.cjs` — 6/6 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added three new workflow security configuration keys.
  * Implemented agent installation validation with instructional warnings in workflows.
  * Added optional auto-commit functionality for planning artifacts.

* **Bug Fixes**
  * Improved path rewriting for configuration directory handling.

* **Documentation**
  * Updated verification command guidelines for improved robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->