### PR TITLE
fix(#2554): include decimal phase dirs (0.x) in state disk-scan progress counts

### DIFF
--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -1624,7 +1624,7 @@ function getMilestonePhaseFilter(cwd) {
   }
 
   const normalized = new Set(
-    [...milestonePhaseNums].map(n => (n.replace(/^0+/, '') || '0').toLowerCase())
+    [...milestonePhaseNums].map(n => (n.replace(/^0+(?=\d)/, '') || '0').toLowerCase())
   );
 
   function isDirInMilestone(dirName) {

--- a/get-shit-done/bin/lib/init.cjs
+++ b/get-shit-done/bin/lib/init.cjs
@@ -1260,7 +1260,7 @@ function cmdInitProgress(cwd, raw) {
       const match = dir.match(/^(\d+[A-Z]?(?:\.\d+)*)-?(.*)/i);
       const phaseNumber = match ? match[1] : dir;
       const phaseName = match && match[2] ? match[2] : null;
-      seenPhaseNums.add(phaseNumber.replace(/^0+/, '') || '0');
+      seenPhaseNums.add(phaseNumber.replace(/^0+(?=\d)/, '') || '0');
 
       const phasePath = path.join(phasesDir, dir);
       const phaseFiles = fs.readdirSync(phasePath);
@@ -1297,7 +1297,7 @@ function cmdInitProgress(cwd, raw) {
 
   // Add phases defined in ROADMAP but not yet scaffolded to disk
   for (const [num, name] of roadmapPhaseNames) {
-    const stripped = num.replace(/^0+/, '') || '0';
+    const stripped = num.replace(/^0+(?=\d)/, '') || '0';
     if (!seenPhaseNums.has(stripped)) {
       const phaseInfo = {
         number: num,

--- a/get-shit-done/bin/lib/phase.cjs
+++ b/get-shit-done/bin/lib/phase.cjs
@@ -497,7 +497,7 @@ function cmdPhaseInsert(cwd, afterPhase, description, raw) {
 
     // Normalize input then strip leading zeros for flexible matching
     const normalizedAfter = normalizePhaseName(afterPhase);
-    const unpadded = normalizedAfter.replace(/^0+/, '');
+    const unpadded = normalizedAfter.replace(/^0+(?=\d)/, '');
     const afterPhaseEscaped = unpadded.replace(/\./g, '\\.');
     const targetPattern = new RegExp(`#{2,4}\\s*Phase\\s+0*${afterPhaseEscaped}:`, 'i');
     if (!targetPattern.test(content)) {

--- a/get-shit-done/bin/lib/state.cjs
+++ b/get-shit-done/bin/lib/state.cjs
@@ -1280,7 +1280,7 @@ function cmdStateValidate(cwd, raw) {
     const normalized = currentPhase.replace(/\s+of\s+\d+.*/, '').trim();
     try {
       const entries = fs.readdirSync(phasesDir, { withFileTypes: true });
-      const phaseDir = entries.find(e => e.isDirectory() && e.name.startsWith(normalized.replace(/^0+/, '').padStart(2, '0')));
+      const phaseDir = entries.find(e => e.isDirectory() && e.name.startsWith(normalized.replace(/^0+(?=\d)/, '').padStart(2, '0')));
       if (phaseDir) {
         const phaseDirPath = path.join(phasesDir, phaseDir.name);
         const files = fs.readdirSync(phaseDirPath);

--- a/get-shit-done/bin/lib/verify.cjs
+++ b/get-shit-done/bin/lib/verify.cjs
@@ -782,7 +782,7 @@ function cmdValidateHealth(cwd, options, raw) {
       const currentPhaseMatch = stateContent.match(/\*\*Current Phase:\*\*\s*(\S+)/i) ||
                                  stateContent.match(/Current Phase:\s*(\S+)/i);
       if (currentPhaseMatch) {
-        const statePhase = currentPhaseMatch[1].replace(/^0+/, '');
+        const statePhase = currentPhaseMatch[1].replace(/^0+(?=\d)/, '');
         // Check if ROADMAP shows this phase as already complete
         const phaseCheckboxRe = new RegExp(`-\\s*\\[x\\].*Phase\\s+0*${escapeRegex(statePhase)}[:\\s]`, 'i');
         if (phaseCheckboxRe.test(roadmapContentFull)) {

--- a/sdk/src/query/init-complex.ts
+++ b/sdk/src/query/init-complex.ts
@@ -221,7 +221,7 @@ export const initProgress: QueryHandler = async (_args, projectDir, _workstream)
       const match = dir.match(/^(\d+[A-Z]?(?:\.\d+)*)-?(.*)/i);
       const phaseNumber = match ? match[1] : dir;
       const phaseName = match && match[2] ? match[2] : null;
-      seenPhaseNums.add(phaseNumber.replace(/^0+/, '') || '0');
+      seenPhaseNums.add(phaseNumber.replace(/^0+(?=\d)/, '') || '0');
 
       const phasePath = join(paths.phases, dir);
       const phaseFiles = readdirSync(phasePath);
@@ -258,7 +258,7 @@ export const initProgress: QueryHandler = async (_args, projectDir, _workstream)
 
   // Add ROADMAP-only phases not yet on disk
   for (const [num, name] of roadmapPhaseNames) {
-    const stripped = num.replace(/^0+/, '') || '0';
+    const stripped = num.replace(/^0+(?=\d)/, '') || '0';
     if (!seenPhaseNums.has(stripped)) {
       const phaseInfo: Record<string, unknown> = {
         number: num,

--- a/sdk/src/query/phase-lifecycle.ts
+++ b/sdk/src/query/phase-lifecycle.ts
@@ -417,7 +417,7 @@ export const phaseInsert: QueryHandler = async (args, projectDir, workstream) =>
 
     // Normalize input then strip leading zeros for flexible matching
     const normalizedAfter = normalizePhaseName(afterPhase);
-    const unpadded = normalizedAfter.replace(/^0+/, '');
+    const unpadded = normalizedAfter.replace(/^0+(?=\d)/, '');
     const afterPhaseEscaped = unpadded.replace(/\./g, '\\.');
     const targetPattern = new RegExp(`#{2,4}\\s*Phase\\s+0*${afterPhaseEscaped}:`, 'i');
     if (!targetPattern.test(content)) {

--- a/sdk/src/query/state.ts
+++ b/sdk/src/query/state.ts
@@ -54,7 +54,7 @@ export async function getMilestonePhaseFilter(projectDir: string, workstream?: s
   }
 
   const normalized = new Set<string>(
-    [...milestonePhaseNums].map(n => (n.replace(/^0+/, '') || '0').toLowerCase())
+    [...milestonePhaseNums].map(n => (n.replace(/^0+(?=\d)/, '') || '0').toLowerCase())
   );
 
   const isDirInMilestone = ((dirName: string): boolean => {

--- a/sdk/src/query/validate.ts
+++ b/sdk/src/query/validate.ts
@@ -587,7 +587,7 @@ export const validateHealth: QueryHandler = async (args, projectDir, _workstream
       const currentPhaseMatch = stateContent.match(/\*\*Current Phase:\*\*\s*(\S+)/i) ||
                                  stateContent.match(/Current Phase:\s*(\S+)/i);
       if (currentPhaseMatch) {
-        const statePhase = currentPhaseMatch[1].replace(/^0+/, '');
+        const statePhase = currentPhaseMatch[1].replace(/^0+(?=\d)/, '');
         const phaseCheckboxRe = new RegExp(`-\\s*\\[x\\].*Phase\\s+0*${escapeRegex(statePhase)}[:\\s]`, 'i');
         if (phaseCheckboxRe.test(roadmapContentFull)) {
           const stateStatus = stateContent.match(/\*\*Status:\*\*\s*(.+)/i);

--- a/tests/bug-2554-decimal-phase-filter.test.cjs
+++ b/tests/bug-2554-decimal-phase-filter.test.cjs
@@ -1,0 +1,165 @@
+/**
+ * Regression test for issue #2554: decimal phase dirs (00.1, 72.1) excluded
+ * from state disk-scan progress counts.
+ *
+ * Root cause: `/^0+/` in getMilestonePhaseFilter() stripped the leading zero
+ * from "0.1" → ".1", mismatching directory extraction that produces "0.1".
+ * Fix: `/^0+(?=\d)/` — only strip zeros followed by another digit.
+ */
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
+
+describe('decimal phase dirs in state progress (#2554)', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  /**
+   * Helper: write a ROADMAP.md with the given phase headers inside a milestone.
+   */
+  function writeRoadmap(phases) {
+    const lines = ['# Roadmap', '', '## v1.0', ''];
+    for (const p of phases) {
+      lines.push(`### Phase ${p.num}: ${p.name}`);
+      lines.push(`**Goal:** ${p.name}`);
+      lines.push('');
+    }
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      lines.join('\n')
+    );
+  }
+
+  /**
+   * Helper: write a minimal STATE.md so `state json` has something to parse.
+   */
+  function writeState(currentPhase) {
+    const content = [
+      '# Project State',
+      '',
+      `**Current Phase:** ${currentPhase}`,
+      '**Status:** Executing',
+      '**Progress:** 0%',
+      '',
+    ].join('\n');
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), content);
+  }
+
+  /**
+   * Helper: create a phase directory with a PLAN.md and optionally a SUMMARY.md.
+   */
+  function createPhaseDir(dirName, { complete = false } = {}) {
+    const dir = path.join(tmpDir, '.planning', 'phases', dirName);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'a-PLAN.md'), '# Plan\n');
+    if (complete) {
+      fs.writeFileSync(path.join(dir, 'a-SUMMARY.md'), '# Summary\n');
+    }
+  }
+
+  test('phase 0.1 dir is counted in progress (zero-before-decimal)', () => {
+    writeRoadmap([
+      { num: '1', name: 'Setup' },
+      { num: '0.1', name: 'Pre-setup patch' },
+    ]);
+    writeState('0.1');
+    createPhaseDir('01-setup');
+    createPhaseDir('00.1-pre-setup-patch', { complete: true });
+
+    const result = runGsdTools('state json', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    const p = output.progress;
+    assert.ok(p, 'progress object should exist');
+    assert.ok(p.total_phases >= 2, `total_phases should be >= 2, got ${p.total_phases}`);
+    assert.ok(p.completed_phases >= 1, `completed_phases should be >= 1, got ${p.completed_phases}`);
+  });
+
+  test('phase 00.1 directory matches ROADMAP "Phase 0.1:"', () => {
+    writeRoadmap([
+      { num: '0.1', name: 'Hotfix' },
+    ]);
+    writeState('0.1');
+    createPhaseDir('00.1-hotfix');
+
+    const result = runGsdTools('state json', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    const p = output.progress;
+    assert.ok(p, 'progress object should exist');
+    assert.ok(p.total_phases >= 1, `total_phases should be >= 1, got ${p.total_phases}`);
+    assert.ok(p.total_plans >= 1, `total_plans should be >= 1, got ${p.total_plans}`);
+  });
+
+  test('phase 72.1 dir is counted (non-zero decimal)', () => {
+    writeRoadmap([
+      { num: '72', name: 'Feature' },
+      { num: '72.1', name: 'Inserted fix' },
+    ]);
+    writeState('72.1');
+    createPhaseDir('72-feature');
+    createPhaseDir('72.1-inserted-fix', { complete: true });
+
+    const result = runGsdTools('state json', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    const p = output.progress;
+    assert.ok(p, 'progress object should exist');
+    assert.ok(p.total_phases >= 2, `total_phases should be >= 2, got ${p.total_phases}`);
+    assert.ok(p.completed_phases >= 1, `completed_phases should be >= 1, got ${p.completed_phases}`);
+  });
+
+  test('phase 0 (pure zero) still normalizes correctly', () => {
+    writeRoadmap([
+      { num: '0', name: 'Bootstrap' },
+      { num: '1', name: 'Setup' },
+    ]);
+    writeState('0');
+    createPhaseDir('00-bootstrap', { complete: true });
+    createPhaseDir('01-setup');
+
+    const result = runGsdTools('state json', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    const p = output.progress;
+    assert.ok(p, 'progress object should exist');
+    assert.ok(p.total_phases >= 2, `total_phases should be >= 2, got ${p.total_phases}`);
+    assert.ok(p.completed_phases >= 1, `completed_phases should be >= 1, got ${p.completed_phases}`);
+  });
+
+  test('multiple decimal phases under same parent are all counted', () => {
+    writeRoadmap([
+      { num: '0.1', name: 'First' },
+      { num: '0.2', name: 'Second' },
+      { num: '0.3', name: 'Third' },
+    ]);
+    writeState('0.3');
+    createPhaseDir('00.1-first', { complete: true });
+    createPhaseDir('00.2-second', { complete: true });
+    createPhaseDir('00.3-third');
+
+    const result = runGsdTools('state json', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    const p = output.progress;
+    assert.ok(p, 'progress object should exist');
+    assert.ok(p.total_phases >= 3, `total_phases should be >= 3, got ${p.total_phases}`);
+    assert.strictEqual(p.completed_phases, 2, 'exactly 2 phases should be complete');
+    assert.ok(p.total_plans >= 3, `total_plans should be >= 3, got ${p.total_plans}`);
+  });
+});


### PR DESCRIPTION
## Summary
- **Bug:** `/^0+/` regex stripped the leading zero from decimal phase numbers like `"0.1"` → `".1"`, causing `getMilestonePhaseFilter()` to exclude `0.x` phase directories from progress counts
- **Fix:** Changed to `/^0+(?=\d)/` (positive lookahead) across 6 locations in 5 files — only strips zeros when followed by another digit
- **Scope:** Also fixed the same pattern in `verify.cjs`, `state.cjs`, `init.cjs`, and `phase.cjs` for consistency

## Test plan
- [x] New regression test: `tests/bug-2554-decimal-phase-filter.test.cjs` (5 cases)
- [x] Existing `tests/next-decimal-roadmap-scan.test.cjs` passes (9/9)
- [ ] Verify `state json` returns correct progress for a project with `0.x` phases
- [ ] Verify `init progress` lists `0.x` phases correctly

Closes #2554

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved phase-number normalization so identifiers with leading zeros and decimal forms (e.g., "0.1", "00.1") are matched and counted correctly in phase discovery and progress reporting.

* **Tests**
  * Added regression tests to validate handling of leading-zero and decimal phase identifiers, including counting and completed-phase detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->