### PR TITLE
ci: explicit rebase check + fail-fast SDK typecheck in install-smoke

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -102,7 +102,7 @@ jobs:
           set -euo pipefail
           git config user.email "ci@gsd-build"
           git config user.name "CI Rebase Check"
-          git fetch origin main --depth=0 || git fetch origin main
+          git fetch origin main
           if ! git merge --no-edit --no-ff origin/main; then
             echo "::error::This PR cannot cleanly merge origin/main. Rebase your branch onto current main and push again."
             echo "::error::Conflicting files:"
@@ -216,6 +216,26 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ inputs.ref || github.ref }}
+          fetch-depth: 0
+
+      # See the `smoke` job above for rationale — refs/pull/N/merge is cached
+      # against the recorded merge-base, not current main. Explicitly merge
+      # origin/main so smoke-unpacked also runs against the latest trunk.
+      - name: Rebase check — merge origin/main into PR head
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.email "ci@gsd-build"
+          git config user.name "CI Rebase Check"
+          git fetch origin main
+          if ! git merge --no-edit --no-ff origin/main; then
+            echo "::error::This PR cannot cleanly merge origin/main. Rebase your branch onto current main and push again."
+            echo "::error::Conflicting files:"
+            git diff --name-only --diff-filter=U
+            git merge --abort
+            exit 1
+          fi
 
       - name: Set up Node.js 22
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0

--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -85,6 +85,31 @@ jobs:
         if: steps.skip.outputs.skip != 'true'
         with:
           ref: ${{ inputs.ref || github.ref }}
+          # Need enough history to merge origin/main for stale-base detection.
+          fetch-depth: 0
+
+      # The default `refs/pull/N/merge` ref GitHub produces for PRs is cached
+      # against the recorded merge-base, not current main. When main advances
+      # after the PR was opened, the merge ref stays stale and CI can fail on
+      # issues that were already fixed upstream. Explicitly merge current
+      # origin/main into the PR head so smoke always tests the PR against the
+      # latest trunk. If the merge conflicts, emit a clear "rebase onto main"
+      # diagnostic instead of a downstream build error that looks unrelated.
+      - name: Rebase check — merge origin/main into PR head
+        if: steps.skip.outputs.skip != 'true' && github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.email "ci@gsd-build"
+          git config user.name "CI Rebase Check"
+          git fetch origin main --depth=0 || git fetch origin main
+          if ! git merge --no-edit --no-ff origin/main; then
+            echo "::error::This PR cannot cleanly merge origin/main. Rebase your branch onto current main and push again."
+            echo "::error::Conflicting files:"
+            git diff --name-only --diff-filter=U
+            git merge --abort
+            exit 1
+          fi
 
       - name: Set up Node.js ${{ matrix.node-version }}
         if: steps.skip.outputs.skip != 'true'
@@ -97,9 +122,22 @@ jobs:
         if: steps.skip.outputs.skip != 'true'
         run: npm ci
 
-      - name: Build SDK dist (required in tarball — sdk/dist is gitignored)
+      # Isolated SDK typecheck — if the build fails, emit a clear "stale base
+      # or real type error" diagnostic instead of letting the failure cascade
+      # into the tarball install step, where the downstream PATH assertion
+      # misreports it as "gsd-sdk not on PATH — installSdkIfNeeded regression".
+      - name: SDK typecheck (fails fast on type regressions)
         if: steps.skip.outputs.skip != 'true'
-        run: npm run build:sdk
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! npm run build:sdk; then
+            echo "::error::SDK build (npm run build:sdk) failed."
+            echo "::error::Common cause: your PR base is behind main and picks up intermediate type errors that are already fixed on trunk."
+            echo "::error::Fix: git fetch origin main && git rebase origin/main && git push --force-with-lease"
+            echo "::error::If the error persists on a fresh rebase, the type error is real — fix it in sdk/src/ and push."
+            exit 1
+          fi
 
       - name: Pack root tarball
         if: steps.skip.outputs.skip != 'true'
@@ -132,9 +170,14 @@ jobs:
           cd "$TMPDIR_ROOT"
           npm install -g "$WORKSPACE/$TARBALL"
           command -v get-shit-done-cc
