### PR TITLE
fix(execute-phase): resurrection-detection must check git history, not just pre-merge tree

### DIFF
--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -649,10 +649,15 @@ Execute each selected wave in sequence. Within a wave: parallel if `PARALLELIZAT
 
        # Detect files deleted on main but re-added by worktree merge
        # (e.g., archived phase directories that were intentionally removed)
+       # A "resurrected" file must have a deletion event in main's ancestry —
+       # brand-new files (e.g. SUMMARY.md just created by the executor) have no
+       # such history and must NOT be removed (#2501).
        DELETED_FILES=$(git diff --diff-filter=A --name-only HEAD~1 -- .planning/ 2>/dev/null || true)
        for RESURRECTED in $DELETED_FILES; do
-         # Check if this file was NOT in main's pre-merge tree
-         if ! echo "$PRE_MERGE_FILES" | grep -qxF "$RESURRECTED"; then
+         # Only delete if this file was previously tracked on main and then
+         # deliberately removed (has a deletion event in git history).
+         WAS_DELETED=$(git log --follow --diff-filter=D --name-only --format="" HEAD~1 -- "$RESURRECTED" 2>/dev/null | grep -c . || true)
+         if [ "${WAS_DELETED:-0}" -gt 0 ]; then
            git rm -f "$RESURRECTED" 2>/dev/null || true
          fi
        done

--- a/tests/bug-2501-resurrection-detection.test.cjs
+++ b/tests/bug-2501-resurrection-detection.test.cjs
@@ -1,0 +1,90 @@
+/**
+ * Tests for bug #2501: resurrection-detection block in execute-phase.md must
+ * check git history before deleting new .planning/ files.
+ *
+ * Root cause: the original logic deleted ANY .planning/ file that was absent
+ * from PRE_MERGE_FILES, which includes brand-new files (e.g. SUMMARY.md)
+ * that the executor just created. A true "resurrection" is a file that was
+ * previously tracked on main, deliberately deleted, and then re-introduced by
+ * a worktree merge. Detecting that requires a git history check, not just a
+ * pre-merge tree membership check.
+ */
+
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const EXECUTE_PHASE = path.join(
+  __dirname, '..', 'get-shit-done', 'workflows', 'execute-phase.md'
+);
+
+describe('execute-phase.md — resurrection-detection guard (#2501)', () => {
+  let content;
+
+  // Load once; each test reads from the cached string.
+  test('file is readable', () => {
+    content = fs.readFileSync(EXECUTE_PHASE, 'utf-8');
+    assert.ok(content.length > 0, 'execute-phase.md must not be empty');
+  });
+
+  test('resurrection block checks git history for a prior deletion event', () => {
+    if (!content) content = fs.readFileSync(EXECUTE_PHASE, 'utf-8');
+    // Scope check to the resurrection block only (up to 1200 chars from its heading).
+    const resurrectionStart = content.indexOf('# Detect files deleted on main');
+    assert.ok(resurrectionStart !== -1, 'resurrection comment must exist');
+    const window = content.slice(resurrectionStart, resurrectionStart + 1200);
+
+    // The fix must add a git log --diff-filter=D check inside this block so that
+    // only files with a deletion event in the main branch ancestry are removed.
+    const hasHistoryCheck =
+      window.includes('--diff-filter=D') &&
+      window.includes('git log');
+    assert.ok(
+      hasHistoryCheck,
+      'execute-phase.md resurrection block must use "git log ... --diff-filter=D" to verify a file was previously deleted before removing it'
+    );
+  });
+
+  test('resurrection block does not delete files solely because they are absent from PRE_MERGE_FILES', () => {
+    if (!content) content = fs.readFileSync(EXECUTE_PHASE, 'utf-8');
+    // Extract the resurrection section (between the "Detect files deleted on main"
+    // comment and the next empty line / next major comment block).
+    const resurrectionStart = content.indexOf('# Detect files deleted on main');
+    assert.ok(
+      resurrectionStart !== -1,
+      'execute-phase.md must contain the resurrection-detection comment block'
+    );
+
+    // Grab a window of text around the resurrection block (up to 1200 chars).
+    const window = content.slice(resurrectionStart, resurrectionStart + 1200);
+
+    // The ONLY deletion guard should be the history check.
+    // The buggy pattern: `if ! echo "$PRE_MERGE_FILES" | grep -qxF "$RESURRECTED"`
+    // with NO accompanying history check. After the fix the sole condition
+    // determining deletion must involve a git-log history lookup.
+    const hasBuggyStandaloneGuard =
+      /if\s*!\s*echo\s*"\$PRE_MERGE_FILES"\s*\|\s*grep\s+-qxF\s*"\$RESURRECTED"/.test(window) &&
+      !/git log/.test(window);
+
+    assert.ok(
+      !hasBuggyStandaloneGuard,
+      'resurrection block must NOT delete files based solely on absence from PRE_MERGE_FILES without a git-history check'
+    );
+  });
+
+  test('resurrection block still removes files that have a deletion history on main', () => {
+    if (!content) content = fs.readFileSync(EXECUTE_PHASE, 'utf-8');
+    // The fix must still call `git rm` for genuine resurrections.
+    const resurrectionStart = content.indexOf('# Detect files deleted on main');
+    assert.ok(resurrectionStart !== -1, 'resurrection comment must exist');
+
+    const window = content.slice(resurrectionStart, resurrectionStart + 1200);
+    assert.ok(
+      window.includes('git rm'),
+      'resurrection block must still call git rm to remove genuinely resurrected files'
+    );
+  });
+});


### PR DESCRIPTION
Closes #2501

## Root cause

The resurrection-detection block used `if ! echo "$PRE_MERGE_FILES" | grep -qxF "$RESURRECTED"` to decide whether to delete a `.planning/` file added by a worktree merge. This condition is true for **any** file that didn't exist on main before the merge — including brand-new files (e.g. `SUMMARY.md`) that the executor agent just created. Result: every new `.planning/` file produced by the executor was silently deleted on merge.

## Fix

Replace the PRE_MERGE_FILES membership check with a `git log --follow --diff-filter=D` history lookup. A file is only removed if it has a prior deletion event in main's ancestry — i.e., it was previously tracked, deliberately removed, and then resurrected by the worktree merge. Brand-new files have no such history and are left untouched.

## Test

`tests/bug-2501-resurrection-detection.test.cjs` — 4 node:test assertions scoped to the resurrection block:
1. Block is readable
2. Block contains `git log ... --diff-filter=D` history check
3. Block does not use standalone PRE_MERGE_FILES guard without history check
4. Block still calls `git rm` for genuine resurrections

Full suite: 4907/4907 pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed merge cleanup process in worktree operations that was incorrectly deleting newly created files. The deletion detection now uses git history-based tracking to determine which files should be removed, rather than checking pre-merge file state. This prevents newly created orchestrator artifacts from being incorrectly deleted and improves merge safety.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->