### PR TITLE
fix(#2559): remove stale year injection from research agent web search instructions

### DIFF
--- a/agents/gsd-phase-researcher.md
+++ b/agents/gsd-phase-researcher.md
@@ -145,7 +145,7 @@ When researching "best library for X": find what the ecosystem actually uses, do
 1. `mcp__context7__resolve-library-id` with libraryName
 2. `mcp__context7__query-docs` with resolved ID + specific query
 
-**WebSearch tips:** Always include current year. Use multiple query variations. Cross-verify with authoritative sources.
+**WebSearch tips:** Use multiple query variations. Cross-verify with authoritative sources. Do not inject a year into queries — it biases results toward stale dated content; check publication dates on the results you read instead.
 
 ## Enhanced Web Search (Brave API)
 
@@ -836,6 +836,6 @@ Quality indicators:
 - **Verified, not assumed:** Findings cite Context7 or official docs
 - **Honest about gaps:** LOW confidence items flagged, unknowns admitted
 - **Actionable:** Planner could create tasks based on this research
-- **Current:** Year included in searches, publication dates checked
+- **Current:** Publication dates checked on sources (do not inject year into queries)
 
 </success_criteria>

--- a/agents/gsd-project-researcher.md
+++ b/agents/gsd-project-researcher.md
@@ -116,12 +116,12 @@ For finding what exists, community patterns, real-world usage.
 
 **Query templates:**
 ```
-Ecosystem: "[tech] best practices [current year]", "[tech] recommended libraries [current year]"
+Ecosystem: "[tech] best practices", "[tech] recommended libraries"
 Patterns:  "how to build [type] with [tech]", "[tech] architecture patterns"
 Problems:  "[tech] common mistakes", "[tech] gotchas"
 ```
 
-Always include current year. Use multiple query variations. Mark WebSearch-only findings as LOW confidence.
+Use multiple query variations. Mark WebSearch-only findings as LOW confidence. Do not inject a year into queries — it biases results toward stale dated content; check publication dates on the results you read instead.
 
 ### Enhanced Web Search (Brave API)
 
@@ -672,6 +672,6 @@ Research is complete when:
 - [ ] Files written (DO NOT commit — orchestrator handles this)
 - [ ] Structured return provided to orchestrator
 
-**Quality:** Comprehensive not shallow. Opinionated not wishy-washy. Verified not assumed. Honest about gaps. Actionable for roadmap. Current (year in searches).
+**Quality:** Comprehensive not shallow. Opinionated not wishy-washy. Verified not assumed. Honest about gaps. Actionable for roadmap. Current (check publication dates, do not inject year into queries).
 
 </success_criteria>

--- a/tests/bug-2559-stale-search-year.test.cjs
+++ b/tests/bug-2559-stale-search-year.test.cjs
@@ -1,0 +1,73 @@
+/**
+ * Bug #2559: Stale document references in Research phase
+ *
+ * The gsd-phase-researcher and gsd-project-researcher agents instruct
+ * WebSearch queries to always include "current year" (or a hardcoded
+ * year). This biases results toward stale dated content as time passes
+ * (e.g., a 2024 query run in 2026 returns stale results).
+ *
+ * Fix: Remove year-injection instructions from research agent
+ * WebSearch guidance so searches return current results.
+ */
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const PHASE_RESEARCHER = path.join(
+  __dirname,
+  '..',
+  'agents',
+  'gsd-phase-researcher.md'
+);
+const PROJECT_RESEARCHER = path.join(
+  __dirname,
+  '..',
+  'agents',
+  'gsd-project-researcher.md'
+);
+
+const FILES = [
+  { label: 'gsd-phase-researcher.md', path: PHASE_RESEARCHER },
+  { label: 'gsd-project-researcher.md', path: PROJECT_RESEARCHER },
+];
+
+describe('research agents do not inject year into web searches (#2559)', () => {
+  for (const { label, path: filePath } of FILES) {
+    test(`${label} contains no CURRENT_YEAR placeholder`, () => {
+      const content = fs.readFileSync(filePath, 'utf-8');
+      assert.ok(
+        !/CURRENT_YEAR/.test(content),
+        `${label} must not contain CURRENT_YEAR placeholder (causes stale-year injection)`
+      );
+    });
+
+    test(`${label} contains no hardcoded year in web search instructions`, () => {
+      const content = fs.readFileSync(filePath, 'utf-8');
+      const match = content.match(/\b20(2[3-9]|[3-9]\d)\b/);
+      assert.ok(
+        !match,
+        `${label} must not contain hardcoded year (found "${match && match[0]}") — biases searches toward stale content`
+      );
+    });
+
+    test(`${label} does not instruct searches to include year or current year`, () => {
+      const content = fs.readFileSync(filePath, 'utf-8');
+      // Match phrases like "include current year", "year in searches",
+      // "[current year]", "with year", etc.
+      const patterns = [
+        /include\s+(?:the\s+)?current\s+year/i,
+        /current\s+year/i,
+        /year\s+in\s+(?:searches|queries)/i,
+        /\[current year\]/i,
+      ];
+      for (const pat of patterns) {
+        assert.ok(
+          !pat.test(content),
+          `${label} must not instruct year injection (matched /${pat.source}/)`
+        );
+      }
+    });
+  }
+});


### PR DESCRIPTION
Closes #2559

## Problem

The `gsd-phase-researcher` and `gsd-project-researcher` agents instructed WebSearch queries to always include "current year". Users reported (issue #2559) that research runs in 2026 were producing queries like `Razorpay "payment.failed" ... checkout.js 2024` — hardcoded years bias results toward stale dated content as time passes.

## Fix

Remove year-injection guidance from both agent files:

- `agents/gsd-phase-researcher.md` — WebSearch tips section and success criteria
- `agents/gsd-project-researcher.md` — WebSearch query templates, guidance, and quality criteria

Replace with guidance to check publication dates on the returned sources instead of baking a year into the query.

## Test plan

- [x] New regression test `tests/bug-2559-stale-search-year.test.cjs` (6 cases) that greps both agent files for `CURRENT_YEAR`, hardcoded years, and year-injection phrasing
- [x] Test fails on main for the right reason; passes after fix
- [x] `npm run test:coverage` green (88.59% lines, above 70% threshold)
- [x] Diff scope: only the two agent files plus the new test