### PR TITLE
fix(hooks): derive hookEventName from input payload, not env var

### DIFF
--- a/hooks/gsd-context-monitor.js
+++ b/hooks/gsd-context-monitor.js
@@ -177,9 +177,15 @@ process.stdin.on('end', () => {
           'starting new complex work.';
     }
 
+    // Echo the event name from the input payload rather than guessing the
+    // runtime from env vars. Claude Code users with GEMINI_API_KEY in their
+    // shell (e.g. for an unrelated Gemini project or MCP) would otherwise
+    // get "AfterTool" emitted into a CC runtime, which CC's hook validator
+    // rejects as "(root): Invalid input" — silently dropping all context
+    // warnings.
     const output = {
       hookSpecificOutput: {
-        hookEventName: process.env.GEMINI_API_KEY ? "AfterTool" : "PostToolUse",
+        hookEventName: data.hook_event_name || "PostToolUse",
         additionalContext: message
       }
     };


### PR DESCRIPTION
## Summary

- `hooks/gsd-context-monitor.js` used `process.env.GEMINI_API_KEY` as a proxy for "am I running on Gemini CLI?" and emitted `hookEventName: \"AfterTool\"` when that env var was set.
- This leaks: any Claude Code user with `GEMINI_API_KEY` in their shell (for an unrelated Gemini project, MCP server, or credential store) gets `\"AfterTool\"` emitted into a CC runtime.
- CC's hook validator rejects the payload — `PostToolUse:Write hook error / Hook JSON output validation failed — (root): Invalid input` — silently dropping all CONTEXT WARNING / CONTEXT CRITICAL injections the hook exists to deliver.
- Fix: echo `data.hook_event_name` from the input payload directly, with a `\"PostToolUse\"` fallback. The input contract already carries the correct event name on both CC and Gemini.

## Reproduction

```bash
export GEMINI_API_KEY=anything_nonempty
# on Claude Code, push context above ~65% used_pct and trigger any Write/Edit/Bash/Agent/Task
# observe red-alert hook error in the transcript; agent never receives the CONTEXT WARNING
```

## Verification after patch

```bash
SID=\"test-$(date +%s)\"
TMP=\$(node -e \"console.log(require('os').tmpdir())\")
echo '{\"remaining_percentage\":20,\"used_pct\":80,\"timestamp\":'\$(date +%s)'}' > \"\$TMP/claude-ctx-\${SID}.json\"
echo '{\"session_id\":\"'\$SID'\",\"cwd\":\"/tmp\",\"hook_event_name\":\"PostToolUse\",\"tool_name\":\"Write\",\"tool_input\":{\"file_path\":\"/tmp/x\"},\"tool_response\":{\"success\":true}}' | \\
  GEMINI_API_KEY=leak node hooks/gsd-context-monitor.js | python3 -m json.tool
```

Output (post-fix, even with `GEMINI_API_KEY` set):

```json
{
  \"hookSpecificOutput\": {
    \"hookEventName\": \"PostToolUse\",
    \"additionalContext\": \"CONTEXT CRITICAL: Usage at 80%. Remaining: 20%...\"
  }
}
```

Pre-fix with the same env, `hookEventName` was `\"AfterTool\"` and CC rejected the whole payload.

## Test plan

- [ ] CC user with `GEMINI_API_KEY` set: trigger hook at >65% context, confirm no validation error and the CONTEXT WARNING reaches the agent
- [ ] CC user without `GEMINI_API_KEY`: unchanged behaviour
- [ ] Gemini CLI user: `hook_event_name` in the input is `\"AfterTool\"` (or whatever Gemini sends), so the echoed value stays correct for Gemini
- [ ] Missing `hook_event_name` in input: fallback to `\"PostToolUse\"` still produces a CC-valid payload

## Notes

- Single-line change plus a comment block explaining why.
- No behavioural change for users who never set `GEMINI_API_KEY`.
- Discovered while investigating a `PostToolUse:Write hook error` on v1.38.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hook event handling to use input-driven configuration instead of environment-dependent logic for more reliable event routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->