### PR TITLE
fix(#2613): preserve STATE.md frontmatter on write path (option 2)

### DIFF
--- a/sdk/src/query/check-decision-coverage.ts
+++ b/sdk/src/query/check-decision-coverage.ts
@@ -233,7 +233,7 @@ function planSectionsMention(planSections: PlanSections[], decision: ParsedDecis
 async function loadGateConfig(projectDir: string, workstream?: string): Promise<boolean> {
   try {
     const cfg = await loadConfig(projectDir, workstream);
-    const wf = (cfg.workflow ?? {}) as Record<string, unknown>;
+    const wf = (cfg.workflow ?? {}) as unknown as Record<string, unknown>;
     const v = wf.context_coverage_gate;
     if (typeof v === 'boolean') return v;
     // Tolerate stringified booleans coming from environment-variable-style configs,

--- a/sdk/src/query/state-mutation.test.ts
+++ b/sdk/src/query/state-mutation.test.ts
@@ -448,3 +448,221 @@ describe('stateRecordSession', () => {
     expect(content).toContain('Completed 11-01-PLAN.md');
   });
 });
+
+// ─── Bug #2613: write-side frontmatter preservation ─────────────────────────
+
+describe('Bug #2613: STATE.md frontmatter preservation through mutations', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'gsd-state-2613-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('record-session preserves milestone + milestone_name when ROADMAP has a different current milestone', async () => {
+    // STATE.md declares v12.0 / Focus (shipped). ROADMAP's heading-parseable
+    // current is v11.0 / Research-Depth. Before the fix, re-derivation pulled
+    // v11.0 / Research-Depth into STATE.md's frontmatter on every mutation.
+    const stateContent = `---
+gsd_state_version: 1.0
+milestone: v12.0
+milestone_name: Focus
+status: shipped
+---
+
+# Project State
+
+## Session Continuity
+
+Last session: 2026-04-20T00:00:00Z
+Stopped at: v12.0 SHIPPED
+Resume file: None
+`;
+    const roadmapContent = `# Roadmap
+
+## Phases
+
+## v11.0 Research-Depth Scoring (In Progress)
+
+### Phase 55
+- stuff
+
+## v12.0 Focus — ✅ SHIPPED 2026-04-20
+
+### Phase 60
+- shipped stuff
+`;
+    const planningDir = join(tmpDir, '.planning');
+    await mkdir(join(planningDir, 'phases'), { recursive: true });
+    await writeFile(join(planningDir, 'STATE.md'), stateContent, 'utf-8');
+    await writeFile(join(planningDir, 'ROADMAP.md'), roadmapContent, 'utf-8');
+    await writeFile(join(planningDir, 'config.json'), '{}', 'utf-8');
+
+    const { stateRecordSession } = await import('./state-mutation.js');
+    await stateRecordSession(
+      ['--stopped-at', 'regression test', '--resume-file', '.planning/MILESTONES.md'],
+      tmpDir,
+    );
+
+    const after = await readFile(join(planningDir, 'STATE.md'), 'utf-8');
+    const { extractFrontmatter } = await import('./frontmatter.js');
+    const fm = extractFrontmatter(after);
+    expect(fm.milestone).toBe('v12.0');
+    expect(fm.milestone_name).toBe('Focus');
+  });
+
+  it('record-session preserves status from existing frontmatter when body has no Status field', async () => {
+    // STATE.md frontmatter declares status: shipped. Body has no "Status:" line.
+    // Before the fix, derived status defaulted to 'unknown' and the frontmatter
+    // value was lost because existingFm was {} at the preservation branch.
+    const stateContent = `---
+gsd_state_version: 1.0
+milestone: v12.0
+milestone_name: Focus
+status: shipped
+---
+
+# Project State
+
+## Session Continuity
+
+Last session: 2026-04-20T00:00:00Z
+Stopped at: v12.0 SHIPPED
+Resume file: None
+`;
+    const planningDir = join(tmpDir, '.planning');
+    await mkdir(join(planningDir, 'phases'), { recursive: true });
+    await writeFile(join(planningDir, 'STATE.md'), stateContent, 'utf-8');
+    await writeFile(join(planningDir, 'ROADMAP.md'), '# Roadmap\n\n## v12.0 Focus\n', 'utf-8');
+    await writeFile(join(planningDir, 'config.json'), '{}', 'utf-8');
+
+    const { stateRecordSession } = await import('./state-mutation.js');
+    await stateRecordSession(
+      ['--stopped-at', 'regression test', '--resume-file', 'None'],
+      tmpDir,
+    );
+
+    const after = await readFile(join(planningDir, 'STATE.md'), 'utf-8');
+    const { extractFrontmatter } = await import('./frontmatter.js');
+    const fm = extractFrontmatter(after);
+    expect(fm.status).toBe('shipped');
+  });
+
+  it('record-session preserves progress from frontmatter when disk scan returns zero counts', async () => {
+    // Shipped milestone: phase directories have been archived, so disk scan
+    // returns total_plans=0. Existing frontmatter has authoritative counts
+    // (5/5, 12/12, 100%). Before the fix, disk scan stomped the counts to 0/0.
+    const stateContent = `---
+gsd_state_version: 1.0
+milestone: v12.0
+milestone_name: Focus
+status: shipped
+progress:
+  total_phases: 5
+  completed_phases: 5
+  total_plans: 12
+  completed_plans: 12
+  percent: 100
+---
+
+# Project State
+
+## Session Continuity
+
+Last session: 2026-04-20T00:00:00Z
+Stopped at: v12.0 SHIPPED
+Resume file: None
+`;
+    const planningDir = join(tmpDir, '.planning');
+    await mkdir(join(planningDir, 'phases'), { recursive: true });
+    await writeFile(join(planningDir, 'STATE.md'), stateContent, 'utf-8');
+    await writeFile(join(planningDir, 'ROADMAP.md'), '# Roadmap\n\n## v12.0 Focus\n', 'utf-8');
+    await writeFile(join(planningDir, 'config.json'), '{}', 'utf-8');
+
+    const { stateRecordSession } = await import('./state-mutation.js');
+    await stateRecordSession(
+      ['--stopped-at', 'regression test', '--resume-file', 'None'],
+      tmpDir,
+    );
+
+    const after = await readFile(join(planningDir, 'STATE.md'), 'utf-8');
+    const { extractFrontmatter } = await import('./frontmatter.js');
+    const fm = extractFrontmatter(after);
+    const progress = fm.progress as Record<string, unknown>;
+    expect(Number(progress.total_plans)).toBe(12);
+    expect(Number(progress.completed_plans)).toBe(12);
+    expect(Number(progress.percent)).toBe(100);
+  });
+
+  it('regression guard: state.update Status still updates frontmatter status when body is mutated', async () => {
+    // Legitimate status change must still propagate. If the body's Status
+    // field becomes "executing", derived status is 'executing' and option 2
+    // must NOT overwrite it with the frontmatter's prior 'shipped'.
+    await setupTestProject(tmpDir);
+
+    const { stateUpdate } = await import('./state-mutation.js');
+    await stateUpdate(['Status', 'executing'], tmpDir);
+
+    const after = await readFile(join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    const { extractFrontmatter } = await import('./frontmatter.js');
+    const fm = extractFrontmatter(after);
+    expect(fm.status).toBe('executing');
+  });
+
+  it('regression guard: disk-scanned progress wins when scan returns non-zero counts', async () => {
+    // Mid-milestone: disk has real phase directories with plans + summaries.
+    // Disk is the ground truth — frontmatter progress must not override it.
+    const stateContent = `---
+gsd_state_version: 1.0
+milestone: v3.0
+milestone_name: SDK-First Migration
+status: executing
+progress:
+  total_phases: 99
+  completed_phases: 99
+  total_plans: 99
+  completed_plans: 99
+  percent: 99
+---
+
+# Project State
+
+## Current Position
+
+Status: Executing
+Last activity: today
+
+## Session Continuity
+
+Last session: 2026-04-08T05:00:00Z
+Stopped at: work
+Resume file: None
+`;
+    const planningDir = join(tmpDir, '.planning');
+    const phasesDir = join(planningDir, 'phases');
+    await mkdir(phasesDir, { recursive: true });
+    // Real phase with 1 plan and 1 summary — disk scan must report these.
+    const phase10 = join(phasesDir, '10-foo');
+    await mkdir(phase10, { recursive: true });
+    await writeFile(join(phase10, '10-01-PLAN.md'), 'plan', 'utf-8');
+    await writeFile(join(phase10, '10-01-SUMMARY.md'), 'summary', 'utf-8');
+    await writeFile(join(planningDir, 'STATE.md'), stateContent, 'utf-8');
+    await writeFile(join(planningDir, 'ROADMAP.md'), '# Roadmap\n\n### Phase 10: Foo\n', 'utf-8');
+    await writeFile(join(planningDir, 'config.json'), '{}', 'utf-8');
+
+    const { stateRecordSession } = await import('./state-mutation.js');
+    await stateRecordSession(['--stopped-at', 'x', '--resume-file', 'None'], tmpDir);
+
+    const after = await readFile(join(planningDir, 'STATE.md'), 'utf-8');
+    const { extractFrontmatter } = await import('./frontmatter.js');
+    const fm = extractFrontmatter(after);
+    const progress = fm.progress as Record<string, unknown>;
+    // Disk ground truth — not the stale 99/99 from frontmatter.
+    expect(Number(progress.total_plans)).toBe(1);
+    expect(Number(progress.completed_plans)).toBe(1);
+    expect(Number(progress.percent)).toBe(100);
+  });
+});

