### PR TITLE
fix(sdk): surface current milestone wrapped in <details>/<summary> (#2641)

### DIFF
--- a/sdk/src/query/init.test.ts
+++ b/sdk/src/query/init.test.ts
@@ -447,6 +447,68 @@ describe('initMilestoneOp', () => {
     expect(data.completed_phases).toBeGreaterThanOrEqual(0);
     expect(data.project_root).toBe(tmpDir);
   });
+
+  // Bug #2641: phase_count/completed_phases must scope to the CURRENT
+  // milestone, not every phase directory ever shipped. STATE.md's
+  // progress.{total_phases, completed_phases} is authoritative.
+  it('scopes phase_count/completed_phases to current milestone via STATE.md', async () => {
+    const { writeFile, mkdir } = await import('node:fs/promises');
+    const { join } = await import('node:path');
+
+    // Simulate 5 archived phase directories from prior milestones (each
+    // with a -SUMMARY.md, which the legacy code counted toward completion).
+    for (let i = 1; i <= 5; i++) {
+      const dir = join(tmpDir, '.planning', 'phases', `${String(i).padStart(2, '0')}-old-phase-${i}`);
+      await mkdir(dir, { recursive: true });
+      await writeFile(join(dir, `${String(i).padStart(2, '0')}-PLAN.md`), '');
+      await writeFile(join(dir, `${String(i).padStart(2, '0')}-SUMMARY.md`), '');
+    }
+
+    // STATE.md says we are on a fresh milestone with 4 phases and 1 done.
+    await writeFile(
+      join(tmpDir, '.planning', 'STATE.md'),
+      [
+        '---',
+        'milestone: v2.0',
+        'milestone_name: Current Milestone',
+        'progress:',
+        '  total_phases: 4',
+        '  completed_phases: 1',
+        '---',
+      ].join('\n'),
+    );
+
+    const result = await initMilestoneOp([], tmpDir);
+    const data = result.data as Record<string, unknown>;
+    expect(data.phase_count).toBe(4);
+    expect(data.completed_phases).toBe(1);
+    expect(data.all_phases_complete).toBe(false);
+  });
+
+  it('falls back to disk scan when STATE.md has no progress block', async () => {
+    const { writeFile, mkdir, rm } = await import('node:fs/promises');
+    const { join } = await import('node:path');
+
+    // Reset the phases/ directory so we own the entire fixture.
+    await rm(join(tmpDir, '.planning', 'phases'), { recursive: true, force: true });
+    for (let i = 1; i <= 3; i++) {
+      const dir = join(tmpDir, '.planning', 'phases', `${String(i).padStart(2, '0')}-legacy-${i}`);
+      await mkdir(dir, { recursive: true });
+      await writeFile(join(dir, `${String(i).padStart(2, '0')}-PLAN.md`), '');
+      if (i < 3) await writeFile(join(dir, `${String(i).padStart(2, '0')}-SUMMARY.md`), '');
+    }
+    // STATE.md without a progress block — legacy behaviour applies.
+    await writeFile(
+      join(tmpDir, '.planning', 'STATE.md'),
+      '---\nmilestone: v1.0\n---\n',
+    );
+
+    const result = await initMilestoneOp([], tmpDir);
+    const data = result.data as Record<string, unknown>;
+    expect(data.phase_count).toBe(3);
+    expect(data.completed_phases).toBe(2);
+    expect(data.all_phases_complete).toBe(false);
+  });
 });
 
 describe('initMapCodebase', () => {

--- a/sdk/src/query/init.ts
+++ b/sdk/src/query/init.ts
@@ -777,22 +777,42 @@ export const initMilestoneOp: QueryHandler = async (_args, projectDir) => {
   const milestone = await getMilestoneInfo(projectDir);
 
   const phasesDir = join(planningDir, 'phases');
+  // Scope phase counts to the CURRENT milestone. The previous implementation
+  // counted every phase directory on disk — including archived milestones —
+  // which produced misleading "N/N complete, all_phases_complete=true"
+  // readings the moment a new milestone started (issue #2641). Priority:
+  //   1. STATE.md `progress.{total_phases, completed_phases}` (authoritative —
+  //      updated per-phase by the workflow itself).
+  //   2. Fall back to the legacy disk scan when STATE.md has no progress block.
   let phaseCount = 0;
   let completedPhases = 0;
-
+  let progressSourceFromState = false;
   try {
-    const entries = readdirSync(phasesDir, { withFileTypes: true });
-    const dirs = entries.filter(e => e.isDirectory()).map(e => e.name);
-    phaseCount = dirs.length;
-
-    for (const dir of dirs) {
-      try {
-        const phaseFiles = readdirSync(join(phasesDir, dir));
-        const hasSummary = phaseFiles.some(f => f.endsWith('-SUMMARY.md') || f === 'SUMMARY.md');
-        if (hasSummary) completedPhases++;
-      } catch { /* intentionally empty */ }
+    const stateRaw = readFileSync(join(planningDir, 'STATE.md'), 'utf-8');
+    const totalMatch = stateRaw.match(/^\s*total_phases:\s*(\d+)/m);
+    const doneMatch = stateRaw.match(/^\s*completed_phases:\s*(\d+)/m);
+    if (totalMatch && doneMatch) {
+      phaseCount = parseInt(totalMatch[1], 10);
+      completedPhases = parseInt(doneMatch[1], 10);
+      progressSourceFromState = true;
     }
-  } catch { /* intentionally empty */ }
+  } catch { /* STATE.md optional */ }
+
+  if (!progressSourceFromState) {
+    try {
+      const entries = readdirSync(phasesDir, { withFileTypes: true });
+      const dirs = entries.filter(e => e.isDirectory()).map(e => e.name);
+      phaseCount = dirs.length;
+
+      for (const dir of dirs) {
+        try {
+          const phaseFiles = readdirSync(join(phasesDir, dir));
+          const hasSummary = phaseFiles.some(f => f.endsWith('-SUMMARY.md') || f === 'SUMMARY.md');
+          if (hasSummary) completedPhases++;
+        } catch { /* intentionally empty */ }
+      }
+    } catch { /* intentionally empty */ }
+  }
 
   const archiveDir = join(projectDir, '.planning', 'archive');
   let archivedMilestones: string[] = [];

--- a/sdk/src/query/roadmap.test.ts
+++ b/sdk/src/query/roadmap.test.ts
@@ -159,6 +159,57 @@ describe('stripShippedMilestones', () => {
     expect(stripped).toContain('v2.0');
     expect(stripped).toContain('Current');
   });
+
+  // Bug #2641: current-milestone <details> block with "IN PROGRESS"
+  // summary must NOT be stripped (common GitHub collapse layout for
+  // long-running ROADMAPs that accumulate many shipped milestones).
+  it('preserves <details> block when <summary> says IN PROGRESS', () => {
+    const content = [
+      '<details>',
+      '<summary>v1.0 Old (Phases 1-2) — SHIPPED 2026-01-01</summary>',
+      'shipped stuff',
+      '</details>',
+      '',
+      '<details>',
+      '<summary>v2.0 Current (Phases 3-4) -- IN PROGRESS 2026-04-23</summary>',
+      '',
+      '### Phase 3: Work',
+      '',
+      '</details>',
+    ].join('\n');
+    const stripped = stripShippedMilestones(content);
+    expect(stripped).not.toContain('v1.0 Old');
+    expect(stripped).not.toContain('shipped stuff');
+    expect(stripped).toContain('v2.0 Current');
+    expect(stripped).toContain('### Phase 3: Work');
+  });
+
+  it('strips <details> block when <summary> contains SHIPPED marker', () => {
+    const content = [
+      '<details>',
+      '<summary>v1.0 Old — SHIPPED 2026-01-01</summary>',
+      'shipped phase list',
+      '</details>',
+      'after',
+    ].join('\n');
+    expect(stripShippedMilestones(content)).toBe('\nafter');
+  });
+
+  it('strips <details> block when <summary> uses ✅ marker', () => {
+    const content = [
+      '<details>',
+      '<summary>✅ v1.0 Old — SHIPPED 2026-01-01</summary>',
+      'shipped phase list',
+      '</details>',
+    ].join('\n');
+    expect(stripShippedMilestones(content).trim()).toBe('');
+  });
+
+  it('strips <details> block when <summary> is missing (back-compat)', () => {
+    // Legacy ROADMAPs without a <summary> are still treated as shipped.
+    const content = '<details>legacy content</details>after';
+    expect(stripShippedMilestones(content)).toBe('after');
+  });
 });
 
 // ─── getMilestoneInfo ─────────────────────────────────────────────────────
@@ -537,6 +588,111 @@ describe('roadmapAnalyze', () => {
     const data2 = result2.data as Record<string, unknown>;
 
     expect((data1.phases as unknown[]).length).toBe((data2.phases as unknown[]).length);
+  });
+
+  // Bug #2641: surfaces the current milestone's phases when the milestone
+  // block is wrapped in <details>/<summary> (common GitHub layout).
+  it('surfaces current-milestone phases wrapped in <details>/<summary>', async () => {
+    const roadmap = [
+      '# Roadmap',
+      '',
+      '<details>',
+      '<summary>v1.0 Old (Phases 1-2) — SHIPPED 2026-01-01</summary>',
+      '',
+      '- [x] **Phase 1: Foundation** (shipped)',
+      '- [x] **Phase 2: Polish** (shipped)',
+      '',
+      '</details>',
+      '',
+      '<details>',
+      '<summary>v2.0 Current (Phases 3-4) -- IN PROGRESS 2026-04-23</summary>',
+      '',
+      '- [ ] Phase 3: New Feature',
+      '- [ ] Phase 4: Harden',
+      '',
+      '### Phase 3: New Feature',
+      '**Goal:** Ship the new feature end to end.',
+      '',
+      '### Phase 4: Harden',
+      '**Goal:** Close gaps.',
+      '',
+      '</details>',
+    ].join('\n');
+    await writeFile(join(tmpDir, '.planning', 'ROADMAP.md'), roadmap);
+    await writeFile(
+      join(tmpDir, '.planning', 'STATE.md'),
+      '---\nmilestone: v2.0\nmilestone_name: Current\n---\n',
+    );
+
+    const result = await roadmapAnalyze([], tmpDir);
+    const phases = (result.data as Record<string, unknown>).phases as Array<Record<string, unknown>>;
+    const numbers = phases.map(p => p.number).sort();
+    expect(numbers).toContain('3');
+    expect(numbers).toContain('4');
+    const p3 = phases.find(p => p.number === '3');
+    const p4 = phases.find(p => p.number === '4');
+    expect(p3!.roadmap_complete).toBe(false);
+    expect(p4!.roadmap_complete).toBe(false);
+  });
+
+  // Bug #2641: appendix "### Phase N" headings from archived milestones
+  // must be marked `roadmap_complete=true` via their `[x]` in the raw
+  // ROADMAP, not falsely `false` via a stale "- [ ] TBD (run …)"
+  // placeholder under the appendix heading's Plans subsection.
+  it('honours archived-milestone [x] in raw ROADMAP over appendix [ ] TBD placeholders', async () => {
+    const roadmap = [
+      '# Roadmap',
+      '',
+      '<details>',
+      '<summary>v1.0 Old (Phases 1-2) — SHIPPED 2026-01-01</summary>',
+      '',
+      '- [x] **Phase 1: Foundation** (shipped)',
+      '- [x] **Phase 2: Polish** (shipped)',
+      '',
+      '</details>',
+      '',
+      '<details>',
+      '<summary>v2.0 Current -- IN PROGRESS</summary>',
+      '',
+      '- [ ] Phase 3: Work',
+      '',
+      '### Phase 3: Work',
+      '**Goal:** do the thing.',
+      '',
+      '</details>',
+      '',
+      '## v1.0 Phase Details (appendix — kept for cross-reference)',
+      '',
+      '### Phase 1: Foundation',
+      '**Goal:** Original v1.0 foundation.',
+      '',
+      'Plans:',
+      '- [ ] TBD (run /gsd-plan-phase 1 to break down)',
+      '',
+      '### Phase 2: Polish',
+      '**Goal:** Original v1.0 polish.',
+      '',
+      'Plans:',
+      '- [ ] TBD (run /gsd-plan-phase 2 to break down)',
+    ].join('\n');
+    await writeFile(join(tmpDir, '.planning', 'ROADMAP.md'), roadmap);
+    await writeFile(
+      join(tmpDir, '.planning', 'STATE.md'),
+      '---\nmilestone: v2.0\nmilestone_name: Current\n---\n',
+    );
+
+    const result = await roadmapAnalyze([], tmpDir);
+    const phases = (result.data as Record<string, unknown>).phases as Array<Record<string, unknown>>;
+    const p1 = phases.find(p => p.number === '1');
+    const p2 = phases.find(p => p.number === '2');
+    const p3 = phases.find(p => p.number === '3');
+    // Archived-milestone phases surface (via appendix heading) but are
+    // flagged complete from their [x] in the archived <details> block —
+    // NOT false-incomplete from the "- [ ] TBD" appendix placeholder.
+    expect(p1!.roadmap_complete).toBe(true);
+    expect(p2!.roadmap_complete).toBe(true);
+    // Current-milestone phase is correctly incomplete.
+    expect(p3!.roadmap_complete).toBe(false);
   });
 });
 

