### PR TITLE
fix(workflow): worktree merge must not delete legitimate new files (#2501)

### DIFF
--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -602,9 +602,6 @@ Execute each selected wave in sequence. Within a wave: parallel if `PARALLELIZAT
        [ -f .planning/STATE.md ] && cp .planning/STATE.md "$STATE_BACKUP" || true
        [ -f .planning/ROADMAP.md ] && cp .planning/ROADMAP.md "$ROADMAP_BACKUP" || true
 
-       # Snapshot list of files on main BEFORE merge to detect resurrections
-       PRE_MERGE_FILES=$(git ls-files .planning/)
-
        # Pre-merge deletion check: warn if the worktree branch deletes tracked files
        DELETIONS=$(git diff --diff-filter=D --name-only HEAD..."$WT_BRANCH" 2>/dev/null || true)
        if [ -n "$DELETIONS" ]; then
@@ -647,19 +644,25 @@ Execute each selected wave in sequence. Within a wave: parallel if `PARALLELIZAT
        fi
        rm -f "$STATE_BACKUP" "$ROADMAP_BACKUP"
 
-       # Detect files deleted on main but re-added by worktree merge
-       # (e.g., archived phase directories that were intentionally removed)
-       DELETED_FILES=$(git diff --diff-filter=A --name-only HEAD~1 -- .planning/ 2>/dev/null || true)
-       for RESURRECTED in $DELETED_FILES; do
-         # Check if this file was NOT in main's pre-merge tree
-         if ! echo "$PRE_MERGE_FILES" | grep -qxF "$RESURRECTED"; then
-           git rm -f "$RESURRECTED" 2>/dev/null || true
+       # Detect true resurrections: files added by the merge that were previously
+       # committed on main AND subsequently deleted (e.g., archived phase directories
+       # removed during milestone transition). Legitimate new files from worktrees
+       # (SUMMARY.md etc.) never existed on main and must be kept.
+       # Fix for #2501 — the previous check deleted every newly-added file.
+       ADDED_BY_MERGE=$(git diff --diff-filter=A --name-only HEAD~1..HEAD -- .planning/ 2>/dev/null || true)
+       RESURRECTED_FILES=""
+       for CANDIDATE in $ADDED_BY_MERGE; do
+         # Ask history (pre-merge main tip) whether this path was ever deleted there.
+         if git log HEAD~1 --diff-filter=D --format= --name-only -- "$CANDIDATE" 2>/dev/null \
+              | grep -qxF "$CANDIDATE"; then
+           git rm -f "$CANDIDATE" 2>/dev/null || true
+           RESURRECTED_FILES="$RESURRECTED_FILES $CANDIDATE"
          fi
        done
 
        # Amend merge commit with restored files if any changed
        if ! git diff --quiet .planning/STATE.md .planning/ROADMAP.md 2>/dev/null || \
-          [ -n "$DELETED_FILES" ]; then
+          [ -n "$RESURRECTED_FILES" ]; then
          # Only amend the commit with .planning/ files if commit_docs is enabled (#1783)
          COMMIT_DOCS=$(gsd-sdk query config-get commit_docs 2>/dev/null || echo "true")
          if [ "$COMMIT_DOCS" != "false" ]; then

--- a/get-shit-done/workflows/quick.md
+++ b/get-shit-done/workflows/quick.md
@@ -649,9 +649,6 @@ After executor returns:
        [ -f .planning/STATE.md ] && cp .planning/STATE.md "$STATE_BACKUP" || true
        [ -f .planning/ROADMAP.md ] && cp .planning/ROADMAP.md "$ROADMAP_BACKUP" || true
 
-       # Snapshot files on main to detect resurrections
-       PRE_MERGE_FILES=$(git ls-files .planning/)
-
        # Pre-merge deletion guard: block merges that delete tracked .planning/ files
        DELETIONS=$(git diff --diff-filter=D --name-only HEAD..."$WT_BRANCH" 2>/dev/null || true)
        if [ -n "$DELETIONS" ]; then
@@ -674,16 +671,22 @@ After executor returns:
        if [ -s "$ROADMAP_BACKUP" ]; then cp "$ROADMAP_BACKUP" .planning/ROADMAP.md; fi
        rm -f "$STATE_BACKUP" "$ROADMAP_BACKUP"
 
-       # Remove files deleted on main but re-added by worktree (--no-ff guarantees a merge commit so HEAD~1 is reliable)
-       DELETED_FILES=$(git diff --diff-filter=A --name-only HEAD~1 -- .planning/ 2>/dev/null || true)
-       for RESURRECTED in $DELETED_FILES; do
-         if ! echo "$PRE_MERGE_FILES" | grep -qxF "$RESURRECTED"; then
-           git rm -f "$RESURRECTED" 2>/dev/null || true
+       # Remove true resurrections — paths that were previously committed on main
+       # and deleted, then re-added by the worktree branch. Legitimate new files from
+       # worktrees (SUMMARY.md etc.) never existed on main and must be kept.
+       # Fix for #2501 — previous check deleted every newly-added file.
+       ADDED_BY_MERGE=$(git diff --diff-filter=A --name-only HEAD~1..HEAD -- .planning/ 2>/dev/null || true)
+       RESURRECTED_FILES=""
+       for CANDIDATE in $ADDED_BY_MERGE; do
+         if git log HEAD~1 --diff-filter=D --format= --name-only -- "$CANDIDATE" 2>/dev/null \
+              | grep -qxF "$CANDIDATE"; then
+           git rm -f "$CANDIDATE" 2>/dev/null || true
+           RESURRECTED_FILES="$RESURRECTED_FILES $CANDIDATE"
          fi
        done
 
        if ! git diff --quiet .planning/STATE.md .planning/ROADMAP.md 2>/dev/null || \
-          [ -n "$DELETED_FILES" ]; then
+          [ -n "$RESURRECTED_FILES" ]; then
          COMMIT_DOCS=$(gsd-sdk query config-get commit_docs 2>/dev/null || echo "true")
          if [ "$COMMIT_DOCS" != "false" ]; then
            git add .planning/STATE.md .planning/ROADMAP.md 2>/dev/null || true

--- a/tests/bug-2501-worktree-resurrection-false-positive.test.cjs
+++ b/tests/bug-2501-worktree-resurrection-false-positive.test.cjs
@@ -1,0 +1,76 @@
+/**
+ * Regression test for #2501.
+ *
+ * The worktree-merge resurrection-detection block introduced by #1764
+ * had inverted logic: it staged `git rm` against every path that the
+ * merge commit added under `.planning/` — including legitimate new
+ * files from executor agents (SUMMARY.md etc.).
+ *
+ * Failure mode in parallel mode: first worktree merges, post-merge
+ * loop stages `rm` on its own `SUMMARY.md`, second worktree's merge
+ * aborts with "Your local changes to the following files would be
+ * overwritten by merge".
+ *
+ * Fix: the check must ask git history whether the candidate path was
+ * ever deleted on main — not merely whether it existed in main's tree
+ * immediately before the merge.
+ */
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const EXECUTE_PHASE_PATH = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'execute-phase.md');
+const QUICK_PATH = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'quick.md');
+
+const FILES = [
+  { label: 'execute-phase.md', path: EXECUTE_PHASE_PATH },
+  { label: 'quick.md',          path: QUICK_PATH },
+];
+
+describe('worktree merge: resurrection detection (#2501)', () => {
+  for (const { label, path: p } of FILES) {
+    test(`${label} does not delete every newly-added path under .planning/`, () => {
+      const content = fs.readFileSync(p, 'utf-8');
+
+      // The broken pattern checked "not in pre-merge tree" and staged rm.
+      // Any fresh file (like SUMMARY.md) satisfies that trivially, so the
+      // pattern must be gone.
+      assert.ok(
+        !/PRE_MERGE_FILES=\$\(git ls-files/.test(content),
+        `${label} still snapshots PRE_MERGE_FILES — the inverted resurrection check must be removed (#2501)`,
+      );
+
+      assert.ok(
+        !/if ! echo "\$PRE_MERGE_FILES" \| grep -qxF/.test(content),
+        `${label} still contains the broken "not in pre-merge tree → rm" condition (#2501)`,
+      );
+    });
+
+    test(`${label} uses git history to identify true resurrections`, () => {
+      const content = fs.readFileSync(p, 'utf-8');
+
+      // The correct check consults git log for prior deletions of the
+      // candidate path. Without this, we cannot distinguish a brand-new
+      // SUMMARY.md from an archived phase directory being re-added.
+      assert.ok(
+        /git log HEAD~1 --diff-filter=D/.test(content),
+        `${label} must use \`git log HEAD~1 --diff-filter=D\` to detect true resurrections (#2501)`,
+      );
+    });
+
+    test(`${label} amend condition references the new resurrection variable`, () => {
+      const content = fs.readFileSync(p, 'utf-8');
+
+      // The amend guard previously checked [ -n "$DELETED_FILES" ] — that
+      // variable name is misleading (it held added paths) and is removed
+      // together with the broken loop. The amend should now key off the
+      // new RESURRECTED_FILES variable.
+      assert.ok(
+        /\[ -n "\$RESURRECTED_FILES" \]/.test(content),
+        `${label} amend condition must reference RESURRECTED_FILES (#2501)`,
+      );
+    });
+  }
+});


### PR DESCRIPTION
## Fix PR

> Opened as **draft** pending the `confirmed-bug` label on #2501. Happy to undraft the moment a maintainer confirms — the fix is small, tests pass locally, and reproducing the bug takes under a minute (see #2501).

---

## Linked Issue

Fixes #2501

## What was broken

The worktree-merge resurrection-detection block in `execute-phase.md` and `quick.md` staged `git rm` against every path that the merge commit added under `.planning/` — including legitimate new artifacts (e.g. `SUMMARY.md`). In parallel mode the next worktree merge then aborted with `Your local changes to the following files would be overwritten by merge`.

## What this fix does

Replaces the check with a history-based lookup: a path is a true resurrection only if it was previously committed on main **and** later deleted. Brand-new files from worktrees (which never existed on main) are kept.

Removes the now-unused `PRE_MERGE_FILES=$(git ls-files .planning/)` snapshot in both files, and renames the downstream variable from `DELETED_FILES` (which never actually held deletions) to `RESURRECTED_FILES` so the amend guard reads correctly.

## Root cause

The block introduced by #1764 used `git diff --diff-filter=A --name-only HEAD~1` (paths **added** by the merge) but named the variable `DELETED_FILES` and then checked `! echo "\$PRE_MERGE_FILES" | grep -qxF "\$RESURRECTED"`. Every new file trivially satisfies both conditions — nothing prevents fresh `SUMMARY.md` output from being flagged as a resurrection.

The intended semantic from #1756 was: detect paths main already removed (archived phase directories) that a stale worktree branch reintroduces. That requires checking history, not the current tree.

## Testing

### How I verified the fix

1. Reproduced the bug against 1.38.1 on a real project: parallel-wave execute-phase with 3 plans → first merge staged `rm` on its own SUMMARY.md → second merge aborted. Traced to this exact block.
2. Applied the patch to the local install → same phase executed cleanly, no SUMMARY.md deletions, all merges completed.
3. Ran the full repo test suite locally: `npm test` → 4881 pass / 0 fail.

### Regression test added?

- [x] Yes — `tests/bug-2501-worktree-resurrection-false-positive.test.cjs`

The test asserts three invariants against both `execute-phase.md` and `quick.md`:
- The broken `PRE_MERGE_FILES` snapshot is gone.
- The broken `! echo "\$PRE_MERGE_FILES" | grep -qxF` condition is gone.
- The replacement uses `git log HEAD~1 --diff-filter=D` to detect true resurrections.
- The amend guard references the new `RESURRECTED_FILES` variable.

### Manual verification steps for reviewers

```bash
# Minimal repro of the original bug against unpatched workflow:
git init /tmp/repro && cd /tmp/repro
git commit --allow-empty -m "initial"
git worktree add ../wt-a
cd ../wt-a && mkdir -p .planning/phases/01 && echo "x" > .planning/phases/01/SUMMARY.md
git add . && git commit -m "add summary"
cd ../repro
git merge --no-ff wt-a -m "merge"
# Run the OLD resurrection loop → SUMMARY.md is staged for deletion.
# Run the NEW resurrection loop → SUMMARY.md is left alone (correct).
```

---

**Note on CONTRIBUTING compliance:** I'm aware CONTRIBUTING.md asks contributors to wait for `confirmed-bug` before the PR. I've filed #2501 first; this PR is intentionally a draft until that happens. The bug is reproducible in one minute and the fix is 14 lines + a test, so I'm hoping this speeds up triage rather than short-circuiting it — please redirect if you'd prefer me to close this until #2501 is confirmed.