### PR TITLE
fix(core): write sub_repos to planning.sub_repos, not top-level (#2638)

### DIFF
--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -291,22 +291,34 @@ function loadConfig(cwd) {
     if (parsed.multiRepo === true && !parsed.sub_repos && !parsed.planning?.sub_repos) {
       const detected = detectSubRepos(cwd);
       if (detected.length > 0) {
-        parsed.sub_repos = detected;
         if (!parsed.planning) parsed.planning = {};
+        parsed.planning.sub_repos = detected;
+        delete parsed.sub_repos;
         parsed.planning.commit_docs = false;
         delete parsed.multiRepo;
         configDirty = true;
       }
     }
 
+    // Canonicalize legacy top-level sub_repos to planning.sub_repos (#2638)
+    if (Object.prototype.hasOwnProperty.call(parsed, 'sub_repos')) {
+      if (!parsed.planning) parsed.planning = {};
+      if (parsed.planning.sub_repos === undefined) {
+        parsed.planning.sub_repos = parsed.sub_repos;
+      }
+      delete parsed.sub_repos;
+      configDirty = true;
+    }
+
     // Keep sub_repos in sync with actual filesystem
-    const currentSubRepos = parsed.sub_repos || parsed.planning?.sub_repos || [];
+    const currentSubRepos = parsed.planning?.sub_repos || [];
     if (Array.isArray(currentSubRepos) && currentSubRepos.length > 0) {
       const detected = detectSubRepos(cwd);
       if (detected.length > 0) {
         const sorted = [...currentSubRepos].sort();
         if (JSON.stringify(sorted) !== JSON.stringify(detected)) {
-          parsed.sub_repos = detected;
+          if (!parsed.planning) parsed.planning = {};
+          parsed.planning.sub_repos = detected;
           configDirty = true;
         }
       }

--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -300,7 +300,9 @@ function loadConfig(cwd) {
       }
     }
 
-    // Canonicalize legacy top-level sub_repos to planning.sub_repos (#2638)
+    // Canonicalize legacy top-level sub_repos to planning.sub_repos (#2638).
+    // Ensures stale top-level keys are cleaned up even when detected repos
+    // match the current list (no-drift case), preventing repeated warnings.
     if (Object.prototype.hasOwnProperty.call(parsed, 'sub_repos')) {
       if (!parsed.planning) parsed.planning = {};
       if (parsed.planning.sub_repos === undefined) {

--- a/tests/core.test.cjs
+++ b/tests/core.test.cjs
@@ -1509,17 +1509,61 @@ describe('loadConfig sub_repos auto-sync', () => {
     assert.deepStrictEqual(config.sub_repos, ['backend', 'frontend']);
     assert.strictEqual(config.commit_docs, false);
 
-    // Verify config was persisted
+    // Verify config was persisted under planning.sub_repos (canonical location)
     const saved = JSON.parse(fs.readFileSync(path.join(projectRoot, '.planning', 'config.json'), 'utf-8'));
-    assert.deepStrictEqual(saved.sub_repos, ['backend', 'frontend']);
+    assert.strictEqual(saved.sub_repos, undefined, 'sub_repos should not be written to top-level');
+    assert.deepStrictEqual(saved.planning?.sub_repos, ['backend', 'frontend']);
     assert.strictEqual(saved.multiRepo, undefined, 'multiRepo should be removed');
+  });
+
+  // Bug #2638: loadConfig wrote sub_repos to top-level, triggering unknown-key warning
+  test('writes sub_repos under planning and does not emit unknown-key warning (#2638)', (t) => {
+    fs.writeFileSync(
+      path.join(projectRoot, '.planning', 'config.json'),
+      JSON.stringify({ model_profile: 'balanced', planning: { sub_repos: ['backend', 'frontend'] } })
+    );
+    fs.mkdirSync(path.join(projectRoot, 'backend', '.git'), { recursive: true });
+    fs.mkdirSync(path.join(projectRoot, 'frontend', '.git'), { recursive: true });
+    fs.mkdirSync(path.join(projectRoot, 'shared', '.git'), { recursive: true });
+
+    const origWrite = process.stderr.write;
+    let stderrOutput = '';
+    process.stderr.write = (chunk) => { stderrOutput += chunk; };
+    t.after(() => { process.stderr.write = origWrite; });
+
+    const config = loadConfig(projectRoot);
+    assert.deepStrictEqual(config.sub_repos, ['backend', 'frontend', 'shared']);
+
+    const saved = JSON.parse(fs.readFileSync(path.join(projectRoot, '.planning', 'config.json'), 'utf-8'));
+    assert.strictEqual(saved.sub_repos, undefined, 'top-level sub_repos should not exist');
+    assert.deepStrictEqual(saved.planning?.sub_repos, ['backend', 'frontend', 'shared']);
+    assert.ok(
+      !stderrOutput.includes('unknown config key(s): sub_repos'),
+      'should not warn about sub_repos as unknown key'
+    );
+  });
+
+  // Bug #2638: stale top-level sub_repos should be canonicalized even when no drift
+  test('removes stale top-level sub_repos even when detected repos are unchanged (#2638)', () => {
+    fs.writeFileSync(
+      path.join(projectRoot, '.planning', 'config.json'),
+      JSON.stringify({ model_profile: 'balanced', sub_repos: ['backend'] })
+    );
+    fs.mkdirSync(path.join(projectRoot, 'backend', '.git'), { recursive: true });
+
+    const config = loadConfig(projectRoot);
+    assert.deepStrictEqual(config.sub_repos, ['backend']);
+
+    const saved = JSON.parse(fs.readFileSync(path.join(projectRoot, '.planning', 'config.json'), 'utf-8'));
+    assert.strictEqual(saved.sub_repos, undefined, 'top-level sub_repos should be canonicalized away');
+    assert.deepStrictEqual(saved.planning?.sub_repos, ['backend']);
   });
 
   test('adds newly detected repos to sub_repos', () => {
     fs.mkdirSync(path.join(projectRoot, 'backend', '.git'), { recursive: true });
     fs.writeFileSync(
       path.join(projectRoot, '.planning', 'config.json'),
-      JSON.stringify({ sub_repos: ['backend'] })
+      JSON.stringify({ planning: { sub_repos: ['backend'] } })
     );
 
     // Add a new repo
@@ -1533,7 +1577,7 @@ describe('loadConfig sub_repos auto-sync', () => {
     fs.mkdirSync(path.join(projectRoot, 'backend', '.git'), { recursive: true });
     fs.writeFileSync(
       path.join(projectRoot, '.planning', 'config.json'),
-      JSON.stringify({ sub_repos: ['backend', 'old-repo'] })
+      JSON.stringify({ planning: { sub_repos: ['backend', 'old-repo'] } })
     );
 
     const config = loadConfig(projectRoot);
@@ -1543,7 +1587,7 @@ describe('loadConfig sub_repos auto-sync', () => {
   test('does not sync when sub_repos is empty and no repos detected', () => {
     fs.writeFileSync(
       path.join(projectRoot, '.planning', 'config.json'),
-      JSON.stringify({ sub_repos: [] })
+      JSON.stringify({ planning: { sub_repos: [] } })
     );
 
     const config = loadConfig(projectRoot);


### PR DESCRIPTION
Fixes #2638.

As triaged in #2638, the two write paths in \`loadConfig\` (legacy \`multiRepo\` migration and filesystem auto-sync) were targeting \`parsed.sub_repos\` instead of \`parsed.planning.sub_repos\`. Since \`sub_repos\` isn't in \`KNOWN_TOP_LEVEL\`, every \`loadConfig\` call in a multi-repo workspace emits:

\`\`\`
gsd-tools: warning: unknown config key(s): sub_repos — these will be ignored
\`\`\`

**Fix:**
- Write to \`parsed.planning.sub_repos\` (canonical since #2561).
- \`delete parsed.sub_repos\` to clean up any stale top-level copy, preventing \`get()\` from falling back to outdated data.

**Test:**
- Updated migration test to assert canonical location.
- Added regression test verifying no top-level key and no stderr warning after sync.

Ran full \`tests/core.test.cjs\` suite: 171 pass, 0 fail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated multi-repository configuration so sub-repo lists are stored and managed in a single canonical location.

* **Bug Fixes**
  * Ensured detected sub-repositories are persisted reliably, removed stale legacy entries, and suppressed an incorrect stderr warning during load.

* **Tests**
  * Added coverage for migration, detection, canonicalization, and auto-sync of multi-repo configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->