### PR TITLE
fix(#2544): config-get exits 1 on missing key (UNIX convention)

### DIFF
--- a/sdk/src/query/config-query.test.ts
+++ b/sdk/src/query/config-query.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtemp, writeFile, mkdir, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { GSDError } from '../errors.js';
+import { GSDError, ErrorClassification, exitCodeFor } from '../errors.js';
 
 // ─── Test setup ─────────────────────────────────────────────────────────────
 
@@ -56,6 +56,41 @@ describe('configGet', () => {
       JSON.stringify({ model_profile: 'quality' }),
     );
     await expect(configGet(['nonexistent.key'], tmpDir)).rejects.toThrow(GSDError);
+  });
+
+  it('throws GSDError that maps to exit code 1 for missing key (bug #2544)', async () => {
+    const { configGet } = await import('./config-query.js');
+    await writeFile(
+      join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ model_profile: 'quality' }),
+    );
+    try {
+      await configGet(['nonexistent.key'], tmpDir);
+      throw new Error('expected configGet to throw for missing key');
+    } catch (err) {
+      expect(err).toBeInstanceOf(GSDError);
+      const gsdErr = err as GSDError;
+      // UNIX convention: missing config key should exit 1 (like `git config --get`).
+      // Validation (exit 10) is the previous buggy classification — see issue #2544.
+      expect(gsdErr.classification).toBe(ErrorClassification.Execution);
+      expect(exitCodeFor(gsdErr.classification)).toBe(1);
+    }
+  });
+
+  it('throws GSDError that maps to exit code 1 when traversing into non-object (bug #2544)', async () => {
+    const { configGet } = await import('./config-query.js');
+    await writeFile(
+      join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ model_profile: 'quality' }),
+    );
+    try {
+      await configGet(['model_profile.subkey'], tmpDir);
+      throw new Error('expected configGet to throw');
+    } catch (err) {
+      expect(err).toBeInstanceOf(GSDError);
+      const gsdErr = err as GSDError;
+      expect(exitCodeFor(gsdErr.classification)).toBe(1);
+    }
   });
 
   it('reads raw config without merging defaults', async () => {

--- a/sdk/src/query/config-query.ts
+++ b/sdk/src/query/config-query.ts
@@ -104,12 +104,14 @@ export const configGet: QueryHandler = async (args, projectDir, _workstream) => 
   let current: unknown = config;
   for (const key of keys) {
     if (current === undefined || current === null || typeof current !== 'object') {
-      throw new GSDError(`Key not found: ${keyPath}`, ErrorClassification.Validation);
+      // UNIX convention (cf. `git config --get`): missing key exits 1, not 10.
+      // See issue #2544 — callers use `if ! gsd-sdk query config-get k; then` patterns.
+      throw new GSDError(`Key not found: ${keyPath}`, ErrorClassification.Execution);
     }
     current = (current as Record<string, unknown>)[key];
   }
   if (current === undefined) {
-    throw new GSDError(`Key not found: ${keyPath}`, ErrorClassification.Validation);
+    throw new GSDError(`Key not found: ${keyPath}`, ErrorClassification.Execution);
   }
 
   return { data: current };


### PR DESCRIPTION
Closes #2544

## Root cause

`configGet` in `sdk/src/query/config-query.ts` threw `GSDError` with
`ErrorClassification.Validation` for the "Key not found" case.
`exitCodeFor(Validation)` returns 10, so `gsd-sdk query config-get
<missing>` exited 10 — not the UNIX-conventional 1.

Shell callers that wrote

```bash
if ! gsd-sdk query config-get workflow.discuss_mode; then
  fallback
fi
```

still took the fallback branch (any non-zero is failure), but the
exit-10 classification is semantically wrong: a missing key is an
expected runtime outcome, not a validation/schema error. It also
diverges from `git config --get`, which the issue cites as the
reference contract.

## Fix

Change the classification for the two `Key not found` throw sites in
`configGet` from `Validation` to `Execution`, which maps to exit 1.
Usage errors (no key argument), missing `config.json`, and malformed
JSON remain `Validation` (exit 10) — those are genuine input/schema
faults.

One-line change at each throw site; no API or output-format changes.

## Test

Added two regression tests in `sdk/src/query/config-query.test.ts`:

1. Missing top-level key → `ErrorClassification.Execution`, `exitCodeFor` returns 1.
2. Traversing into a non-object (e.g. `model_profile.subkey`) → exit 1.

Both fail on `main` (assertion: `expected 'validation' to be 'execution'`) and pass with the fix.

Full suite: `npm run test:coverage` — 4951 passing, 0 failing.

## Files touched

- `sdk/src/query/config-query.ts` — classification change, 2 call sites.
- `sdk/src/query/config-query.test.ts` — 2 new regression tests + import of `ErrorClassification`, `exitCodeFor`.