### PR TITLE
fix(sdk): honor global model defaults

### DIFF
--- a/sdk/src/config.test.ts
+++ b/sdk/src/config.test.ts
@@ -1,52 +1,47 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { loadConfig, CONFIG_DEFAULTS } from './config.js';
-import { mkdir, writeFile, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, writeFile, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 describe('loadConfig', () => {
   let tmpDir: string;
-  let fakeHome: string;
-  let prevHome: string | undefined;
-  let prevGsdHome: string | undefined;
+  let homeDir: string;
 
   beforeEach(async () => {
-    tmpDir = join(tmpdir(), `gsd-config-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    tmpDir = await mkdtemp(join(tmpdir(), 'gsd-config-test-'));
+    homeDir = await mkdtemp(join(tmpdir(), 'gsd-home-test-'));
     await mkdir(join(tmpDir, '.planning'), { recursive: true });
-    // Isolate ~/.gsd/defaults.json by pointing HOME at an empty tmp dir.
-    fakeHome = join(tmpdir(), `gsd-home-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
-    await mkdir(fakeHome, { recursive: true });
-    prevHome = process.env.HOME;
-    process.env.HOME = fakeHome;
-    // Also isolate GSD_HOME (loadUserDefaults prefers it over HOME).
-    prevGsdHome = process.env.GSD_HOME;
-    delete process.env.GSD_HOME;
   });
 
   afterEach(async () => {
     await rm(tmpDir, { recursive: true, force: true });
-    await rm(fakeHome, { recursive: true, force: true });
-    if (prevHome === undefined) delete process.env.HOME;
-    else process.env.HOME = prevHome;
-    if (prevGsdHome === undefined) delete process.env.GSD_HOME;
-    else process.env.GSD_HOME = prevGsdHome;
+    await rm(homeDir, { recursive: true, force: true });
   });
 
+  /**
+   * Write isolated user-level defaults under the test-controlled home dir.
+   */
   async function writeUserDefaults(defaults: unknown) {
-    await mkdir(join(fakeHome, '.gsd'), { recursive: true });
-    await writeFile(join(fakeHome, '.gsd', 'defaults.json'), JSON.stringify(defaults));
+    await mkdir(join(homeDir, '.gsd'), { recursive: true });
+    const content = typeof defaults === 'string' ? defaults : JSON.stringify(defaults);
+    await writeFile(join(homeDir, '.gsd', 'defaults.json'), content);
+  }
+
+  function loadTestConfig() {
+    return loadConfig(tmpDir, undefined, { homeDir });
   }
 
   it('returns all defaults when config file is missing', async () => {
     // No config.json created
     await rm(join(tmpDir, '.planning', 'config.json'), { force: true });
-    const config = await loadConfig(tmpDir);
+    const config = await loadTestConfig();
     expect(config).toEqual(CONFIG_DEFAULTS);
   });
 
   it('returns all defaults when config file is empty', async () => {
     await writeFile(join(tmpDir, '.planning', 'config.json'), '');
-    const config = await loadConfig(tmpDir);
+    const config = await loadTestConfig();
     expect(config).toEqual(CONFIG_DEFAULTS);
   });
 
@@ -60,7 +55,7 @@ describe('loadConfig', () => {
       JSON.stringify(userConfig),
     );
 
-    const config = await loadConfig(tmpDir);
+    const config = await loadTestConfig();
 
     expect(config.model_profile).toBe('fast');
     expect(config.workflow.research).toBe(false);
@@ -70,6 +65,94 @@ describe('loadConfig', () => {
     // Top-level defaults preserved
     expect(config.commit_docs).toBe(true);
     expect(config.parallelization).toBe(true);
+  });
+
+  it('layers user defaults from ~/.gsd/defaults.json when project config is missing', async () => {
+    await rm(join(tmpDir, '.planning', 'config.json'), { force: true });
+    await writeUserDefaults({
+      resolve_model_ids: 'omit',
+      workflow: { auto_advance: true },
+      agent_skills: { 'gsd-planner': ['codex-skill'] },
+      features: { global_learnings: true },
+      model_overrides: { 'gsd-planner': 'openai/gpt-5.4' },
+    });
+
+    const config = await loadTestConfig();
+
+    expect(config.resolve_model_ids).toBe('omit');
+    expect(config.workflow.auto_advance).toBe(true);
+    expect(config.workflow.research).toBe(true);
+    expect(config.agent_skills).toEqual({ 'gsd-planner': ['codex-skill'] });
+    expect(config.features).toEqual({ global_learnings: true });
+    expect(config.model_overrides).toEqual({ 'gsd-planner': 'openai/gpt-5.4' });
+  });
+
+  it('lets project config override user defaults while preserving nested fallbacks', async () => {
+    await writeUserDefaults({
+      resolve_model_ids: 'omit',
+      workflow: { auto_advance: true, research: false },
+      git: { branching_strategy: 'phase' },
+      agent_skills: { 'gsd-planner': 'global-skill' },
+      features: { global_learnings: true, thinking_partner: true },
+      model_overrides: {
+        'gsd-planner': 'global-planner',
+        'gsd-executor': 'global-executor',
+      },
+    });
+    await writeFile(
+      join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({
+        resolve_model_ids: false,
+        workflow: { auto_advance: false },
+        git: { branching_strategy: 'none' },
+        agent_skills: { 'gsd-planner': 'project-skill' },
+        features: { thinking_partner: false },
+        model_overrides: { 'gsd-planner': 'project-planner' },
+      }),
+    );
+
+    const config = await loadTestConfig();
+
+    expect(config.resolve_model_ids).toBe(false);
+    expect(config.workflow.auto_advance).toBe(false);
+    expect(config.workflow.research).toBe(false);
+    expect(config.git.branching_strategy).toBe('none');
+    expect(config.agent_skills).toEqual({ 'gsd-planner': 'project-skill' });
+    expect(config.features).toEqual({ global_learnings: true, thinking_partner: false });
+    expect(config.model_overrides).toEqual({
+      'gsd-planner': 'project-planner',
+      'gsd-executor': 'global-executor',
+    });
+  });
+
+  it('deep-merges features from defaults, user defaults, and project config', async () => {
+    await writeUserDefaults({
+      features: { global_learnings: true, thinking_partner: true },
+    });
+    await writeFile(
+      join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ features: { thinking_partner: false } }),
+    );
+
+    const config = await loadTestConfig();
+
+    expect(config.features).toEqual({
+      global_learnings: true,
+      thinking_partner: false,
+    });
+  });
+
+  it('ignores malformed user defaults', async () => {
+    await writeUserDefaults('{bad json');
+    await writeFile(
+      join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ model_profile: 'fast' }),
+    );
+
+    const config = await loadTestConfig();
+
+    expect(config.model_profile).toBe('fast');
+    expect(config.resolve_model_ids).toBe(CONFIG_DEFAULTS.resolve_model_ids);
   });
 
   it('partial config merges correctly for nested objects', async () => {
@@ -82,7 +165,7 @@ describe('loadConfig', () => {
       JSON.stringify(userConfig),
     );
 
-    const config = await loadConfig(tmpDir);
+    const config = await loadTestConfig();
 
     expect(config.git.branching_strategy).toBe('milestone');
     // Other git defaults preserved
@@ -97,7 +180,7 @@ describe('loadConfig', () => {
       JSON.stringify(userConfig),
     );
 
-    const config = await loadConfig(tmpDir);
+    const config = await loadTestConfig();
     expect(config.custom_key).toBe('custom_value');
   });
 
@@ -110,7 +193,7 @@ describe('loadConfig', () => {
       JSON.stringify(userConfig),
     );
 
-    const config = await loadConfig(tmpDir);
+    const config = await loadTestConfig();
     expect(config.agent_skills).toEqual({ planner: 'custom-skill' });
   });
 
@@ -122,7 +205,7 @@ describe('loadConfig', () => {
       '{bad json',
     );
 
-    await expect(loadConfig(tmpDir)).rejects.toThrow(/Failed to parse config/);
+    await expect(loadTestConfig()).rejects.toThrow(/Failed to parse config/);
   });
 
   it('throws when config is not an object (array)', async () => {
@@ -131,7 +214,7 @@ describe('loadConfig', () => {
       '[1, 2, 3]',
     );
 
-    await expect(loadConfig(tmpDir)).rejects.toThrow(/must be a JSON object/);
+    await expect(loadTestConfig()).rejects.toThrow(/must be a JSON object/);
   });
 
   it('throws when config is not an object (string)', async () => {
@@ -140,7 +223,7 @@ describe('loadConfig', () => {
       '"just a string"',
     );
 
-    await expect(loadConfig(tmpDir)).rejects.toThrow(/must be a JSON object/);
+    await expect(loadTestConfig()).rejects.toThrow(/must be a JSON object/);
   });
 
   it('ignores unknown keys without error', async () => {
@@ -153,7 +236,7 @@ describe('loadConfig', () => {
       JSON.stringify(userConfig),
     );
 
-    const config = await loadConfig(tmpDir);
+    const config = await loadTestConfig();
     // Should load fine, with unknowns passed through
     expect(config.model_profile).toBe('balanced');
     expect((config as Record<string, unknown>).totally_unknown).toBe(true);
@@ -169,73 +252,10 @@ describe('loadConfig', () => {
       JSON.stringify(userConfig),
     );
 
-    const config = await loadConfig(tmpDir);
+    const config = await loadTestConfig();
     // We pass through the user's values as-is — runtime code handles type mismatches
     expect(config.commit_docs).toBe('yes');
     expect(config.parallelization).toBe(0);
-  });
-
-  // ─── User-level defaults (~/.gsd/defaults.json) ─────────────────────────
-  // Regression: issue #2652 — SDK loadConfig ignored user-level defaults
-  // for pre-project Codex installs, so init.quick still emitted Claude
-  // model aliases from MODEL_PROFILES via resolveModel even when the user
-  // had `resolve_model_ids: "omit"` in ~/.gsd/defaults.json.
-  //
-  // Mirrors CJS behavior in get-shit-done/bin/lib/core.cjs:421 (#1683):
-  // user-level defaults only apply when no project .planning/config.json
-  // exists (pre-project context). Once a project is initialized, its
-  // config.json is authoritative — buildNewProjectConfig baked the user
-  // defaults in at /gsd:new-project time.
-
-  it('pre-project: layers user defaults from ~/.gsd/defaults.json', async () => {
-    await writeUserDefaults({ resolve_model_ids: 'omit' });
-    // No project config.json
-    const config = await loadConfig(tmpDir);
-    expect((config as Record<string, unknown>).resolve_model_ids).toBe('omit');
-    // Built-in defaults still present for keys user did not override
-    expect(config.model_profile).toBe('balanced');
-    expect(config.workflow.plan_check).toBe(true);
-  });
-
-  it('pre-project: deep-merges nested keys from user defaults', async () => {
-    await writeUserDefaults({
-      git: { branching_strategy: 'milestone' },
-      agent_skills: { planner: 'user-skill' },
-    });
-
-    const config = await loadConfig(tmpDir);
-    expect(config.git.branching_strategy).toBe('milestone');
-    expect(config.git.phase_branch_template).toBe('gsd/phase-{phase}-{slug}');
-    expect(config.agent_skills).toEqual({ planner: 'user-skill' });
-  });
-
-  it('project config is authoritative over user defaults (CJS parity)', async () => {
-    // User defaults set resolve_model_ids: "omit", but project config omits it.
-    // Per CJS core.cjs loadConfig (#1683): once .planning/config.json exists,
-    // ~/.gsd/defaults.json is ignored — buildNewProjectConfig already baked
-    // the user defaults in at project creation time.
-    await writeUserDefaults({
-      resolve_model_ids: 'omit',
-      model_profile: 'fast',
-    });
-    await writeFile(
-      join(tmpDir, '.planning', 'config.json'),
-      JSON.stringify({ model_profile: 'quality' }),
-    );
-
-    const config = await loadConfig(tmpDir);
-    expect(config.model_profile).toBe('quality');
-    // User-defaults not layered when project config present
-    expect((config as Record<string, unknown>).resolve_model_ids).toBeUndefined();
-  });
-
-  it('ignores malformed ~/.gsd/defaults.json', async () => {
-    await mkdir(join(fakeHome, '.gsd'), { recursive: true });
-    await writeFile(join(fakeHome, '.gsd', 'defaults.json'), '{not json');
-
-    const config = await loadConfig(tmpDir);
-    // Falls back to built-in defaults
-    expect(config).toEqual(CONFIG_DEFAULTS);
   });
 
   it('does not mutate CONFIG_DEFAULTS between calls', async () => {
@@ -245,7 +265,7 @@ describe('loadConfig', () => {
       join(tmpDir, '.planning', 'config.json'),
       JSON.stringify({ model_profile: 'fast', workflow: { research: false } }),
     );
-    await loadConfig(tmpDir);
+    await loadTestConfig();
 
     expect(CONFIG_DEFAULTS).toEqual(before);
   });

--- a/sdk/src/config.test.ts
+++ b/sdk/src/config.test.ts
@@ -142,6 +142,78 @@ describe('loadConfig', () => {
     });
   });
 
+  it('recursively merges deeper config trees without clobbering sibling defaults', async () => {
+    await writeUserDefaults({
+      review: {
+        models: {
+          codex: 'codex exec --model gpt-5',
+          gemini: 'gemini -m gemini-2.5-pro',
+        },
+      },
+      claude_md_assembly: {
+        mode: 'embed',
+        blocks: {
+          architecture: 'link',
+          workflow: 'embed',
+        },
+      },
+      model_profile_overrides: {
+        codex: {
+          opus: { model: 'gpt-5.5', reasoning_effort: 'xhigh' },
+          sonnet: 'gpt-5.4',
+        },
+        gemini: {
+          opus: 'gemini-2.5-pro',
+        },
+      },
+    });
+    await writeFile(
+      join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({
+        review: {
+          models: {
+            codex: 'codex exec --model gpt-5.5',
+          },
+        },
+        claude_md_assembly: {
+          blocks: {
+            workflow: 'link',
+          },
+        },
+        model_profile_overrides: {
+          codex: {
+            sonnet: { model: 'gpt-5.4', reasoning_effort: 'high' },
+          },
+        },
+      }),
+    );
+
+    const config = await loadTestConfig();
+
+    expect(config.review).toEqual({
+      models: {
+        codex: 'codex exec --model gpt-5.5',
+        gemini: 'gemini -m gemini-2.5-pro',
+      },
+    });
+    expect(config.claude_md_assembly).toEqual({
+      mode: 'embed',
+      blocks: {
+        architecture: 'link',
+        workflow: 'link',
+      },
+    });
+    expect(config.model_profile_overrides).toEqual({
+      codex: {
+        opus: { model: 'gpt-5.5', reasoning_effort: 'xhigh' },
+        sonnet: { model: 'gpt-5.4', reasoning_effort: 'high' },
+      },
+      gemini: {
+        opus: 'gemini-2.5-pro',
+      },
+    });
+  });
+
   it('ignores malformed user defaults', async () => {
     await writeUserDefaults('{bad json');
     await writeFile(

--- a/sdk/src/config.ts
+++ b/sdk/src/config.ts
@@ -52,6 +52,11 @@ export interface HooksConfig {
   context_warnings: boolean;
 }
 
+export interface LoadConfigOptions {
+  /** Home directory used to resolve `.gsd/defaults.json`; injectable for tests. */
+  homeDir?: string;
+}
+
 export interface GSDConfig {
   model_profile: string;
   commit_docs: boolean;
@@ -64,6 +69,9 @@ export interface GSDConfig {
   workflow: WorkflowConfig;
   hooks: HooksConfig;
   agent_skills: Record<string, unknown>;
+  features: Record<string, unknown>;
+  /** Per-agent model override map, e.g. `{ 'gsd-planner': 'claude-opus-4-7' }`. */
+  model_overrides: Record<string, string>;
   /** Project slug for branch templates; mirrors gsd-tools `config.project_code`. */
   project_code?: string | null;
   /** Interactive vs headless; mirrors gsd-tools flat `config.mode`. */
@@ -112,6 +120,8 @@ export const CONFIG_DEFAULTS: GSDConfig = {
     context_warnings: true,
   },
   agent_skills: {},
+  features: {},
+  model_overrides: {},
   project_code: null,
   mode: 'interactive',
   _auto_chain_active: false,
@@ -119,78 +129,103 @@ export const CONFIG_DEFAULTS: GSDConfig = {
 
 // ─── Loader ──────────────────────────────────────────────────────────────────
 
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+const NESTED_CONFIG_SECTIONS = [
+  'git',
+  'workflow',
+  'hooks',
+  'agent_skills',
+  'features',
+  'model_overrides',
+] as const;
+
 /**
- * Load project config from `.planning/config.json`, merging with defaults.
- * When project config is missing or empty, layers user defaults
- * (`~/.gsd/defaults.json`) over built-in defaults.
- * Throws on malformed JSON with a helpful error message.
+ * Merge a config override onto a fully materialized base config.
+ *
+ * Top-level keys override directly while known nested sections retain defaults
+ * for omitted fields. Shared by config loading and project config creation so
+ * nested merge allowlists do not drift.
  */
-/**
- * Read user-level defaults from `~/.gsd/defaults.json` (or `$GSD_HOME/.gsd/`
- * when set). Returns `{}` when the file is missing, empty, or malformed —
- * matches CJS behavior in `get-shit-done/bin/lib/core.cjs` (#1683, #2652).
- */
-async function loadUserDefaults(): Promise<Record<string, unknown>> {
-  const home = process.env.GSD_HOME || homedir();
-  const defaultsPath = join(home, '.gsd', 'defaults.json');
-  let raw: string;
-  try {
-    raw = await readFile(defaultsPath, 'utf-8');
-  } catch {
-    return {};
-  }
-  const trimmed = raw.trim();
-  if (trimmed === '') return {};
-  try {
-    const parsed = JSON.parse(trimmed);
-    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
-      return {};
+export function mergeConfig<T extends Record<string, unknown>>(base: T, override: Record<string, unknown>): T {
+  const merged: Record<string, unknown> = {
+    ...base,
+    ...override,
+  };
+
+  for (const section of NESTED_CONFIG_SECTIONS) {
+    const baseSection = base[section];
+    const overrideSection = override[section];
+
+    if (isPlainRecord(baseSection) || isPlainRecord(overrideSection)) {
+      merged[section] = {
+        ...(isPlainRecord(baseSection) ? baseSection : {}),
+        ...(isPlainRecord(overrideSection) ? overrideSection : {}),
+      };
     }
-    return parsed as Record<string, unknown>;
+  }
+
+  return merged as T;
+}
+
+/**
+ * Read user-level defaults from `<homeDir>/.gsd/defaults.json`.
+ *
+ * Missing, empty, malformed, or non-object defaults are ignored because global
+ * defaults must never block SDK query execution.
+ */
+export async function loadUserDefaults(homeDir = homedir()): Promise<Record<string, unknown>> {
+  const defaultsPath = join(homeDir, '.gsd', 'defaults.json');
+
+  try {
+    const raw = await readFile(defaultsPath, 'utf-8');
+    const trimmed = raw.trim();
+    if (trimmed === '') return {};
+
+    const parsed: unknown = JSON.parse(trimmed);
+    return isPlainRecord(parsed) ? parsed : {};
   } catch {
     return {};
   }
 }
 
-export async function loadConfig(projectDir: string, workstream?: string): Promise<GSDConfig> {
+/**
+ * Load project config from `.planning/config.json`, merging with defaults and
+ * optional user defaults from `~/.gsd/defaults.json`.
+ * Returns merged defaults when file is missing or empty.
+ * Throws on malformed JSON with a helpful error message.
+ */
+export async function loadConfig(
+  projectDir: string,
+  workstream?: string,
+  options: LoadConfigOptions = {},
+): Promise<GSDConfig> {
   const configPath = join(projectDir, relPlanningPath(workstream), 'config.json');
   const rootConfigPath = join(projectDir, '.planning', 'config.json');
+  const baseConfig = mergeConfig(CONFIG_DEFAULTS, await loadUserDefaults(options.homeDir));
 
   let raw: string;
-  let projectConfigFound = false;
   try {
     raw = await readFile(configPath, 'utf-8');
-    projectConfigFound = true;
   } catch {
     // If workstream config missing, fall back to root config
     if (workstream) {
       try {
         raw = await readFile(rootConfigPath, 'utf-8');
-        projectConfigFound = true;
       } catch {
-        raw = '';
+        return baseConfig;
       }
     } else {
-      raw = '';
+      // File missing — normal for new projects
+      return baseConfig;
     }
-  }
-
-  // Pre-project context: no .planning/config.json exists. Layer user-level
-  // defaults from ~/.gsd/defaults.json over built-in defaults. Mirrors the
-  // CJS fall-back branch in get-shit-done/bin/lib/core.cjs:421 (#1683) so
-  // SDK-dispatched init queries (e.g. resolveModel in Codex installs, #2652)
-  // honor user-level knobs like `resolve_model_ids: "omit"`.
-  if (!projectConfigFound) {
-    const userDefaults = await loadUserDefaults();
-    return mergeDefaults(userDefaults);
   }
 
   const trimmed = raw.trim();
   if (trimmed === '') {
-    // Empty project config — treat as no project config (CJS core.cjs
-    // catches JSON.parse on empty and falls through to the pre-project path).
-    const userDefaults = await loadUserDefaults();
-    return mergeDefaults(userDefaults);
+    return baseConfig;
   }
 
   let parsed: Record<string, unknown>;
@@ -205,30 +240,6 @@ export async function loadConfig(projectDir: string, workstream?: string): Promi
     throw new Error(`Config at ${configPath} must be a JSON object`);
   }
 
-  // Project config exists — user-level defaults are ignored (CJS parity).
-  // `buildNewProjectConfig` already baked them into config.json at /gsd:new-project.
-  return mergeDefaults(parsed);
-}
-
-function mergeDefaults(parsed: Record<string, unknown>): GSDConfig {
-  return {
-    ...structuredClone(CONFIG_DEFAULTS),
-    ...parsed,
-    git: {
-      ...CONFIG_DEFAULTS.git,
-      ...(parsed.git as Partial<GitConfig> ?? {}),
-    },
-    workflow: {
-      ...CONFIG_DEFAULTS.workflow,
-      ...(parsed.workflow as Partial<WorkflowConfig> ?? {}),
-    },
-    hooks: {
-      ...CONFIG_DEFAULTS.hooks,
-      ...(parsed.hooks as Partial<HooksConfig> ?? {}),
-    },
-    agent_skills: {
-      ...CONFIG_DEFAULTS.agent_skills,
-      ...(parsed.agent_skills as Record<string, unknown> ?? {}),
-    },
-  };
+  // Three-level deep merge: defaults <- global defaults <- project config
+  return mergeConfig(baseConfig, parsed);
 }

--- a/sdk/src/config.ts
+++ b/sdk/src/config.ts
@@ -136,18 +136,46 @@ function isPlainRecord(value: unknown): value is Record<string, unknown> {
 const NESTED_CONFIG_SECTIONS = [
   'git',
   'workflow',
+  'planning',
   'hooks',
+  'statusline',
   'agent_skills',
+  'review',
   'features',
+  'learnings',
+  'manager',
+  'intel',
+  'graphify',
+  'claude_md_assembly',
   'model_overrides',
+  'model_profile_overrides',
 ] as const;
+
+function mergePlainRecords(
+  base: Record<string, unknown>,
+  override: Record<string, unknown>,
+): Record<string, unknown> {
+  const merged: Record<string, unknown> = {
+    ...base,
+    ...override,
+  };
+
+  for (const [key, overrideValue] of Object.entries(override)) {
+    const baseValue = base[key];
+    if (isPlainRecord(baseValue) && isPlainRecord(overrideValue)) {
+      merged[key] = mergePlainRecords(baseValue, overrideValue);
+    }
+  }
+
+  return merged;
+}
 
 /**
  * Merge a config override onto a fully materialized base config.
  *
- * Top-level keys override directly while known nested sections retain defaults
- * for omitted fields. Shared by config loading and project config creation so
- * nested merge allowlists do not drift.
+ * Top-level keys override directly while known nested config trees retain
+ * omitted sibling keys recursively. Shared by config loading and project config
+ * creation so nested merge allowlists do not drift.
  */
 export function mergeConfig<T extends Record<string, unknown>>(base: T, override: Record<string, unknown>): T {
   const merged: Record<string, unknown> = {
@@ -160,10 +188,10 @@ export function mergeConfig<T extends Record<string, unknown>>(base: T, override
     const overrideSection = override[section];
 
     if (isPlainRecord(baseSection) || isPlainRecord(overrideSection)) {
-      merged[section] = {
-        ...(isPlainRecord(baseSection) ? baseSection : {}),
-        ...(isPlainRecord(overrideSection) ? overrideSection : {}),
-      };
+      merged[section] = mergePlainRecords(
+        isPlainRecord(baseSection) ? baseSection : {},
+        isPlainRecord(overrideSection) ? overrideSection : {},
+      );
     }
   }
 

--- a/sdk/src/query/config-mutation.test.ts
+++ b/sdk/src/query/config-mutation.test.ts
@@ -265,11 +265,32 @@ describe('configNewProject global defaults (D11)', () => {
         workflow: { auto_advance: true, research: false },
         agent_skills: { 'gsd-planner': 'global-planner-skill' },
         features: { global_learnings: true, thinking_partner: true },
+        review: {
+          models: {
+            codex: 'codex exec --model gpt-5',
+            gemini: 'gemini -m gemini-2.5-pro',
+          },
+        },
+        claude_md_assembly: {
+          blocks: {
+            architecture: 'link',
+            workflow: 'embed',
+          },
+        },
+        model_profile_overrides: {
+          codex: {
+            opus: 'gpt-5.5',
+            sonnet: 'gpt-5.4',
+          },
+        },
       }),
     );
     const choices = JSON.stringify({
       workflow: { research: true },
       features: { thinking_partner: false },
+      review: { models: { codex: 'codex exec --model gpt-5.5' } },
+      claude_md_assembly: { blocks: { workflow: 'link' } },
+      model_profile_overrides: { codex: { sonnet: 'gpt-5.4-mini' } },
     });
 
     const result = await configNewProject([choices], tmpDir);
@@ -282,6 +303,24 @@ describe('configNewProject global defaults (D11)', () => {
     expect(raw.workflow.research).toBe(true);
     expect(raw.agent_skills).toEqual({ 'gsd-planner': 'global-planner-skill' });
     expect(raw.features).toEqual({ global_learnings: true, thinking_partner: false });
+    expect(raw.review).toEqual({
+      models: {
+        codex: 'codex exec --model gpt-5.5',
+        gemini: 'gemini -m gemini-2.5-pro',
+      },
+    });
+    expect(raw.claude_md_assembly).toEqual({
+      blocks: {
+        architecture: 'link',
+        workflow: 'link',
+      },
+    });
+    expect(raw.model_profile_overrides).toEqual({
+      codex: {
+        opus: 'gpt-5.5',
+        sonnet: 'gpt-5.4-mini',
+      },
+    });
   });
 });
 

--- a/sdk/src/query/config-mutation.test.ts
+++ b/sdk/src/query/config-mutation.test.ts
@@ -14,14 +14,25 @@ import { GSDError } from '../errors.js';
 // ─── Test setup ─────────────────────────────────────────────────────────────
 
 let tmpDir: string;
+let homeDir: string;
+let previousHome: string | undefined;
 
 beforeEach(async () => {
   tmpDir = await mkdtemp(join(tmpdir(), 'gsd-cfgmut-'));
+  homeDir = await mkdtemp(join(tmpdir(), 'gsd-cfgmut-home-'));
+  previousHome = process.env.HOME;
+  process.env.HOME = homeDir;
   await mkdir(join(tmpDir, '.planning'), { recursive: true });
 });
 
 afterEach(async () => {
-  await rm(tmpDir, { recursive: true, force: true });
+  try {
+    await rm(tmpDir, { recursive: true, force: true });
+    await rm(homeDir, { recursive: true, force: true });
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+  }
 });
 
 // ─── isValidConfigKey ──────────────────────────────────────────────────────
@@ -242,6 +253,35 @@ describe('configNewProject global defaults (D11)', () => {
 
     const raw = JSON.parse(await readFile(join(tmpDir, '.planning', 'config.json'), 'utf-8'));
     expect(raw.model_profile).toBe('balanced');
+  });
+
+  it('deep-merges global defaults before user choices', async () => {
+    const { configNewProject } = await import('./config-mutation.js');
+    await mkdir(join(homeDir, '.gsd'), { recursive: true });
+    await writeFile(
+      join(homeDir, '.gsd', 'defaults.json'),
+      JSON.stringify({
+        git: { branching_strategy: 'milestone' },
+        workflow: { auto_advance: true, research: false },
+        agent_skills: { 'gsd-planner': 'global-planner-skill' },
+        features: { global_learnings: true, thinking_partner: true },
+      }),
+    );
+    const choices = JSON.stringify({
+      workflow: { research: true },
+      features: { thinking_partner: false },
+    });
+
+    const result = await configNewProject([choices], tmpDir);
+
+    expect((result.data as { created: boolean }).created).toBe(true);
+    const raw = JSON.parse(await readFile(join(tmpDir, '.planning', 'config.json'), 'utf-8'));
+    expect(raw.git.branching_strategy).toBe('milestone');
+    expect(raw.git.phase_branch_template).toBe('gsd/phase-{phase}-{slug}');
+    expect(raw.workflow.auto_advance).toBe(true);
+    expect(raw.workflow.research).toBe(true);
+    expect(raw.agent_skills).toEqual({ 'gsd-planner': 'global-planner-skill' });
+    expect(raw.features).toEqual({ global_learnings: true, thinking_partner: false });
   });
 });
 

--- a/sdk/src/query/config-mutation.ts
+++ b/sdk/src/query/config-mutation.ts
@@ -21,6 +21,7 @@ import { readFile, writeFile, mkdir, rename, unlink } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
+import { loadUserDefaults, mergeConfig } from '../config.js';
 import { GSDError, ErrorClassification } from '../errors.js';
 import { VALID_PROFILES, getAgentToModelMapForProfile } from './config-query.js';
 import { VALID_CONFIG_KEYS, DYNAMIC_KEY_PATTERNS } from './config-schema.js';
@@ -342,16 +343,8 @@ export const configNewProject: QueryHandler = async (args, projectDir, _workstre
     await mkdir(planningDir, { recursive: true });
   }
 
-  // D11: Load global defaults from ~/.gsd/defaults.json if present
   const homeDir = homedir();
-  let globalDefaults: Record<string, unknown> = {};
-  try {
-    const defaultsPath = join(homeDir, '.gsd', 'defaults.json');
-    const defaultsRaw = await readFile(defaultsPath, 'utf-8');
-    globalDefaults = JSON.parse(defaultsRaw) as Record<string, unknown>;
-  } catch {
-    // No global defaults — continue with hardcoded defaults only
-  }
+  const globalDefaults = await loadUserDefaults(homeDir);
 
   // Detect API key availability (boolean only, never store keys)
   const hasBraveSearch = !!(process.env.BRAVE_API_KEY || existsSync(join(homeDir, '.gsd', 'brave_api_key')));
@@ -399,32 +392,8 @@ export const configNewProject: QueryHandler = async (args, projectDir, _workstre
     features: {},
   };
 
-  // Deep merge: hardcoded <- globalDefaults <- userChoices (D11)
-  const config: Record<string, unknown> = {
-    ...defaults,
-    ...globalDefaults,
-    ...userChoices,
-    git: {
-      ...(defaults.git as Record<string, unknown>),
-      ...((userChoices.git as Record<string, unknown>) || {}),
-    },
-    workflow: {
-      ...(defaults.workflow as Record<string, unknown>),
-      ...((userChoices.workflow as Record<string, unknown>) || {}),
-    },
-    hooks: {
-      ...(defaults.hooks as Record<string, unknown>),
-      ...((userChoices.hooks as Record<string, unknown>) || {}),
-    },
-    agent_skills: {
-      ...((defaults.agent_skills as Record<string, unknown>) || {}),
-      ...((userChoices.agent_skills as Record<string, unknown>) || {}),
-    },
-    features: {
-      ...((defaults.features as Record<string, unknown>) || {}),
-      ...((userChoices.features as Record<string, unknown>) || {}),
-    },
-  };
+  // Shared deep merge: hardcoded <- globalDefaults <- userChoices (D11).
+  const config = mergeConfig(mergeConfig(defaults, globalDefaults), userChoices);
 
   await atomicWriteConfig(paths.config, config);
 

--- a/sdk/src/query/config-mutation.ts
+++ b/sdk/src/query/config-mutation.ts
@@ -354,8 +354,8 @@ export const configNewProject: QueryHandler = async (args, projectDir, _workstre
   // Build default config
   const defaults: Record<string, unknown> = {
     model_profile: 'balanced',
-    commit_docs: false,
-    parallelization: 1,
+    commit_docs: true,
+    parallelization: true,
     search_gitignored: false,
     brave_search: hasBraveSearch,
     firecrawl: hasFirecrawl,

--- a/sdk/src/query/config-query.test.ts
+++ b/sdk/src/query/config-query.test.ts
@@ -11,14 +11,22 @@ import { GSDError, ErrorClassification, exitCodeFor } from '../errors.js';
 // ─── Test setup ─────────────────────────────────────────────────────────────
 
 let tmpDir: string;
+let previousHome: string | undefined;
 
 beforeEach(async () => {
   tmpDir = await mkdtemp(join(tmpdir(), 'gsd-cfg-'));
+  previousHome = process.env.HOME;
+  process.env.HOME = join(tmpDir, 'home');
   await mkdir(join(tmpDir, '.planning'), { recursive: true });
 });
 
 afterEach(async () => {
-  await rm(tmpDir, { recursive: true, force: true });
+  try {
+    await rm(tmpDir, { recursive: true, force: true });
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+  }
 });
 
 // ─── configGet ──────────────────────────────────────────────────────────────
@@ -160,6 +168,22 @@ describe('resolveModel', () => {
         model_profile: 'balanced',
         resolve_model_ids: 'omit',
       }),
+    );
+    const result = await resolveModel(['gsd-planner'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+    expect(data).toHaveProperty('model', '');
+  });
+
+  it('returns empty model when resolve_model_ids omit comes from global defaults', async () => {
+    const { resolveModel } = await import('./config-query.js');
+    await mkdir(join(tmpDir, 'home', '.gsd'), { recursive: true });
+    await writeFile(
+      join(tmpDir, 'home', '.gsd', 'defaults.json'),
+      JSON.stringify({ resolve_model_ids: 'omit' }),
+    );
+    await writeFile(
+      join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ model_profile: 'balanced' }),
     );
     const result = await resolveModel(['gsd-planner'], tmpDir);
     const data = result.data as Record<string, unknown>;

--- a/sdk/src/query/config-query.ts
+++ b/sdk/src/query/config-query.ts
@@ -157,8 +157,7 @@ export const resolveModel: QueryHandler = async (args, projectDir) => {
   const profile = String(config.model_profile || 'balanced').toLowerCase();
 
   // Check per-agent override first
-  const overrides = (config as Record<string, unknown>).model_overrides as Record<string, string> | undefined;
-  const override = overrides?.[agentType];
+  const override = config.model_overrides[agentType];
   if (override) {
     const agentModels = MODEL_PROFILES[agentType];
     const result = agentModels

--- a/sdk/src/query/init.test.ts
+++ b/sdk/src/query/init.test.ts
@@ -28,9 +28,12 @@ import {
 } from './init.js';
 
 let tmpDir: string;
+let previousHome: string | undefined;
 
 beforeEach(async () => {
   tmpDir = await mkdtemp(join(tmpdir(), 'gsd-init-'));
+  previousHome = process.env.HOME;
+  process.env.HOME = join(tmpDir, 'home');
   // Create minimal .planning structure
   await mkdir(join(tmpDir, '.planning', 'phases', '09-foundation'), { recursive: true });
   await mkdir(join(tmpDir, '.planning', 'phases', '10-read-only-queries'), { recursive: true });
@@ -92,7 +95,12 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-  await rm(tmpDir, { recursive: true, force: true });
+  try {
+    await rm(tmpDir, { recursive: true, force: true });
+  } finally {
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+  }
 });
 
 describe('withProjectRoot', () => {
@@ -375,6 +383,20 @@ describe('initQuick', () => {
     expect(data.executor_model).toBeDefined();
     expect(data.quick_dir).toBe('.planning/quick');
     expect(data.project_root).toBe(tmpDir);
+  });
+
+  it('omits model aliases when global defaults set resolve_model_ids to omit', async () => {
+    await mkdir(join(tmpDir, 'home', '.gsd'), { recursive: true });
+    await writeFile(
+      join(tmpDir, 'home', '.gsd', 'defaults.json'),
+      JSON.stringify({ resolve_model_ids: 'omit' }),
+    );
+
+    const result = await initQuick(['codex-task'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+
+    expect(data.planner_model).toBe('');
+    expect(data.executor_model).toBe('');
   });
 });
 

--- a/sdk/src/query/init.ts
+++ b/sdk/src/query/init.ts
@@ -39,7 +39,7 @@ import type { QueryHandler } from './utils.js';
 async function getModelAlias(agentType: string, projectDir: string): Promise<string> {
   const result = await resolveModel([agentType], projectDir);
   const data = result.data as Record<string, unknown>;
-  return (data.model as string) || 'sonnet';
+  return typeof data.model === 'string' ? data.model : 'sonnet';
 }
 
 /**


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

Fixes #2652

> The linked issue has the `confirmed-bug` label.

---

## What was broken

Codex installs write `resolve_model_ids: "omit"` into `~/.gsd/defaults.json`, but SDK `loadConfig()` did not read user-level defaults. SDK init queries therefore fell back to Claude model aliases like `opus` and `sonnet` even in Codex runtime flows.

## What this fix does

SDK `loadConfig()` now merges `CONFIG_DEFAULTS <- ~/.gsd/defaults.json <- .planning/config.json`. It also preserves explicit empty model IDs from `resolveModel()` so `init.quick` does not replace an intentionally omitted model with `sonnet`.

## Root cause

The SDK config loader only layered hardcoded defaults under project config. It lacked the CJS config path's user-level defaults layer, so Codex runtime defaults were ignored by SDK query callers.

## Testing

### How I verified the fix

- `npx vitest run --project unit src/config.test.ts src/query/config-query.test.ts src/query/init.test.ts`
- `npm run build`
- `git diff --check`

Full `npx vitest run --project unit` still has unrelated failures on current upstream main in `state-mutation`, `config-mutation`, `decomposed-handlers`, and `registry` tests.

### Regression test added?

- [x] Yes — added tests that verify global defaults merge behavior, `resolveModel()` with `resolve_model_ids: "omit"` from global defaults, and `initQuick()` preserving omitted model aliases.
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: Codex SDK query path
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`) — focused regression tests and SDK build pass; full SDK unit suite has unrelated existing failures on upstream main
- [ ] CHANGELOG.md updated if this is a user-facing fix
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Global user defaults, feature flags, and per-agent model overrides are now supported and layered into project configs; new defaults influence project creation (e.g., docs commits and parallelization).

* **Bug Fixes**
  * Model alias handling tightened to accept only valid strings.
  * Malformed or missing global defaults are safely ignored in favor of sane defaults.

* **Tests**
  * Expanded, isolated tests for config layering, deep-merge behavior, and model-resolution scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->