### PR TITLE
fix(#2545): use word boundary in path replacement

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -877,14 +877,18 @@ function convertCopilotToolName(claudeTool) {
  */
 function convertClaudeToCopilotContent(content, isGlobal = false) {
   let c = content;
-  // CONV-06: Path replacement — most specific first to avoid substring matches
+  // CONV-06: Path replacement — most specific first to avoid substring matches.
+  // Handle both `~/.claude/foo` (trailing slash) and bare `~/.claude` forms in
+  // one pass via a capture group, matching the approach used by Antigravity,
+  // OpenCode, Kilo, and Codex converters (issue #2545).
   if (isGlobal) {
-    c = c.replace(/\$HOME\/\.claude\//g, '$HOME/.copilot/');
-    c = c.replace(/~\/\.claude\//g, '~/.copilot/');
+    c = c.replace(/\$HOME\/\.claude(\/|\b)/g, '$HOME/.copilot$1');
+    c = c.replace(/~\/\.claude(\/|\b)/g, '~/.copilot$1');
   } else {
     c = c.replace(/\$HOME\/\.claude\//g, '.github/');
     c = c.replace(/~\/\.claude\//g, '.github/');
-    c = c.replace(/~\/\.claude\n/g, '.github/');
+    c = c.replace(/\$HOME\/\.claude\b/g, '.github');
+    c = c.replace(/~\/\.claude\b/g, '.github');
   }
   c = c.replace(/\.\/\.claude\//g, './.github/');
   c = c.replace(/\.claude\//g, '.github/');

--- a/tests/bug-2545-copilot-unreplaced-paths.test.cjs
+++ b/tests/bug-2545-copilot-unreplaced-paths.test.cjs
@@ -1,0 +1,64 @@
+/**
+ * Regression test for issue #2545.
+ *
+ * The Copilot content converter's `~/.claude/` and `$HOME/.claude/` replacements
+ * only matched when a literal slash followed, so bare `~/.claude` references
+ * (end of line, quotes, punctuation) were left unreplaced. Those leaks then
+ * triggered the installer's "Found N unreplaced .claude path reference(s)"
+ * warning, which scans for `(?:~|$HOME)/\.claude\b`.
+ *
+ * Fix: replace with a word-boundary pattern so both forms are caught in a
+ * single pass, matching the approach already used by the Antigravity, OpenCode,
+ * Kilo, and Codex converters.
+ */
+
+process.env.GSD_TEST_MODE = '1';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { convertClaudeToCopilotContent } = require('../bin/install.js');
+
+describe('convertClaudeToCopilotContent — bare ~/.claude (issue #2545)', () => {
+  test('global install replaces bare ~/.claude at end of line', () => {
+    const input = 'configDir = ~/.claude\n';
+    const out = convertClaudeToCopilotContent(input, /* isGlobal */ true);
+    assert.ok(
+      !/(?:~|\$HOME)\/\.claude\b/.test(out),
+      `expected no leaked ~/.claude reference, got: ${JSON.stringify(out)}`,
+    );
+    assert.match(out, /~\/\.copilot\b/);
+  });
+
+  test('global install replaces bare $HOME/.claude at end of line', () => {
+    const input = 'configDir = $HOME/.claude\n';
+    const out = convertClaudeToCopilotContent(input, /* isGlobal */ true);
+    assert.ok(
+      !/(?:~|\$HOME)\/\.claude\b/.test(out),
+      `expected no leaked $HOME/.claude reference, got: ${JSON.stringify(out)}`,
+    );
+    assert.match(out, /\$HOME\/\.copilot\b/);
+  });
+
+  test('global install replaces bare ~/.claude before punctuation', () => {
+    const input = 'paths include `~/.claude`, `~/.copilot`';
+    const out = convertClaudeToCopilotContent(input, true);
+    assert.ok(!/(?:~|\$HOME)\/\.claude\b/.test(out));
+  });
+
+  test('local install replaces bare ~/.claude', () => {
+    const input = 'configDir = ~/.claude\n';
+    const out = convertClaudeToCopilotContent(input, /* isGlobal */ false);
+    assert.ok(
+      !/(?:~|\$HOME)\/\.claude\b/.test(out),
+      `expected no leaked ~/.claude reference, got: ${JSON.stringify(out)}`,
+    );
+  });
+
+  test('does not double-replace trailing-slash form', () => {
+    const input = '@~/.claude/get-shit-done/foo.md\n';
+    const out = convertClaudeToCopilotContent(input, true);
+    assert.match(out, /~\/\.copilot\/get-shit-done\/foo\.md/);
+    assert.ok(!/\.copilot\/\.copilot/.test(out));
+  });
+});


### PR DESCRIPTION
Closes #2545

## Summary

When installing GSD for Copilot via `npx get-shit-done-cc@latest`, the post-install scanner reports:

> Found 2 unreplaced .claude path reference(s) in 2 file(s):
>      agents/gsd-debugger.agent.md (1)
>      get-shit-done/workflows/update.md (1)

Root cause: `convertClaudeToCopilotContent` only replaced `~/.claude/` and `$HOME/.claude/` when followed by a literal `/`. Bare references (e.g. `configDir = ~/.claude` at end of a line, or `~/.claude,` before punctuation) slipped through. The leak scanner at line 5923 uses the broader `(?:~|\$HOME)/\.claude\b` pattern and flagged them.

Fix: use a `(\/|\b)` capture group so both trailing-slash and bare forms are replaced in a single pass, matching the approach already used by the Antigravity, OpenCode, Kilo, and Codex converters.

## Test plan

- [x] New regression test `tests/bug-2545-copilot-unreplaced-paths.test.cjs` exercises bare `~/.claude` / `$HOME/.claude` forms (end-of-line, punctuation, local + global modes) and asserts no leaks remain
- [x] Test fails on `main`, passes with the fix
- [x] Full `npm run test:coverage` passes locally (4956/4956, coverage thresholds met)
- [x] Existing `tests/copilot-install.test.cjs` still passes — no double-replacement (`.copilot/.copilot`) regression

## Notes

This PR supersedes closed PR #2577 (closed due to cross-worktree contamination); the fix itself is unchanged in intent. Diff is scoped to the Copilot converter and the new test file.