### PR TITLE
test(#2694): eliminate shared mutable content state across node:test tests

### DIFF
--- a/tests/bug-2346-agent-read-loop-guards.test.cjs
+++ b/tests/bug-2346-agent-read-loop-guards.test.cjs
@@ -28,15 +28,13 @@ describe('bug #2346: agent read loop guards', () => {
 
   describe('gsd-ui-checker', () => {
     const agentPath = path.join(AGENTS_DIR, 'gsd-ui-checker.md');
-    let content;
+    const content = fs.readFileSync(agentPath, 'utf-8');
 
     test('agent file exists', () => {
       assert.ok(fs.existsSync(agentPath), 'agents/gsd-ui-checker.md must exist');
-      content = fs.readFileSync(agentPath, 'utf-8');
     });
 
     test('has <critical_rules> block', () => {
-      content = content || fs.readFileSync(agentPath, 'utf-8');
       assert.ok(
         content.includes('<critical_rules>'),
         'gsd-ui-checker.md must have a <critical_rules> block to prevent unbounded read loops (#2346)'
@@ -44,7 +42,6 @@ describe('bug #2346: agent read loop guards', () => {
     });
 
     test('critical_rules contains no-re-read constraint', () => {
-      content = content || fs.readFileSync(agentPath, 'utf-8');
       const rulesStart = content.indexOf('<critical_rules>');
       const rulesEnd = content.indexOf('</critical_rules>', rulesStart);
       assert.ok(rulesStart !== -1 && rulesEnd !== -1, '<critical_rules> block must be complete');
@@ -56,7 +53,6 @@ describe('bug #2346: agent read loop guards', () => {
     });
 
     test('critical_rules appears before success_criteria', () => {
-      content = content || fs.readFileSync(agentPath, 'utf-8');
       const rulesIdx = content.indexOf('<critical_rules>');
       const successIdx = content.indexOf('<success_criteria>');
       assert.ok(rulesIdx !== -1 && successIdx !== -1, 'both sections must exist');
@@ -69,15 +65,13 @@ describe('bug #2346: agent read loop guards', () => {
 
   describe('gsd-planner', () => {
     const agentPath = path.join(AGENTS_DIR, 'gsd-planner.md');
-    let content;
+    const content = fs.readFileSync(agentPath, 'utf-8');
 
     test('agent file exists', () => {
       assert.ok(fs.existsSync(agentPath), 'agents/gsd-planner.md must exist');
-      content = fs.readFileSync(agentPath, 'utf-8');
     });
 
     test('has <critical_rules> block', () => {
-      content = content || fs.readFileSync(agentPath, 'utf-8');
       assert.ok(
         content.includes('<critical_rules>'),
         'gsd-planner.md must have a <critical_rules> block to prevent unbounded read loops (#2346)'
@@ -85,7 +79,6 @@ describe('bug #2346: agent read loop guards', () => {
     });
 
     test('critical_rules contains no-re-read constraint', () => {
-      content = content || fs.readFileSync(agentPath, 'utf-8');
       const rulesStart = content.indexOf('<critical_rules>');
       const rulesEnd = content.indexOf('</critical_rules>', rulesStart);
       assert.ok(rulesStart !== -1 && rulesEnd !== -1, '<critical_rules> block must be complete');
@@ -97,7 +90,6 @@ describe('bug #2346: agent read loop guards', () => {
     });
 
     test('critical_rules appears before success_criteria', () => {
-      content = content || fs.readFileSync(agentPath, 'utf-8');
       const rulesIdx = content.indexOf('<critical_rules>');
       const successIdx = content.lastIndexOf('<success_criteria>');
       assert.ok(rulesIdx !== -1 && successIdx !== -1, 'both sections must exist');

--- a/tests/plan-bounce.test.cjs
+++ b/tests/plan-bounce.test.cjs
@@ -86,10 +86,9 @@ describe('Plan Bounce: config template defaults', () => {
 // plan-phase.md is the installed AI workflow instruction — its text content IS what executes.
 // String presence tests guard against accidental deletion of bounce step clauses.
 describe('Plan Bounce: plan-phase.md step 12.5', () => {
-  let content;
+  const content = fs.readFileSync(PLAN_PHASE_PATH, 'utf-8');
 
   test('plan-phase.md contains step 12.5', () => {
-    content = fs.readFileSync(PLAN_PHASE_PATH, 'utf-8');
     assert.ok(
       content.includes('## 12.5'),
       'plan-phase.md should contain step 12.5'
@@ -97,7 +96,6 @@ describe('Plan Bounce: plan-phase.md step 12.5', () => {
   });
 
   test('step 12.5 references plan bounce', () => {
-    content = content || fs.readFileSync(PLAN_PHASE_PATH, 'utf-8');
     // The step title should mention bounce
     assert.ok(
       /## 12\.5.*[Bb]ounce/i.test(content),
@@ -106,7 +104,6 @@ describe('Plan Bounce: plan-phase.md step 12.5', () => {
   });
 
   test('plan-phase.md has --bounce flag handling', () => {
-    content = content || fs.readFileSync(PLAN_PHASE_PATH, 'utf-8');
     assert.ok(
       content.includes('--bounce'),
       'plan-phase.md should handle --bounce flag'
@@ -114,7 +111,6 @@ describe('Plan Bounce: plan-phase.md step 12.5', () => {
   });
 
   test('plan-phase.md has --skip-bounce flag handling', () => {
-    content = content || fs.readFileSync(PLAN_PHASE_PATH, 'utf-8');
     assert.ok(
       content.includes('--skip-bounce'),
       'plan-phase.md should handle --skip-bounce flag'
@@ -122,7 +118,6 @@ describe('Plan Bounce: plan-phase.md step 12.5', () => {
   });
 
   test('plan-phase.md has backup pattern (pre-bounce.md)', () => {
-    content = content || fs.readFileSync(PLAN_PHASE_PATH, 'utf-8');
     assert.ok(
       content.includes('pre-bounce.md'),
       'plan-phase.md should reference pre-bounce.md backup files'
@@ -130,7 +125,6 @@ describe('Plan Bounce: plan-phase.md step 12.5', () => {
   });
 
   test('plan-phase.md has frontmatter integrity validation for bounced plans', () => {
-    content = content || fs.readFileSync(PLAN_PHASE_PATH, 'utf-8');
     // Should mention YAML frontmatter validation after bounce
     assert.ok(
       /frontmatter.*bounced|bounced.*frontmatter|YAML.*bounce|bounce.*YAML/i.test(content),
@@ -139,7 +133,6 @@ describe('Plan Bounce: plan-phase.md step 12.5', () => {
   });
 
   test('plan-phase.md re-runs checker on bounced plans', () => {
-    content = content || fs.readFileSync(PLAN_PHASE_PATH, 'utf-8');
     // Should mention re-running plan checker after bounce
     assert.ok(
       /[Rr]e-run.*checker.*bounce|bounce.*checker.*re-run|checker.*bounced/i.test(content),
@@ -148,7 +141,6 @@ describe('Plan Bounce: plan-phase.md step 12.5', () => {
   });
 
   test('plan-phase.md references plan_bounce config keys', () => {
-    content = content || fs.readFileSync(PLAN_PHASE_PATH, 'utf-8');
     assert.ok(
       content.includes('plan_bounce_script'),
       'plan-phase.md should reference plan_bounce_script config'
@@ -160,7 +152,6 @@ describe('Plan Bounce: plan-phase.md step 12.5', () => {
   });
 
   test('plan-phase.md disables bounce when --gaps flag is present', () => {
-    content = content || fs.readFileSync(PLAN_PHASE_PATH, 'utf-8');
     // Should mention that --gaps disables bounce
     assert.ok(
       /--gaps.*bounce|bounce.*--gaps/i.test(content),
@@ -169,7 +160,6 @@ describe('Plan Bounce: plan-phase.md step 12.5', () => {
   });
 
   test('plan-phase.md restores original on script failure', () => {
-    content = content || fs.readFileSync(PLAN_PHASE_PATH, 'utf-8');
     // Should mention restoring from backup on failure
     assert.ok(
       /restore.*original|restore.*pre-bounce|original.*restore/i.test(content),


### PR DESCRIPTION
## Linked Issue

Fixes #2694

> Issue carries the `confirmed-bug` label (labeled during triage on 2026-04-25).

## What was broken

Two test files used a `let content` variable set in the first test and fallback-read via `content || fs.readFileSync(...)` in subsequent tests. When the first test fails, `content` is unset and every subsequent test re-attempts the `readFileSync` call — producing an ENOENT cascade that buries the real failure.

## What this fix does

Moves `fs.readFileSync` to describe scope (before any `test()` calls) in both affected files. The read happens once, the dependency is explicit, and a failure produces exactly one clear error.

## Root cause

The `content ||` guard was intended as defensive recovery but is actually an ordering trap. It makes subsequent tests silently depend on the first test's side effect.

## Testing

### Regression test added?
- [x] Yes — the fix removes the ordering trap; future `{ concurrency: true }` on these blocks will not cause silent cascade failures

### Platforms tested
- [x] macOS
- [x] Linux

### Runtimes tested
- [x] N/A (test-only change)

## Checklist
- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug
- [x] All existing tests pass (`npm test`)

## Breaking changes

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test suite efficiency by consolidating file reading operations at initialization instead of per-test lazy loading, reducing redundant I/O operations and streamlining test execution flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->