### PR TITLE
fix(#2597): expand dotted query tokens with trailing args

### DIFF
--- a/sdk/src/query/registry.test.ts
+++ b/sdk/src/query/registry.test.ts
@@ -178,4 +178,31 @@ describe('resolveQueryArgv', () => {
       args: [],
     });
   });
+
+  // Regression: #2597 — dotted command token followed by positional args.
+  // Before the fix, argv like ['init.execute-phase', '1'] returned null because
+  // expansion only ran for single-token input.
+  it('matches a dotted command token when positional args follow (#2597)', () => {
+    const registry = createRegistry();
+    expect(resolveQueryArgv(['init.execute-phase', '1'], registry)).toEqual({
+      cmd: 'init.execute-phase',
+      args: ['1'],
+    });
+  });
+
+  it('matches dotted state.update with trailing args (#2597)', () => {
+    const registry = createRegistry();
+    expect(resolveQueryArgv(['state.update', 'status', 'X'], registry)).toEqual({
+      cmd: 'state.update',
+      args: ['status', 'X'],
+    });
+  });
+
+  it('matches dotted phase.add with trailing args (#2597)', () => {
+    const registry = createRegistry();
+    expect(resolveQueryArgv(['phase.add', 'desc'], registry)).toEqual({
+      cmd: 'phase.add',
+      args: ['desc'],
+    });
+  });
 });

--- a/sdk/src/query/registry.ts
+++ b/sdk/src/query/registry.ts
@@ -126,15 +126,28 @@ export class QueryRegistry {
   }
 }
 
-function expandSingleDottedToken(tokens: string[]): string[] {
-  if (tokens.length !== 1 || tokens[0].startsWith('--')) {
+/**
+ * If the first token contains a dot (e.g. `init.execute-phase`), split it into
+ * segments and prepend those segments in place of the original token. Args that
+ * follow the dotted token are preserved.
+ *
+ * Examples:
+ *   ['init.new-project']               -> ['init', 'new-project']
+ *   ['init.execute-phase', '1']        -> ['init', 'execute-phase', '1']
+ *   ['state.update', 'status', 'X']    -> ['state', 'update', 'status', 'X']
+ *
+ * Returns the original array (by reference) when no expansion applies so callers
+ * can detect "nothing changed" via identity comparison.
+ */
+function expandFirstDottedToken(tokens: string[]): string[] {
+  if (tokens.length === 0) {
     return tokens;
   }
-  const t = tokens[0];
-  if (!t.includes('.')) {
+  const first = tokens[0];
+  if (first.startsWith('--') || !first.includes('.')) {
     return tokens;
   }
-  return t.split('.');
+  return [...first.split('.'), ...tokens.slice(1)];
 }
 
 function matchRegisteredPrefix(
@@ -166,7 +179,7 @@ export function resolveQueryArgv(
 ): { cmd: string; args: string[] } | null {
   let matched = matchRegisteredPrefix(tokens, registry);
   if (!matched) {
-    const expanded = expandSingleDottedToken(tokens);
+    const expanded = expandFirstDottedToken(tokens);
     if (expanded !== tokens) {
       matched = matchRegisteredPrefix(expanded, registry);
     }


### PR DESCRIPTION
## TL;DR

`gsd-sdk query init.execute-phase 1` returned \"Unknown command\" even though `init.execute-phase` is a registered handler. Every workflow calling the dotted form with args was broken silently. One-token expansion path now covers tokens with trailing args.

## What

- `resolveQueryArgv` used `expandSingleDottedToken`, which returned early unless `tokens.length === 1`.
- Workflow files invoke the dotted form with positional args (`state.update status X`, `phase.add desc`, `init.execute-phase 1`), giving `tokens.length >= 2`. Expansion was skipped, no prefix matched, handler missed.
- Renamed to `expandFirstDottedToken` and changed the guard: if `tokens[0]` is a non-flag string containing a dot, split it on dots and keep the remaining args as the tail.
- Identity-preservation on \"no change\" is retained so the caller's `expanded !== tokens` check still works.

## Why

- 50+ workflow files use the dotted form with arguments. Every one currently fails at runtime on the SDK's dotted-with-args routes.
- `init.new-project` happened to work because it takes no args (length 1).

## How

### Regression tests (`sdk/src/query/registry.test.ts`)
- `init.execute-phase 1` → `{ cmd: 'init.execute-phase', args: ['1'] }`
- `state.update status X` → `{ cmd: 'state.update', args: ['status', 'X'] }`
- `phase.add desc` → `{ cmd: 'phase.add', args: ['desc'] }`

All three failed before the fix and pass after. Existing resolveQueryArgv tests remain green.

### Test results
```
resolveQueryArgv: 8/8 PASS
```
(Unrelated pre-existing `dispatch` spy-signature test failure is not introduced by this change — it expects the spy to be called with 2 args but the dispatch signature now passes 3 including optional `workstream`.)

## Docs

No user-facing behavior change — this fixes the documented dotted-form invocations documented in workflow files. No doc update required.

Closes #2597

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced command token matching to correctly process positional arguments that follow dotted command notation, improving reliability in command resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->