-          # `--claude --local` is the non-interactive code path.
-          # Tolerate non-zero: the authoritative assertion is the next step.
-          get-shit-done-cc --claude --local || true
+          # `--claude --local` is the non-interactive code path. Don't swallow
+          # non-zero exit — if the installer fails, that IS the CI failure, and
+          # its own error message is more useful than the downstream "shim
+          # regression" assertion masking the real cause.
+          if ! get-shit-done-cc --claude --local; then
+            echo "::error::get-shit-done-cc --claude --local failed. See the install.js output above for the real error (SDK build, PATH resolution, chmod, etc.)."
+            exit 1
+          fi
 
       - name: Assert gsd-sdk resolves on PATH
         if: steps.skip.outputs.skip != 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,31 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          # Fetch full history so we can merge origin/main for stale-base detection.
+          fetch-depth: 0
+
+      # GitHub's `refs/pull/N/merge` is cached against the recorded merge-base.
+      # When main advances after a PR is opened, the cache stays stale and CI
+      # runs against the pre-advance state — hiding bugs that are already fixed
+      # on trunk and surfacing type errors that were introduced and then patched
+      # on main in between. Explicitly merge current origin/main here so tests
+      # always run against the latest trunk.
+      - name: Rebase check — merge origin/main into PR head
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.email "ci@gsd-build"
+          git config user.name "CI Rebase Check"
+          git fetch origin main --depth=0 || git fetch origin main
+          if ! git merge --no-edit --no-ff origin/main; then
+            echo "::error::This PR cannot cleanly merge origin/main. Rebase your branch onto current main and push again."
+            echo "::error::Conflicting files:"
+            git diff --name-only --diff-filter=U
+            git merge --abort
+            exit 1
+          fi
 
       - name: Set up Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
           set -euo pipefail
           git config user.email "ci@gsd-build"
           git config user.name "CI Rebase Check"
-          git fetch origin main --depth=0 || git fetch origin main
+          git fetch origin main
           if ! git merge --no-edit --no-ff origin/main; then
             echo "::error::This PR cannot cleanly merge origin/main. Rebase your branch onto current main and push again."
             echo "::error::Conflicting files:"


### PR DESCRIPTION
Closes #2632

## Summary

Harden CI against the stale-merge-ref failure mode that caused PR #2616's smoke CI to report "installSdkIfNeeded() regression" when the real cause was a TypeScript error that was already fixed on main.

## Root cause

GitHub's `refs/pull/N/merge` is cached against the PR's recorded merge-base, not current main. When main advances after a PR is opened, the merge ref stays stale — CI runs against the pre-advance tree. This hides fixes that have already landed on trunk and replays intermediate broken states in stale PRs.

Observed in the wild today: #2611 introduced a `WorkflowConfig` → `Record<string, unknown>` cast that trips `strict` mode. #2622 patched it with a double-cast shortly after. Every PR opened between those two commits (and not rebased since) runs its smoke CI against the broken intermediate state and fails with a misleading "gsd-sdk not on PATH — installSdkIfNeeded regression" message. PR #2616 hit this for hours.

## Changes

**`.github/workflows/install-smoke.yml`:**
- Explicit `git merge origin/main` step with a clear "rebase onto main" diagnostic on conflict. Catches stale bases before any build runs.
- Dedicated SDK-typecheck step (`npm run build:sdk`) that fails fast with actionable guidance: "rebase onto main — the error may already be fixed on trunk." Replaces the silent build-then-blame-the-assertion flow.
- Dropped `|| true` on `get-shit-done-cc --claude --local` so installer failures surface at the install step (where install.js's own error is visible), not at the downstream PATH assertion where the message misleadingly reads "shim regression."
- `fetch-depth: 0` on checkout so the merge-base check has history.

**`.github/workflows/test.yml`:**
- Same rebase-check step — test suite runs on every PR (no path filter), so catching staleness here surfaces the issue even before smoke triggers.

## Why this matters long-term

Any time a type or contract regression lands on main and is patched within hours, every PR opened before the patch will fail CI with a cryptic error until it rebases. The new rebase-check gives contributors a clear message instead of sending them hunting through install.js internals.

## Test plan

- [x] YAML parses cleanly (`python3 -c "import yaml; yaml.safe_load(open(...))"`)
- [ ] CI passes on this PR itself
- [ ] Re-trigger on a known stale PR to confirm the new error message is visible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal CI/CD workflows to validate code changes against the latest main branch before testing and installation, with improved error diagnostics for merge conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->