### PR TITLE
feat: add settings layers to /gsd-settings (Group A toggles) (closes #2527)

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1037,7 +1037,16 @@ Manage parallel workstreams for concurrent work on different milestone areas.
 
 ### `/gsd-settings`
 
-Interactive configuration of workflow toggles and model profile.
+Interactive configuration of workflow toggles and model profile. Questions are grouped into six visual sections:
+
+- **Planning** — Research, Plan Checker, Pattern Mapper, Nyquist, UI Phase, UI Gate, AI Phase
+- **Execution** — Verifier, TDD Mode, Code Review, Code Review Depth _(conditional — only when Code Review is on)_, UI Review
+- **Docs & Output** — Commit Docs, Skip Discuss, Worktrees
+- **Features** — Intel, Graphify
+- **Model & Pipeline** — Model Profile, Auto-Advance, Branching
+- **Misc** — Context Warnings, Research Qs
+
+All answers are merged into `.planning/config.json` via `gsd-sdk query config-set`, preserving unrelated keys. After confirmation, the user may save the full settings object to `~/.gsd/defaults.json` so future `/gsd-new-project` runs start from the same baseline.
 
 ```bash
 /gsd-settings                       # Interactive config

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1046,7 +1046,7 @@ Interactive configuration of workflow toggles and model profile. Questions are g
 - **Model & Pipeline** — Model Profile, Auto-Advance, Branching
 - **Misc** — Context Warnings, Research Qs
 
-All answers are merged into `.planning/config.json` via `gsd-sdk query config-set`, preserving unrelated keys. After confirmation, the user may save the full settings object to `~/.gsd/defaults.json` so future `/gsd-new-project` runs start from the same baseline.
+All answers are merged via `gsd-sdk query config-set` into the resolved project config path (`.planning/config.json` for a standard install, or `.planning/workstreams/<active>/config.json` when a workstream is active), preserving unrelated keys. After confirmation, the user may save the full settings object to `~/.gsd/defaults.json` so future `/gsd-new-project` runs start from the same baseline.
 
 ```bash
 /gsd-settings                       # Interactive config

--- a/get-shit-done/workflows/settings.md
+++ b/get-shit-done/workflows/settings.md
@@ -40,9 +40,17 @@ Parse current values (default to `true` if not present):
 - `workflow.plan_check` — spawn plan checker during plan-phase
 - `workflow.verifier` — spawn verifier during execute-phase
 - `workflow.nyquist_validation` — validation architecture research during plan-phase (default: true if absent)
+- `workflow.pattern_mapper` — run gsd-pattern-mapper between research and planning (default: true if absent)
 - `workflow.ui_phase` — generate UI-SPEC.md design contracts for frontend phases (default: true if absent)
 - `workflow.ui_safety_gate` — prompt to run /gsd:ui-phase before planning frontend phases (default: true if absent)
 - `workflow.ai_integration_phase` — framework selection + eval strategy for AI phases (default: true if absent)
+- `workflow.tdd_mode` — enforce RED/GREEN/REFACTOR gate sequence during execute-phase (default: false if absent)
+- `workflow.code_review` — enable /gsd:code-review and /gsd:code-review-fix commands (default: true if absent)
+- `workflow.code_review_depth` — default depth for /gsd:code-review: `quick`, `standard`, or `deep` (default: `"standard"` if absent; only relevant when `code_review` is on)
+- `workflow.ui_review` — run visual quality audit (/gsd:ui-review) in autonomous mode (default: true if absent)
+- `commit_docs` — whether `.planning/` files are committed to git (default: true if absent)
+- `intel.enabled` — enable queryable codebase intelligence (/gsd:intel) (default: false if absent)
+- `graphify.enabled` — enable project knowledge graph (/gsd:graphify) (default: false if absent)
 - `model_profile` — which model each agent uses (default: `balanced`)
 - `git.branching_strategy` — branching approach (default: `"none"`)
 - `workflow.use_worktrees` — whether parallel executor agents run in worktree isolation (default: `true`)
@@ -62,7 +70,29 @@ Choose "Inherit" to use the session model for all agents, or configure model_ove
 manually in .planning/config.json to target specific models for this runtime.
 ```
 
-Use AskUserQuestion with current values pre-selected:
+Use AskUserQuestion with current values pre-selected. Questions are grouped into six visual sections; the first question in each section carries the section-denoting `header` field (AskUserQuestion renders abbreviated section tags for grouping, max 12 chars).
+
+Section layout:
+
+### Planning
+Research, Plan Checker, Pattern Mapper, Nyquist, UI Phase, UI Gate, AI Phase
+
+### Execution
+Verifier, TDD Mode, Code Review, Code Review Depth _(conditional — only when code_review=on)_, UI Review
+
+### Docs & Output
+Commit Docs, Skip Discuss, Worktrees
+
+### Features
+Intel, Graphify
+
+### Model & Pipeline
+Model Profile, Auto-Advance, Branching
+
+### Misc
+Context Warnings, Research Qs
+
+**Conditional visibility — code_review_depth:** This question is shown only when the user's chosen `code_review` value (after they answer that question, or the pre-selected value if unchanged) is on. If `code_review` is off, omit the `code_review_depth` question from the AskUserQuestion block and preserve the existing `workflow.code_review_depth` value in config (do not overwrite). Implementation: ask the Model + Planning + Execution-up-to-Code-Review questions first; if `code_review=on`, include `code_review_depth` in the same batch; otherwise skip it. Conceptually this is a one-branch split on the `code_review` answer.
 
 ```
 AskUserQuestion([
@@ -105,12 +135,61 @@ AskUserQuestion([
     ]
   },
   {
+    question: "Enable TDD Mode? (RED/GREEN/REFACTOR gates for eligible tasks)",
+    header: "TDD",
+    multiSelect: false,
+    options: [
+      { label: "No (Recommended)", description: "Execute tasks normally. Tests written alongside implementation." },
+      { label: "Yes", description: "Planner applies type:tdd to business logic/APIs/validations; executor enforces gate sequence. End-of-phase review checks compliance." }
+    ]
+  },
+  {
+    question: "Enable Code Review? (/gsd:code-review and /gsd:code-review-fix commands)",
+    header: "Code Review",
+    multiSelect: false,
+    options: [
+      { label: "Yes (Recommended)", description: "Enable /gsd:code-review commands for reviewing source files changed during a phase." },
+      { label: "No", description: "Commands exit with a configuration gate message. Use when code review is handled externally." }
+    ]
+  },
+  // Conditional: include the following code_review_depth question ONLY when the user's
+  // chosen code_review value is "Yes". If code_review is "No", omit this question from
+  // the AskUserQuestion call and do not touch the existing workflow.code_review_depth value.
+  {
+    question: "Code Review Depth? (default depth for /gsd:code-review — override per-run with --depth=)",
+    header: "Review Depth",
+    multiSelect: false,
+    options: [
+      { label: "Standard (Recommended)", description: "Per-file analysis. Balanced cost and signal." },
+      { label: "Quick", description: "Pattern-matching only. Fastest, lowest cost." },
+      { label: "Deep", description: "Cross-file analysis with import graphs. Highest cost, highest signal." }
+    ]
+  },
+  {
+    question: "Enable UI Review? (visual quality audit via /gsd:ui-review in autonomous mode)",
+    header: "UI Review",
+    multiSelect: false,
+    options: [
+      { label: "Yes (Recommended)", description: "Run visual quality audit after phase execution in autonomous mode." },
+      { label: "No", description: "Skip the UI audit step. Good for backend-only projects." }
+    ]
+  },
+  {
     question: "Auto-advance pipeline? (discuss → plan → execute automatically)",
     header: "Auto",
     multiSelect: false,
     options: [
       { label: "No (Recommended)", description: "Manual /clear + paste between stages" },
       { label: "Yes", description: "Chain stages via Task() subagents (same isolation)" }
+    ]
+  },
+  {
+    question: "Run Pattern Mapper? (maps new files to existing codebase analogs between research and planning)",
+    header: "Pattern Mapper",
+    multiSelect: false,
+    options: [
+      { label: "Yes (Recommended)", description: "gsd-pattern-mapper runs between research and plan steps. Surfaces conventions so new code follows house style." },
+      { label: "No", description: "Skip pattern mapping. Faster; lose consistency hinting for new files." }
     ]
   },
   {
@@ -147,7 +226,7 @@ AskUserQuestion([
     header: "AI Phase",
     multiSelect: false,
     options: [
-      { label: "Yes (Recommended)", description: "Run /gsd-ai-phase before planning AI system phases. Surfaces the right framework, researches its docs, and designs the evaluation strategy." },
+      { label: "Yes (Recommended)", description: "Run /gsd:ai-integration-phase before planning AI system phases. Surfaces the right framework, researches its docs, and designs the evaluation strategy." },
       { label: "No", description: "Skip AI design contract. Good for non-AI phases or when framework is already decided." }
     ]
   },
@@ -180,6 +259,15 @@ AskUserQuestion([
     ]
   },
   {
+    question: "Commit .planning/ files to git? (controls whether plans/artifacts are tracked in your repo)",
+    header: "Commit Docs",
+    multiSelect: false,
+    options: [
+      { label: "Yes (Recommended)", description: "Commit .planning/ to git. Plans, research, and phase artifacts travel with the repo." },
+      { label: "No", description: "Do not commit .planning/. Keep planning local only. Automatic when .planning/ is in .gitignore." }
+    ]
+  },
+  {
     question: "Skip discuss-phase in autonomous mode? (use ROADMAP phase goals as spec)",
     header: "Skip Discuss",
     multiSelect: false,
@@ -196,6 +284,24 @@ AskUserQuestion([
       { label: "Yes (Recommended)", description: "Each parallel executor runs in its own worktree branch — no conflicts between agents." },
       { label: "No", description: "Disable worktree isolation. Agents run sequentially on the main working tree. Use if EnterWorktree creates branches from wrong base (known cross-platform issue)." }
     ]
+  },
+  {
+    question: "Enable Intel? (queryable codebase intelligence via /gsd:intel — builds a JSON index in .planning/intel/)",
+    header: "Intel",
+    multiSelect: false,
+    options: [
+      { label: "No (Recommended)", description: "Skip intel indexing. Use when codebase is small or intel queries are not needed." },
+      { label: "Yes", description: "Enable /gsd:intel commands. Builds and queries a JSON index of the codebase." }
+    ]
+  },
+  {
+    question: "Enable Graphify? (project knowledge graph via /gsd:graphify — builds a graph in .planning/graphs/)",
+    header: "Graphify",
+    multiSelect: false,
+    options: [
+      { label: "No (Recommended)", description: "Skip knowledge graph. Use when dependency graphs are not needed." },
+      { label: "Yes", description: "Enable /gsd:graphify commands. Builds and queries a project knowledge graph." }
+    ]
   }
 ])
 ```
@@ -208,20 +314,32 @@ Merge new settings into existing config.json:
 {
   ...existing_config,
   "model_profile": "quality" | "balanced" | "budget" | "adaptive" | "inherit",
+  "commit_docs": true/false,
   "workflow": {
     "research": true/false,
     "plan_check": true/false,
     "verifier": true/false,
     "auto_advance": true/false,
     "nyquist_validation": true/false,
+    "pattern_mapper": true/false,
     "ui_phase": true/false,
     "ui_safety_gate": true/false,
     "ai_integration_phase": true/false,
+    "tdd_mode": true/false,
+    "code_review": true/false,
+    "code_review_depth": "quick" | "standard" | "deep",
+    "ui_review": true/false,
     "text_mode": true/false,
     "research_before_questions": true/false,
     "discuss_mode": "discuss" | "assumptions",
     "skip_discuss": true/false,
     "use_worktrees": true/false
+  },
+  "intel": {
+    "enabled": true/false
+  },
+  "graphify": {
+    "enabled": true/false
   },
   "git": {
     "branching_strategy": "none" | "phase" | "milestone",
@@ -233,6 +351,8 @@ Merge new settings into existing config.json:
   }
 }
 ```
+
+**Safe merge:** Apply each chosen value via `gsd-sdk query config-set <key.path> <value>` so unrelated keys are never clobbered. `code_review_depth` is written only if the code_review question was answered `on`; otherwise leave the existing value in place.
 
 Write updated config to `$GSD_CONFIG_PATH` (the workstream-aware path resolved in `ensure_and_load_config`). Never hardcode `.planning/config.json` — workstream installs route to `.planning/workstreams/<slug>/config.json`.
 </step>
@@ -276,10 +396,21 @@ Write `~/.gsd/defaults.json` with:
     "verifier": <current>,
     "auto_advance": <current>,
     "nyquist_validation": <current>,
+    "pattern_mapper": <current>,
     "ui_phase": <current>,
     "ui_safety_gate": <current>,
     "ai_integration_phase": <current>,
+    "tdd_mode": <current>,
+    "code_review": <current>,
+    "code_review_depth": <current>,
+    "ui_review": <current>,
     "skip_discuss": <current>
+  },
+  "intel": {
+    "enabled": <current>
+  },
+  "graphify": {
+    "enabled": <current>
   }
 }
 ```
@@ -298,7 +429,15 @@ Display:
 | Model Profile        | {quality/balanced/budget/inherit} |
 | Plan Researcher      | {On/Off} |
 | Plan Checker         | {On/Off} |
+| Pattern Mapper       | {On/Off} |
 | Execution Verifier   | {On/Off} |
+| TDD Mode             | {On/Off} |
+| Code Review          | {On/Off} |
+| Code Review Depth    | {quick/standard/deep} |
+| UI Review            | {On/Off} |
+| Commit Docs          | {On/Off} |
+| Intel                | {On/Off} |
+| Graphify             | {On/Off} |
 | Auto-Advance         | {On/Off} |
 | Nyquist Validation   | {On/Off} |
 | UI Phase             | {On/Off} |
@@ -323,7 +462,7 @@ Quick commands:
 
 <success_criteria>
 - [ ] Current config read
-- [ ] User presented with 14 settings (profile + 11 workflow toggles + git branching + ctx warnings)
+- [ ] User presented with 22 settings (profile + workflow toggles + features + git branching + ctx warnings), grouped into six sections: Planning, Execution, Docs & Output, Features, Model & Pipeline, Misc. `code_review_depth` is conditional on `code_review=on`.
 - [ ] Config updated with model_profile, workflow, and git sections
 - [ ] User offered to save as global defaults (~/.gsd/defaults.json)
 - [ ] Changes confirmed to user

--- a/tests/feat-2527-settings-layers.test.cjs
+++ b/tests/feat-2527-settings-layers.test.cjs
@@ -1,0 +1,189 @@
+'use strict';
+
+/**
+ * Feature test for #2527 — /gsd-settings expands to 22 settings grouped into
+ * six visual sections. Adds 8 new fields (pattern_mapper, tdd_mode, code_review,
+ * code_review_depth, ui_review, commit_docs, intel.enabled, graphify.enabled)
+ * and verifies each is present in the AskUserQuestion block, the update_config
+ * step, the confirmation table, the ~/.gsd/defaults.json save step, and
+ * VALID_CONFIG_KEYS.
+ *
+ * Closes: #2527
+ */
+
+const { describe, test, before } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
+
+const SETTINGS_PATH = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'settings.md');
+const { VALID_CONFIG_KEYS } = require('../get-shit-done/bin/lib/config-schema.cjs');
+
+const NEW_FIELDS = [
+  'workflow.pattern_mapper',
+  'workflow.tdd_mode',
+  'workflow.code_review',
+  'workflow.code_review_depth',
+  'workflow.ui_review',
+  'commit_docs',
+  'intel.enabled',
+  'graphify.enabled',
+];
+
+const SECTION_HEADERS = ['Planning', 'Execution', 'Docs & Output', 'Features', 'Model & Pipeline', 'Misc'];
+
+describe('#2527: settings.md adds grouped settings layers', () => {
+  let content;
+
+  before(() => {
+    content = fs.readFileSync(SETTINGS_PATH, 'utf-8');
+  });
+
+  describe('Acceptance: all 8 new fields present in AskUserQuestion block', () => {
+    for (const field of NEW_FIELDS) {
+      test(`settings.md mentions ${field}`, () => {
+        assert.ok(
+          content.includes(field),
+          `settings.md must reference the config key "${field}" in its AskUserQuestion/update_config step`
+        );
+      });
+    }
+  });
+
+  describe('Acceptance: section headers applied', () => {
+    for (const section of SECTION_HEADERS) {
+      test(`settings.md declares a "${section}" section header`, () => {
+        // The convention for grouping AskUserQuestion items is a markdown section heading
+        // of the form "### <Section>" inside the present_settings step.
+        const heading = new RegExp(`^#{2,4}\\s+${section.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\$&')}\\b`, 'm');
+        assert.ok(
+          heading.test(content),
+          `settings.md must declare a "${section}" section header to group questions`
+        );
+      });
+    }
+  });
+
+  describe('Acceptance: update_config step includes all new fields', () => {
+    test('update_config step references every new field', () => {
+      const updateMatch = content.match(/<step name="update_config">[\s\S]*?<\/step>/);
+      assert.ok(updateMatch, 'settings.md must have an update_config step');
+      const updateBlock = updateMatch[0];
+      for (const field of NEW_FIELDS) {
+        // keys may appear as nested JSON (e.g., "pattern_mapper" under workflow)
+        const leaf = field.split('.').pop();
+        assert.ok(
+          updateBlock.includes(leaf),
+          `update_config step must write "${leaf}" (from ${field})`
+        );
+      }
+    });
+  });
+
+  describe('Acceptance: save_as_defaults step includes all new fields', () => {
+    test('save_as_defaults step references every new field', () => {
+      const defaultsMatch = content.match(/<step name="save_as_defaults">[\s\S]*?<\/step>/);
+      assert.ok(defaultsMatch, 'settings.md must have a save_as_defaults step');
+      const block = defaultsMatch[0];
+      for (const field of NEW_FIELDS) {
+        const leaf = field.split('.').pop();
+        assert.ok(
+          block.includes(leaf),
+          `save_as_defaults step must persist "${leaf}" (from ${field}) into ~/.gsd/defaults.json`
+        );
+      }
+    });
+  });
+
+  describe('Acceptance: confirmation display includes all new fields', () => {
+    test('confirm step table lists every new setting by name', () => {
+      const confirmMatch = content.match(/<step name="confirm">[\s\S]*?<\/step>/);
+      assert.ok(confirmMatch, 'settings.md must have a confirm step');
+      const block = confirmMatch[0];
+      const expectedLabels = [
+        'Pattern Mapper',
+        'TDD Mode',
+        'Code Review',
+        'Code Review Depth',
+        'UI Review',
+        'Commit Docs',
+        'Intel',
+        'Graphify',
+      ];
+      for (const label of expectedLabels) {
+        assert.ok(
+          block.includes(label),
+          `confirm step table must display "${label}"`
+        );
+      }
+    });
+  });
+
+  describe('Acceptance: all 8 new fields registered in VALID_CONFIG_KEYS', () => {
+    for (const field of NEW_FIELDS) {
+      test(`VALID_CONFIG_KEYS contains ${field}`, () => {
+        assert.ok(
+          VALID_CONFIG_KEYS.has(field),
+          `${field} must be in VALID_CONFIG_KEYS so config-set accepts it`
+        );
+      });
+    }
+  });
+
+  describe('Acceptance: code_review_depth is conditional on code_review=on', () => {
+    test('settings.md documents conditional visibility for code_review_depth', () => {
+      // Must explicitly note that code_review_depth only appears when code_review is on.
+      const conditionalRegex = /code_review_depth[\s\S]{0,400}(only|conditional|when|if)[\s\S]{0,80}code_review/i;
+      assert.ok(
+        conditionalRegex.test(content) ||
+          /code_review\s*=\s*on[\s\S]{0,400}code_[…]*depth/i.test(content),
+        'settings.md must document that code_review_depth is only shown when code_review is on'
+      );
+    });
+  });
+
+  describe('Negative: config-set rejects an invalid code_review_depth value', () => {
+    test('config-set workflow.code_review_depth "bogus" fails or is flagged', (t) => {
+      const tmpDir = createTempProject();
+      t.after(() => cleanup(tmpDir));
+
+      // Depth accepts string values (quick|standard|deep). We do not block arbitrary
+      // strings at config-set time today; instead confirm settings.md constrains
+      // the AskUserQuestion options to the valid set, so users can't pick "bogus".
+      const depthOptionsRegex =
+        /code_review_depth[\s\S]{0,800}(quick|standard|deep|surface)/i;
+      assert.ok(
+        depthOptionsRegex.test(content),
+        'settings.md must constrain code_review_depth options to a known set'
+      );
+
+      // Meanwhile, config-set still works on a known-bad key path (negative path).
+      const bad = runGsdTools(['config-set', 'workflow.code_review_bogus_key', 'x'], tmpDir);
+      assert.ok(!bad.success, 'config-set on an unknown key must fail');
+    });
+  });
+
+  describe('Acceptance: all 6 section headers are used as header: field on first question in each section', () => {
+    test('the header field appears for each section in the AskUserQuestion block', () => {
+      // Map user-visible section names to the short `header:` strings used in AskUserQuestion.
+      // settings.md uses abbreviated headers (max 12 chars). Verify at least one header
+      // per section-intent appears on a question.
+      const requiredHeaders = [
+        /header:\s*"Model"/,           // Model & Pipeline opener
+        /header:\s*"Research"/,        // Planning opener (first Planning-section question)
+        /header:\s*"Pattern Mapper"|header:\s*"Patterns"/, // new Planning addition
+        /header:\s*"Verifier"/,        // Execution existing
+        /header:\s*"TDD"/,             // new Execution
+        /header:\s*"Code Review"/,     // new Execution
+        /header:\s*"UI Review"/,       // new Execution
+        /header:\s*"Commit Docs"/,     // new Docs & Output
+        /header:\s*"Intel"/,           // new Features
+        /header:\s*"Graphify"/,        // new Features
+      ];
+      for (const re of requiredHeaders) {
+        assert.ok(re.test(content), `settings.md must include an AskUserQuestion header matching ${re}`);
+      }
+    });
+  });
+});

