### PR TITLE
fix(#2660): capture prose after labeled bold in extractOneLinerFromBody

### DIFF
--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -1744,9 +1744,24 @@ function extractOneLinerFromBody(content) {
   if (!content) return null;
   // Strip frontmatter first
   const body = content.replace(/^---\n[\s\S]*?\n---\n*/, '');
-  // Find the first **...** line after a # heading
-  const match = body.match(/^#[^\n]*\n+\*\*([^*]+)\*\*/m);
-  return match ? match[1].trim() : null;
+  // Find the first **...** span on a line after a # heading.
+  // Two supported template forms:
+  //   1) Labeled:  **One-liner:** Real prose here.   (bug #2660 — new template)
+  //   2) Bare:     **Real prose here.**              (legacy template)
+  // For (1), the first bold span ends in a colon and the prose that follows
+  // on the same line is the one-liner. For (2), the bold span itself is the
+  // one-liner.
+  const match = body.match(/^#[^\n]*\n+\*\*([^*\n]+)\*\*([^\n]*)/m);
+  if (!match) return null;
+  const boldInner = match[1].trim();
+  const afterBold = match[2];
+  // Labeled form: bold span is a "Label:" prefix — capture prose after it.
+  if (/:\s*$/.test(boldInner)) {
+    const prose = afterBold.trim();
+    return prose.length > 0 ? prose : null;
+  }
+  // Bare form: the bold content itself is the one-liner.
+  return boldInner.length > 0 ? boldInner : null;
 }
 
 // ─── Misc utilities ───────────────────────────────────────────────────────────

--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -1742,8 +1742,10 @@ function resolveReasoningEffortInternal(cwd, agentType) {
  */
 function extractOneLinerFromBody(content) {
   if (!content) return null;
+  // Normalize EOLs so matching works for LF and CRLF files.
+  const normalized = content.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
   // Strip frontmatter first
-  const body = content.replace(/^---\n[\s\S]*?\n---\n*/, '');
+  const body = normalized.replace(/^---\n[\s\S]*?\n---\n*/, '');
   // Find the first **...** span on a line after a # heading.
   // Two supported template forms:
   //   1) Labeled:  **One-liner:** Real prose here.   (bug #2660 — new template)

--- a/tests/bug-2660-one-liner-extraction.test.cjs
+++ b/tests/bug-2660-one-liner-extraction.test.cjs
@@ -70,4 +70,13 @@ describe('bug #2660: extractOneLinerFromBody', () => {
       '# Phase 1: Foundation Summary\n\n**Summary:** Built the thing.\n';
     assert.strictEqual(extractOneLinerFromBody(content), 'Built the thing.');
   });
+
+  test('h) CRLF line endings (Windows) are handled', () => {
+    const content =
+      '---\r\nphase: "01"\r\n---\r\n\r\n# Phase 1: Foundation Summary\r\n\r\n**One-liner:** Windows-authored prose.\r\n';
+    assert.strictEqual(
+      extractOneLinerFromBody(content),
+      'Windows-authored prose.'
+    );
+  });
 });

--- a/tests/bug-2660-one-liner-extraction.test.cjs
+++ b/tests/bug-2660-one-liner-extraction.test.cjs
@@ -1,0 +1,73 @@
+/**
+ * Bug #2660: `gsd-tools milestone complete <version>` writes MILESTONES.md
+ * bullets that read "- One-liner:" (the literal label) instead of the prose
+ * after the label.
+ *
+ * Root cause: extractOneLinerFromBody() matches the first **...** span. In
+ * `**One-liner:** prose`, the first span contains only `One-liner:` so the
+ * function returns the label instead of the prose after it.
+ */
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+
+const { extractOneLinerFromBody } = require(
+  path.join(__dirname, '..', 'get-shit-done', 'bin', 'lib', 'core.cjs')
+);
+
+describe('bug #2660: extractOneLinerFromBody', () => {
+  test('a) body-style **One-liner:** label returns prose after the label', () => {
+    const content =
+      '# Phase 2 Plan 01: Foundation Summary\n\n**One-liner:** Real prose here.\n';
+    assert.strictEqual(extractOneLinerFromBody(content), 'Real prose here.');
+  });
+
+  test('b) frontmatter-only one-liner returns null (caller handles frontmatter)', () => {
+    const content =
+      '---\none-liner: Set up project\n---\n\n# Phase 1: Foundation Summary\n\nBody prose with no bold line.\n';
+    assert.strictEqual(extractOneLinerFromBody(content), null);
+  });
+
+  test('c) no one-liner at all returns null', () => {
+    const content =
+      '# Phase 1: Foundation Summary\n\nJust some narrative, no bold line.\n';
+    assert.strictEqual(extractOneLinerFromBody(content), null);
+  });
+
+  test('d) bold spans inside the prose are preserved', () => {
+    const content =
+      '# Phase 1: Foundation Summary\n\n**One-liner:** This is **important** stuff.\n';
+    assert.strictEqual(
+      extractOneLinerFromBody(content),
+      'This is **important** stuff.'
+    );
+  });
+
+  test('e) empty prose after label returns null (no bogus bullet)', () => {
+    const empty =
+      '# Phase 1: Foundation Summary\n\n**One-liner:**\n\nRest of body.\n';
+    const whitespace =
+      '# Phase 1: Foundation Summary\n\n**One-liner:**   \n\nRest of body.\n';
+    assert.strictEqual(extractOneLinerFromBody(empty), null);
+    assert.strictEqual(extractOneLinerFromBody(whitespace), null);
+  });
+
+  test('f) legacy bare **prose** format still works (no label, no colon)', () => {
+    // Preserve pre-existing behavior: SUMMARY files historically used
+    // `**bold prose**` with no label. See tests/commands.test.cjs:366 and
+    // tests/milestone.test.cjs:451 — both assert this form.
+    const content =
+      '---\nphase: "01"\n---\n\n# Phase 1: Foundation Summary\n\n**JWT auth with refresh rotation using jose library**\n\n## Performance\n';
+    assert.strictEqual(
+      extractOneLinerFromBody(content),
+      'JWT auth with refresh rotation using jose library'
+    );
+  });
+
+  test('g) other **Label:** prefixes (e.g. Summary:) also capture prose after label', () => {
+    const content =
+      '# Phase 1: Foundation Summary\n\n**Summary:** Built the thing.\n';
+    assert.strictEqual(extractOneLinerFromBody(content), 'Built the thing.');
+  });
+});


### PR DESCRIPTION
## Linked Issue

Fixes #2660

## What was broken

`extractOneLinerFromBody` in \`get-shit-done/bin/lib/core.cjs\` returned the literal label \`\"One-liner:\"\` instead of the prose following it. All 29 v4.0 milestone SUMMARY entries rendered as \`- One-liner:\` bullets under \"Key accomplishments\" in \`MILESTONES.md\`.

## What this fix does

Rewrites the regex to anchor on the colon-terminated bold label (\`\*\*Label:\*\*\`) and capture the prose that follows it on the same line. Preserves the legacy bare-bold form (\`\*\*prose\*\*\`) for backwards compatibility and returns \`null\` for empty/whitespace prose so the caller doesn't write bogus bullets.

## Root cause

The original regex \`\\\*\\\*([^*]+)\\\*\\\*\` matches the **first** \`\*\*...\*\*\` span in \`\*\*One-liner:\*\* prose\`. The first span contains only the label (\`One-liner:\`), so group 1 captured the label, not the content. The frontmatter path (\`fm['one-liner']\`) was never populated by the SUMMARY template, so the broken body path always fired.

## Testing

### How I verified the fix

Added \`tests/bug-2660-one-liner-extraction.test.cjs\` with 7 cases (a–g): body-labeled prose, frontmatter-only, no one-liner, nested bold in prose, empty/whitespace prose, legacy bare-bold form, and other \`**Label:**\` prefixes.

- **Pre-fix:** 4/7 tests fail (the function returns \`\"One-liner:\"\`/\`\"Summary:\"\`).
- **Post-fix:** 7/7 pass.
- **Regression suite:** \`tests/milestone.test.cjs\`, \`core.test.cjs\`, \`commands.test.cjs\`, \`milestone-summary.test.cjs\` — 308/308 pass. No existing tests asserted the broken behavior.

### Regression test added?

- [x] Yes — \`tests/bug-2660-one-liner-extraction.test.cjs\`

### Platforms tested

- [x] macOS
- [ ] Windows
- [ ] Linux
- [ ] N/A

### Runtimes tested

- [x] N/A (pure string function, runtime-independent)

---

## Follow-up (not in this PR)

Existing \`MILESTONES.md\` entries still contain the wrong \`One-liner:\` strings because they were generated before the fix. Regenerating from source SUMMARY files is a one-shot script, idempotent, and should be a separate PR to keep this diff focused on the code defect.

## Checklist

- [x] Issue linked above with \`Fixes #\"
- [x] Linked issue has the \`confirmed-bug\` label
- [x] Fix is scoped to the reported bug
- [x] Regression test added
- [x] All existing tests pass
- [ ] CHANGELOG.md — fix is user-visible via MILESTONES.md output; flag for CHANGELOG on merge
- [x] No unnecessary dependencies

## Breaking changes

None. The function signature and null-return contract are preserved. Callers that previously got the string \`\"One-liner:\"\` now get the intended prose — that's the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved one-liner extraction to normalize line endings, handle labeled and legacy bold formats, and return null for empty or missing prose, preserving backward compatibility.

* **Tests**
  * Added regression tests covering labeled and unlabeled one-liners, empty/frontmatter-only inputs, embedded bold in prose, and CRLF vs LF handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->