### PR TITLE
fix(#2639): route Codex TOML emit through full Claude→Codex neutralization pipeline

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -1873,6 +1873,14 @@ function convertClaudeToCodexMarkdown(content) {
   converted = converted.replace(/\$HOME\/\.claude\//g, '$HOME/.codex/');
   converted = converted.replace(/~\/\.claude\//g, '~/.codex/');
   converted = converted.replace(/\.\/\.claude\//g, './.codex/');
+  // Bare/project-relative .claude/... references (#2639). Covers strings like
+  // "check `.claude/skills/`" where there is no ~/, $HOME/, or ./ anchor.
+  // Negative lookbehind prevents double-replacing already-anchored forms and
+  // avoids matching inside URLs or other slash-prefixed paths.
+  converted = converted.replace(/(?<![A-Za-z0-9_\-./~$])\.claude\//g, '.codex/');
+  // `.claudeignore` → `.codexignore` (#2639). Codex honors its own ignore
+  // file; leaving the Claude-specific name is misleading in agent prompts.
+  converted = converted.replace(/\.claudeignore\b/g, '.codexignore');
   // Runtime-neutral agent name replacement (#766)
   converted = neutralizeAgentReferences(converted, 'AGENTS.md');
   return converted;
@@ -3232,15 +3240,16 @@ function installCodexConfig(targetDir, agentsSrc) {
 
   for (const file of agentEntries) {
     let content = fs.readFileSync(path.join(agentsSrc, file), 'utf8');
-    // Replace full .claude/get-shit-done prefix so path resolves to codex GSD install
+    // Replace full .claude/get-shit-done prefix so path resolves to the Codex
+    // GSD install before generic .claude → .codex conversion rewrites it.
     content = content.replace(/~\/\.claude\/get-shit-done\//g, codexGsdPath);
     content = content.replace(/\$HOME\/\.claude\/get-shit-done\//g, codexGsdPath);
-    // Replace remaining .claude paths with .codex equivalents (#2320).
-    // Capture group handles both trailing-slash form (~/.claude/) and
-    // bare end-of-string form (~/.claude) in a single pass.
-    content = content.replace(/\$HOME\/\.claude(\/|$)/g, '$HOME/.codex$1');
-    content = content.replace(/~\/\.claude(\/|$)/g, '~/.codex$1');
-    content = content.replace(/\.\/\.claude(\/|$)/g, './.codex$1');
+    // Route TOML emit through the same full Claude→Codex conversion pipeline
+    // used on the `.md` emit path (#2639). Covers: slash-command rewrites,
+    // $ARGUMENTS → {{GSD_ARGS}}, /clear removal, anchored and bare .claude/
+    // paths, .claudeignore → .codexignore, and standalone "Claude" /
+    // CLAUDE.md neutralization via neutralizeAgentReferences(..., 'AGENTS.md').
+    content = convertClaudeToCodexMarkdown(content);
     const { frontmatter } = extractFrontmatterAndBody(content);
     const name = extractFrontmatterField(frontmatter, 'name') || file.replace('.md', '');
     const description = extractFrontmatterField(frontmatter, 'description') || '';

--- a/tests/issue-2639-codex-toml-neutralization.test.cjs
+++ b/tests/issue-2639-codex-toml-neutralization.test.cjs
@@ -1,0 +1,105 @@
+/**
+ * Regression: issue #2639 — Codex install generated agent TOMLs with stale
+ * Claude-specific references (CLAUDE.md, .claude/skills/, .claudeignore).
+ *
+ * RCA: `installCodexConfig()` applied a narrow path-only regex pass before
+ * calling `generateCodexAgentToml()`, bypassing the full
+ * `convertClaudeToCodexMarkdown()` + `neutralizeAgentReferences(..., 'AGENTS.md')`
+ * pipeline used on the .md emit path. Fix routes the TOML path through the
+ * same pipeline and extends the pipeline to cover bare `.claude/skills/`,
+ * `.claude/commands/`, `.claude/agents/`, and `.claudeignore`.
+ */
+
+process.env.GSD_TEST_MODE = '1';
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const { installCodexConfig } = require('../bin/install.js');
+
+function makeTempDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-2639-'));
+}
+
+function writeAgentFixture(agentsSrc, name, body) {
+  const content = `---
+name: ${name}
+description: Test agent for #2639
+---
+
+${body}
+`;
+  fs.writeFileSync(path.join(agentsSrc, `${name}.md`), content);
+}
+
+describe('#2639 — Codex TOML emit routes through full neutralization pipeline', () => {
+  let tmpDir;
+  let agentsSrc;
+  let targetDir;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+    agentsSrc = path.join(tmpDir, 'agents');
+    targetDir = path.join(tmpDir, 'codex');
+    fs.mkdirSync(agentsSrc, { recursive: true });
+    fs.mkdirSync(targetDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('strips CLAUDE.md, .claude/skills/, .claude/commands/, .claude/agents/, and .claudeignore from emitted TOML', () => {
+    writeAgentFixture(agentsSrc, 'gsd-code-reviewer', [
+      '**Project instructions:** Read `./CLAUDE.md` if it exists.',
+      '',
+      '**CLAUDE.md enforcement:** If `./CLAUDE.md` exists, treat it as hard constraints.',
+      '',
+      '**Project skills:** Check `.claude/skills/` or `.agents/skills/` directory.',
+      '',
+      'Also check `.claude/commands/` and `.claude/agents/` for definitions.',
+      '',
+      'DO respect .gitignore and .claudeignore. Do not review ignored files.',
+      '',
+      'Claude will refuse the task if policy violated.',
+    ].join('\n'));
+
+    installCodexConfig(targetDir, agentsSrc);
+
+    const tomlPath = path.join(targetDir, 'agents', 'gsd-code-reviewer.toml');
+    assert.ok(fs.existsSync(tomlPath), 'per-agent TOML written');
+    const toml = fs.readFileSync(tomlPath, 'utf8');
+
+    assert.ok(!toml.includes('CLAUDE.md'), 'no CLAUDE.md references remain in TOML');
+    assert.ok(!toml.includes('.claude/skills/'), 'no .claude/skills/ references remain');
+    assert.ok(!toml.includes('.claude/commands/'), 'no .claude/commands/ references remain');
+    assert.ok(!toml.includes('.claude/agents/'), 'no .claude/agents/ references remain');
+    assert.ok(!toml.includes('.claudeignore'), 'no .claudeignore references remain');
+
+    assert.ok(toml.includes('AGENTS.md'), 'AGENTS.md substituted for CLAUDE.md');
+    assert.ok(
+      toml.includes('.codex/skills/') || toml.includes('.agents/skills/'),
+      'skills path neutralized'
+    );
+
+    // Standalone "Claude" agent-name references replaced
+    assert.ok(!/\bClaude\b(?! Code| Opus| Sonnet| Haiku| native| based)/.test(toml),
+      'standalone Claude agent-name references replaced');
+  });
+
+  test('preserves Claude product/model names (Claude Code, Claude Opus) in TOML', () => {
+    writeAgentFixture(agentsSrc, 'gsd-executor', [
+      'This agent runs under Claude Code with the Claude Opus 4 model.',
+      'Do not confuse with Claude Sonnet or Claude Haiku.',
+    ].join('\n'));
+
+    installCodexConfig(targetDir, agentsSrc);
+    const toml = fs.readFileSync(path.join(targetDir, 'agents', 'gsd-executor.toml'), 'utf8');
+
+    assert.ok(toml.includes('Claude Code'), 'Claude Code product name preserved');
+    assert.ok(toml.includes('Claude Opus'), 'Claude Opus model name preserved');
+  });
+});


### PR DESCRIPTION
## Summary

- `installCodexConfig()` applied a narrow path-only regex pass before calling `generateCodexAgentToml()`, bypassing the full `convertClaudeToCodexMarkdown()` + `neutralizeAgentReferences(..., 'AGENTS.md')` pipeline used on the `.md` emit path. Emitted Codex agent TOMLs carried stale Claude-specific references.
- Route the TOML path through `convertClaudeToCodexMarkdown` and extend that pipeline to cover bare `.claude/<subdir>/` references and `.claudeignore` (both previously unhandled on the `.md` path too). The `$HOME/.claude/get-shit-done` prefix substitution still runs first so the absolute Codex install path is preserved before the generic `.claude` → `.codex` rewrite.
- Blame: 0da696eb (#2320).

## Test plan

- [x] RED: new `tests/issue-2639-codex-toml-neutralization.test.cjs` drives `installCodexConfig` against a fixture containing `CLAUDE.md`, `.claude/skills/`, `.claude/commands/`, `.claude/agents/`, `.claudeignore`, and standalone `Claude` and asserts the emitted TOML is clean (first assertion fails on main).
- [x] GREEN: same test passes after the pipeline routing + extension.
- [x] Product/model names preserved: second test asserts `Claude Code` and `Claude Opus` survive in the emitted TOML.
- [x] Full suite: `npm test` — 5451/5451 pass.

Fixes #2639