### PR TITLE
test(#2695): replace CR-CONFIG bypass tests with behavioral config-set assertions

### DIFF
--- a/tests/code-review.test.cjs
+++ b/tests/code-review.test.cjs
@@ -290,53 +290,30 @@ describe('CR-CONFIG: config key registration', () => {
     }
   });
 
-  test('gsd-tools config-get workflow.code_review succeeds', () => {
+  test('config-get workflow.code_review returns value set via config-set', (t) => {
     const tmpDir = createTempProject();
+    t.after(() => cleanup(tmpDir));
 
-    try {
-      // Initialize config with code_review key
-      const configPath = path.join(tmpDir, '.planning', 'config.json');
-      fs.writeFileSync(configPath, JSON.stringify({
-        workflow: {
-          code_review: true,
-          code_review_depth: 'standard'
-        }
-      }, null, 2), 'utf-8');
+    const setResult = runGsdTools(['config-set', 'workflow.code_review', 'true'], tmpDir);
+    assert.ok(setResult.success, `config-set workflow.code_review failed: ${setResult.error}`);
 
-      const result = runGsdTools(['config-get', 'workflow.code_review'], tmpDir);
-
-      assert.ok(result.success,
-        'config-get workflow.code_review failed — key not recognized');
-      assert.strictEqual(result.output, 'true',
-        'workflow.code_review should return "true"');
-    } finally {
-      cleanup(tmpDir);
-    }
+    const getResult = runGsdTools(['config-get', 'workflow.code_review'], tmpDir);
+    assert.ok(getResult.success, `config-get workflow.code_review failed: ${getResult.error}`);
+    assert.strictEqual(getResult.output, 'true',
+      `workflow.code_review should return "true", got ${getResult.output}`);
   });
 
-  test('gsd-tools config-get workflow.code_review_depth succeeds', () => {
+  test('config-get workflow.code_review_depth returns value set via config-set', (t) => {
     const tmpDir = createTempProject();
+    t.after(() => cleanup(tmpDir));
 
-    try {
-      // Initialize config with code_review_depth key
-      const configPath = path.join(tmpDir, '.planning', 'config.json');
-      fs.writeFileSync(configPath, JSON.stringify({
-        workflow: {
-          code_review: true,
-          code_review_depth: 'standard'
-        }
-      }, null, 2), 'utf-8');
+    const setResult = runGsdTools(['config-set', 'workflow.code_review_depth', 'standard'], tmpDir);
+    assert.ok(setResult.success, `config-set workflow.code_review_depth failed: ${setResult.error}`);
 
-      const result = runGsdTools(['config-get', 'workflow.code_review_depth'], tmpDir);
-
-      assert.ok(result.success,
-        'config-get workflow.code_review_depth failed — key not recognized');
-      // Output may include quotes from JSON serialization
-      assert.ok(result.output === 'standard' || result.output === '"standard"',
-        `workflow.code_review_depth should return "standard", got ${result.output}`);
-    } finally {
-      cleanup(tmpDir);
-    }
+    const getResult = runGsdTools(['config-get', 'workflow.code_review_depth'], tmpDir);
+    assert.ok(getResult.success, `config-get workflow.code_review_depth failed: ${getResult.error}`);
+    assert.strictEqual(getResult.output, '"standard"',
+      `workflow.code_review_depth should return '"standard"', got ${getResult.output}`);
   });
 });
 


### PR DESCRIPTION
## Linked Issue

Fixes #2695

> Issue carries the `confirmed-bug` label (labeled during triage on 2026-04-25).

## What was broken

The CR-CONFIG section in `tests/code-review.test.cjs` had two broken `config-get` tests that used `fs.writeFileSync` to write directly to `.planning/config.json` before calling `config-get`. This bypassed the `config-set` validator entirely — testing only the read path, not whether the keys are actually accepted by the validation layer.

## What this fix does

Replaces both bypass `config-get` tests with end-to-end behavioral tests that:
1. Call `config-set workflow.code_review true` (exercises the full write-validation path)
2. Call `config-get workflow.code_review` and assert the returned value matches

The same pattern is applied for `workflow.code_review_depth`. A regression that removes these keys from `VALID_CONFIG_KEYS` would now correctly cause the tests to fail.

## Root cause

The test setup used `fs.writeFileSync` as a shortcut, collapsing `config-set + config-get` into just a direct write + read. This hid the validation layer from the test.

## Testing

### Regression test added?
- [x] Yes — the fix IS the test improvement; new behavioral tests would have caught the original regression

### Platforms tested
- [x] macOS
- [x] Linux

### Runtimes tested
- [x] N/A (test-only change)

## Checklist
- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes
- [x] `node scripts/lint-no-source-grep.cjs` passes
- [x] All existing tests pass (`npm test`) — 5494 tests, 0 failures

## Breaking changes

None