### PR TITLE
test(#2659): regression guard against bare output() in audit-open handler

### DIFF
--- a/tests/bug-2659-audit-open-crash.test.cjs
+++ b/tests/bug-2659-audit-open-crash.test.cjs
@@ -1,0 +1,64 @@
+'use strict';
+
+/**
+ * Regression test for #2659.
+ *
+ * The `audit-open` dispatch case in bin/gsd-tools.cjs previously called bare
+ * `output(...)` on both the --json and text branches. `output` is never in
+ * local scope — the entire core module is imported as `const core`, so every
+ * other case uses `core.output(...)`. The bare calls therefore crashed with
+ * `ReferenceError: output is not defined` the moment `audit-open` ran.
+ *
+ * This test runs both invocations against a minimal temp project and asserts
+ * they exit successfully with non-empty stdout. It fails with the
+ * ReferenceError on any revision that still has the bare `output(...)` calls.
+ */
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+
+const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
+
+describe('audit-open — does not crash with ReferenceError (#2659)', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject('gsd-bug-2659-');
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('audit-open (text output) succeeds and produces stdout', () => {
+    const result = runGsdTools('audit-open', tmpDir);
+    assert.ok(
+      result.success,
+      `audit-open must not crash. stderr: ${result.error}`
+    );
+    assert.ok(
+      !/ReferenceError.*output is not defined/.test(result.error || ''),
+      `audit-open must not throw ReferenceError. stderr: ${result.error}`
+    );
+    assert.ok(
+      result.output && result.output.length > 0,
+      'audit-open must write a non-empty report to stdout'
+    );
+  });
+
+  test('audit-open --json succeeds and produces stdout', () => {
+    const result = runGsdTools(['audit-open', '--json'], tmpDir);
+    assert.ok(
+      result.success,
+      `audit-open --json must not crash. stderr: ${result.error}`
+    );
+    assert.ok(
+      !/ReferenceError.*output is not defined/.test(result.error || ''),
+      `audit-open --json must not throw ReferenceError. stderr: ${result.error}`
+    );
+    assert.ok(
+      result.output && result.output.length > 0,
+      'audit-open --json must write output to stdout'
+    );
+  });
+});

--- a/tests/bug-2659-audit-open-crash.test.cjs
+++ b/tests/bug-2659-audit-open-crash.test.cjs
@@ -60,5 +60,14 @@ describe('audit-open — does not crash with ReferenceError (#2659)', () => {
       result.output && result.output.length > 0,
       'audit-open --json must write output to stdout'
     );
+    let parsed;
+    assert.doesNotThrow(
+      () => { parsed = JSON.parse(result.output); },
+      'audit-open --json must emit valid JSON'
+    );
+    assert.ok(
+      parsed !== null && typeof parsed === 'object',
+      'audit-open --json must emit a JSON object or array'
+    );
   });
 });


### PR DESCRIPTION
## Linked Issue

Fixes #2659

## What was broken

\`gsd-tools audit-open\` crashed with \`ReferenceError: output is not defined\` in the 1.36.0 Claude Code plugin bundle. The source fix already landed on \`main\` (\`bin/gsd-tools.cjs:810\` now uses \`core.output(...)\`), but there was no regression test to prevent the bare-\`output\` form from being reintroduced in future refactors.

## What this fix does

Adds a regression test at \`tests/bug-2659-audit-open-crash.test.cjs\` that invokes \`audit-open\` in both text and \`--json\` modes against a temp project and asserts exit code 0 + non-empty stdout. The next time any \`audit-open\` refactor drops the \`core.\` prefix, CI catches it pre-merge.

No source change — the bug is already fixed. This PR closes the regression vector.

## Root cause

Issue #2236 / PR #2239 was the earlier fix attempt; that PR was closed without merging but the fix appears to have landed through another path. The regression test fills the class-level gap: no test exercised the \`audit-open\` handler end-to-end, so a future regression to bare \`output()\` would be silent until a user hit it.

## Testing

### How I verified the fix

1. Confirmed \`audit-open\` exits 0 at HEAD against a fresh temp project.
2. Temporarily reintroduced bare \`output(...)\` in \`bin/gsd-tools.cjs\` in a scratch branch — the new test failed with \`ReferenceError: output is not defined\`, matching the original issue report exactly.
3. Restored source, re-ran the test — passes.
4. Ran subset \`node --test tests/bug-2659-audit-open-crash.test.cjs tests/audit-fix-command.test.cjs tests/bug-2384-post-merge-deletion-audit.test.cjs tests/milestone-audit.test.cjs\` — 59/59 pass.

### Regression test added?

- [x] Yes — \`tests/bug-2659-audit-open-crash.test.cjs\`

### Platforms tested

- [x] macOS
- [ ] Windows
- [ ] Linux
- [ ] N/A

### Runtimes tested

- [x] N/A — the test exercises the CLI dispatch directly.

---

## Downstream note

Users on the Claude Code plugin-bundled GSD (1.36.0) may still see the crash until the next bundle refresh. This PR does not backport to that distribution; it prevents recurrence on \`main\`. If a 1.36.x patch release is desired for the bundle, happy to cherry-pick.

## Checklist

- [x] Issue linked above with \`Fixes #\"
- [x] Linked issue has the \`confirmed-bug\` label
- [x] Fix is scoped to the reported bug
- [x] Regression test added
- [x] All existing tests pass
- [ ] CHANGELOG.md — test-only, no user-visible change on \`main\`
- [x] No unnecessary dependencies

## Breaking changes

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a regression test for the audit-open command to ensure it no longer crashes, that stderr contains no ReferenceError, that standard output is non-empty in both normal and JSON modes, that JSON output parses as an object/array, and that temporary test directories are cleaned up.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->