--- a/sdk/src/query/state.ts
+++ b/sdk/src/query/state.ts
@@ -89,6 +89,19 @@ export async function buildStateFrontmatter(bodyContent: string, projectDir: str
   const stoppedAt = stateExtractField(bodyContent, 'Stopped At') || stateExtractField(bodyContent, 'Stopped at');
   const pausedAt = stateExtractField(bodyContent, 'Paused At');
 
+  // Bug #2613: read existing STATE.md frontmatter as preservation backstop.
+  // The write path through `readModifyWriteStateMd` strips frontmatter before
+  // invoking the modifier, so callers of `buildStateFrontmatter` only see the
+  // body. Without reading frontmatter here, status defaults to 'unknown' when
+  // body has no Status field, and progress is stomped to 0/0 when the current
+  // milestone's phase directories have been archived. Matches the #2495 READ
+  // pattern: STATE.md is authoritative, re-derive only when absent.
+  let existingFm: Record<string, unknown> = {};
+  try {
+    const raw = await readFile(planningPaths(projectDir, workstream).state, 'utf-8');
+    existingFm = extractFrontmatter(raw);
+  } catch { /* STATE.md missing on first write — no preservation needed */ }
+
   let milestone: string | null = null;
   let milestoneName: string | null = null;
   try {
@@ -160,6 +173,12 @@ export async function buildStateFrontmatter(bodyContent: string, projectDir: str
     normalizedStatus = 'executing';
   }
 
+  // Bug #2613: status preservation — if body has no Status field and existing
+  // frontmatter has a non-unknown status, prefer existing.
+  if (normalizedStatus === 'unknown' && typeof existingFm.status === 'string' && existingFm.status && existingFm.status !== 'unknown') {
+    normalizedStatus = existingFm.status;
+  }
+
   const fm: Record<string, unknown> = { gsd_state_version: '1.0' };
 
   if (milestone) fm.milestone = milestone;
@@ -180,6 +199,20 @@ export async function buildStateFrontmatter(bodyContent: string, projectDir: str
   if (completedPlans !== null) progress.completed_plans = completedPlans;
   if (progressPercent !== null) progress.percent = progressPercent;
   if (Object.keys(progress).length > 0) fm.progress = progress;
+
+  // Bug #2613: progress preservation — when disk scan returns zero counts
+  // (archived/shipped milestone) and existing frontmatter has non-zero counts,
+  // prefer existing. Legitimate mid-milestone updates see non-zero disk counts
+  // and fall through, keeping disk as ground truth.
+  const existingProgress = existingFm.progress as Record<string, unknown> | undefined;
+  if (existingProgress && typeof existingProgress === 'object') {
+    const derivedTotalPlans = Number(progress.total_plans ?? 0);
+    const derivedCompletedPlans = Number(progress.completed_plans ?? 0);
+    const existingTotalPlans = Number(existingProgress.total_plans ?? 0);
+    if (derivedTotalPlans === 0 && derivedCompletedPlans === 0 && existingTotalPlans > 0) {
+      fm.progress = existingProgress;
+    }
+  }
 
   return fm;
 }


### PR DESCRIPTION
## Summary

Closes #2613

Fixes the write-side analogue of #2495. `readModifyWriteStateMd` strips STATE.md frontmatter before invoking the modifier, so `syncStateFrontmatter` received body-only content and `existingFm` was always `{}` — the preservation branch at `state-mutation.ts:243` never fired. Every mutation re-derived `status` (to `'unknown'` when body had no `Status:` line) and `progress.*` (to 0/0 when the shipped milestone's phase directories were archived), silently overwriting authoritative frontmatter values.

## Fix (option 2 per escalation discussion on the issue)

Write-side analogue of #2495's READ fix: `buildStateFrontmatter` now reads the current STATE.md frontmatter from disk as a preservation backstop.

- **Status:** preserved when derived is `'unknown'` and existing is non-unknown.
- **Progress:** preserved when disk scan returns all zeros AND existing has non-zero counts.
- **Milestone / milestone_name:** already preserved via `getMilestoneInfo`'s #2495 fix — regression test added to lock it in.

Legitimate body-driven status changes (`state.update Status executing`) still win, and non-zero disk counts still win over stale frontmatter counts (mid-milestone mutations keep ground-truth progress).

## Root cause

\`\`\`ts
// state-mutation.ts:260–286 (before fix)
const body = stripFrontmatter(content);         // frontmatter gone
const modified = await modifier(body);
const synced = await syncStateFrontmatter(modified, projectDir);
//                                        ^ body-only content
// → inside syncStateFrontmatter:
const existingFm = extractFrontmatter(content); // always {} — nothing to preserve
\`\`\`

## Tests

5 new regression tests in `sdk/src/query/state-mutation.test.ts`:

1. `record-session preserves milestone + milestone_name when ROADMAP has a different current milestone` — locks in the #2495 behavior.
2. `record-session preserves status from existing frontmatter when body has no Status field` — direct repro of the reporter's `status: shipped → executing` regression.
3. `record-session preserves progress from frontmatter when disk scan returns zero counts` — direct repro of the reporter's `progress: 12/12 100% → 0/0 0%` regression.
4. `regression guard: state.update Status still updates frontmatter status when body is mutated` — ensures legitimate status transitions still propagate.
5. `regression guard: disk-scanned progress wins when scan returns non-zero counts` — ensures mid-milestone mutations keep disk as ground truth.

## Verification

- Full `sdk/src/query/` suite: **636 pass / 6 fail** (same 6 pre-existing `bug-2420` flag-parsing failures unrelated to this change; branch is behind main).
- Before this change (on same stashed base): **631 pass / 6 fail**.
- Net: +5 new passing tests, 0 new failures.

## Test plan
- [x] RED — 3 new tests fail for the right reason (status=unknown, progress=0, milestone preserved via #2495)
- [x] GREEN — all 5 tests pass after fix
- [x] No regressions on the rest of `sdk/src/query/` (identical failure count)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserve existing milestone and milestone_name when derived milestone differs.
  * Keep frontmatter status when body yields unknown or omits Status.
  * Retain existing progress counts when disk scan returns zero totals; allow scan to override when non-zero.

* **Tests**
  * Added regression and guard tests validating state mutation and progress/status preservation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->