### PR TITLE
fix(#2554): preserve leading zero before decimal in getMilestonePhaseFilter

### DIFF
--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -1624,7 +1624,7 @@ function getMilestonePhaseFilter(cwd) {
   }
 
   const normalized = new Set(
-    [...milestonePhaseNums].map(n => (n.replace(/^0+/, '') || '0').toLowerCase())
+    [...milestonePhaseNums].map(n => (n.replace(/^0+(?=\d)/, '') || '0').toLowerCase())
   );
 
   function isDirInMilestone(dirName) {

--- a/tests/bug-2554-decimal-phase-filter.test.cjs
+++ b/tests/bug-2554-decimal-phase-filter.test.cjs
@@ -1,0 +1,78 @@
+/**
+ * Regression test for bug #2554:
+ * state disk-scan excludes decimal phase dirs (e.g. "00.1") from progress counts.
+ *
+ * Root cause: getMilestonePhaseFilter normalized phase IDs with `replace(/^0+/, '')`,
+ * which over-strips on decimals: "00.1" → ".1", while the disk-side extractor
+ * applied to "00.1-<slug>" yields "0.1" — so the dir is excluded from the milestone.
+ *
+ * Fix: strip leading zeros only when followed by a digit (`replace(/^0+(?=\d)/, '')`),
+ * preserving the zero before the decimal point.
+ */
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { createTempProject, cleanup } = require('./helpers.cjs');
+const { getMilestonePhaseFilter } = require('../get-shit-done/bin/lib/core.cjs');
+
+describe('bug #2554 — getMilestonePhaseFilter decimal phase dirs', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('matches decimal phase directory like "00.1-<slug>" against ROADMAP phase "00.1"', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      [
+        '## Roadmap v1.0: Current',
+        '',
+        '### Phase 0: Foundation',
+        '**Goal:** foundation',
+        '',
+        '### Phase 00.1: Inserted urgent work',
+        '**Goal:** inserted',
+        '',
+        '### Phase 1: Feature',
+        '**Goal:** feature',
+      ].join('\n')
+    );
+
+    const filter = getMilestonePhaseFilter(tmpDir);
+
+    // Phase 00.1 inserted between Phase 0 and Phase 1 must match its on-disk dir.
+    assert.strictEqual(
+      filter('00.1-app-namespace-rename'),
+      true,
+      'decimal phase dir "00.1-<slug>" must be counted in the milestone'
+    );
+
+    // Neighbours should still match (no regression).
+    assert.strictEqual(filter('0-foundation'), true);
+    assert.strictEqual(filter('1-feature'), true);
+  });
+
+  test('preserves existing behavior for zero-padded integer phases', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      [
+        '### Phase 01: One',
+        '**Goal:** g',
+        '',
+        '### Phase 10: Ten',
+        '**Goal:** g',
+      ].join('\n')
+    );
+
+    const filter = getMilestonePhaseFilter(tmpDir);
+    assert.strictEqual(filter('01-one'), true);
+    assert.strictEqual(filter('10-ten'), true);
+  });
+});


### PR DESCRIPTION
Closes #2554

## Summary

`getMilestonePhaseFilter` in `get-shit-done/bin/lib/core.cjs` normalized ROADMAP phase IDs with `n.replace(/^0+/, '')`. That regex over-strips decimal phase IDs like `"00.1"` → `".1"`, while the disk-side extractor applied to `"00.1-<slug>"` yields `"0.1"`. The set-membership check then fails and the directory is silently excluded from every disk scan inside `buildStateFrontmatter` — causing `state json` / `state update` / `state patch` to under-report progress and rewind `completed_phases` / `total_plans` / `completed_plans` whenever any state-mutating SDK call runs.

## Fix

Strip leading zeros only when followed by a digit:

```diff
-[...milestonePhaseNums].map(n => (n.replace(/^0+/, '') || '0').toLowerCase())
+[...milestonePhaseNums].map(n => (n.replace(/^0+(?=\d)/, '') || '0').toLowerCase())
```

Preserves the zero before the decimal point. Zero-padded integer IDs (`01`, `10`) still normalize as before.

## Behavior table

| Input    | Before  | After   | Disk extraction | Match? |
|----------|---------|---------|-----------------|--------|
| `"0"`    | `"0"`   | `"0"`   | `"0"`           | unchanged |
| `"01"`   | `"1"`   | `"1"`   | `"1"`           | unchanged |
| `"00.1"` | `".1"`  | `"0.1"` | `"0.1"`         | fixed  |
| `"10"`   | `"10"`  | `"10"`  | `"10"`          | unchanged |

## Test plan

- [x] New regression test `tests/bug-2554-decimal-phase-filter.test.cjs` asserts decimal phase dir `00.1-<slug>` matches and zero-padded integer phases still match.
- [x] `node --test tests/bug-2554-decimal-phase-filter.test.cjs` — passes; confirmed it failed pre-fix for the right reason.
- [x] `npm run test:coverage` — full suite green (4953 tests, 0 failures).

## Diff scope

Two files only:
- `get-shit-done/bin/lib/core.cjs` (1-line regex change)
- `tests/bug-2554-decimal-phase-filter.test.cjs` (new regression test)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed milestone phase filter to correctly match decimal phase directory names (e.g., "00.1-phase-name").

* **Tests**
  * Added regression tests validating decimal phase directory matching and zero-padded integer phase behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->