### PR TITLE
test: destroy 9 config-schema.cjs/core.cjs source-grep tests, replace with behavioral config-set

### DIFF
--- a/tests/agent-frontmatter.test.cjs
+++ b/tests/agent-frontmatter.test.cjs
@@ -6,6 +6,10 @@
  * - skills: field absent from all agents (breaks Gemini CLI)
  * - Commented hooks: pattern in file-writing agents
  * - Spawn type consistency across workflows
+ *
+ * allow-test-rule: source-text-is-the-product
+ * Agent .md files are the installed AI agents — their frontmatter and body text IS what
+ * Claude Code loads at runtime. Checking text content IS checking the deployed contract.
  */
 
 const { test, describe } = require('node:test');

--- a/tests/agent-frontmatter.test.cjs
+++ b/tests/agent-frontmatter.test.cjs
@@ -1,3 +1,7 @@
+// allow-test-rule: source-text-is-the-product
+// Agent .md files are the installed AI agents — their frontmatter and body text IS what
+// Claude Code loads at runtime. Checking text content IS checking the deployed contract.
+
 /**
  * GSD Agent Frontmatter Tests
  *
@@ -6,10 +10,6 @@
  * - skills: field absent from all agents (breaks Gemini CLI)
  * - Commented hooks: pattern in file-writing agents
  * - Spawn type consistency across workflows
- *
- * allow-test-rule: source-text-is-the-product
- * Agent .md files are the installed AI agents — their frontmatter and body text IS what
- * Claude Code loads at runtime. Checking text content IS checking the deployed contract.
  */
 
 const { test, describe } = require('node:test');

--- a/tests/agent-skills-awareness.test.cjs
+++ b/tests/agent-skills-awareness.test.cjs
@@ -1,3 +1,6 @@
+// allow-test-rule: source-text-is-the-product
+// Agent .md files are the installed AI agents — the "Project skills" block IS the deployed
+// instruction. Checking text content IS checking what runs in production.
 'use strict';
 
 const { describe, test } = require('node:test');

--- a/tests/autonomous-allowed-tools.test.cjs
+++ b/tests/autonomous-allowed-tools.test.cjs
@@ -12,6 +12,9 @@ const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
 
