### PR TITLE
fix(sdk): honor global model defaults

### DIFF
--- a/sdk/src/config.test.ts
+++ b/sdk/src/config.test.ts
@@ -6,15 +6,28 @@ import { tmpdir } from 'node:os';
 
 describe('loadConfig', () => {
   let tmpDir: string;
+  let previousGsdHome: string | undefined;
 
   beforeEach(async () => {
     tmpDir = join(tmpdir(), `gsd-config-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    previousGsdHome = process.env.GSD_HOME;
+    process.env.GSD_HOME = join(tmpDir, 'home');
     await mkdir(join(tmpDir, '.planning'), { recursive: true });
   });
 
   afterEach(async () => {
+    if (previousGsdHome === undefined) delete process.env.GSD_HOME;
+    else process.env.GSD_HOME = previousGsdHome;
     await rm(tmpDir, { recursive: true, force: true });
   });
+
+  async function writeGlobalDefaults(defaults: Record<string, unknown>) {
+    await mkdir(join(tmpDir, 'home', '.gsd'), { recursive: true });
+    await writeFile(
+      join(tmpDir, 'home', '.gsd', 'defaults.json'),
+      JSON.stringify(defaults),
+    );
+  }
 
   it('returns all defaults when config file is missing', async () => {
     // No config.json created
@@ -49,6 +62,73 @@ describe('loadConfig', () => {
     // Top-level defaults preserved
     expect(config.commit_docs).toBe(true);
     expect(config.parallelization).toBe(true);
+  });
+
+  it('merges global defaults when project config is missing', async () => {
+    await rm(join(tmpDir, '.planning', 'config.json'), { force: true });
+    await writeGlobalDefaults({
+      resolve_model_ids: 'omit',
+      workflow: { auto_advance: true },
+      agent_skills: { 'gsd-planner': ['codex-skill'] },
+      model_overrides: { 'gsd-planner': 'openai/gpt-5.4' },
+    });
+
+    const config = await loadConfig(tmpDir);
+
+    expect(config.resolve_model_ids).toBe('omit');
+    expect(config.workflow.auto_advance).toBe(true);
+    expect(config.workflow.research).toBe(true);
+    expect(config.agent_skills).toEqual({ 'gsd-planner': ['codex-skill'] });
+    expect(config.model_overrides).toEqual({ 'gsd-planner': 'openai/gpt-5.4' });
+  });
+
+  it('lets project config override global defaults while preserving nested fallbacks', async () => {
+    await writeGlobalDefaults({
+      resolve_model_ids: 'omit',
+      workflow: { auto_advance: true, research: false },
+      git: { branching_strategy: 'phase' },
+      agent_skills: { 'gsd-planner': 'global-skill' },
+      model_overrides: {
+        'gsd-planner': 'global-planner',
+        'gsd-executor': 'global-executor',
+      },
+    });
+    await writeFile(
+      join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({
+        resolve_model_ids: false,
+        workflow: { auto_advance: false },
+        git: { branching_strategy: 'none' },
+        agent_skills: { 'gsd-planner': 'project-skill' },
+        model_overrides: { 'gsd-planner': 'project-planner' },
+      }),
+    );
+
+    const config = await loadConfig(tmpDir);
+
+    expect(config.resolve_model_ids).toBe(false);
+    expect(config.workflow.auto_advance).toBe(false);
+    expect(config.workflow.research).toBe(false);
+    expect(config.git.branching_strategy).toBe('none');
+    expect(config.agent_skills).toEqual({ 'gsd-planner': 'project-skill' });
+    expect(config.model_overrides).toEqual({
+      'gsd-planner': 'project-planner',
+      'gsd-executor': 'global-executor',
+    });
+  });
+
+  it('ignores malformed global defaults', async () => {
+    await mkdir(join(tmpDir, 'home', '.gsd'), { recursive: true });
+    await writeFile(join(tmpDir, 'home', '.gsd', 'defaults.json'), '{bad json');
+    await writeFile(
+      join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ model_profile: 'fast' }),
+    );
+
+    const config = await loadConfig(tmpDir);
+
+    expect(config.model_profile).toBe('fast');
+    expect(config.resolve_model_ids).toBeUndefined();
   });
 
   it('partial config merges correctly for nested objects', async () => {

--- a/sdk/src/config.ts
+++ b/sdk/src/config.ts
@@ -6,6 +6,7 @@
  */
 
 import { readFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { relPlanningPath } from './workstream-utils.js';
 
@@ -63,6 +64,7 @@ export interface GSDConfig {
   workflow: WorkflowConfig;
   hooks: HooksConfig;
   agent_skills: Record<string, unknown>;
+  model_overrides: Record<string, unknown>;
   /** Project slug for branch templates; mirrors gsd-tools `config.project_code`. */
   project_code?: string | null;
   /** Interactive vs headless; mirrors gsd-tools flat `config.mode`. */
@@ -111,6 +113,7 @@ export const CONFIG_DEFAULTS: GSDConfig = {
     context_warnings: true,
   },
   agent_skills: {},
+  model_overrides: {},
   project_code: null,
   mode: 'interactive',
   _auto_chain_active: false,
@@ -118,14 +121,64 @@ export const CONFIG_DEFAULTS: GSDConfig = {
 
 // ─── Loader ──────────────────────────────────────────────────────────────────
 
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function mergeConfig(base: GSDConfig, override: Record<string, unknown>): GSDConfig {
+  return {
+    ...structuredClone(base),
+    ...override,
+    git: {
+      ...base.git,
+      ...(isPlainRecord(override.git) ? override.git : {}),
+    },
+    workflow: {
+      ...base.workflow,
+      ...(isPlainRecord(override.workflow) ? override.workflow : {}),
+    },
+    hooks: {
+      ...base.hooks,
+      ...(isPlainRecord(override.hooks) ? override.hooks : {}),
+    },
+    agent_skills: {
+      ...base.agent_skills,
+      ...(isPlainRecord(override.agent_skills) ? override.agent_skills : {}),
+    },
+    model_overrides: {
+      ...base.model_overrides,
+      ...(isPlainRecord(override.model_overrides) ? override.model_overrides : {}),
+    },
+  };
+}
+
+async function loadGlobalDefaults(): Promise<Record<string, unknown>> {
+  const home = process.env.GSD_HOME || homedir();
+  const globalDefaultsPath = join(home, '.gsd', 'defaults.json');
+
+  try {
+    const raw = await readFile(globalDefaultsPath, 'utf-8');
+    const trimmed = raw.trim();
+    if (trimmed === '') return {};
+
+    const parsed: unknown = JSON.parse(trimmed);
+    return isPlainRecord(parsed) ? parsed : {};
+  } catch {
+    // User defaults are optional and should never block SDK queries.
+    return {};
+  }
+}
+
 /**
- * Load project config from `.planning/config.json`, merging with defaults.
- * Returns full defaults when file is missing or empty.
+ * Load project config from `.planning/config.json`, merging with defaults and
+ * optional user defaults from `~/.gsd/defaults.json`.
+ * Returns merged defaults when file is missing or empty.
  * Throws on malformed JSON with a helpful error message.
  */
 export async function loadConfig(projectDir: string, workstream?: string): Promise<GSDConfig> {
   const configPath = join(projectDir, relPlanningPath(workstream), 'config.json');
   const rootConfigPath = join(projectDir, '.planning', 'config.json');
+  const baseConfig = mergeConfig(CONFIG_DEFAULTS, await loadGlobalDefaults());
 
   let raw: string;
   try {
@@ -136,17 +189,17 @@ export async function loadConfig(projectDir: string, workstream?: string): Promi
       try {
         raw = await readFile(rootConfigPath, 'utf-8');
       } catch {
-        return structuredClone(CONFIG_DEFAULTS);
+        return structuredClone(baseConfig);
       }
     } else {
       // File missing — normal for new projects
-      return structuredClone(CONFIG_DEFAULTS);
+      return structuredClone(baseConfig);
     }
   }
 
   const trimmed = raw.trim();
   if (trimmed === '') {
-    return structuredClone(CONFIG_DEFAULTS);
+    return structuredClone(baseConfig);
   }
 
   let parsed: Record<string, unknown>;
@@ -161,25 +214,6 @@ export async function loadConfig(projectDir: string, workstream?: string): Promi
     throw new Error(`Config at ${configPath} must be a JSON object`);
   }
 
-  // Three-level deep merge: defaults <- parsed
-  return {
-    ...structuredClone(CONFIG_DEFAULTS),
-    ...parsed,
-    git: {
-      ...CONFIG_DEFAULTS.git,
-      ...(parsed.git as Partial<GitConfig> ?? {}),
-    },
-    workflow: {
-      ...CONFIG_DEFAULTS.workflow,
-      ...(parsed.workflow as Partial<WorkflowConfig> ?? {}),
-    },
-    hooks: {
-      ...CONFIG_DEFAULTS.hooks,
-      ...(parsed.hooks as Partial<HooksConfig> ?? {}),
-    },
-    agent_skills: {
-      ...CONFIG_DEFAULTS.agent_skills,
-      ...(parsed.agent_skills as Record<string, unknown> ?? {}),
-    },
-  };
+  // Three-level deep merge: defaults <- global defaults <- project config
+  return mergeConfig(baseConfig, parsed);
 }

--- a/sdk/src/query/config-query.test.ts
+++ b/sdk/src/query/config-query.test.ts
@@ -11,13 +11,18 @@ import { GSDError, ErrorClassification, exitCodeFor } from '../errors.js';
 // ─── Test setup ─────────────────────────────────────────────────────────────
 
 let tmpDir: string;
+let previousGsdHome: string | undefined;
 
 beforeEach(async () => {
   tmpDir = await mkdtemp(join(tmpdir(), 'gsd-cfg-'));
+  previousGsdHome = process.env.GSD_HOME;
+  process.env.GSD_HOME = join(tmpDir, 'home');
   await mkdir(join(tmpDir, '.planning'), { recursive: true });
 });
 
 afterEach(async () => {
+  if (previousGsdHome === undefined) delete process.env.GSD_HOME;
+  else process.env.GSD_HOME = previousGsdHome;
   await rm(tmpDir, { recursive: true, force: true });
 });
 
@@ -160,6 +165,22 @@ describe('resolveModel', () => {
         model_profile: 'balanced',
         resolve_model_ids: 'omit',
       }),
+    );
+    const result = await resolveModel(['gsd-planner'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+    expect(data).toHaveProperty('model', '');
+  });
+
+  it('returns empty model when resolve_model_ids omit comes from global defaults', async () => {
+    const { resolveModel } = await import('./config-query.js');
+    await mkdir(join(tmpDir, 'home', '.gsd'), { recursive: true });
+    await writeFile(
+      join(tmpDir, 'home', '.gsd', 'defaults.json'),
+      JSON.stringify({ resolve_model_ids: 'omit' }),
+    );
+    await writeFile(
+      join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ model_profile: 'balanced' }),
     );
     const result = await resolveModel(['gsd-planner'], tmpDir);
     const data = result.data as Record<string, unknown>;

--- a/sdk/src/query/init.test.ts
+++ b/sdk/src/query/init.test.ts
@@ -28,9 +28,12 @@ import {
 } from './init.js';
 
 let tmpDir: string;
+let previousGsdHome: string | undefined;
 
 beforeEach(async () => {
   tmpDir = await mkdtemp(join(tmpdir(), 'gsd-init-'));
+  previousGsdHome = process.env.GSD_HOME;
+  process.env.GSD_HOME = join(tmpDir, 'home');
   // Create minimal .planning structure
   await mkdir(join(tmpDir, '.planning', 'phases', '09-foundation'), { recursive: true });
   await mkdir(join(tmpDir, '.planning', 'phases', '10-read-only-queries'), { recursive: true });
@@ -92,6 +95,8 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  if (previousGsdHome === undefined) delete process.env.GSD_HOME;
+  else process.env.GSD_HOME = previousGsdHome;
   await rm(tmpDir, { recursive: true, force: true });
 });
 
@@ -375,6 +380,20 @@ describe('initQuick', () => {
     expect(data.executor_model).toBeDefined();
     expect(data.quick_dir).toBe('.planning/quick');
     expect(data.project_root).toBe(tmpDir);
+  });
+
+  it('omits model aliases when global defaults set resolve_model_ids to omit', async () => {
+    await mkdir(join(tmpDir, 'home', '.gsd'), { recursive: true });
+    await writeFile(
+      join(tmpDir, 'home', '.gsd', 'defaults.json'),
+      JSON.stringify({ resolve_model_ids: 'omit' }),
+    );
+
+    const result = await initQuick(['codex-task'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+
+    expect(data.planner_model).toBe('');
+    expect(data.executor_model).toBe('');
   });
 });
 

--- a/sdk/src/query/init.ts
+++ b/sdk/src/query/init.ts
@@ -39,7 +39,7 @@ import type { QueryHandler } from './utils.js';
 async function getModelAlias(agentType: string, projectDir: string): Promise<string> {
   const result = await resolveModel([agentType], projectDir);
   const data = result.data as Record<string, unknown>;
-  return (data.model as string) || 'sonnet';
+  return typeof data.model === 'string' ? data.model : 'sonnet';
 }
 
 /**


### PR DESCRIPTION
Addresses #2652.

Summary:
- Teach SDK loadConfig() to merge hardcoded defaults <- ~/.gsd/defaults.json <- .planning/config.json.
- Preserve deep-merge behavior for git, workflow, hooks, agent_skills, and model_overrides.
- Preserve explicit empty model aliases from resolveModel() so init.quick does not fall back to sonnet when resolve_model_ids is omit.
- Add regression coverage for config loading, resolveModel(), and initQuick().

Verification:
- PASS: `npx vitest run --project unit src/config.test.ts src/query/config-query.test.ts src/query/init.test.ts`
- PASS: `npm run build`
- PASS: `git diff --check`
- NOTE: full `npx vitest run --project unit` still has unrelated failures on this upstream fix branch in state-mutation, config-mutation, decomposed-handlers, and registry tests.