### PR TITLE
fix(#2676): phase.complete next-phase lookup respects parallel milestones

### DIFF
--- a/sdk/src/query/phase-lifecycle.test.ts
+++ b/sdk/src/query/phase-lifecycle.test.ts
@@ -951,6 +951,91 @@ describe('phaseComplete', () => {
     expect(state).toMatch(/Status:\s*Milestone complete/);
   });
 
+  it('finds next phase across parallel milestones (STATE points at different milestone)', async () => {
+    // Regression test: a project with two active milestones where STATE.md
+    // points at milestone vA (e.g. feature work), but the phase being
+    // completed belongs to vB (e.g. parallel rebrand). Without the
+    // parallel-milestone fix, getMilestonePhaseFilter excludes all vB
+    // phases, both the directory scan and ROADMAP fallback find no
+    // candidate, and is_last_phase falsely returns true.
+    const { phaseComplete } = await import('./phase-lifecycle.js');
+
+    const PARALLEL_ROADMAP = `# Roadmap
+
+## Current Milestone: vA Feature Work
+
+| Phase | Plans | Status | Completed |
+|-------|-------|--------|-----------|
+| 9.    | 3/3   | Complete | 2026-04-01 |
+
+- [x] Phase 9: Foundation (completed 2026-04-01)
+
+### Phase 9: Foundation
+
+**Goal:** Build foundation
+**Plans:** 3/3 plans complete
+
+## Parallel Milestone: vB Rebrand
+
+- [x] Phase 41.1: Tokens (completed 2026-04-23)
+- [x] Phase 41.2: Primitives
+- [ ] Phase 41.3: Screens
+
+### Phase 41.1: Tokens
+
+**Goal:** Design tokens
+
+### Phase 41.2: Primitives
+
+**Goal:** UI primitives
+
+### Phase 41.3: Screens
+
+**Goal:** Solver screens
+`;
+
+    const PARALLEL_STATE = `---
+gsd_state_version: 1.0
+milestone: vA
+milestone_name: Feature Work
+status: executing
+progress:
+  total_phases: 1
+  completed_phases: 1
+  total_plans: 3
+  completed_plans: 3
+  percent: 100
+---
+
+# Project State
+
+## Current Position
+
+Phase: 9 of 1 (Foundation)
+Plan: 3 of 3
+Status: Executing
+Last activity: 2026-04-23
+`;
+
+    await setupTestProject(tmpDir, {
+      roadmap: PARALLEL_ROADMAP,
+      state: PARALLEL_STATE,
+      phases: ['09-foundation', '41.1-tokens', '41.2-primitives', '41.3-screens'],
+    });
+
+    // Phase 41.2 has plan + summary so it's "complete" on disk
+    const p412Dir = join(tmpDir, '.planning', 'phases', '41.2-primitives');
+    await writeFile(join(p412Dir, '41.2-01-PLAN.md'), 'plan', 'utf-8');
+    await writeFile(join(p412Dir, '41.2-01-SUMMARY.md'), 'summary', 'utf-8');
+
+    const result = await phaseComplete(['41.2'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+
+    // Despite STATE pointing at vA, completing 41.2 should find 41.3 as next.
+    expect(data.next_phase).toBe('41.3');
+    expect(data.is_last_phase).toBe(false);
+  });
+
   it('collects UAT/VERIFICATION warnings without blocking', async () => {
     const { phaseComplete } = await import('./phase-lifecycle.js');
     await setupTestProject(tmpDir, {

--- a/sdk/src/query/phase-lifecycle.ts
+++ b/sdk/src/query/phase-lifecycle.ts
@@ -1258,10 +1258,19 @@ export const phaseComplete: QueryHandler = async (args, projectDir, workstream) 
   let isLastPhase = true;
 
   try {
+    // Parallel-milestone fix: if STATE.milestone differs from the milestone
+    // that owns the completed phase, the milestone filter excludes sibling
+    // phases and the handler falsely returns is_last_phase: true. Detect the
+    // mismatch by checking whether the completed phase passes the filter; if
+    // not, drop the filter for next-phase detection.
     const isDirInMilestone = await getMilestonePhaseFilter(projectDir, workstream);
+    const completedPhaseInCurrentMilestone = isDirInMilestone(`${phaseNum}-x`)
+      || isDirInMilestone(phaseNum);
     const entries = await readdir(paths.phases, { withFileTypes: true });
-    const dirs = entries.filter(e => e.isDirectory()).map(e => e.name)
-      .filter(isDirInMilestone)
+    const baseDirs = entries.filter(e => e.isDirectory()).map(e => e.name);
+    const dirs = (completedPhaseInCurrentMilestone
+        ? baseDirs.filter(isDirInMilestone)
+        : baseDirs)
       .sort((a, b) => comparePhaseNum(a, b));
 
     for (const dir of dirs) {
@@ -1281,7 +1290,13 @@ export const phaseComplete: QueryHandler = async (args, projectDir, workstream) 
   if (isLastPhase && existsSync(paths.roadmap)) {
     try {
       const roadmapContent = await readFile(paths.roadmap, 'utf-8');
-      const roadmapForPhases = await extractCurrentMilestone(roadmapContent, projectDir);
+      // Same parallel-milestone fix: if the milestone slice does not contain
+      // the completed phase, scan the full ROADMAP instead.
+      const milestoneSlice = await extractCurrentMilestone(roadmapContent, projectDir);
+      const sliceContainsCompletedPhase = new RegExp(
+        `#{2,4}\\s*Phase\\s+${phaseNum.replace(/\./g, '\\.')}\\s*:`, 'i'
+      ).test(milestoneSlice);
+      const roadmapForPhases = sliceContainsCompletedPhase ? milestoneSlice : roadmapContent;
       const phasePattern = /#{2,4}\s*Phase\s+(\d+[A-Z]?(?:\.\d+)*)\s*:\s*([^\n]+)/gi;
       let pm: RegExpExecArray | null;
       while ((pm = phasePattern.exec(roadmapForPhases)) !== null) {


### PR DESCRIPTION
Fixes #2676.

## Summary

When STATE.md's `milestone:` differs from the milestone that owns the phase being completed, `getMilestonePhaseFilter` excludes the completed phase's siblings from the next-phase scan. The handler falsely reports `is_last_phase: true` and `next_phase: null`, causing orchestrators to suggest milestone-end actions instead of obvious next-phase routing.

This is a real workflow: parallel milestones (e.g. a rebrand running alongside feature work) where STATE.milestone makes one "primary" but should not invalidate routing for phases in the other.

## Fix

In `sdk/src/query/phase-lifecycle.ts` Step E (next-phase detection), detect the mismatch by checking whether the completed phase passes the milestone filter:

- **Directory scan:** if the completed phase fails the filter, drop the filter and scan all phase directories.
- **ROADMAP fallback:** if the milestone slice does not contain the completed phase, scan the full ROADMAP instead of the slice.

Single-milestone behavior is unchanged — the relaxed path only fires when the completed phase clearly does not belong to STATE's current milestone. Other call sites of `getMilestonePhaseFilter` (e.g. `buildStateFrontmatter`, milestone progress counts) keep filtering by STATE.milestone since that's the correct semantics for those uses.

## Test Plan

- All 44 existing `phase-lifecycle.test.ts` tests still pass.
- New regression test added: project with two milestone sections in ROADMAP (vA + vB), STATE points at vA, `phaseComplete('41.2')` (a vB phase) returns `next_phase: '41.3'` and `is_last_phase: false`.
- Total: **45/45 phase-lifecycle tests passing**.

## Notes

- The filter is also used in `buildStateFrontmatter`, `phase-lifecycle.ts:1411`, and `state-mutation.ts:549`. This patch only changes behavior in `phase.complete`'s next-phase lookup. The other call sites have different semantics (milestone progress counting) and should keep filtering by STATE.milestone.
- A future enhancement could add an explicit `milestone` parameter to `getMilestonePhaseFilter` so callers can request a specific milestone slice. Out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved phase completion handling to correctly identify subsequent phases when milestone information doesn't match, ensuring accurate detection of final phase status.

* **Tests**
  * Added test coverage for phase completion with parallel milestones to validate next phase detection and final phase identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->