### PR TITLE
fix(insert-phase): update STATE.md next-phase recommendation after phase insertion

### DIFF
--- a/get-shit-done/workflows/insert-phase.md
+++ b/get-shit-done/workflows/insert-phase.md
@@ -66,8 +66,10 @@ Extract from result: `phase_number`, `after_phase`, `name`, `slug`, `directory`.
 Update STATE.md to reflect the inserted phase:
 
 1. Read `.planning/STATE.md`
-2. Update the "Current Phase" / next-phase recommendation to point to the newly inserted phase:
-   - Find the line that recommends the next phase to run (e.g. `current_phase:`, `## Current Phase`, or `Next recommended run:`) and update it to reference `{decimal_phase}` instead of the old next phase.
+2. Update STATE.md's next-phase pointers to the newly inserted phase `{decimal_phase}`:
+   - Update structured field(s) used by tooling (e.g. `current_phase:`) to `{decimal_phase}`.
+   - Update human-readable recommendation text (e.g. `## Current Phase`, `Next recommended run:`) to `{decimal_phase}`.
+   - If multiple pointer locations exist, update all of them in the same edit.
 3. Under "## Accumulated Context" → "### Roadmap Evolution" add entry:
    ```
    - Phase {decimal_phase} inserted after Phase {after_phase}: {description} (URGENT)

--- a/get-shit-done/workflows/insert-phase.md
+++ b/get-shit-done/workflows/insert-phase.md
@@ -66,7 +66,9 @@ Extract from result: `phase_number`, `after_phase`, `name`, `slug`, `directory`.
 Update STATE.md to reflect the inserted phase:
 
 1. Read `.planning/STATE.md`
-2. Under "## Accumulated Context" → "### Roadmap Evolution" add entry:
+2. Update the "Current Phase" / next-phase recommendation to point to the newly inserted phase:
+   - Find the line that recommends the next phase to run (e.g. `current_phase:`, `## Current Phase`, or `Next recommended run:`) and update it to reference `{decimal_phase}` instead of the old next phase.
+3. Under "## Accumulated Context" → "### Roadmap Evolution" add entry:
    ```
    - Phase {decimal_phase} inserted after Phase {after_phase}: {description} (URGENT)
    ```

--- a/tests/bug-2502-insert-phase-state-update.test.cjs
+++ b/tests/bug-2502-insert-phase-state-update.test.cjs
@@ -44,14 +44,14 @@ describe('bug-2502: insert-phase must update STATE.md next-phase recommendation'
   test('insert-phase.md update_project_state step covers next-phase pointer', () => {
     const content = fs.readFileSync(INSERT_PHASE_PATH, 'utf-8');
 
-    // The update_project_state step (or equivalent) must mention updating
-    // the current/next phase value, not just the Roadmap Evolution log.
+    const stepMatch = content.match(/<step name="update_project_state">([\s\S]*?)<\/step>/i);
+    assert.ok(stepMatch, 'insert-phase.md must contain update_project_state step');
+    const stepContent = stepMatch[1];
+
     const hasNextPhasePointerUpdate = (
-      content.includes('current_phase') ||
-      content.includes('next phase') ||
-      content.includes('next-phase') ||
-      /update.{0,60}STATE\.md.{0,200}(decimal_phase|inserted phase|new phase)/is.test(content) ||
-      /(decimal_phase|inserted phase|new phase).{0,200}update.{0,60}STATE\.md/is.test(content)
+      /\bcurrent[_ -]?phase\b/i.test(stepContent) ||
+      /\bnext[_ -]?phase\b/i.test(stepContent) ||
+      /\bnext recommended run\b/i.test(stepContent)
     );
 
     assert.ok(

--- a/tests/bug-2502-insert-phase-state-update.test.cjs
+++ b/tests/bug-2502-insert-phase-state-update.test.cjs
@@ -1,0 +1,62 @@
+/**
+ * Regression test for #2502: insert-phase does not update STATE.md's
+ * next-phase recommendation after inserting a decimal phase.
+ *
+ * Root cause: insert-phase.md's update_project_state step only added a
+ * "Roadmap Evolution" note to STATE.md, but never updated the "Current Phase"
+ * / next-run recommendation to point at the newly inserted phase.
+ *
+ * Fix: insert-phase.md must include a step that updates STATE.md's next-phase
+ * pointer (current_phase / next recommended run) to the newly inserted phase.
+ */
+
+'use strict';
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const INSERT_PHASE_PATH = path.join(
+  __dirname, '..', 'get-shit-done', 'workflows', 'insert-phase.md'
+);
+
+describe('bug-2502: insert-phase must update STATE.md next-phase recommendation', () => {
+  test('insert-phase.md exists', () => {
+    assert.ok(fs.existsSync(INSERT_PHASE_PATH), 'insert-phase.md should exist');
+  });
+
+  test('insert-phase.md contains a STATE.md next-phase update instruction', () => {
+    const content = fs.readFileSync(INSERT_PHASE_PATH, 'utf-8');
+
+    // Must reference STATE.md and the concept of updating the next/current phase pointer
+    const mentionsStateUpdate = (
+      /STATE\.md.{0,200}(next.phase|current.phase|next.run|recommendation)/is.test(content) ||
+      /(next.phase|current.phase|next.run|recommendation).{0,200}STATE\.md/is.test(content)
+    );
+
+    assert.ok(
+      mentionsStateUpdate,
+      'insert-phase.md must instruct updating STATE.md\'s next-phase recommendation to point to the newly inserted phase'
+    );
+  });
+
+  test('insert-phase.md update_project_state step covers next-phase pointer', () => {
+    const content = fs.readFileSync(INSERT_PHASE_PATH, 'utf-8');
+
+    // The update_project_state step (or equivalent) must mention updating
+    // the current/next phase value, not just the Roadmap Evolution log.
+    const hasNextPhasePointerUpdate = (
+      content.includes('current_phase') ||
+      content.includes('next phase') ||
+      content.includes('next-phase') ||
+      /update.{0,60}STATE\.md.{0,200}(decimal_phase|inserted phase|new phase)/is.test(content) ||
+      /(decimal_phase|inserted phase|new phase).{0,200}update.{0,60}STATE\.md/is.test(content)
+    );
+
+    assert.ok(
+      hasNextPhasePointerUpdate,
+      'insert-phase.md update_project_state step must update STATE.md\'s next-phase pointer (current_phase) to the inserted decimal phase'
+    );
+  });
+});


### PR DESCRIPTION
Closes #2502

## Root cause
insert-phase.md had no step to update STATE.md's next-phase recommendation after inserting the new phase. STATE.md retained its old pointer (e.g. phase 4) even when a new decimal phase (e.g. 3.1) was inserted before it.

## Fix
Added a STATE.md update instruction to the `update_project_state` step: after writing the Roadmap Evolution log entry, the workflow now also updates the "Current Phase" / next-phase pointer in STATE.md to reference the newly inserted decimal phase.

## Test
`tests/bug-2502-insert-phase-state-update.test.cjs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Phase-insertion workflow now updates project state pointers (current/next phase and related recommendation lines) across the roadmap and still appends the “roadmap evolution” entry for the inserted phase.

* **Tests**
  * Added regression tests to verify the insertion workflow file exists and that the insertion step updates state pointers and human-readable next-run/recommendation lines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->