### PR TITLE
fix(workflows): agent-skills query keys must match subagent_type (follow-up to #2555)

### DIFF
--- a/get-shit-done/workflows/discuss-phase.md
+++ b/get-shit-done/workflows/discuss-phase.md
@@ -111,7 +111,7 @@ Phase number from argument (required).
 ```bash
 INIT=$(gsd-sdk query init.phase-op "${PHASE}")
 if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
-AGENT_SKILLS_ADVISOR=$(gsd-sdk query agent-skills gsd-advisor 2>/dev/null)
+AGENT_SKILLS_ADVISOR=$(gsd-sdk query agent-skills gsd-advisor-researcher 2>/dev/null)
 ```
 
 Parse JSON for: `commit_docs`, `phase_found`, `phase_dir`, `phase_number`, `phase_name`, `phase_slug`, `padded_phase`, `has_research`, `has_context`, `has_plans`, `has_verification`, `plan_count`, `roadmap_exists`, `planning_exists`, `response_language`.

--- a/get-shit-done/workflows/new-milestone.md
+++ b/get-shit-done/workflows/new-milestone.md
@@ -204,7 +204,7 @@ gsd-sdk query commit "docs: start milestone v[X.Y] [Name]" .planning/PROJECT.md 
 INIT=$(gsd-sdk query init.new-milestone)
 if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 AGENT_SKILLS_RESEARCHER=$(gsd-sdk query agent-skills gsd-project-researcher 2>/dev/null)
-AGENT_SKILLS_SYNTHESIZER=$(gsd-sdk query agent-skills gsd-synthesizer 2>/dev/null)
+AGENT_SKILLS_SYNTHESIZER=$(gsd-sdk query agent-skills gsd-research-synthesizer 2>/dev/null)
 AGENT_SKILLS_ROADMAPPER=$(gsd-sdk query agent-skills gsd-roadmapper 2>/dev/null)
 ```
 

--- a/get-shit-done/workflows/new-project.md
+++ b/get-shit-done/workflows/new-project.md
@@ -60,7 +60,7 @@ The document should describe what you want to build.
 INIT=$(gsd-sdk query init.new-project)
 if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 AGENT_SKILLS_RESEARCHER=$(gsd-sdk query agent-skills gsd-project-researcher 2>/dev/null)
-AGENT_SKILLS_SYNTHESIZER=$(gsd-sdk query agent-skills gsd-synthesizer 2>/dev/null)
+AGENT_SKILLS_SYNTHESIZER=$(gsd-sdk query agent-skills gsd-research-synthesizer 2>/dev/null)
 AGENT_SKILLS_ROADMAPPER=$(gsd-sdk query agent-skills gsd-roadmapper 2>/dev/null)
 ```
 

--- a/get-shit-done/workflows/plan-phase.md
+++ b/get-shit-done/workflows/plan-phase.md
@@ -33,9 +33,9 @@ Load all context in one call (paths only to minimize orchestrator context):
 ```bash
 INIT=$(gsd-sdk query init.plan-phase "$PHASE")
 if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
-AGENT_SKILLS_RESEARCHER=$(gsd-sdk query agent-skills gsd-researcher 2>/dev/null)
+AGENT_SKILLS_RESEARCHER=$(gsd-sdk query agent-skills gsd-phase-researcher 2>/dev/null)
 AGENT_SKILLS_PLANNER=$(gsd-sdk query agent-skills gsd-planner 2>/dev/null)
-AGENT_SKILLS_CHECKER=$(gsd-sdk query agent-skills gsd-checker 2>/dev/null)
+AGENT_SKILLS_CHECKER=$(gsd-sdk query agent-skills gsd-plan-checker 2>/dev/null)
 CONTEXT_WINDOW=$(gsd-sdk query config-get context_window 2>/dev/null || echo "200000")
 TDD_MODE=$(gsd-sdk query config-get workflow.tdd_mode 2>/dev/null || echo "false")
 ```

--- a/get-shit-done/workflows/quick.md
+++ b/get-shit-done/workflows/quick.md
@@ -142,7 +142,7 @@ INIT=$(gsd-sdk query init.quick "$DESCRIPTION")
 if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 AGENT_SKILLS_PLANNER=$(gsd-sdk query agent-skills gsd-planner 2>/dev/null)
 AGENT_SKILLS_EXECUTOR=$(gsd-sdk query agent-skills gsd-executor 2>/dev/null)
-AGENT_SKILLS_CHECKER=$(gsd-sdk query agent-skills gsd-checker 2>/dev/null)
+AGENT_SKILLS_CHECKER=$(gsd-sdk query agent-skills gsd-plan-checker 2>/dev/null)
 AGENT_SKILLS_VERIFIER=$(gsd-sdk query agent-skills gsd-verifier 2>/dev/null)
 ```
 

--- a/get-shit-done/workflows/research-phase.md
+++ b/get-shit-done/workflows/research-phase.md
@@ -42,7 +42,7 @@ If exists: Offer update/view/skip options.
 INIT=$(gsd-sdk query init.phase-op "${PHASE}")
 if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 # Extract: phase_dir, padded_phase, phase_number, state_path, requirements_path, context_path
-AGENT_SKILLS_RESEARCHER=$(gsd-sdk query agent-skills gsd-researcher 2>/dev/null)
+AGENT_SKILLS_RESEARCHER=$(gsd-sdk query agent-skills gsd-phase-researcher 2>/dev/null)
 ```
 
 ## Step 4: Spawn Researcher

--- a/get-shit-done/workflows/ui-review.md
+++ b/get-shit-done/workflows/ui-review.md
@@ -18,7 +18,7 @@ Valid GSD subagent types (use exact names — do not fall back to 'general-purpo
 ```bash
 INIT=$(gsd-sdk query init.phase-op "${PHASE_ARG}")
 if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
-AGENT_SKILLS_UI_REVIEWER=$(gsd-sdk query agent-skills gsd-ui-reviewer 2>/dev/null)
+AGENT_SKILLS_UI_REVIEWER=$(gsd-sdk query agent-skills gsd-ui-auditor 2>/dev/null)
 ```
 
 Parse: `phase_dir`, `phase_number`, `phase_name`, `phase_slug`, `padded_phase`, `commit_docs`.

--- a/get-shit-done/workflows/verify-work.md
+++ b/get-shit-done/workflows/verify-work.md
@@ -33,7 +33,7 @@ If $ARGUMENTS contains a phase number, load context:
 INIT=$(gsd-sdk query init.verify-work "${PHASE_ARG}")
 if [[ "$INIT" == @file:* ]]; then INIT=$(cat "${INIT#@file:}"); fi
 AGENT_SKILLS_PLANNER=$(gsd-sdk query agent-skills gsd-planner 2>/dev/null)
-AGENT_SKILLS_CHECKER=$(gsd-sdk query agent-skills gsd-checker 2>/dev/null)
+AGENT_SKILLS_CHECKER=$(gsd-sdk query agent-skills gsd-plan-checker 2>/dev/null)
 ```
 
 Parse JSON for: `planner_model`, `checker_model`, `commit_docs`, `phase_found`, `phase_dir`, `phase_number`, `phase_name`, `has_verification`, `uat_path`.

--- a/sdk/src/workflow-agent-skills-consistency.test.ts
+++ b/sdk/src/workflow-agent-skills-consistency.test.ts
@@ -20,7 +20,14 @@ const repoRoot = join(__dirname, '..', '..');
 const workflowsDir = join(repoRoot, 'get-shit-done', 'workflows');
 const agentsDir = join(repoRoot, 'agents');
 
-const QUERY_KEY_PATTERN = /agent-skills\s+([a-z][a-z0-9-]*)/g;
+/**
+ * Matches a full `gsd-sdk query agent-skills <slug>` invocation and captures
+ * the slug. Requires a token boundary before `gsd-sdk` and a word boundary
+ * after the slug so that prose references (e.g. documentation mentioning the
+ * string "agent-skills") do not produce false positives. The `\s+` between
+ * tokens accepts newlines, so commands wrapped across lines still match.
+ */
+const QUERY_KEY_PATTERN = /\bgsd-sdk\s+query\s+agent-skills\s+([a-z][a-z0-9-]*)\b/g;
 
 interface QueryUsage {
   readonly file: string;
@@ -28,6 +35,7 @@ interface QueryUsage {
   readonly slug: string;
 }
 
+/** Recursively collects all `.md` file paths under `dir`. */
 function walkMarkdown(dir: string): string[] {
   const out: string[] = [];
   for (const entry of readdirSync(dir)) {
@@ -41,6 +49,7 @@ function walkMarkdown(dir: string): string[] {
   return out;
 }
 
+/** Returns the set of agent slugs defined by `<slug>.md` files in `dir`. */
 function collectAgentSlugs(dir: string): Set<string> {
   return new Set(
     readdirSync(dir)
@@ -49,15 +58,21 @@ function collectAgentSlugs(dir: string): Set<string> {
   );
 }
 
+/**
+ * Extracts every `gsd-sdk query agent-skills <slug>` usage from the given
+ * markdown files. Runs the regex over each file's full content (not line by
+ * line) so wrapped commands still match, then resolves the 1-based line number
+ * from the match index.
+ */
 function collectQueryUsages(files: readonly string[]): QueryUsage[] {
   const usages: QueryUsage[] = [];
   for (const file of files) {
-    const lines = readFileSync(file, 'utf8').split('\n');
-    lines.forEach((line, idx) => {
-      for (const match of line.matchAll(QUERY_KEY_PATTERN)) {
-        usages.push({ file, line: idx + 1, slug: match[1]! });
-      }
-    });
+    const content = readFileSync(file, 'utf8');
+    for (const match of content.matchAll(QUERY_KEY_PATTERN)) {
+      const index = match.index ?? 0;
+      const line = content.slice(0, index).split('\n').length;
+      usages.push({ file, line, slug: match[1]! });
+    }
   }
   return usages;
 }

--- a/sdk/src/workflow-agent-skills-consistency.test.ts
+++ b/sdk/src/workflow-agent-skills-consistency.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Contract test: every `gsd-sdk query agent-skills <slug>` invocation in
+ * `get-shit-done/workflows/**\/*.md` must reference a slug that exists as
+ * `agents/<slug>.md` at the repository root.
+ *
+ * A mismatch produces a silent no-op at runtime — the SDK returns `""` for an
+ * unknown key, and the workflow interpolates the empty string into the spawn
+ * prompt, so any `agent_skills.<correct-slug>` configuration in
+ * `.planning/config.json` is silently ignored. This test prevents regression.
+ *
+ * Related: https://github.com/gsd-build/get-shit-done/issues/2615
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, '..', '..');
+const workflowsDir = join(repoRoot, 'get-shit-done', 'workflows');
+const agentsDir = join(repoRoot, 'agents');
+
+const QUERY_KEY_PATTERN = /agent-skills\s+([a-z][a-z0-9-]*)/g;
+
+interface QueryUsage {
+  readonly file: string;
+  readonly line: number;
+  readonly slug: string;
+}
+
+function walkMarkdown(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...walkMarkdown(full));
+    } else if (entry.endsWith('.md')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function collectAgentSlugs(dir: string): Set<string> {
+  return new Set(
+    readdirSync(dir)
+      .filter((name) => name.endsWith('.md'))
+      .map((name) => name.replace(/\.md$/, '')),
+  );
+}
+
+function collectQueryUsages(files: readonly string[]): QueryUsage[] {
+  const usages: QueryUsage[] = [];
+  for (const file of files) {
+    const lines = readFileSync(file, 'utf8').split('\n');
+    lines.forEach((line, idx) => {
+      for (const match of line.matchAll(QUERY_KEY_PATTERN)) {
+        usages.push({ file, line: idx + 1, slug: match[1]! });
+      }
+    });
+  }
+  return usages;
+}
+
+describe('workflow agent-skills query consistency', () => {
+  it('every `agent-skills <slug>` query refers to an existing `agents/<slug>.md`', () => {
+    const validSlugs = collectAgentSlugs(agentsDir);
+    const workflowFiles = walkMarkdown(workflowsDir);
+    const usages = collectQueryUsages(workflowFiles);
+    const invalid = usages.filter((u) => !validSlugs.has(u.slug));
+
+    const report = invalid
+      .map((u) => `  ${relative(repoRoot, u.file)}:${u.line} — unknown slug '${u.slug}'`)
+      .join('\n');
+
+    expect(
+      invalid,
+      invalid.length
+        ? `Found ${invalid.length} agent-skills query keys with no matching agents/<slug>.md:\n${report}`
+        : '',
+    ).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2615

Follow-up to #2555. Issue #2615 was filed as part of this PR and has not yet been triaged by a maintainer. Evidence, reproduction, and the full mismatch table are in the issue and repeated below. Happy to wait on a `confirmed-bug` relabel before merge.

---

## What was broken

Nine `gsd-sdk query agent-skills <KEY>` invocations across eight workflow files used keys that did not match any `subagent_type` Task() spawns in the same workflow, nor any existing `agents/<KEY>.md`. As a result, `agent_skills.<correct-type>` entries configured in `.planning/config.json` were silently ignored on those paths, regardless of whether the SDK fix from #2555 was installed. The SDK correctly returned `""` for the unknown key, which interpolated as an empty string into the spawn prompt — a silent no-op, not a visible error.

## What this fix does

Updates each query to use the slug that matches the adjacent Task() spawn (or, for the advisor case, the agent identity loaded via `Read`):

| File | Line | Wrong → Correct |
|---|---|---|
| `research-phase.md` | 45 | `gsd-researcher` → `gsd-phase-researcher` |
| `plan-phase.md` | 36 | `gsd-researcher` → `gsd-phase-researcher` |
| `plan-phase.md` | 38 | `gsd-checker` → `gsd-plan-checker` |
| `quick.md` | 145 | `gsd-checker` → `gsd-plan-checker` |
| `verify-work.md` | 36 | `gsd-checker` → `gsd-plan-checker` |
| `new-milestone.md` | 207 | `gsd-synthesizer` → `gsd-research-synthesizer` |
| `new-project.md` | 63 | `gsd-synthesizer` → `gsd-research-synthesizer` |
| `ui-review.md` | 21 | `gsd-ui-reviewer` → `gsd-ui-auditor` |
| `discuss-phase.md` | 114 | `gsd-advisor` → `gsd-advisor-researcher` |

Bash variable names (`AGENT_SKILLS_RESEARCHER` etc.) are deliberately left unchanged — only the argument to `gsd-sdk query agent-skills` changes.

The `discuss-phase.md` advisor case is a subtle variant: the actual Task() spawn (in `workflows/discuss-phase/modes/advisor.md`) uses `subagent_type="general-purpose"` and loads the agent role via `Read(~/.claude/agents/gsd-advisor-researcher.md)`. The injection key therefore follows the agent **identity** (`gsd-advisor-researcher`, matching the agent file name and `resolve-model gsd-advisor-researcher`), not the technical spawn type.

## Root cause

Three typo patterns compounding with a missing regression check:

1. **Dropped adjective** — `gsd-researcher` vs `gsd-phase-researcher`, `gsd-checker` vs `gsd-plan-checker`, `gsd-synthesizer` vs `gsd-research-synthesizer`. The queries were written with a shorter intended slug and never reconciled with the final agent file naming.
2. **Synonym drift** — `gsd-ui-reviewer` → `gsd-ui-auditor`. The agent was renamed; the query wasn't updated.
3. **Slug truncation** — `gsd-advisor` used standalone; the only matching agent file is `agents/gsd-advisor-researcher.md`.

There was no automated check that every `agent-skills <slug>` argument in a workflow corresponded to an existing `agents/<slug>.md`. The bug was invisible until #2555 fixed the SDK handler; prior to that, the query returned a discovery dump regardless of key.

---

## Testing

### How I verified the fix

**TDD:** Wrote `sdk/src/workflow-agent-skills-consistency.test.ts` *first* — a contract test that scans every `get-shit-done/workflows/**/*.md`, extracts `gsd-sdk query agent-skills <slug>` invocations, and asserts each slug has a matching `agents/<slug>.md`. Ran on base (`f30da83`) → 9 failures (the enumerated mismatches above). Applied the 9 edits → test green.

Per review feedback from @coderabbitai in this PR, the extraction regex was hardened (commit `45c4f1e`) to require the full `gsd-sdk query agent-skills` prefix + word boundaries (no false positives from prose) and to scan full file content instead of per-line (so commands wrapped across lines still match). Verified: same 9 violations detected on base; green on fixed tree.

**Evidence (run from a worktree of `gsd-build/get-shit-done`):**

```bash
grep -hoE "agent-skills [a-z-]+" get-shit-done/workflows/*.md | awk '{print $2}' | sort -u
# → every output key corresponds to an existing agents/<key>.md
```

**SDK test suite:** 7 pre-existing unrelated failures in `sdk/src/query/*.test.ts` are present on `main` at `f30da83` prior to this branch — confirmed by stashing the PR's changes and re-running. Orthogonal to this change.

### Regression test added?

- [x] Yes — `sdk/src/workflow-agent-skills-consistency.test.ts` would have caught every one of the 9 mismatches.

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

*(PR CI ran the new test on ubuntu-latest + macos-latest, Node 22 + 24 — all passed. The one failing check `smoke (ubuntu-latest, 22, false)` is pre-existing on `main` at `f30da83` — see PR discussion.)*

### Runtimes tested

- [x] Claude Code (where the workflows run)
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A

*(The keys must match regardless of runtime — this is about how workflow markdown is parsed before any runtime dispatch.)*

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [ ] Linked issue has the `confirmed-bug` label — **pending maintainer triage of #2615**
- [x] Fix is scoped to the reported bug — no unrelated changes
- [x] Regression test added
- [x] All existing tests pass (new test green; 7 pre-existing failures unrelated — see Testing)
- [ ] CHANGELOG.md updated — *not updated; user-visible only via `agent_skills` injection working as documented, no new behavior*
- [x] No unnecessary dependencies added

## Breaking changes

None. Variable names are preserved; only the slug passed to `gsd-sdk query agent-skills` changes. A user who had somehow configured `agent_skills.<wrong-slug>` to work around the bug would see that setting become inert — but the documented keys (per `docs/CONFIGURATION.md#agent-skills-injection`) continue to work as documented.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added validation test to ensure all agent skill references in workflows point to valid definitions.

* **Chores**
  * Updated agent skill configurations across multiple workflows to use specialized agent versions, improving consistency and reliability of workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->