--- a/sdk/src/query/roadmap.ts
+++ b/sdk/src/query/roadmap.ts
@@ -45,13 +45,28 @@ interface PhaseSection {
 // ─── Exported helpers ─────────────────────────────────────────────────────
 
 /**
- * Strip <details>...</details> blocks from content (shipped milestones).
+ * Strip <details>...</details> blocks from content (shipped milestones only).
+ *
+ * Only strips blocks whose <summary> contains a SHIPPED/✅/COMPLETE marker.
+ * Blocks with no marker (or an "IN PROGRESS" marker) are preserved so the
+ * current-milestone block — which is commonly rendered inside <details> for
+ * collapsible UX on GitHub — remains visible to downstream parsers. Fixes
+ * the case where a new milestone wrapped in <details> disappeared from
+ * `roadmap.analyze` output (issue #2641).
  *
  * Port of stripShippedMilestones from core.cjs line 1082-1084.
  */
 export function stripShippedMilestones(content: string): string {
-  // Pattern 1: <details>...</details> blocks (explicit collapse)
-  let result = content.replace(/<details>[\s\S]*?<\/details>/gi, '');
+  // Pattern 1: <details>...</details> blocks — strip only when the
+  // <summary> marks the block as shipped. A missing summary is treated
+  // as shipped for backward compatibility with pre-summary ROADMAPs.
+  let result = content.replace(/<details>[\s\S]*?<\/details>/gi, (block) => {
+    const summaryMatch = block.match(/<summary>([\s\S]*?)<\/summary>/i);
+    if (!summaryMatch) return '';
+    const summary = summaryMatch[1];
+    const isShipped = /\bSHIPPED\b|✅|\bCOMPLETE\b/i.test(summary);
+    return isShipped ? '' : block;
+  });
   // Pattern 2: inline milestone headings marked as shipped.
   // Keep aligned with heading levels accepted by extractCurrentMilestone() (## and ###).
   const sections = result.split(/(?=^#{2,3}\s)/m);
@@ -524,10 +539,15 @@ export const roadmapAnalyze: QueryHandler = async (_args, projectDir, workstream
       }
     } catch { /* intentionally empty */ }
 
-    // Check ROADMAP checkbox status
-    const checkboxPattern = new RegExp(`-\\s*\\[(x| )\\]\\s*.*Phase\\s+${escapeRegex(phaseNum)}[:\\s]`, 'i');
-    const checkboxMatch = content.match(checkboxPattern);
-    const roadmapComplete = checkboxMatch ? checkboxMatch[1] === 'x' : false;
+    // Check ROADMAP checkbox status against the RAW ROADMAP — archived
+    // milestones' shipped checkboxes live inside <details> blocks that
+    // `extractCurrentMilestone` strips, so they were invisible before.
+    // Require `[x]` followed by a space/`**` then `Phase N` — this avoids
+    // false positives from "- [ ] TBD (run /gsd-plan-phase N to break down)"
+    // placeholders in appendix Plans subsections, which otherwise overrode
+    // the authoritative `[x]` marker in the milestone block (issue #2641).
+    const checkedPattern = new RegExp(`-\\s*\\[x\\]\\s+(?:\\*\\*)?Phase\\s+${escapeRegex(phaseNum)}[:\\s]`, 'i');
+    const roadmapComplete = checkedPattern.test(rawContent);
 
     // If roadmap marks phase complete, trust that over disk
     if (roadmapComplete && diskStatus !== 'complete') {


### PR DESCRIPTION
## Linked Issue

Fixes #2641

> Issue is currently labeled `bug, needs-triage`. Opening this PR as **draft** so the code is visible to any maintainer reviewing the issue; happy to mark ready-for-review once the bug is confirmed per `CONTRIBUTING.md`. No changes until then.

## What was broken

Three tightly-related bugs caused `roadmap.analyze` + `init.milestone-op` to miss the current milestone when its block is wrapped in `<details>/<summary>` (a common GitHub layout for ROADMAPs that collapse shipped milestones by default):

1. `stripShippedMilestones` deleted *every* `<details>` block, so the current milestone's `### Phase N` headings vanished from downstream parsing.
2. `roadmapAnalyze`'s checkbox check ran against the stripped-and-scoped content with an inclusive `(x| )` + `.*` pattern, so archived-milestone `[x]` markers were invisible (inside the stripped block) *and* `- [ ] TBD (run /gsd-plan-phase N to break down)` placeholders in appendix `Plans:` subsections silently overrode the real `[x]`.
3. `initMilestoneOp` counted every phase directory on disk — including archived milestones — giving a false `"N/N complete, all_phases_complete=true"` the moment a new milestone started, because every archived directory has a `-SUMMARY.md`.

## What this fix does

1. **`stripShippedMilestones`** now inspects `<summary>` and only strips blocks marked `SHIPPED` / `✅` / `COMPLETE`. Blocks with "IN PROGRESS" or no marker are preserved. Blocks with no `<summary>` are treated as shipped for back-compat with pre-summary ROADMAPs.
2. **`roadmapAnalyze` checkbox check** now scans the **raw ROADMAP** for a tight `[x] Phase N` pattern (requires space or `**` before `Phase`). This surfaces archived-milestone `[x]` markers and avoids false positives from appendix `[ ] TBD` placeholders.
3. **`initMilestoneOp`** reads STATE.md's `progress.{total_phases, completed_phases}` (authoritative — updated per-phase by the workflow). Falls back to the legacy disk scan only when STATE.md has no progress block.

## Root cause

The strip-details regex was written when the convention was "`<details>` = shipped" and predates the now-common GitHub layout of collapsing the *current* milestone to keep the ROADMAP scannable. The checkbox check relied on the same stripped output for truth, which meant anything stripped was lost; and `initMilestoneOp`'s disk-scan semantics conflated "total shipped across history" with "current milestone progress." Each bug reinforced the others: the strip hid the milestone, which left the analyzer looking in the wrong place, which left `initMilestoneOp` falling back to disk-globals.

## Testing

### How I verified the fix

- Ran the end-to-end repro fixture from #2641 against the patched SDK. All observed outputs now match the "expected" table in the issue body.
- Ran the unit test suites for both touched files: **76/76 pass** (`vitest run src/query/roadmap.test.ts src/query/init.test.ts`).
- Ran the full suite: 1539 pass / 9 unrelated failures. Baseline-verified that all 9 failures exist on upstream `main` without any of my changes (3 state-mutation flag-parser tests, `agentSkills`, `configNewProject`, `QueryRegistry dispatch`, and 3 golden-parity integration tests that need an external `gsd-tools.cjs` binary). Zero regressions from this PR.

### Regression test added?

- [x] Yes — 8 new tests across both files:
  - `stripShippedMilestones`: preserves IN-PROGRESS `<details>`, strips SHIPPED/✅-marked blocks, back-compat for `<details>` without `<summary>` (3 tests)
  - `roadmapAnalyze`: surfaces current milestone wrapped in `<details>/<summary>`, honours archived-milestone `[x]` over appendix `[ ] TBD` placeholders (2 tests)
  - `initMilestoneOp`: scopes counts to current milestone via STATE.md, falls back to disk scan when STATE.md has no progress block (2 tests)
  - Plus a back-compat test ensuring existing behaviour preserved for legacy ROADMAPs.

### Platforms tested

- [x] macOS
- [ ] Windows — not platform-specific (pure string parsing)
- [ ] Linux — not platform-specific

### Runtimes tested

- [x] Claude Code
- [ ] Other: not runtime-specific (pure SDK query handlers)

---

## Checklist

- [x] Issue linked above with `Fixes #2641`
- [ ] Linked issue has the `confirmed-bug` label — **pending triage**; opening as draft per CONTRIBUTING
- [x] Fix is scoped to the reported bug — no unrelated changes
- [x] Regression test added
- [x] All roadmap.ts + init.ts tests pass; full-suite unrelated failures baseline-checked on upstream `main`
- [x] No unnecessary dependencies added

## Breaking changes

None. The `<details>` without `<summary>` case (legacy ROADMAPs) still strips identically. STATE.md fallback only activates when a `progress:` block is present — absent that, behavior is byte-identical to the previous disk scan.
