### PR TITLE
fix(execute-phase): post-merge deletion audit for bulk file deletions (closes #2384)

### DIFF
--- a/docs/INVENTORY.md
+++ b/docs/INVENTORY.md
@@ -173,7 +173,7 @@ Full roster at `commands/gsd/*.md`. The groupings below mirror `docs/COMMANDS.md
 
 ---
 
-## Workflows (80 shipped)
+## Workflows (81 shipped)
 
 Full roster at `get-shit-done/workflows/*.md`. Workflows are thin orchestrators that commands reference internally; most are not read directly by end users. Rows below map each workflow file to its role (derived from the `<purpose>` block) and, where applicable, to the command that invokes it.
 

--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -623,6 +623,21 @@ Execute each selected wave in sequence. Within a wave: parallel if `PARALLELIZAT
          break
        }
 
+       # Post-merge deletion audit: detect bulk file deletions in merge commit (#2384)
+       # --diff-filter=D HEAD~1 HEAD shows files deleted by the merge commit itself.
+       # Exclude .planning/ — orchestrator-owned deletions there are expected (resurrections
+       # are handled below). Require ALLOW_BULK_DELETE=1 to bypass for intentional large refactors.
+       MERGE_DEL_COUNT=$(git diff --diff-filter=D --name-only HEAD~1 HEAD 2>/dev/null | grep -vc '^\.planning/' || true)
+       if [ "$MERGE_DEL_COUNT" -gt 5 ] && [ "${ALLOW_BULK_DELETE:-0}" != "1" ]; then
+         MERGE_DELETIONS=$(git diff --diff-filter=D --name-only HEAD~1 HEAD 2>/dev/null | grep -v '^\.planning/' || true)
+         echo "⚠ BLOCKED: Merge of $WT_BRANCH deleted $MERGE_DEL_COUNT files outside .planning/ — reverting to protect repository integrity (#2384)"
+         echo "$MERGE_DELETIONS"
+         echo "  If these deletions are intentional, re-run with ALLOW_BULK_DELETE=1"
+         git reset --hard HEAD~1 2>/dev/null || true
+         rm -f "$STATE_BACKUP" "$ROADMAP_BACKUP"
+         continue
+       fi
+
        # Restore orchestrator-owned files (main always wins)
        if [ -s "$STATE_BACKUP" ]; then
          cp "$STATE_BACKUP" .planning/STATE.md

--- a/tests/bug-2384-post-merge-deletion-audit.test.cjs
+++ b/tests/bug-2384-post-merge-deletion-audit.test.cjs
@@ -23,27 +23,32 @@ const EXECUTE_PHASE = path.join(
 describe('execute-phase.md — post-merge deletion audit (#2384)', () => {
   const content = fs.readFileSync(EXECUTE_PHASE, 'utf-8');
 
-  test('post-merge deletion audit uses git diff HEAD~1 HEAD to check merge commit', () => {
-    assert.ok(
-      content.includes('HEAD~1') && content.includes('--diff-filter=D'),
-      'execute-phase.md must include a post-merge check using git diff --diff-filter=D HEAD~1 HEAD ' +
-      'to detect bulk deletions that made it into the merge commit'
+  test('post-merge deletion audit uses merge-commit diff', () => {
+    assert.match(
+      content,
+      /git diff --diff-filter=D --name-only HEAD~1 HEAD/,
+      'execute-phase.md must diff HEAD~1..HEAD with --diff-filter=D for post-merge deletion audit'
     );
   });
 
-  test('post-merge audit includes a revert path when bulk deletions are found', () => {
-    assert.ok(
-      content.includes('reset --hard HEAD~1') || content.includes('BULK_DELETIONS'),
-      'execute-phase.md must include a git reset --hard HEAD~1 revert when bulk deletions ' +
-      'are detected in the merge commit'
+  test('post-merge audit includes threshold gate + escape hatch + revert path', () => {
+    assert.match(
+      content,
+      /\[\s*"\$MERGE_DEL_COUNT"\s*-gt\s*5\s*\]\s*&&\s*\[\s*"\$\{ALLOW_BULK_DELETE:-0\}"\s*!=\s*"1"\s*\]/,
+      'execute-phase.md must gate on MERGE_DEL_COUNT threshold and ALLOW_BULK_DELETE override'
+    );
+    assert.match(
+      content,
+      /git reset --hard HEAD~1/,
+      'execute-phase.md must revert the merge commit when bulk deletions are blocked'
     );
   });
 
-  test('post-merge audit uses a threshold to distinguish bulk from intentional deletions', () => {
-    // The check must count deletions and only trigger above a threshold (5 or configurable)
-    assert.ok(
-      content.match(/MERGE_DEL_COUNT|del_count|DEL_COUNT|BULK_DEL/i),
-      'execute-phase.md must count post-merge deletions and compare against a threshold'
+  test('post-merge audit computes deletion count outside .planning/', () => {
+    assert.match(
+      content,
+      /MERGE_DEL_COUNT=.*grep -vc '\^\\\.planning\//,
+      'execute-phase.md must count non-.planning deletions for the bulk-delete guard'
     );
   });
 });

--- a/tests/bug-2384-post-merge-deletion-audit.test.cjs
+++ b/tests/bug-2384-post-merge-deletion-audit.test.cjs
@@ -1,0 +1,49 @@
+'use strict';
+
+/**
+ * Regression test for #2384.
+ *
+ * During execute-phase, the orchestrator merges per-plan worktree branches into
+ * main. The pre-merge deletion check (git diff --diff-filter=D HEAD...WT_BRANCH)
+ * only catches files deleted on the worktree branch. A post-merge audit is also
+ * required to catch deletions that made it into the merge commit (e.g., files
+ * that were in the common ancestor but deleted by the merged worktree) and to
+ * provide a revert safety net.
+ */
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const EXECUTE_PHASE = path.join(
+  __dirname, '..', 'get-shit-done', 'workflows', 'execute-phase.md'
+);
+
+describe('execute-phase.md — post-merge deletion audit (#2384)', () => {
+  const content = fs.readFileSync(EXECUTE_PHASE, 'utf-8');
+
+  test('post-merge deletion audit uses git diff HEAD~1 HEAD to check merge commit', () => {
+    assert.ok(
+      content.includes('HEAD~1') && content.includes('--diff-filter=D'),
+      'execute-phase.md must include a post-merge check using git diff --diff-filter=D HEAD~1 HEAD ' +
+      'to detect bulk deletions that made it into the merge commit'
+    );
+  });
+
+  test('post-merge audit includes a revert path when bulk deletions are found', () => {
+    assert.ok(
+      content.includes('reset --hard HEAD~1') || content.includes('BULK_DELETIONS'),
+      'execute-phase.md must include a git reset --hard HEAD~1 revert when bulk deletions ' +
+      'are detected in the merge commit'
+    );
+  });
+
+  test('post-merge audit uses a threshold to distinguish bulk from intentional deletions', () => {
+    // The check must count deletions and only trigger above a threshold (5 or configurable)
+    assert.ok(
+      content.match(/MERGE_DEL_COUNT|del_count|DEL_COUNT|BULK_DEL/i),
+      'execute-phase.md must count post-merge deletions and compare against a threshold'
+    );
+  });
+});


### PR DESCRIPTION
Closes #2384

## Root cause

Two data-loss incidents occurred when executor worktree merges brought in bulk file deletions silently. The existing pre-merge check (`git diff --diff-filter=D HEAD...WT_BRANCH`) detects files deleted on the worktree branch, but files deleted as part of the merge itself (from stale branch state or merge conflict resolution) were not audited after the merge commit landed.

## Fix

Added a post-merge deletion audit immediately after `git merge --no-ff` succeeds:

1. Counts files deleted outside `.planning/` in the merge commit: `git diff --diff-filter=D HEAD~1 HEAD`
2. If count > 5 and `ALLOW_BULK_DELETE` is not set: reverts the merge with `git reset --hard HEAD~1`, logs the full file list and an escape-hatch instruction, then continues to the next worktree
3. `.planning/` deletions are excluded — orchestrator handles those separately (resurrection detection on lines 635–643)

This adds defense-in-depth on top of the existing pre-merge check: the pre-merge check blocks worktree branches with deletions, and the post-merge audit catches anything that slips through to the actual merge commit.

## Test

`tests/bug-2384-post-merge-deletion-audit.test.cjs` — verifies:
1. `execute-phase.md` uses `git diff --diff-filter=D HEAD~1 HEAD` post-merge
2. A `git reset --hard HEAD~1` revert path exists
3. A deletion count threshold variable is present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added post-merge deletion audit to prevent accidental bulk file deletions. Merges that delete more than 5 files are now blocked unless explicitly allowed via configuration.

* **Tests**
  * Added regression tests for the deletion audit feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->