### PR TITLE
fix(#2619): prevent extractCurrentMilestone from truncating on phase-vX.Y headings

### DIFF
--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -1309,8 +1309,11 @@ function extractCurrentMilestone(content, cwd) {
   // Milestone headings look like: ## v2.0, ## Roadmap v2.0, ## ✅ v1.0, etc.
   const headingLevel = sectionMatch[1].match(/^(#{1,3})\s/)[1].length;
   const restContent = content.slice(sectionStart + sectionMatch[0].length);
+  // Exclude phase headings (e.g. "### Phase 12: v1.0 Tech-Debt Closure") from
+  // being treated as milestone boundaries just because they mention vX.Y in
+  // the title. Phase headings always start with the literal `Phase `. See #2619.
   const nextMilestonePattern = new RegExp(
-    `^#{1,${headingLevel}}\\s+(?:.*v\\d+\\.\\d+|✅|📋|🚧)`,
+    `^#{1,${headingLevel}}\\s+(?!Phase\\s+\\S)(?:.*v\\d+\\.\\d+|✅|📋|🚧)`,
     'mi'
   );
   const nextMatch = restContent.match(nextMilestonePattern);

--- a/sdk/src/query/roadmap.test.ts
+++ b/sdk/src/query/roadmap.test.ts
@@ -358,6 +358,37 @@ describe('extractCurrentMilestone', () => {
     expect(result).toContain('### Phase 19: Security Audit');
   });
 
+  // ─── Bug #2619 (CodeRabbit follow-up): case-insensitive Phase lookahead ───
+  it('bug-2619: does not truncate at PHASE/phase heading containing vX.Y (case-insensitive)', async () => {
+    // The negative lookahead `(?!Phase\s+\S)` must be case-insensitive so that
+    // headings like "### PHASE 12: v1.0 Tech-Debt" or "### phase 12: v1.0 …"
+    // are also excluded from milestone-boundary matching.
+    const roadmapMixedCase = `# ROADMAP
+
+## Phases
+
+### 🚧 v1.1 Launch-Ready (In Progress)
+
+### PHASE 11: Structured Logging
+**Goal**: Add structured logging
+
+### phase 12: v1.0 Tech-Debt Closure
+**Goal**: Close out v1.0 debt
+
+### Phase 19: Security Audit
+**Goal**: Full security audit
+`;
+    const state = `---\nmilestone: v1.1\n---\n# State\n`;
+    await writeFile(join(tmpDir, '.planning', 'STATE.md'), state);
+    await writeFile(join(tmpDir, '.planning', 'ROADMAP.md'), roadmapMixedCase);
+
+    const result = await extractCurrentMilestone(roadmapMixedCase, tmpDir);
+
+    expect(result).toContain('### PHASE 11: Structured Logging');
+    expect(result).toContain('### phase 12: v1.0 Tech-Debt Closure');
+    expect(result).toContain('### Phase 19: Security Audit');
+  });
+
   // ─── Bug #2422: same-version sub-heading truncation ───────────────────
   it('bug-2422: does not truncate at same-version sub-heading (## v2.0 Phase Details)', async () => {
     const roadmapWithDetails = `# ROADMAP

--- a/sdk/src/query/roadmap.test.ts
+++ b/sdk/src/query/roadmap.test.ts
@@ -326,6 +326,38 @@ describe('extractCurrentMilestone', () => {
     expect(result).toContain('Phase 100');
   });
 
+  // ─── Bug #2619: phase heading containing vX.Y triggers truncation ─────
+  it('bug-2619: does not truncate at a phase heading containing vX.Y', async () => {
+    // A phase title like "Phase 12: v1.0 Tech-Debt Closure" was being treated
+    // as a milestone boundary because the greedy `.*v(\d+(?:\.\d+)+)` branch
+    // in nextMilestoneRegex matched any heading with a version literal.
+    const roadmapWithPhaseVersion = `# ROADMAP
+
+## Phases
+
+### 🚧 v1.1 Launch-Ready (In Progress)
+
+### Phase 11: Structured Logging
+**Goal**: Add structured logging
+
+### Phase 12: v1.0 Tech-Debt Closure
+**Goal**: Close out v1.0 debt
+
+### Phase 19: Security Audit
+**Goal**: Full security audit
+`;
+    const state = `---\nmilestone: v1.1\n---\n# State\n`;
+    await writeFile(join(tmpDir, '.planning', 'STATE.md'), state);
+    await writeFile(join(tmpDir, '.planning', 'ROADMAP.md'), roadmapWithPhaseVersion);
+
+    const result = await extractCurrentMilestone(roadmapWithPhaseVersion, tmpDir);
+
+    // Phase 12 and Phase 19 must both survive — the slice cannot be truncated
+    // at "### Phase 12: v1.0 Tech-Debt Closure".
+    expect(result).toContain('### Phase 12: v1.0 Tech-Debt Closure');
+    expect(result).toContain('### Phase 19: Security Audit');
+  });
+
   // ─── Bug #2422: same-version sub-heading truncation ───────────────────
   it('bug-2422: does not truncate at same-version sub-heading (## v2.0 Phase Details)', async () => {
     const roadmapWithDetails = `# ROADMAP

--- a/sdk/src/query/roadmap.ts
+++ b/sdk/src/query/roadmap.ts
@@ -195,8 +195,11 @@ export async function extractCurrentMilestone(content: string, projectDir: strin
   const currentVersionMatch = version ? version.match(/v(\d+(?:\.\d+)+)/i) : null;
   const currentVersionStr = currentVersionMatch ? currentVersionMatch[1] : '';
 
+  // Exclude phase headings (e.g. "### Phase 12: v1.0 Tech-Debt Closure") from
+  // being treated as milestone boundaries just because they mention vX.Y in
+  // the title. Phase headings always start with the literal `Phase `. See #2619.
   const nextMilestoneRegex = new RegExp(
-    `^#{1,${headingLevel}}\\s+(?:.*v(\\d+(?:\\.\\d+)+)[^\\n]*|.*(?:✅|📋|🚧|🟡))`,
+    `^#{1,${headingLevel}}\\s+(?!Phase\\s+\\S)(?:.*v(\\d+(?:\\.\\d+)+)[^\\n]*|.*(?:✅|📋|🚧|🟡))`,
     'gm'
   );
 
@@ -303,7 +306,8 @@ export async function extractNextMilestoneSection(
 
   // Look for the next ## milestone heading after the current one.
   const tail = cleaned.slice(currentMatch.index + currentMatch[0].length);
-  const nextMilestonePattern = /^##\s+([^\n]*(?:v(\d+(?:\.\d+)+)|✅|🚧|🟡|📋)[^\n]*)$/gim;
+  // Exclude phase headings — see #2619.
+  const nextMilestonePattern = /^##\s+(?!Phase\s+\S)([^\n]*(?:v(\d+(?:\.\d+)+)|✅|🚧|🟡|📋)[^\n]*)$/gim;
   let nextMatch: RegExpExecArray | null;
   while ((nextMatch = nextMilestonePattern.exec(tail)) !== null) {
     const heading = nextMatch[1];

--- a/sdk/src/query/roadmap.ts
+++ b/sdk/src/query/roadmap.ts
@@ -200,7 +200,9 @@ export async function extractCurrentMilestone(content: string, projectDir: strin
   // the title. Phase headings always start with the literal `Phase `. See #2619.
   const nextMilestoneRegex = new RegExp(
     `^#{1,${headingLevel}}\\s+(?!Phase\\s+\\S)(?:.*v(\\d+(?:\\.\\d+)+)[^\\n]*|.*(?:✅|📋|🚧|🟡))`,
-    'gm'
+    // `i` flag ensures the `(?!Phase\s+\S)` lookahead matches PHASE/phase too
+    // (CodeRabbit follow-up on #2619).
+    'gmi'
   );
 
   let sectionEnd = content.length;

--- a/tests/roadmap-phase-fallback.test.cjs
+++ b/tests/roadmap-phase-fallback.test.cjs
@@ -207,6 +207,38 @@ describe('roadmap get-phase fallback to full ROADMAP.md (#1634)', () => {
     assert.equal(output.goal, 'Remove deprecated modules');
   });
 
+  test('extractCurrentMilestone does not truncate on phase heading containing vX.Y (#2619)', () => {
+    // Regression: phase heading like "### Phase 12: v1.0 Tech-Debt Closure"
+    // was incorrectly treated as a milestone boundary because the greedy
+    // `.*v\d+\.\d+` subpattern in nextMilestonePattern matched it.
+    const core = require('../get-shit-done/bin/lib/core.cjs');
+    writeState(tmpDir, 'v1.1');
+    const roadmap = `# Roadmap
+
+## Phases
+
+### 🚧 v1.1 Launch-Ready (In Progress)
+
+### Phase 11: Structured Logging
+**Goal:** Add structured logging
+
+### Phase 12: v1.0 Tech-Debt Closure
+**Goal:** Close out v1.0 debt
+
+### Phase 19: Security Audit
+**Goal:** Full security audit
+`;
+    const slice = core.extractCurrentMilestone(roadmap, tmpDir);
+    assert.ok(
+      slice.includes('### Phase 12: v1.0 Tech-Debt Closure'),
+      'slice must include Phase 12 (it lives inside the active milestone)'
+    );
+    assert.ok(
+      slice.includes('### Phase 19: Security Audit'),
+      'slice must include Phase 19 (truncation at Phase 12 would hide it)'
+    );
+  });
+
   test('section extraction from fallback includes correct content boundaries', () => {
     writeState(tmpDir, 'v1.0');
     fs.writeFileSync(

--- a/tests/roadmap-phase-fallback.test.cjs
+++ b/tests/roadmap-phase-fallback.test.cjs
@@ -239,6 +239,41 @@ describe('roadmap get-phase fallback to full ROADMAP.md (#1634)', () => {
     );
   });
 
+  test('extractCurrentMilestone handles PHASE/phase (case-insensitive) containing vX.Y (#2619 follow-up)', () => {
+    // CodeRabbit follow-up: the negative lookahead `(?!Phase\s+\S)` must be
+    // case-insensitive so PHASE/phase variants are also excluded.
+    const core = require('../get-shit-done/bin/lib/core.cjs');
+    writeState(tmpDir, 'v1.1');
+    const roadmap = `# Roadmap
+
+## Phases
+
+### 🚧 v1.1 Launch-Ready (In Progress)
+
+### PHASE 11: Structured Logging
+**Goal:** Add structured logging
+
+### phase 12: v1.0 Tech-Debt Closure
+**Goal:** Close out v1.0 debt
+
+### Phase 19: Security Audit
+**Goal:** Full security audit
+`;
+    const slice = core.extractCurrentMilestone(roadmap, tmpDir);
+    assert.ok(
+      slice.includes('### PHASE 11: Structured Logging'),
+      'slice must include PHASE 11 (uppercase)'
+    );
+    assert.ok(
+      slice.includes('### phase 12: v1.0 Tech-Debt Closure'),
+      'slice must include phase 12 (lowercase with vX.Y)'
+    );
+    assert.ok(
+      slice.includes('### Phase 19: Security Audit'),
+      'slice must include Phase 19 (truncation at phase 12 would hide it)'
+    );
+  });
+
   test('section extraction from fallback includes correct content boundaries', () => {
     writeState(tmpDir, 'v1.0');
     fs.writeFileSync(


### PR DESCRIPTION
## Summary

Fixes #2619. `extractCurrentMilestone()` used a greedy regex to detect the next milestone heading:

```js
^#{1,N}\s+(?:.*v\d+\.\d+|✅|📋|🚧)
```

The `.*v\d+\.\d+` branch matched **any** heading containing a version literal — including phase headings like `### Phase 12: v1.0 Tech-Debt Closure`. When the current milestone was at the same level as phases (e.g. `### 🚧 v1.1 Launch-Ready`), the slice terminated at the first such phase, hiding every phase that followed. That broke `phase.insert`, `validate.health` (spammed W007 for every phase after the truncation point), and any other SDK command that reads ROADMAP via the current-milestone slice.

## Root cause

Greedy `.*v\d+\.\d+` with no exclusion for phase-style headings. Phase titles legitimately reference prior versions (e.g. "v1.0 Tech-Debt Closure" in a v1.1 milestone).

## Fix

Add a `(?!Phase\s+\S)` negative lookahead to exclude phase headings from milestone-boundary detection. Phase headings always start with the literal `Phase `, so this is a clean, minimal exclusion that preserves every other boundary-detection path.

Applied to:
- `get-shit-done/bin/lib/core.cjs` — `extractCurrentMilestone`
- `sdk/src/query/roadmap.ts` — `extractCurrentMilestone` **and** `extractNextMilestoneSection` (same vulnerability in sibling regex)

## Test plan

- [x] New regression test: `tests/roadmap-phase-fallback.test.cjs` → `extractCurrentMilestone does not truncate on phase heading containing vX.Y (#2619)` — fails without fix, passes with fix.
- [x] New regression test: `sdk/src/query/roadmap.test.ts` → `extractCurrentMilestone bug-2619: does not truncate at a phase heading containing vX.Y` — fails without fix, passes with fix.
- [x] Full CJS suite: `node scripts/run-tests.cjs` — 5411/5411 pass.
- [x] `sdk/src/query/roadmap.test.ts` — 35/35 pass.
- [x] `sdk && npm run build` (tsc) — clean.
- [x] `sdk && npx vitest run src/query/` — 683 pass, 7 fail. All 7 failures are **pre-existing on main** and unrelated to this change (configNewProject defaults, agentSkills, QueryRegistry dispatch, stateBeginPhase flag parsing).

Closes #2619

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Phase headings that include semantic version text (e.g., "Phase 12: v1.0") are no longer treated as milestone boundaries, preventing premature truncation of roadmap sections.

* **Tests**
  * Added regression tests to ensure phase headings with embedded version numbers (case-insensitive) are preserved during roadmap parsing and milestone extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->