### PR TITLE
feat(settings): add search-provider toggles to /gsd:settings

### DIFF
--- a/get-shit-done/workflows/settings.md
+++ b/get-shit-done/workflows/settings.md
@@ -32,8 +32,21 @@ Parse current values (default to `true` if not present):
 - `workflow.nyquist_validation` — validation architecture research during plan-phase (default: true if absent)
 - `workflow.ui_phase` — generate UI-SPEC.md design contracts for frontend phases (default: true if absent)
 - `workflow.ui_safety_gate` — prompt to run /gsd:ui-phase before planning frontend phases (default: true if absent)
+- `brave_search`, `firecrawl`, `exa_search` — search-provider flags (top-level, default: `false`)
 - `model_profile` — which model each agent uses (default: `balanced`)
 - `git.branching_strategy` — branching approach (default: `"none"`)
+</step>
+
+<step name="detect_search_providers">
+Detect which search-provider API keys are available on this machine. These flags are gated on a key being present — flipping the flag on without a key is a no-op (see `references/planning-config.md`). Surface availability in the question so the user can make an informed choice.
+
+```bash
+BRAVE_AVAILABLE=$([ -n "$BRAVE_API_KEY" ] || [ -f "$HOME/.gsd/brave_api_key" ] && echo "available" || echo "no key")
+FIRECRAWL_AVAILABLE=$([ -n "$FIRECRAWL_API_KEY" ] || [ -f "$HOME/.gsd/firecrawl_api_key" ] && echo "available" || echo "no key")
+EXA_AVAILABLE=$([ -n "$EXA_API_KEY" ] || [ -f "$HOME/.gsd/exa_api_key" ] && echo "available" || echo "no key")
+```
+
+Use these values to fill `{BRAVE_STATUS}`, `{FIRECRAWL_STATUS}`, `{EXA_STATUS}` in the Search Providers question below.
 </step>
 
 <step name="present_settings">
@@ -153,9 +166,24 @@ AskUserQuestion([
       { label: "No (Recommended)", description: "Run smart discuss before each phase — surfaces gray areas and captures decisions." },
       { label: "Yes", description: "Skip discuss in /gsd:autonomous — chain directly to plan. Best for backend/pipeline work where phase descriptions are the spec." }
     ]
+  },
+  // Substitute {BRAVE_STATUS} / {FIRECRAWL_STATUS} / {EXA_STATUS} with the values
+  // detected in `detect_search_providers` (either "available" or "no key"). Pre-select
+  // providers whose flag is currently `true` in config.json.
+  {
+    question: "Enable which search providers? (used by research agents during plan-phase)",
+    header: "Search",
+    multiSelect: true,
+    options: [
+      { label: "Brave Search [{BRAVE_STATUS}]", description: "Web search via Brave API. Requires BRAVE_API_KEY env var or ~/.gsd/brave_api_key. Flag without key is a no-op." },
+      { label: "Firecrawl [{FIRECRAWL_STATUS}]", description: "Page scraping via Firecrawl API. Requires FIRECRAWL_API_KEY env var or ~/.gsd/firecrawl_api_key. Flag without key is a no-op." },
+      { label: "Exa Search [{EXA_STATUS}]", description: "Semantic web search via Exa API. Requires EXA_API_KEY env var or ~/.gsd/exa_api_key. Flag without key is a no-op." }
+    ]
   }
 ])
 ```
+
+After the user answers: for any selected provider whose status is "no key", append a note to the confirm output advising the user how to set the key (env var or `~/.gsd/<name>_api_key` file). Still persist the flag — it'll start working once a key becomes available.
 </step>
 
 <step name="update_config">
@@ -165,6 +193,9 @@ Merge new settings into existing config.json:
 {
   ...existing_config,
   "model_profile": "quality" | "balanced" | "budget" | "inherit",
+  "brave_search": true/false,
+  "firecrawl": true/false,
+  "exa_search": true/false,
   "workflow": {
     "research": true/false,
     "plan_check": true/false,
@@ -188,6 +219,8 @@ Merge new settings into existing config.json:
   }
 }
 ```
+
+The three search-provider flags (`brave_search`, `firecrawl`, `exa_search`) are top-level, not nested under `workflow`. Set each to `true` if the user selected it in the Search Providers question, `false` otherwise.
 
 Write updated config to `.planning/config.json`.
 </step>
@@ -260,6 +293,7 @@ Display:
 | Git Branching        | {None/Per Phase/Per Milestone} |
 | Skip Discuss         | {On/Off} |
 | Context Warnings     | {On/Off} |
