### PR TITLE
fix(#2674): align initProgress with initManager ROADMAP [x] precedence

### DIFF
--- a/sdk/src/query/init-complex.ts
+++ b/sdk/src/query/init-complex.ts
@@ -262,10 +262,21 @@ export const initProgress: QueryHandler = async (_args, projectDir, _workstream)
       const summaries = phaseFiles.filter(f => f.endsWith('-SUMMARY.md') || f === 'SUMMARY.md');
       const hasResearch = phaseFiles.some(f => f.endsWith('-RESEARCH.md') || f === 'RESEARCH.md');
 
-      const status =
+      let status =
         summaries.length >= plans.length && plans.length > 0 ? 'complete' :
         plans.length > 0 ? 'in_progress' :
         hasResearch ? 'researched' : 'pending';
+
+      // #2674: align with initManager — a ROADMAP `- [x] Phase N` checkbox
+      // wins over disk state. A stub phase dir with no SUMMARY is leftover
+      // scaffolding; the user's explicit [x] is the authoritative signal.
+      const strippedNum = phaseNumber.replace(/^0+/, '') || '0';
+      const roadmapComplete =
+        checkboxStates.get(phaseNumber) === true ||
+        checkboxStates.get(strippedNum) === true;
+      if (roadmapComplete && status !== 'complete') {
+        status = 'complete';
+      }
 
       const phaseInfo: Record<string, unknown> = {
         number: phaseNumber,

--- a/sdk/src/query/init-progress-precedence.test.ts
+++ b/sdk/src/query/init-progress-precedence.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Regression guard for #2674.
+ *
+ * initProgress and initManager must agree on phase status given the same
+ * inputs. Specifically, a ROADMAP `- [x] Phase N` checkbox wins over disk
+ * state: a stub phase directory with no SUMMARY.md that is checked in
+ * ROADMAP reports as `complete` from both handlers.
+ *
+ * Pre-fix: initManager reported `complete` (explicit override at line ~451),
+ * initProgress reported `pending` (disk-only policy). This mismatch meant
+ * /gsd-manager and /gsd-progress disagreed on the same data. Post-fix:
+ * both apply the ROADMAP-[x]-wins policy.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, writeFile, mkdir, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { initProgress, initManager } from './init-complex.js';
+
+/** Find a phase by numeric value regardless of zero-padding ('3' vs '03'). */
+function findPhase(
+  phases: Record<string, unknown>[],
+  num: number,
+): Record<string, unknown> | undefined {
+  return phases.find(p => parseInt(p.number as string, 10) === num);
+}
+
+let tmpDir: string;
+
+const CONFIG = JSON.stringify({
+  model_profile: 'balanced',
+  commit_docs: false,
+  git: {
+    branching_strategy: 'none',
+    phase_branch_template: 'gsd/phase-{phase}-{slug}',
+    milestone_branch_template: 'gsd/{milestone}-{slug}',
+    quick_branch_template: null,
+  },
+  workflow: { research: true, plan_check: true, verifier: true, nyquist_validation: true },
+});
+
+const STATE = [
+  '---',
+  'milestone: v1.0',
+  '---',
+].join('\n');
+
+/**
+ * Write a ROADMAP.md with the given phase list. Each entry is
+ * `{num, name, checked}`. Emits both the checkbox summary lines AND the
+ * `### Phase N:` heading sections (so initManager picks them up).
+ */
+async function writeRoadmap(
+  dir: string,
+  phases: Array<{ num: string; name: string; checked: boolean }>,
+): Promise<void> {
+  const checkboxes = phases
+    .map(p => `- [${p.checked ? 'x' : ' '}] Phase ${p.num}: ${p.name}`)
+    .join('\n');
+  const sections = phases
+    .map(p => `### Phase ${p.num}: ${p.name}\n\n**Goal:** ${p.name} goal\n\n**Depends on:** None\n`)
+    .join('\n');
+  await writeFile(join(dir, '.planning', 'ROADMAP.md'), [
+    '# Roadmap',
+    '',
+    '## v1.0: Test',
+    '',
+    checkboxes,
+    '',
+    sections,
+  ].join('\n'));
+}
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(join(tmpdir(), 'gsd-2674-'));
+  await mkdir(join(tmpDir, '.planning', 'phases'), { recursive: true });
+  await writeFile(join(tmpDir, '.planning', 'config.json'), CONFIG);
+  await writeFile(join(tmpDir, '.planning', 'STATE.md'), STATE);
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+describe('initProgress + initManager precedence (#2674)', () => {
+  it('case 1: ROADMAP [x] + stub phase dir + no SUMMARY → both report complete', async () => {
+    await writeRoadmap(tmpDir, [{ num: '3', name: 'Stubbed', checked: true }]);
+    await mkdir(join(tmpDir, '.planning', 'phases', '03-stubbed'), { recursive: true });
+    // stub dir, no PLAN/SUMMARY/RESEARCH/CONTEXT files
+
+    const progress = (await initProgress([], tmpDir)).data as Record<string, unknown>;
+    const manager = (await initManager([], tmpDir)).data as Record<string, unknown>;
+
+    const pPhase = findPhase(progress.phases as Record<string, unknown>[], 3);
+    const mPhase = findPhase(manager.phases as Record<string, unknown>[], 3);
+
+    expect(pPhase?.status).toBe('complete');
+    expect(mPhase?.disk_status).toBe('complete');
+  });
+
+  it('case 2: ROADMAP [x] + phase dir + SUMMARY present → both complete (sanity)', async () => {
+    await writeRoadmap(tmpDir, [{ num: '3', name: 'Done', checked: true }]);
+    await mkdir(join(tmpDir, '.planning', 'phases', '03-done'), { recursive: true });
+    await writeFile(join(tmpDir, '.planning', 'phases', '03-done', '03-01-PLAN.md'), '# plan');
+    await writeFile(join(tmpDir, '.planning', 'phases', '03-done', '03-01-SUMMARY.md'), '# done');
+
+    const progress = (await initProgress([], tmpDir)).data as Record<string, unknown>;
+    const manager = (await initManager([], tmpDir)).data as Record<string, unknown>;
+
+    const pPhase = findPhase(progress.phases as Record<string, unknown>[], 3);
+    const mPhase = findPhase(manager.phases as Record<string, unknown>[], 3);
+
+    expect(pPhase?.status).toBe('complete');
+    expect(mPhase?.disk_status).toBe('complete');
+  });
+
+  it('case 3: ROADMAP [ ] + phase dir + SUMMARY present → disk authoritative (complete)', async () => {
+    await writeRoadmap(tmpDir, [{ num: '3', name: 'Disk', checked: false }]);
+    await mkdir(join(tmpDir, '.planning', 'phases', '03-disk'), { recursive: true });
+    await writeFile(join(tmpDir, '.planning', 'phases', '03-disk', '03-01-PLAN.md'), '# plan');
+    await writeFile(join(tmpDir, '.planning', 'phases', '03-disk', '03-01-SUMMARY.md'), '# done');
+
+    const progress = (await initProgress([], tmpDir)).data as Record<string, unknown>;
+    const manager = (await initManager([], tmpDir)).data as Record<string, unknown>;
+
+    const pPhase = findPhase(progress.phases as Record<string, unknown>[], 3);
+    const mPhase = findPhase(manager.phases as Record<string, unknown>[], 3);
+
+    expect(pPhase?.status).toBe('complete');
+    expect(mPhase?.disk_status).toBe('complete');
+  });
+
+  it('case 4: ROADMAP [ ] + stub phase dir + no SUMMARY → not complete', async () => {
+    await writeRoadmap(tmpDir, [{ num: '3', name: 'Empty', checked: false }]);
+    await mkdir(join(tmpDir, '.planning', 'phases', '03-empty'), { recursive: true });
+
+    const progress = (await initProgress([], tmpDir)).data as Record<string, unknown>;
+    const manager = (await initManager([], tmpDir)).data as Record<string, unknown>;
+
+    const pPhase = findPhase(progress.phases as Record<string, unknown>[], 3);
+    const mPhase = findPhase(manager.phases as Record<string, unknown>[], 3);
+
+    // Neither should be 'complete' — preserves pre-existing classification.
+    expect(pPhase?.status).not.toBe('complete');
+    expect(mPhase?.disk_status).not.toBe('complete');
+  });
+
+  it('case 5: ROADMAP [x] + no phase dir → both complete (ROADMAP-only branch preserved)', async () => {
+    await writeRoadmap(tmpDir, [{ num: '3', name: 'Paper', checked: true }]);
+    // no directory for phase 3
+
+    const progress = (await initProgress([], tmpDir)).data as Record<string, unknown>;
+    const manager = (await initManager([], tmpDir)).data as Record<string, unknown>;
+
+    const pPhase = findPhase(progress.phases as Record<string, unknown>[], 3);
+    const mPhase = findPhase(manager.phases as Record<string, unknown>[], 3);
+
+    expect(pPhase?.status).toBe('complete');
+    expect(mPhase?.disk_status).toBe('complete');
+  });
+
+  it('case 6: completed_count agrees across handlers for the stub-dir [x] case', async () => {
+    await writeRoadmap(tmpDir, [
+      { num: '3', name: 'Stub', checked: true },
+      { num: '4', name: 'Todo', checked: false },
+    ]);
+    await mkdir(join(tmpDir, '.planning', 'phases', '03-stub'), { recursive: true });
+    await mkdir(join(tmpDir, '.planning', 'phases', '04-todo'), { recursive: true });
+
+    const progress = (await initProgress([], tmpDir)).data as Record<string, unknown>;
+    const manager = (await initManager([], tmpDir)).data as Record<string, unknown>;
+
+    expect(progress.completed_count).toBe(1);
+    expect(manager.completed_count).toBe(1);
+  });
+});


### PR DESCRIPTION
## Linked Issue

Fixes #2674

## What was broken

Two phase-status resolvers in `sdk/src/query/init-complex.ts` diverged on ROADMAP `[x]` vs disk precedence:

- `initManager` (lines 450-453): ROADMAP `[x]` overrides `diskStatus` to `'complete'` when the checkbox is ticked.
- `initProgress` (lines 265-268): computed status purely from on-disk PLAN/SUMMARY counts; `[x]` only consulted for phases with no directory.

Net effect: a phase marked `[x]` in ROADMAP but with a stub phase directory lacking SUMMARY.md reported as `complete` in `/gsd-manager` and `pending` in `/gsd-progress` — same data, different answers.

## What this fix does

Adds the same `roadmapComplete` override to `initProgress` that `initManager` already has. After the on-disk scan computes a tentative status, if ROADMAP has `[x]` for that phase number and the tentative status is not already `'complete'`, promote it to `'complete'`. Both handlers now return the same status for the same inputs.

Policy chosen: **ROADMAP `[x]` wins**. A user typing `- [x] Phase N` is making an explicit assertion; a stub directory without SUMMARY.md is leftover scaffolding, not progress evidence.

## Root cause

The two handlers grew independently. `initManager` (newer, powers `/gsd-manager`) was written with the ROADMAP-wins policy in mind. `initProgress` (older, powers `/gsd-progress`) predates that decision. No shared resolver exists, so the policies drifted. Class-level fix (extract shared `resolvePhaseStatus`) is a follow-up; this PR aligns the instance.

## Testing

### How I verified the fix

Added `sdk/src/query/init-progress-precedence.test.ts` with 6 cross-handler parity tests covering:

1. ROADMAP `[x]` + stub directory + no SUMMARY.md → both handlers return `complete` (**fails pre-fix**: initProgress returns `pending`).
2. `[x]` + directory + SUMMARY.md → both return `complete` (passes pre-fix, regression guard).
3. `[ ]` + directory + SUMMARY.md → both return `complete` (disk authoritative when ROADMAP doesn't assert).
4. `[ ]` + stub directory → both return the computed partial/planned status (unchanged).
5. `[x]` + no directory → both return `complete` (ROADMAP-only phase branch preserved).
6. `completed_count` parity across both handlers under mixed inputs (**fails pre-fix**: count is 0 instead of 1).

**Pre-fix:** 2 of 6 fail.
**Post-fix:** 6 of 6 pass. Full `init-complex.test.ts` suite still passes (including the #2646 ROADMAP-only-phase test).
**Regression sweep:** sdk unit suite failure count went from 9 (baseline on `main`) to 7 — no new failures. The remaining 7 are pre-existing and unrelated (assembled-prompts, cli, ws-*, config-mutation, decomposed-handlers, registry, state-mutation).

### Regression test added?

- [x] Yes — `sdk/src/query/init-progress-precedence.test.ts`

### Platforms tested

- [x] macOS
- [ ] Windows
- [ ] Linux
- [ ] N/A

### Runtimes tested

- [x] N/A (SDK-level logic, runtime-independent)

---

## Follow-up (not in this PR)

Extract a single `resolvePhaseStatus({diskStatus, roadmapChecked, hasDirectory, hasSummary})` function used by both handlers. The current fix aligns the instance; the shared resolver kills the bug class.

## Checklist

- [x] Issue linked with `Fixes #2674`
- [x] Linked issue has `confirmed-bug`
- [x] Fix scoped to the reported bug
- [x] Regression test added
- [x] Existing tests pass (no new failures introduced)
- [ ] CHANGELOG.md — user-visible via `/gsd-progress` accuracy; flag on merge
- [x] No new dependencies

## Breaking changes

`/gsd-progress` now reports `complete` for phases that are `[x]` in ROADMAP even if a stub directory exists. This is a user-visible behavior change, but it aligns `/gsd-progress` with `/gsd-manager` (which already behaves this way) — so the direction is toward internal consistency, not away.