### PR TITLE
fix(#2544): config-get exits 1 silently for missing keys, adds --default flag

### DIFF
--- a/sdk/src/cli.ts
+++ b/sdk/src/cli.ts
@@ -419,7 +419,11 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<void
       }
     } catch (err) {
       if (err instanceof GSDError) {
-        console.error(`Error: ${err.message}`);
+        // NotFound is an expected condition (e.g. config key absent) — exit 1
+        // silently, matching `git config --get` convention. No stderr noise.
+        if (err.classification !== ErrorClassification.NotFound) {
+          console.error(`Error: ${err.message}`);
+        }
         process.exitCode = exitCodeFor(err.classification);
       } else if (err instanceof GSDToolsError) {
         console.error(`Error: ${err.message}`);

--- a/sdk/src/errors.ts
+++ b/sdk/src/errors.ts
@@ -30,6 +30,9 @@ export enum ErrorClassification {
 
   /** Timeout, signal, user cancel. Exit code 1. */
   Interruption = 'interruption',
+
+  /** Lookup target does not exist (e.g. config key absent). Exit code 1, silent stderr. */
+  NotFound = 'not_found',
 }
 
 // ─── GSDError ───────────────────────────────────────────────────────────────
@@ -64,6 +67,8 @@ export function exitCodeFor(classification: ErrorClassification): number {
       return 10;
     case ErrorClassification.Blocked:
       return 11;
+    case ErrorClassification.NotFound:
+      return 1;
     case ErrorClassification.Execution:
     case ErrorClassification.Interruption:
     default:

--- a/sdk/src/query/config-query.test.ts
+++ b/sdk/src/query/config-query.test.ts
@@ -49,24 +49,106 @@ describe('configGet', () => {
     await expect(configGet([], tmpDir)).rejects.toThrow(GSDError);
   });
 
-  it('throws GSDError for nonexistent key', async () => {
+  it('throws GSDError with NotFound classification for nonexistent key', async () => {
+    const { configGet } = await import('./config-query.js');
+    const { ErrorClassification } = await import('../errors.js');
+    await writeFile(
+      join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ model_profile: 'quality' }),
+    );
+    try {
+      await configGet(['nonexistent.key'], tmpDir);
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(GSDError);
+      expect((err as GSDError).classification).toBe(ErrorClassification.NotFound);
+    }
+  });
+
+  it('returns --default value when key is absent', async () => {
     const { configGet } = await import('./config-query.js');
     await writeFile(
       join(tmpDir, '.planning', 'config.json'),
       JSON.stringify({ model_profile: 'quality' }),
     );
-    await expect(configGet(['nonexistent.key'], tmpDir)).rejects.toThrow(GSDError);
+    const result = await configGet(['nonexistent.key', '--default', 'fallback'], tmpDir);
+    expect(result.data).toBe('fallback');
+  });
+
+  it('returns --default when config.json does not exist', async () => {
+    const { configGet } = await import('./config-query.js');
+    const result = await configGet(['any.key', '--default', 'safe'], tmpDir);
+    expect(result.data).toBe('safe');
+  });
+
+  it('ignores --default when key exists', async () => {
+    const { configGet } = await import('./config-query.js');
+    await writeFile(
+      join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ model_profile: 'quality' }),
+    );
+    const result = await configGet(['model_profile', '--default', 'balanced'], tmpDir);
+    expect(result.data).toBe('quality');
+  });
+
+  it('returns --default for nested key traversal failure', async () => {
+    const { configGet } = await import('./config-query.js');
+    await writeFile(
+      join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ model_profile: 'quality' }),
+    );
+    const result = await configGet(['workflow.auto_advance', '--default', 'true'], tmpDir);
+    expect(result.data).toBe(true); // JSON-parsed: "true" → true
+  });
+
+  it('parses --default as JSON for type preservation', async () => {
+    const { configGet } = await import('./config-query.js');
+    await writeFile(
+      join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ model_profile: 'quality' }),
+    );
+    // Number
+    const num = await configGet(['missing', '--default', '42'], tmpDir);
+    expect(num.data).toBe(42);
+    // Boolean
+    const bool = await configGet(['missing', '--default', 'false'], tmpDir);
+    expect(bool.data).toBe(false);
+    // Null
+    const nul = await configGet(['missing', '--default', 'null'], tmpDir);
+    expect(nul.data).toBe(null);
+    // Plain string (not valid JSON) stays as string
+    const str = await configGet(['missing', '--default', 'interactive'], tmpDir);
+    expect(str.data).toBe('interactive');
+  });
+
+  it('throws Validation when --default has no value', async () => {
+    const { configGet } = await import('./config-query.js');
+    const { ErrorClassification } = await import('../errors.js');
+    try {
+      await configGet(['some.key', '--default'], tmpDir);
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(GSDError);
+      expect((err as GSDError).classification).toBe(ErrorClassification.Validation);
+    }
   });
 
   it('reads raw config without merging defaults', async () => {
     const { configGet } = await import('./config-query.js');
+    const { ErrorClassification } = await import('../errors.js');
     // Write config with only model_profile -- no workflow section
     await writeFile(
       join(tmpDir, '.planning', 'config.json'),
       JSON.stringify({ model_profile: 'balanced' }),
     );
-    // Accessing workflow should fail (not merged with defaults)
-    await expect(configGet(['workflow.auto_advance'], tmpDir)).rejects.toThrow(GSDError);
+    // Accessing workflow should fail with NotFound (not merged with defaults)
+    try {
+      await configGet(['workflow.auto_advance'], tmpDir);
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(GSDError);
+      expect((err as GSDError).classification).toBe(ErrorClassification.NotFound);
+    }
   });
 });
 

