### PR TITLE
perf(discuss-phase): defer mode-specific and reference @file imports (closes #2548)

### DIFF
--- a/commands/gsd/discuss-phase.md
+++ b/commands/gsd/discuss-phase.md
@@ -30,10 +30,15 @@ Extract implementation decisions that downstream agents need — researcher and 
 
 <execution_context>
 @~/.claude/get-shit-done/workflows/discuss-phase.md
-@~/.claude/get-shit-done/workflows/discuss-phase-assumptions.md
-@~/.claude/get-shit-done/workflows/discuss-phase-power.md
-@~/.claude/get-shit-done/templates/context.md
 </execution_context>
+
+<deferred_reads>
+The files below are NOT pre-loaded — the process block and workflow branches direct `Read` at the moment the file is actually needed. This avoids ~13k tokens of up-front load for files that are mode-specific or only used by one step.
+
+- `~/.claude/get-shit-done/workflows/discuss-phase-assumptions.md` — Read when `workflow.discuss_mode` is `"assumptions"` (see <process>).
+- `~/.claude/get-shit-done/workflows/discuss-phase-power.md` — Read when `--power` is in ARGUMENTS (see workflow's `power_user_mode` branch).
+- `~/.claude/get-shit-done/templates/context.md` — Read in the workflow's `write_context` step.
+</deferred_reads>
 
 <runtime_note>
 **Copilot (VS Code):** Use `vscode_askquestions` wherever this workflow calls `AskUserQuestion`. They are equivalent — `vscode_askquestions` is the VS Code Copilot implementation of the same interactive question API.

--- a/get-shit-done/workflows/discuss-phase.md
+++ b/get-shit-done/workflows/discuss-phase.md
@@ -6,9 +6,15 @@ You are a thinking partner, not an interviewer. The user is the visionary — yo
 
 <required_reading>
 @~/.claude/get-shit-done/references/domain-probes.md
-@~/.claude/get-shit-done/references/gate-prompts.md
-@~/.claude/get-shit-done/references/universal-anti-patterns.md
 </required_reading>
+
+<deferred_reads>
+The files below are NOT pre-loaded — individual steps direct `Read` at the point they are actually needed. This keeps the up-front load small while still giving steps access to the canonical patterns when relevant.
+
+- `~/.claude/get-shit-done/references/gate-prompts.md` — Read in `check_existing` (and any step that designs a new AskUserQuestion gate) when you need the standard approve/revise/yes-no patterns.
+- `~/.claude/get-shit-done/references/universal-anti-patterns.md` — Read in `advisor_research` before spawning subagents (the rules govern subagent usage and context budget).
+- `~/.claude/get-shit-done/templates/context.md` — Read in `write_context` for the canonical CONTEXT.md template, annotated examples, and concrete-vs-vague decision guidelines.
+</deferred_reads>
 
 <downstream_awareness>
 **CONTEXT.md feeds into:**
@@ -240,6 +246,8 @@ ls ${phase_dir}/*-SPEC.md 2>/dev/null | grep -v AI-SPEC | head -1 || true
 
 <step name="check_existing">
 Check if CONTEXT.md already exists using `has_context` from init.
+
+**Gate prompt reference (JIT):** This step and several that follow design `AskUserQuestion` gates (Update/View/Skip, Resume/Start fresh, Continue/View/Cancel). If you need the canonical gate patterns, `Read ~/.claude/get-shit-done/references/gate-prompts.md` now — it defines approve-revise-abort, yes-no, and stale-continue, plus the 12-char header and "Other" handling rules. Skip the Read if you already know the conventions.
 
 ```bash
 ls ${phase_dir}/*-CONTEXT.md 2>/dev/null || true
@@ -651,6 +659,8 @@ Continue to discuss_areas with selected areas (or advisor_research if ADVISOR_MO
 <step name="advisor_research">
 **Advisor Research** (only when ADVISOR_MODE is true)
 
+**Anti-pattern reference (JIT):** Before spawning subagents in this step, `Read ~/.claude/get-shit-done/references/universal-anti-patterns.md` — it covers the rules that apply when orchestrating subagents (don't read agent definition files, don't inline large files into prompts, delegate heavy work, context-budget scaling). If `ADVISOR_MODE` is false and this step is skipped entirely, skip the Read too.
+
 After user selects gray areas in present_gray_areas, spawn parallel research agents.
 
 1. Display brief status: "Researching {N} areas..."
@@ -959,6 +969,8 @@ This data is used to generate DISCUSSION-LOG.md in the `write_context` step.
 
 <step name="write_context">
 Create CONTEXT.md capturing decisions made.
+
+**Template reference (JIT):** `Read ~/.claude/get-shit-done/templates/context.md` now — it contains the canonical template, three annotated good examples (visual feature, CLI tool, organization task), and guidelines distinguishing concrete decisions from vague aspirations. The inline skeleton below mirrors the template's structure; the examples and guidelines in the template file are the source of truth for what "good content" looks like.
 
 **Also generate DISCUSSION-LOG.md** — a full audit trail of the discuss-phase Q&A.
 This file is for human reference only (software audits, compliance reviews). It is NOT


### PR DESCRIPTION
## Summary

Closes #2548. The `gsd-discuss-phase` skill was chain-loading ~13k tokens of
mutually exclusive mode workflows and background reference files on every
invocation, regardless of the user's selected mode. This PR defers those
imports to just-in-time `Read` calls at the specific steps that need them.

## What changed

### `commands/gsd/discuss-phase.md`
Removed 3 `@file` entries from `<execution_context>`:
- `discuss-phase-assumptions.md` — only needed when `discuss_mode=assumptions`
- `discuss-phase-power.md` — only needed when `--power` flag is present
- `templates/context.md` — only needed in the `write_context` step

Kept `@~/.claude/get-shit-done/workflows/discuss-phase.md` (the core
workflow body — always needed).

Added a `<deferred_reads>` index documenting where each file is now read.

### `get-shit-done/workflows/discuss-phase.md`
Removed 2 `@file` entries from `<required_reading>`:
- `references/gate-prompts.md` — only a style guide for `AskUserQuestion` gates
- `references/universal-anti-patterns.md` — rules apply only when spawning
  subagents (i.e., the `advisor_research` step)

Kept `@~/.claude/get-shit-done/references/domain-probes.md` — actively used in
`analyze_phase` to generate domain-specific gray areas on every discuss run.

Added three JIT `Read` callouts at the exact steps that need each file:
- `check_existing` — `Read gate-prompts.md` if the canonical gate patterns are needed
- `advisor_research` — `Read universal-anti-patterns.md` before spawning subagents
- `write_context` — `Read templates/context.md` for the canonical template +
  three annotated good examples + concrete-vs-vague guidelines

## Why this approach

The issue proposed four steps:
1. Remove 5 entries from the `@file` chain — done
2. Add mode-specific `Read` ops in workflow branches — the branches at
   `discuss-phase.md:59`, `discuss-phase.md:61`, and the workflow's
   `power_user_mode` already say "Read and execute @…", so the JIT hook was
   already wired for the two mode files; I left those instructions untouched
3. Convert reference files to JIT reads within relevant steps — added
   explicit `Read` directives in `check_existing` and `advisor_research`
4. Inline template reads only where needed — added the `Read` in
   `write_context` (previously the workflow inlined a skeleton but never
   read the template file that holds the annotated examples)

## Measured impact

Total lines removed from the auto-load chain: 1,476 (670 + 291 + 352 + 100 + 63)
across the 5 files. At ~9 tokens/line in skill bodies this matches the
~13k-token figure reported in the issue.

The main workflow (`discuss-phase.md`, 1,324 lines) is still `@file`-loaded
because it is always needed. The ~13k token savings is the overhead on top
of that baseline.

## Test plan

- [x] `node --test tests/discuss-mode.test.cjs tests/discuss-phase-power.test.cjs tests/discuss-all-flag.test.cjs tests/discuss-checkpoint.test.cjs tests/prompt-thinning.test.cjs tests/agent-required-reading-consistency.test.cjs` — 114/114 pass
- [x] Full suite `npm test` — 4932/4945 pass; the 5 failures are pre-existing (confirmed by stash comparison) in `agents/gsd-debug-session-manager.md` path replacement, `stats` command git history, and `workspace worktree integration`. None touch the modified files.
- [x] String-presence assertions in existing tests still pass:
  - `tests/discuss-mode.test.cjs:24` (`discuss-phase-assumptions.md` in command file) — preserved via `<deferred_reads>` list
  - `tests/discuss-phase-power.test.cjs:32` (`discuss-phase-power` in command file) — preserved via `<deferred_reads>` list
  - `tests/discuss-phase-power.test.cjs:42` (`discuss-phase-power` in main workflow) — preserved at `:171` and `:1294` (unchanged)

## Risks / follow-ups

1. `advisor_research` JIT read must be honored serially by the orchestrator — the step says "Before spawning subagents" explicitly, so agents following steps in order will be fine.
2. `gate-prompts.md` is phrased as opt-in ("skip the Read if you already know the conventions") — low risk of convention drift over time; could be tightened later if reviewers prefer.
3. Pre-existing: the inline template skeleton in `write_context` duplicates most of `templates/context.md`. Not addressed here to keep the diff focused on the issue. Worth a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor
- Optimized workflow documentation loading strategy by shifting from preloading all reference materials to on-demand (just-in-time) reads, improving system efficiency and performance.
- Enhanced workflow documentation with explicit step-level instructions detailing when specific reference materials are read and consulted, providing clearer workflow dependency tracking and usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->