### PR TITLE
fix(#2601): include 'inherit' in VALID_PROFILES and unify allowlists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ If you use GSD **as a workflow**—milestones, phases, `.planning/` artifacts, b
 
 ### Fixed
 
+- **`config-set-model-profile` rejected `inherit` despite runtime support** — `VALID_PROFILES` was derived solely from `MODEL_PROFILES` keys, which cannot include `inherit` (a meta-profile that bypasses the map). The health validator had its own hardcoded list that included `inherit` but omitted `adaptive`. Unified all three allowlists into a single `VALID_PROFILES` constant that appends `inherit` after the `MODEL_PROFILES`-derived entries (#2601)
 - **Shell hooks falsely flagged as stale on every session** — `gsd-phase-boundary.sh`, `gsd-session-state.sh`, and `gsd-validate-commit.sh` now ship with a `# gsd-hook-version: {{GSD_VERSION}}` header; the installer substitutes `{{GSD_VERSION}}` in `.sh` hooks the same way it does for `.js` hooks; and the stale-hook detector in `gsd-check-update.js` now matches bash `#` comment syntax in addition to JS `//` syntax. All three changes are required together — neither the regex fix alone nor the install fix alone is sufficient to resolve the false positive (#2136, #2206, #2209, #2210, #2212)
 
 ### Added

--- a/sdk/src/query/config-mutation.test.ts
+++ b/sdk/src/query/config-mutation.test.ts
@@ -295,6 +295,20 @@ describe('configSetModelProfile', () => {
     await expect(configSetModelProfile(['invalid_profile'], tmpDir)).rejects.toThrow(GSDError);
   });
 
+  it('accepts inherit profile', async () => {
+    const { configSetModelProfile } = await import('./config-mutation.js');
+    await writeFile(
+      join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ model_profile: 'balanced' }),
+    );
+    const result = await configSetModelProfile(['inherit'], tmpDir);
+    expect((result.data as { updated: boolean }).updated).toBe(true);
+    expect((result.data as { profile: string }).profile).toBe('inherit');
+
+    const raw = JSON.parse(await readFile(join(tmpDir, '.planning', 'config.json'), 'utf-8'));
+    expect(raw.model_profile).toBe('inherit');
+  });
+
   it('normalizes profile name to lowercase', async () => {
     const { configSetModelProfile } = await import('./config-mutation.js');
     await writeFile(

--- a/sdk/src/query/config-query.test.ts
+++ b/sdk/src/query/config-query.test.ts
@@ -194,3 +194,25 @@ describe('VALID_PROFILES', () => {
     expect(VALID_PROFILES).toEqual(['quality', 'balanced', 'budget', 'adaptive', 'inherit']);
   });
 });
+
+// ─── getAgentToModelMapForProfile ───────────────────────────────────────────
+
+describe('getAgentToModelMapForProfile', () => {
+  it('returns inherit for all agents when profile is inherit', async () => {
+    const { getAgentToModelMapForProfile } = await import('./config-query.js');
+    const map = getAgentToModelMapForProfile('inherit');
+    expect(Object.keys(map).length).toBeGreaterThan(0);
+    for (const model of Object.values(map)) {
+      expect(model).toBe('inherit');
+    }
+  });
+
+  it('returns concrete models for non-inherit profiles', async () => {
+    const { getAgentToModelMapForProfile } = await import('./config-query.js');
+    const map = getAgentToModelMapForProfile('balanced');
+    for (const model of Object.values(map)) {
+      expect(model).not.toBe('inherit');
+      expect(['opus', 'sonnet', 'haiku']).toContain(model);
+    }
+  });
+});

--- a/sdk/src/query/config-query.test.ts
+++ b/sdk/src/query/config-query.test.ts
@@ -189,8 +189,8 @@ describe('MODEL_PROFILES', () => {
 // ─── VALID_PROFILES ─────────────────────────────────────────────────────────
 
 describe('VALID_PROFILES', () => {
-  it('contains the four profile names', async () => {
+  it('contains the five profile names including inherit', async () => {
     const { VALID_PROFILES } = await import('./config-query.js');
-    expect(VALID_PROFILES).toEqual(['quality', 'balanced', 'budget', 'adaptive']);
+    expect(VALID_PROFILES).toEqual(['quality', 'balanced', 'budget', 'adaptive', 'inherit']);
   });
 });

--- a/sdk/src/query/config-query.ts
+++ b/sdk/src/query/config-query.ts
@@ -57,6 +57,13 @@ export const VALID_PROFILES: string[] = [...Object.keys(MODEL_PROFILES['gsd-plan
  * Flat map of agent name → model alias for one profile tier (matches `model-profiles.cjs`).
  */
 export function getAgentToModelMapForProfile(normalizedProfile: string): Record<string, string> {
+  if (normalizedProfile === 'inherit') {
+    const agentToModelMap: Record<string, string> = {};
+    for (const agent of Object.keys(MODEL_PROFILES)) {
+      agentToModelMap[agent] = 'inherit';
+    }
+    return agentToModelMap;
+  }
   const profile = VALID_PROFILES.includes(normalizedProfile) ? normalizedProfile : 'balanced';
   const agentToModelMap: Record<string, string> = {};
   for (const [agent, profileToModelMap] of Object.entries(MODEL_PROFILES)) {

--- a/sdk/src/query/config-query.ts
+++ b/sdk/src/query/config-query.ts
@@ -50,8 +50,8 @@ export const MODEL_PROFILES: Record<string, Record<string, string>> = {
   'gsd-doc-verifier': { quality: 'sonnet', balanced: 'sonnet', budget: 'haiku', adaptive: 'haiku' },
 };
 
-/** Valid model profile names. */
-export const VALID_PROFILES: string[] = Object.keys(MODEL_PROFILES['gsd-planner']);
+/** Valid model profile names (includes 'inherit' which bypasses MODEL_PROFILES). */
+export const VALID_PROFILES: string[] = [...Object.keys(MODEL_PROFILES['gsd-planner']), 'inherit'];
 
 /**
  * Flat map of agent name → model alias for one profile tier (matches `model-profiles.cjs`).

--- a/sdk/src/query/validate.ts
+++ b/sdk/src/query/validate.ts
@@ -465,8 +465,11 @@ export const validateHealth: QueryHandler = async (args, projectDir, _workstream
     try {
       const raw = await readFile(configPath, 'utf-8');
       const parsed = JSON.parse(raw) as Record<string, unknown>;
-      if (parsed.model_profile && !VALID_PROFILES.includes(parsed.model_profile as string)) {
-        addIssue('warning', 'W004', `config.json: invalid model_profile "${parsed.model_profile}"`, `Valid values: ${VALID_PROFILES.join(', ')}`);
+      if (parsed.model_profile !== undefined) {
+        const profile = String(parsed.model_profile).trim().toLowerCase();
+        if (!VALID_PROFILES.includes(profile)) {
+          addIssue('warning', 'W004', `config.json: invalid model_profile "${parsed.model_profile}"`, `Valid values: ${VALID_PROFILES.join(', ')}`);
+        }
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);

--- a/sdk/src/query/validate.ts
+++ b/sdk/src/query/validate.ts
@@ -20,7 +20,7 @@ import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { homedir } from 'node:os';
 
-import { MODEL_PROFILES } from './config-query.js';
+import { MODEL_PROFILES, VALID_PROFILES } from './config-query.js';
 import { GSDError, ErrorClassification } from '../errors.js';
 import { extractFrontmatter, parseMustHavesBlock } from './frontmatter.js';
 import { escapeRegex, normalizePhaseName, planningPaths, resolvePathUnderProject } from './helpers.js';
@@ -465,9 +465,8 @@ export const validateHealth: QueryHandler = async (args, projectDir, _workstream
     try {
       const raw = await readFile(configPath, 'utf-8');
       const parsed = JSON.parse(raw) as Record<string, unknown>;
-      const validProfiles = ['quality', 'balanced', 'budget', 'inherit'];
-      if (parsed.model_profile && !validProfiles.includes(parsed.model_profile as string)) {
-        addIssue('warning', 'W004', `config.json: invalid model_profile "${parsed.model_profile}"`, `Valid values: ${validProfiles.join(', ')}`);
+      if (parsed.model_profile && !VALID_PROFILES.includes(parsed.model_profile as string)) {
+        addIssue('warning', 'W004', `config.json: invalid model_profile "${parsed.model_profile}"`, `Valid values: ${VALID_PROFILES.join(', ')}`);
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #2601

---

## What was broken

`gsd-sdk query config-set-model-profile inherit` failed with "Invalid profile 'inherit'. Valid profiles: quality, balanced, budget, adaptive" — despite `inherit` being a supported meta-profile that the runtime getter and health validator both accept.

## What this fix does

Adds `'inherit'` to the shared `VALID_PROFILES` constant and replaces the hardcoded allowlist in `validate.ts` with that same constant, so all three consumers (setter, getter, health validator) agree on valid profiles.

## Root cause

Three independent allowlists had drifted out of sync:

| Source | File | Has `inherit`? | Has `adaptive`? |
|---|---|---|---|
| `VALID_PROFILES` | `config-query.ts:54` | **No** | Yes |
| Health validator | `validate.ts:468` | **Yes** | **No** |
| Runtime getter | `config-query.ts:171` | **Yes** (special-cased) | N/A |

`VALID_PROFILES` was derived from `Object.keys(MODEL_PROFILES['gsd-planner'])`, and `inherit` cannot be a key there since its purpose is to bypass the map entirely. The health validator had a separate hardcoded list that included `inherit` but omitted `adaptive`.

## Testing

### How I verified the fix

1. Ran `npx vitest run` on config-query, config-mutation, and validate test files — 82 tests pass
2. New regression test `'accepts inherit profile'` in `config-mutation.test.ts` calls `configSetModelProfile(['inherit'], ...)` and verifies it writes to `config.json` successfully

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] CHANGELOG.md updated if this is a user-facing fix
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The `inherit` model profile is now accepted during configuration updates and validated consistently across health checks.

* **Tests**
  * New tests verify `inherit` is recognized as valid, returned by queries, and persisted correctly.

* **Documentation**
  * Changelog updated to reflect the profile validation and behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->