--- a/tests/feat-2527-settings-layers.test.cjs
+++ b/tests/feat-2527-settings-layers.test.cjs
@@ -33,6 +33,20 @@ const NEW_FIELDS = [
 
 const SECTION_HEADERS = ['Planning', 'Execution', 'Docs & Output', 'Features', 'Model & Pipeline', 'Misc'];
 
+/**
+ * Match a dotted config-key path inside a block of text. Falls back to a
+ * simple substring check for single-segment keys; for nested keys, requires
+ * each segment to appear in order within a bounded window so distinct fields
+ * (e.g., intel.enabled vs graphify.enabled) cannot collapse to the same leaf.
+ */
+function hasPathLike(block, field) {
+  const parts = field.split('.');
+  if (parts.length === 1) return block.includes(parts[0]);
+  const escaped = parts.map((p) => p.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+  const pattern = new RegExp(escaped.join('[\\s\\S]{0,600}'), 'i');
+  return pattern.test(block);
+}
+
 describe('#2527: settings.md adds grouped settings layers', () => {
   let content;
 
@@ -71,11 +85,12 @@ describe('#2527: settings.md adds grouped settings layers', () => {
       assert.ok(updateMatch, 'settings.md must have an update_config step');
       const updateBlock = updateMatch[0];
       for (const field of NEW_FIELDS) {
-        // keys may appear as nested JSON (e.g., "pattern_mapper" under workflow)
-        const leaf = field.split('.').pop();
+        // Keys may appear as nested JSON (e.g., "pattern_mapper" under workflow).
+        // Use hasPathLike so distinct dotted keys (e.g., intel.enabled,
+        // graphify.enabled) cannot share a single "enabled" occurrence.
         assert.ok(
-          updateBlock.includes(leaf),
-          `update_config step must write "${leaf}" (from ${field})`
+          hasPathLike(updateBlock, field),
+          `update_config step must write "${field}"`
         );
       }
     });
@@ -87,10 +102,9 @@ describe('#2527: settings.md adds grouped settings layers', () => {
       assert.ok(defaultsMatch, 'settings.md must have a save_as_defaults step');
       const block = defaultsMatch[0];
       for (const field of NEW_FIELDS) {
-        const leaf = field.split('.').pop();
         assert.ok(
-          block.includes(leaf),
-          `save_as_defaults step must persist "${leaf}" (from ${field}) into ~/.gsd/defaults.json`
+          hasPathLike(block, field),
+          `save_as_defaults step must persist "${field}" into ~/.gsd/defaults.json`
         );
       }
     });
@@ -143,22 +157,26 @@ describe('#2527: settings.md adds grouped settings layers', () => {
     });
   });
 
-  describe('Negative: config-set rejects an invalid code_review_depth value', () => {
-    test('config-set workflow.code_review_depth "bogus" fails or is flagged', (t) => {
-      const tmpDir = createTempProject();
-      t.after(() => cleanup(tmpDir));
-
-      // Depth accepts string values (quick|standard|deep). We do not block arbitrary
-      // strings at config-set time today; instead confirm settings.md constrains
-      // the AskUserQuestion options to the valid set, so users can't pick "bogus".
+  describe('Negative: settings.md constrains code_review_depth options', () => {
+    test('settings.md restricts code_review_depth to a known option set', () => {
+      // Depth accepts string values (quick|standard|deep). config-set does not
+      // block arbitrary strings at the value level today; instead settings.md
+      // constrains the AskUserQuestion options to the valid set so users
+      // cannot pick "bogus" via the interactive flow.
       const depthOptionsRegex =
         /code_review_depth[\s\S]{0,800}(quick|standard|deep|surface)/i;
       assert.ok(
         depthOptionsRegex.test(content),
         'settings.md must constrain code_review_depth options to a known set'
       );
+    });
+  });
 
-      // Meanwhile, config-set still works on a known-bad key path (negative path).
+  describe('Negative: config-set rejects an unknown key path', () => {
+    test('config-set workflow.code_review_bogus_key fails', (t) => {
+      const tmpDir = createTempProject();
+      t.after(() => cleanup(tmpDir));
+
       const bad = runGsdTools(['config-set', 'workflow.code_review_bogus_key', 'x'], tmpDir);
       assert.ok(!bad.success, 'config-set on an unknown key must fail');
     });


### PR DESCRIPTION
Closes #2527

## Summary

**What this feature does:** Expands `/gsd:settings` from 14 settings to 22, adding 8 workflow toggles that currently have no interactive configuration path. Groups all questions into six visual sections (Planning, Execution, Docs & Output, Features, Model & Pipeline, Misc) via the `header` field on the first question of each section.

**User-facing flow:**
1. User runs `/gsd:settings`. Settings workflow ensures `.planning/config.json` exists.
2. Workflow reads current config, extracts current values for all 22 settings (falling back to documented defaults).
3. `AskUserQuestion` is invoked with 22 questions (21 if `code_review=off`) — each with its current value pre-selected. The first question of each section carries a section-denoting `header`.
4. `code_review_depth` is conditionally presented only when the chosen `code_review` value is on.
5. Answers are merged into config via `gsd-sdk query config-set` one key at a time so unrelated keys are never clobbered.
6. User is asked whether to save these as global defaults; if yes, `~/.gsd/defaults.json` is written with the full settings object.
7. A confirmation table displays all 22 settings.

**The 8 new fields, defaults, sections:**

| Field | Default | Section |
|---|---|---|
| `workflow.pattern_mapper` | on | Planning |
| `workflow.tdd_mode` | off | Execution |
| `workflow.code_review` | on (codebase default) | Execution |
| `workflow.code_review_depth` | `standard` | Execution (conditional on `code_review=on`) |
| `workflow.ui_review` | on | Execution |
| `commit_docs` | on | Docs & Output |
| `intel.enabled` | off | Features |
| `graphify.enabled` | off | Features |

**Config merge safety:** The `update_config` step merges via `config-set` per key, which reads the full config, sets the target path, and writes atomically. Unrelated keys are preserved.

**`VALID_CONFIG_KEYS` status:** All 8 keys already exist in `get-shit-done/bin/lib/config-schema.cjs`; no additions needed. The `config-schema-docs-parity` test remains green because docs already cover them.

## Changes

- `get-shit-done/workflows/settings.md` — add Planning/Execution/Docs & Output/Features section headers, 8 new AskUserQuestion items with abbreviated `header:` tags, conditional-visibility note for `code_review_depth`, update the `update_config` JSON schema, extend `~/.gsd/defaults.json` save step, extend confirmation table.
- `docs/COMMANDS.md` — document the grouped sections on the `/gsd-settings` entry.
- `tests/feat-2527-settings-layers.test.cjs` — 28 tests covering field presence, section headers, update_config, save_as_defaults, confirmation table, VALID_CONFIG_KEYS membership, conditional visibility, and a negative path.

## Documentation

- `docs/COMMANDS.md` — updated `/gsd-settings` section to list the six visual groupings.
- `docs/CONFIGURATION.md` — no changes required; all 8 keys were already documented with type, default, and description.

## Tests

Full suite green: `npm test` — 5015 tests, 0 failures.

New test file: `tests/feat-2527-settings-layers.test.cjs` — 28 tests, written TDD-first (failed against the pre-change file, pass after the change).

## Design decisions

1. **`code_review_depth` vocabulary: `quick|standard|deep` with default `standard`.** The original issue table used `surface` as the default, but the codebase has shipped `quick|standard|deep` since v1.34 (see `docs/CONFIGURATION.md:154`). Introducing `surface` would require a fourth option and a rename that breaks existing configs. Aligned with the codebase.
2. **`workflow.code_review` default: on (not off).** The issue table listed `off`, but the codebase default (in `buildNewProjectConfig` and documented in `docs/CONFIGURATION.md:153`) is `true`. Per the issue's own stated rule ("Fields that are currently true/on in the codebase default to on"), preserved the codebase default so the setting flow does not silently flip user behavior on existing installs.
3. **`intel.enabled` default: off (not on).** The issue table said on; the codebase and docs default is `false`. Preserved codebase default for the same reason as above.
4. **Section headers as markdown `###` headings in the workflow document, and abbreviated `header:` fields on the first question of each section.** The `header:` field is max 12 chars, so section names like "Docs & Output" are represented by per-question abbreviations (e.g., `"Commit Docs"`, `"Intel"`, `"Graphify"`). This matches the existing pattern used for `"Ctx Warnings"` and `"Research Qs"`.
5. **Conditional visibility implementation.** The workflow instructs the orchestrator to omit the `code_review_depth` question from the AskUserQuestion batch when `code_review=off` and to leave the existing config value untouched. This is the simplest approach that avoids writing an invalid-by-context value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workflow configuration options: pattern mapping, TDD mode, code review (with conditional depth), UI review, commit docs, intel and graphify toggles.

* **Documentation**
  * Expanded /gsd-settings docs: six-section settings UI, per-key merging to preserve unrelated keys, ability to save defaults to ~/.gsd/defaults.json, and updated AI phase command reference.

* **Tests**
  * Added end-to-end tests validating settings layers, conditional visibility, key registration and rejection of unknown keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->