+| Search Providers     | {comma-separated list of enabled providers, or "None"} |
 | Saved as Defaults    | {Yes/No} |
 
 These settings apply to future /gsd:plan-phase and /gsd:execute-phase runs.
@@ -270,14 +304,24 @@ Quick commands:
 - /gsd:plan-phase --skip-research — skip research
 - /gsd:plan-phase --skip-verify — skip plan check
 ```
+
+If any enabled search provider had status "no key" during detection, append a separate note after the table advising the user how to activate it:
+
+    Note: you enabled {providers} but no API key was detected.
+    Set the key to activate:
+      - Brave:     export BRAVE_API_KEY=... (or echo <key> > ~/.gsd/brave_api_key)
+      - Firecrawl: export FIRECRAWL_API_KEY=... (or echo <key> > ~/.gsd/firecrawl_api_key)
+      - Exa:       export EXA_API_KEY=... (or echo <key> > ~/.gsd/exa_api_key)
 </step>
 
 </process>
 
 <success_criteria>
 - [ ] Current config read
-- [ ] User presented with 10 settings (profile + 8 workflow toggles + git branching)
-- [ ] Config updated with model_profile, workflow, and git sections
+- [ ] Search-provider API key availability detected
+- [ ] User presented with 13 settings (profile + 10 workflow toggles + git branching + search providers)
+- [ ] Config updated with model_profile, top-level search flags, workflow, and git sections
 - [ ] User offered to save as global defaults (~/.gsd/defaults.json)
+- [ ] If any selected provider lacks an API key, activation note shown
 - [ ] Changes confirmed to user
 </success_criteria>


### PR DESCRIPTION
## Summary

Adds a multi-select **Search Providers** question to `/gsd:settings`, covering `brave_search`, `firecrawl`, and `exa_search`.

Today these three flags are set *only* at project creation via `buildNewProjectConfig()` (`bin/lib/config.cjs:111-117`), based on `BRAVE_API_KEY` / `FIRECRAWL_API_KEY` / `EXA_API_KEY` env vars or `~/.gsd/<name>_api_key` files. For an existing project, flipping them on requires hand-editing `.planning/config.json` — there is no slash command.

## What changed

`get-shit-done/workflows/settings.md` only. No code changes, no new SDK commands, no test changes needed (the config keys already exist in `VALID_CONFIG_KEYS` and are covered by `tests/config.test.cjs`).

Concretely:

1. **New `detect_search_providers` step** — a short bash block that probes the same env-var + key-file sources `buildNewProjectConfig()` uses, resolving `{BRAVE_STATUS}` / `{FIRECRAWL_STATUS}` / `{EXA_STATUS}` to either `available` or `no key`.
2. **New multi-select question** appended to the `AskUserQuestion` call. Each option's label includes the detected status in brackets — e.g. `Brave Search [available]` — so the user sees the footgun up front rather than toggling a flag that silently does nothing.
3. **`update_config` step** writes the three top-level flags (they are NOT under `workflow`).
4. **Confirm step** shows a `Search Providers` row (comma-separated enabled providers, or `None`), and — only when the user enabled something whose key is missing — appends an activation note listing how to set each missing key.
5. **Success criteria** bumped from 10 to 13 settings (the pre-change criteria string was already stale relative to the actual question count; I only counted what's there now).

## Why shape B (informed toggle) instead of A or C

A plain `Yes/No` toggle without availability surfacing would let users flip `exa_search: true` without an `EXA_API_KEY` set, which is a no-op per `references/planning-config.md:366`. That's a bad UX — the settings UI would lie.

Writing the key to `~/.gsd/<name>_api_key` from an interactive flow would be the other extreme; it pushes GSD into secret management and introduces a masked-input dependency. Surfacing availability without capturing the key keeps the scope tight and matches the existing env-var-driven design.

## Test plan

- [ ] Run `/gsd:settings` on a project with no keys set — confirm each provider shows `[no key]` and selecting any of them still writes the flag plus the activation note.
- [ ] Run `/gsd:settings` with `EXA_API_KEY` exported — confirm `Exa Search [available]` appears and no note is shown after enabling it.
- [ ] Run `/gsd:settings` with `~/.gsd/brave_api_key` present but no env var — confirm `Brave Search [available]`.
- [ ] Verify the written `config.json` has the three flags at the top level (not nested under `workflow`).
- [ ] Confirm pre-selection works: toggle on, re-run `/gsd:settings`, confirm the provider is pre-selected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration and automatic detection for search provider integrations, including Brave Search, Firecrawl, and Exa Search, with checks for API key availability.
  * Enhanced the settings interface with new multi-select search provider options and instructions for configuring missing API keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->