+// allow-test-rule: source-text-is-the-product
+// commands/gsd/autonomous.md is the installed command — its frontmatter is what Claude Code
+// reads at runtime to enforce allowed-tools. Checking text content IS checking the contract.
 describe('commands/gsd/autonomous.md allowed-tools', () => {
   test('includes Agent in allowed-tools list', () => {
     const filePath = path.join(__dirname, '..', 'commands', 'gsd', 'autonomous.md');

--- a/tests/bug-2334-quick-gsd-sdk-preflight.test.cjs
+++ b/tests/bug-2334-quick-gsd-sdk-preflight.test.cjs
@@ -19,6 +19,9 @@ const path = require('path');
 
 const WORKFLOW_PATH = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'quick.md');
 
+// allow-test-rule: source-text-is-the-product
+// quick.md is the AI instruction workflow — the `command -v gsd-sdk` guard IS the fix.
+// There is no behavioral equivalent: the check runs inside the AI agent, not in gsd-tools.
 describe('bug #2334: quick workflow gsd-sdk pre-flight check', () => {
   let content;
 

--- a/tests/bug-2346-agent-read-loop-guards.test.cjs
+++ b/tests/bug-2346-agent-read-loop-guards.test.cjs
@@ -21,6 +21,9 @@ const path = require('path');
 
 const AGENTS_DIR = path.join(__dirname, '..', 'agents');
 
+// allow-test-rule: source-text-is-the-product
+// The <critical_rules> block in agent .md files IS the fix — it is the AI instruction that
+// prevents unbounded Read loops. There is no behavioral equivalent without a live LLM run.
 describe('bug #2346: agent read loop guards', () => {
 
   describe('gsd-ui-checker', () => {

--- a/tests/code-review.test.cjs
+++ b/tests/code-review.test.cjs
@@ -28,7 +28,6 @@ const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
 const AGENTS_DIR = path.join(__dirname, '..', 'agents');
 const COMMANDS_DIR = path.join(__dirname, '..', 'commands', 'gsd');
 const WORKFLOWS_DIR = path.join(__dirname, '..', 'get-shit-done', 'workflows');
-const CONFIG_PATH = path.join(__dirname, '..', 'get-shit-done', 'bin', 'lib', 'config-schema.cjs');
 
 // Plugin directory resolution (cross-platform safe)
 const PLUGIN_WORKFLOWS_DIR = process.env.GSD_PLUGIN_ROOT || path.join(os.homedir(), '.claude', 'get-shit-done', 'workflows');
@@ -271,18 +270,24 @@ describe('CR-WORKFLOW: code review workflow structure', () => {
 // --- CR-CONFIG: config key registration ---
 
 describe('CR-CONFIG: config key registration', () => {
-  test('config.cjs contains workflow.code_review key', () => {
-    const content = fs.readFileSync(CONFIG_PATH, 'utf-8');
-
-    assert.ok(content.includes('workflow.code_review'),
-      'config.cjs missing workflow.code_review key registration');
+  test('config-set accepts workflow.code_review', () => {
+    const tmpDir = createTempProject();
+    try {
+      const result = runGsdTools('config-set workflow.code_review true', tmpDir);
+      assert.ok(result.success, `config-set should accept workflow.code_review: ${result.error}`);
+    } finally {
+      cleanup(tmpDir);
+    }
   });
 
-  test('config.cjs contains workflow.code_review_depth key', () => {
-    const content = fs.readFileSync(CONFIG_PATH, 'utf-8');
-
-    assert.ok(content.includes('workflow.code_review_depth'),
-      'config.cjs missing workflow.code_review_depth key registration');
+  test('config-set accepts workflow.code_review_depth', () => {
+    const tmpDir = createTempProject();
+    try {
+      const result = runGsdTools('config-set workflow.code_review_depth standard', tmpDir);
+      assert.ok(result.success, `config-set should accept workflow.code_review_depth: ${result.error}`);
+    } finally {
+      cleanup(tmpDir);
+    }
   });
 
   test('gsd-tools config-get workflow.code_review succeeds', () => {

--- a/tests/execute-phase-wave.test.cjs
+++ b/tests/execute-phase-wave.test.cjs
@@ -12,12 +12,17 @@ const { test, describe } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
+const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
 
 const COMMAND_PATH = path.join(__dirname, '..', 'commands', 'gsd', 'execute-phase.md');
 const WORKFLOW_PATH = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'execute-phase.md');
 const COMMANDS_DOC_PATH = path.join(__dirname, '..', 'docs', 'COMMANDS.md');
 const HELP_PATH = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'help.md');
 
+// allow-test-rule: source-text-is-the-product
+// The workflow and command .md files are the installed AI instructions — their text content
+// IS what executes. String presence tests guard against accidental deletion of critical clauses.
+// See #2692 for the missing behavioral test for --wave N argument parsing.
 describe('execute-phase command: --wave flag', () => {
   test('command file exists', () => {
     assert.ok(fs.existsSync(COMMAND_PATH), 'commands/gsd/execute-phase.md should exist');
@@ -128,7 +133,6 @@ describe('use_worktrees config: cross-workflow structural coverage', () => {
   const DIAGNOSE_PATH = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'diagnose-issues.md');
   const EXECUTE_PLAN_PATH = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'execute-plan.md');
   const PLANNING_CONFIG_PATH = path.join(__dirname, '..', 'get-shit-done', 'references', 'planning-config.md');
-  const CONFIG_CJS_PATH = path.join(__dirname, '..', 'get-shit-done', 'bin', 'lib', 'config-schema.cjs');
 
   test('quick workflow reads USE_WORKTREES from config', () => {
     const content = fs.readFileSync(QUICK_PATH, 'utf-8');
@@ -174,11 +178,14 @@ describe('use_worktrees config: cross-workflow structural coverage', () => {
     );
   });
 
-  test('config.cjs includes workflow.use_worktrees in VALID_CONFIG_KEYS', () => {
-    const content = fs.readFileSync(CONFIG_CJS_PATH, 'utf-8');
-    assert.ok(
-      content.includes("'workflow.use_worktrees'"),
-      'config.cjs VALID_CONFIG_KEYS should include workflow.use_worktrees'
-    );
+  test('config-set accepts workflow.use_worktrees', () => {
+    // allow-test-rule: behavioral — exercises config-set validation, not source text
+    const tmpDir = createTempProject();
+    try {
+      const result = runGsdTools('config-set workflow.use_worktrees true', tmpDir);
+      assert.ok(result.success, `config-set should accept workflow.use_worktrees: ${result.error}`);
+    } finally {
+      cleanup(tmpDir);
+    }
   });
 });

--- a/tests/inline-plan-threshold.test.cjs
+++ b/tests/inline-plan-threshold.test.cjs
@@ -20,7 +20,6 @@ const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
 const repoRoot = path.resolve(__dirname, '..');
 const executePlanPath = path.join(repoRoot, 'get-shit-done', 'workflows', 'execute-plan.md');
 const planningConfigPath = path.join(repoRoot, 'get-shit-done', 'references', 'planning-config.md');
-const configCjsPath = path.join(repoRoot, 'get-shit-done', 'bin', 'lib', 'config-schema.cjs');
 
 describe('inline_plan_threshold config key (#1979)', () => {
   let tmpDir;
@@ -41,15 +40,6 @@ describe('inline_plan_threshold config key (#1979)', () => {
   test('config-set accepts threshold=0 to disable inline routing', () => {
     const result = runGsdTools('config-set workflow.inline_plan_threshold 0', tmpDir);
     assert.ok(result.success, `config-set should accept 0: ${result.error}`);
-  });
-
-  test('VALID_CONFIG_KEYS in config.cjs contains workflow.inline_plan_threshold', () => {
-    const content = fs.readFileSync(configCjsPath, 'utf-8');
-    assert.match(
-      content,
-      /['"]workflow\.inline_plan_threshold['"]/,
-      'workflow.inline_plan_threshold must be in VALID_CONFIG_KEYS'
-    );
   });
 
   test('planning-config.md documents workflow.inline_plan_threshold', () => {

--- a/tests/plan-bounce.test.cjs
+++ b/tests/plan-bounce.test.cjs
@@ -15,35 +15,41 @@ const { test, describe } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
+const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
 
 const GSD_ROOT = path.join(__dirname, '..', 'get-shit-done');
-const CONFIG_CJS_PATH = path.join(GSD_ROOT, 'bin', 'lib', 'config-schema.cjs');
 const CONFIG_TEMPLATE_PATH = path.join(GSD_ROOT, 'templates', 'config.json');
 const PLAN_PHASE_PATH = path.join(GSD_ROOT, 'workflows', 'plan-phase.md');
 
 describe('Plan Bounce: config keys', () => {
-  test('workflow.plan_bounce is in VALID_CONFIG_KEYS', () => {
-    const content = fs.readFileSync(CONFIG_CJS_PATH, 'utf-8');
-    assert.ok(
-      content.includes("'workflow.plan_bounce'"),
-      'VALID_CONFIG_KEYS should contain workflow.plan_bounce'
-    );
+  test('config-set accepts workflow.plan_bounce', () => {
+    const tmpDir = createTempProject();
+    try {
+      const result = runGsdTools('config-set workflow.plan_bounce true', tmpDir);
+      assert.ok(result.success, `config-set should accept workflow.plan_bounce: ${result.error}`);
+    } finally {
+      cleanup(tmpDir);
+    }
   });
 
-  test('workflow.plan_bounce_script is in VALID_CONFIG_KEYS', () => {
-    const content = fs.readFileSync(CONFIG_CJS_PATH, 'utf-8');
-    assert.ok(
-      content.includes("'workflow.plan_bounce_script'"),
-      'VALID_CONFIG_KEYS should contain workflow.plan_bounce_script'
-    );
+  test('config-set accepts workflow.plan_bounce_script', () => {
+    const tmpDir = createTempProject();
+    try {
+      const result = runGsdTools('config-set workflow.plan_bounce_script ./bounce.sh', tmpDir);
+      assert.ok(result.success, `config-set should accept workflow.plan_bounce_script: ${result.error}`);
+    } finally {
+      cleanup(tmpDir);
+    }
   });
 
-  test('workflow.plan_bounce_passes is in VALID_CONFIG_KEYS', () => {
-    const content = fs.readFileSync(CONFIG_CJS_PATH, 'utf-8');
-    assert.ok(
-      content.includes("'workflow.plan_bounce_passes'"),
-      'VALID_CONFIG_KEYS should contain workflow.plan_bounce_passes'
-    );
+  test('config-set accepts workflow.plan_bounce_passes', () => {
+    const tmpDir = createTempProject();
+    try {
+      const result = runGsdTools('config-set workflow.plan_bounce_passes 2', tmpDir);
+      assert.ok(result.success, `config-set should accept workflow.plan_bounce_passes: ${result.error}`);
+    } finally {
+      cleanup(tmpDir);
+    }
   });
 });
 
@@ -76,6 +82,9 @@ describe('Plan Bounce: config template defaults', () => {
   });
 });
 
+// allow-test-rule: source-text-is-the-product
+// plan-phase.md is the installed AI workflow instruction — its text content IS what executes.
+// String presence tests guard against accidental deletion of bounce step clauses.
 describe('Plan Bounce: plan-phase.md step 12.5', () => {
   let content;
 

--- a/tests/thinking-partner.test.cjs
+++ b/tests/thinking-partner.test.cjs
@@ -2,6 +2,7 @@ const { describe, test } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
+const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
 
 const GSD_ROOT = path.join(__dirname, '..', 'get-shit-done');
 
@@ -66,27 +67,16 @@ describe('Thinking Partner Integration (#1726)', () => {
 
   // Config tests
   describe('Config integration', () => {
-    test('features.thinking_partner is in VALID_CONFIG_KEYS', () => {
-      const configSrc = fs.readFileSync(
-        path.join(GSD_ROOT, 'bin', 'lib', 'config-schema.cjs'),
-        'utf-8'
-      );
-      assert.ok(
-        configSrc.includes("'features.thinking_partner'"),
-        'VALID_CONFIG_KEYS should contain features.thinking_partner'
-      );
-    });
-
-    test('features is in KNOWN_TOP_LEVEL section containers', () => {
-      const coreSrc = fs.readFileSync(
-        path.join(GSD_ROOT, 'bin', 'lib', 'core.cjs'),
-        'utf-8'
-      );
-      // The KNOWN_TOP_LEVEL set should include 'features' in section containers
-      assert.ok(
-        coreSrc.includes("'features'"),
-        'KNOWN_TOP_LEVEL should contain features as a section container'
-      );
+    test('config-set accepts features.thinking_partner', () => {
+      // Exercises VALID_CONFIG_KEYS membership and KNOWN_TOP_LEVEL acceptance in one call.
+      // Replaces two source-grep tests that read config-schema.cjs and core.cjs (see #2691).
+      const tmpDir = createTempProject();
+      try {
+        const result = runGsdTools('config-set features.thinking_partner true', tmpDir);
+        assert.ok(result.success, `config-set should accept features.thinking_partner: ${result.error}`);
+      } finally {
+        cleanup(tmpDir);
+      }
     });
   });
 

--- a/tests/thinking-partner.test.cjs
+++ b/tests/thinking-partner.test.cjs
@@ -74,11 +74,13 @@ describe('Thinking Partner Integration (#1726)', () => {
       try {
         const setResult = runGsdTools('config-set features.thinking_partner true', tmpDir);
         assert.ok(setResult.success, `config-set should accept features.thinking_partner: ${setResult.error}`);
-        const getResult = runGsdTools('config-get features.thinking_partner', tmpDir);
-        assert.ok(getResult.success, `config-get should read features.thinking_partner: ${getResult.error}`);
-        assert.ok(
-          getResult.output.trim() === 'true' || getResult.output.includes('true'),
-          `config-get should return "true", got: ${getResult.output}`
+        const configPath = path.join(tmpDir, '.planning', 'config.json');
+        assert.ok(fs.existsSync(configPath), 'config-set should create .planning/config.json');
+        const config = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+        assert.strictEqual(
+          config.features?.thinking_partner,
+          true,
+          'config-set should persist features.thinking_partner=true'
         );
       } finally {
         cleanup(tmpDir);

--- a/tests/thinking-partner.test.cjs
+++ b/tests/thinking-partner.test.cjs
@@ -72,8 +72,14 @@ describe('Thinking Partner Integration (#1726)', () => {
       // Replaces two source-grep tests that read config-schema.cjs and core.cjs (see #2691).
       const tmpDir = createTempProject();
       try {
-        const result = runGsdTools('config-set features.thinking_partner true', tmpDir);
-        assert.ok(result.success, `config-set should accept features.thinking_partner: ${result.error}`);
+        const setResult = runGsdTools('config-set features.thinking_partner true', tmpDir);
+        assert.ok(setResult.success, `config-set should accept features.thinking_partner: ${setResult.error}`);
+        const getResult = runGsdTools('config-get features.thinking_partner', tmpDir);
+        assert.ok(getResult.success, `config-get should read features.thinking_partner: ${getResult.error}`);
+        assert.ok(
+          getResult.output.trim() === 'true' || getResult.output.includes('true'),
+          `config-get should return "true", got: ${getResult.output}`
+        );
       } finally {
         cleanup(tmpDir);
       }


### PR DESCRIPTION
## Summary

- Destroys 9 source-grep tests across 5 files that read `config-schema.cjs` or `core.cjs` to verify config key registration via `includes()` — source-grep theater that proved nothing about runtime behavior
- Replaces with `runGsdTools('config-set <key> <value>', tmpDir)` behavioral tests that would catch VALID_CONFIG_KEYS removal, key misspelling, or schema refactor
- Deletes two tests that were redundant (behavioral `config-set` test already existed in the same file)
- Adds `// allow-test-rule: source-text-is-the-product` annotations to 7 files that legitimately read AI instruction/agent product files

## Why these were wrong

`commit 990c3e64` ("fix(tests): update 5 source-text tests to read config-schema.cjs") already demonstrated the brittleness: when `VALID_CONFIG_KEYS` moved from `config.cjs` to `config-schema.cjs`, all 5 tests broke simultaneously for a pure refactor with no behavior change. That's a maintenance incident caused by testing implementation location, not behavior.

The correct measure is `config-set <key> <value>` succeeding. That's what users hit. That's what breaks when the key is absent.

## Specific changes

| File | Before | After |
|---|---|---|
| `execute-phase-wave.test.cjs` | `fs.readFileSync(CONFIG_CJS_PATH)…includes("'workflow.use_worktrees'")` | `runGsdTools('config-set workflow.use_worktrees true', tmpDir)` |
| `inline-plan-threshold.test.cjs` | source-grep for `workflow.inline_plan_threshold` | **deleted** (behavioral test at L36 already covered it) |
| `plan-bounce.test.cjs` | 3× `fs.readFileSync(CONFIG_CJS_PATH)…includes("'workflow.plan_bounce…'")` | 3× `runGsdTools('config-set workflow.plan_bounce…', tmpDir)` |
| `code-review.test.cjs` | 2× `fs.readFileSync(CONFIG_PATH)…includes('workflow.code_review…')` | 2× `runGsdTools('config-set workflow.code_review…', tmpDir)` |
| `thinking-partner.test.cjs` | 2× source-greps (config-schema.cjs + core.cjs) | 1× `runGsdTools('config-set features.thinking_partner true', tmpDir)` |

## Annotations added

`autonomous-allowed-tools`, `agent-frontmatter`, `agent-skills-awareness`, `bug-2334`, `bug-2346`, `execute-phase-wave` (MD reads), `plan-bounce` (workflow reads) — all now carry `// allow-test-rule: source-text-is-the-product` with a one-line explanation of why text inspection is the correct level for AI instruction files.

## Test plan

- [x] All 5 affected test files pass locally
- [x] Full suite (5,450 tests) passes with 0 failures

## Related issues

Closes #2691
Closes #2693
See also: #2692 (wave filter behavioral coverage gap), #2694 (shared state pattern), #2695 (CR-CONFIG bypasses config-set validation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test validation approach by shifting from static source file inspection to behavioral runtime verification.
  * Enhanced test documentation with clarifying comments on validation rules and test objectives.
  * Strengthened config key validation through integration testing for greater reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->