--- a/sdk/src/query/config-query.ts
+++ b/sdk/src/query/config-query.ts
@@ -11,6 +11,9 @@
  * const result = await configGet(['workflow.auto_advance'], '/project');
  * // { data: true }
  *
+ * const withDefault = await configGet(['workflow.discuss_mode', '--default', 'interactive'], '/project');
+ * // { data: 'interactive' }  (when key is absent)
+ *
  * const model = await resolveModel(['gsd-planner'], '/project');
  * // { data: { model: 'opus', profile: 'balanced' } }
  * ```
@@ -74,15 +77,35 @@ export function getAgentToModelMapForProfile(normalizedProfile: string): Record<
  * Reads raw .planning/config.json and traverses dot-notation key paths.
  * Does NOT merge with defaults (matches gsd-tools.cjs behavior).
  *
- * @param args - args[0] is the dot-notation key path (e.g., 'workflow.auto_advance')
+ * @param args - args[0] is the dot-notation key path (e.g., 'workflow.auto_advance').
+ *   Supports `--default <value>` flag: when provided and the key is absent,
+ *   returns the default value instead of throwing (exit 0).
  * @param projectDir - Project root directory
  * @returns QueryResult with the config value at the given path
- * @throws GSDError with Validation classification if key missing or not found
+ * @throws GSDError with Validation classification if no key provided or config malformed
+ * @throws GSDError with NotFound classification if key absent and no --default given (exit 1, silent stderr)
  */
 export const configGet: QueryHandler = async (args, projectDir, _workstream) => {
-  const keyPath = args[0];
+  // Parse --default flag before extracting key path
+  let defaultValue: unknown | undefined;
+  const filteredArgs: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--default') {
+      if (i + 1 >= args.length) {
+        throw new GSDError('--default requires a value', ErrorClassification.Validation);
+      }
+      const raw = args[++i];
+      // Parse as JSON to preserve types (booleans, numbers, null).
+      // Fall back to raw string for unquoted values like "interactive".
+      try { defaultValue = JSON.parse(raw); } catch { defaultValue = raw; }
+    } else {
+      filteredArgs.push(args[i]);
+    }
+  }
+
+  const keyPath = filteredArgs[0];
   if (!keyPath) {
-    throw new GSDError('Usage: config-get <key.path>', ErrorClassification.Validation);
+    throw new GSDError('Usage: config-get <key.path> [--default <value>]', ErrorClassification.Validation);
   }
 
   const paths = planningPaths(projectDir);
@@ -90,6 +113,7 @@ export const configGet: QueryHandler = async (args, projectDir, _workstream) => 
   try {
     raw = await readFile(paths.config, 'utf-8');
   } catch {
+    if (defaultValue !== undefined) return { data: defaultValue };
     throw new GSDError(`No config.json found at ${paths.config}`, ErrorClassification.Validation);
   }
 
@@ -104,12 +128,14 @@ export const configGet: QueryHandler = async (args, projectDir, _workstream) => 
   let current: unknown = config;
   for (const key of keys) {
     if (current === undefined || current === null || typeof current !== 'object') {
-      throw new GSDError(`Key not found: ${keyPath}`, ErrorClassification.Validation);
+      if (defaultValue !== undefined) return { data: defaultValue };
+      throw new GSDError(`Key not found: ${keyPath}`, ErrorClassification.NotFound);
     }
     current = (current as Record<string, unknown>)[key];
   }
   if (current === undefined) {
-    throw new GSDError(`Key not found: ${keyPath}`, ErrorClassification.Validation);
+    if (defaultValue !== undefined) return { data: defaultValue };
+    throw new GSDError(`Key not found: ${keyPath}`, ErrorClassification.NotFound);
   }
 
   return { data: current };


### PR DESCRIPTION
## Summary
- **Bug:** `gsd-sdk query config-get` threw `GSDError(Validation)` for missing keys — noisy `Error:` on stderr, exit code 10, breaking UNIX convention where absent config keys are expected
- **Fix A:** New `ErrorClassification.NotFound` (exit 1, silent stderr) — matches `git config --get` behavior
- **Fix B:** `--default <value>` flag returns a fallback on absent keys (exit 0). Values are JSON-parsed for type preservation (`"true"` → `true`, `"42"` → `42`) with string fallback
- **Security:** Reviewed — 5/5 threats closed (no injection, no masking, no path traversal)

## Test plan
- [x] 19/19 vitest tests pass (8 new: NotFound classification, --default variants, JSON type parsing, bare --default validation)
- [x] Existing `utils.test.ts` passes (10/10)
- [ ] Verify `gsd-sdk query config-get missing.key` exits 1 with no stderr
- [ ] Verify `gsd-sdk query config-get missing.key --default interactive` exits 0 with `"interactive"` on stdout
- [ ] Verify `gsd-sdk query config-get existing.key --default ignored` returns existing value

Closes #2544

🤖 Generated with [Claude Code](https://claude.com/claude-code)