### PR TITLE
fix(install): harden leaked .claude path scanning for markdown and comments

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -6216,8 +6216,9 @@ function install(isGlobal, runtime = 'claude') {
             }
             throw err;
           }
-          const matches = content.match(/(?:~|\$HOME)\/\.claude\b/g);
-          if (matches) {
+          const isMarkdown = entry.name.endsWith('.md');
+          const matches = detectClaudePathRefs(content, isMarkdown);
+          if (matches.length > 0) {
             leakedPaths.push({ file: fullPath.replace(targetDir + '/', ''), count: matches.length });
           }
         }
@@ -7045,6 +7046,174 @@ function homePathCoveredByRc(globalBin, homeDir, rcFileNames) {
 }
 
 /**
+ * Detect .claude path references in content.
+ *
+ * Behavior:
+ * - Markdown: scan code blocks only (fenced and indented blocks).
+ * - Non-Markdown: scan the whole content.
+ * - Before matching, remove block comments (/* ... *\/) and drop line comments
+ *   that start with # or // to reduce false positives from examples.
+ *
+ * Exported for tests; used by install() when scanning for leaked paths.
+ *
+ * @param {string} content     File content to scan.
+ * @param {boolean} isMarkdown Whether content is from a Markdown file.
+ * @returns {string[]}         Array of matched .claude path patterns.
+ */
+function _parseMarkdownFenceOpen(line) {
+  const fenceOpen = line.match(/^\s{0,3}(`{3,}|~{3,})/);
+  if (!fenceOpen) return null;
+  return { char: fenceOpen[1][0], len: fenceOpen[1].length };
+}
+
+function _isMarkdownFenceClose(line, fenceChar, fenceLen) {
+  const trimmed = line.trim();
+  // Close fence must use the same marker type (` or ~) and be at least
+  // as long as the opening fence.
+  return trimmed.length >= fenceLen && trimmed.split('').every((ch) => ch === fenceChar);
+}
+
+function _isIndentedMarkdownCodeLine(line) {
+  return line.startsWith('    ') || line.startsWith('\t');
+}
+
+function _stripIndentedMarkdownCodeLine(line) {
+  return line.startsWith('\t') ? line.slice(1) : line.slice(4);
+}
+
+function _createMarkdownExtractorState() {
+  return {
+    codeBlocks: [],
+    inFence: false,
+    fenceChar: '',
+    fenceLen: 0,
+    fencedBlock: [],
+    inIndentedBlock: false,
+    indentedBlock: [],
+  };
+}
+
+function _flushMarkdownExtractorState(state) {
+  // Flush unterminated trailing blocks at EOF (best-effort extraction).
+  if (state.inFence && state.fencedBlock.length > 0) {
+    state.codeBlocks.push(state.fencedBlock.join('\n'));
+  }
+  if (state.inIndentedBlock && state.indentedBlock.length > 0) {
+    state.codeBlocks.push(state.indentedBlock.join('\n'));
+  }
+}
+
+function _consumeMarkdownFenceLine(line, state) {
+  if (!state.inFence) return false;
+  if (_isMarkdownFenceClose(line, state.fenceChar, state.fenceLen)) {
+    state.codeBlocks.push(state.fencedBlock.join('\n'));
+    state.inFence = false;
+    state.fencedBlock = [];
+    return true;
+  }
+  state.fencedBlock.push(line);
+  return true;
+}
+
+function _openMarkdownFenceIfPresent(line, state) {
+  const fenceOpen = _parseMarkdownFenceOpen(line);
+  if (!fenceOpen) return false;
+  // Markdown allows up to 3 leading spaces before fenced delimiters.
+  state.inFence = true;
+  state.fenceChar = fenceOpen.char;
+  state.fenceLen = fenceOpen.len;
+  state.fencedBlock = [];
+  return true;
+}
+
+function _consumeMarkdownIndentedLine(line, state) {
+  const isIndented = _isIndentedMarkdownCodeLine(line);
+  const isBlank = line.trim() === '';
+
+  if (state.inIndentedBlock) {
+    // Keep blank lines inside indented blocks; they are valid block content.
+    if (isIndented || isBlank) {
+      state.indentedBlock.push(isIndented ? _stripIndentedMarkdownCodeLine(line) : '');
+      return;
+    }
+    state.codeBlocks.push(state.indentedBlock.join('\n'));
+    state.inIndentedBlock = false;
+    state.indentedBlock = [];
+  }
+
+  if (isIndented) {
+    // For indented code blocks, strip one indentation unit before scanning.
+    state.inIndentedBlock = true;
+    state.indentedBlock.push(_stripIndentedMarkdownCodeLine(line));
+  }
+}
+
+function _extractMarkdownCodeBlocks(content) {
+  // Extract Markdown code blocks only (fenced + 4-space/tab indented).
+  // This skips prose sections that may mention ~/.claude as documentation text.
+  const state = _createMarkdownExtractorState();
+
+  for (const line of content.split('\n')) {
+    if (_consumeMarkdownFenceLine(line, state)) continue;
+    if (_openMarkdownFenceIfPresent(line, state)) continue;
+    _consumeMarkdownIndentedLine(line, state);
+  }
+
+  _flushMarkdownExtractorState(state);
+  return state.codeBlocks.join('\n');
+}
+
+function _stripBlockComments(text) {
+  // Remove C-style block comments while preserving newlines so later line-based
+  // filtering (for # and //) keeps the original line structure intact.
+  if (!text || !text.includes('/*')) return text;
+
+  let out = '';
+  let cursor = 0;
+
+  while (cursor < text.length) {
+    const blockStart = text.indexOf('/*', cursor);
+    if (blockStart === -1) {
+      out += text.slice(cursor);
+      break;
+    }
+
+    out += text.slice(cursor, blockStart);
+
+    const blockEnd = text.indexOf('*/', blockStart + 2);
+    const blockBody = blockEnd === -1
+      ? text.slice(blockStart + 2)
+      : text.slice(blockStart + 2, blockEnd);
+
+    // Drop comment content but keep newline count stable for downstream filters.
+    out += blockBody.replace(/[^\n]/g, '');
+
+    if (blockEnd === -1) break;
+    cursor = blockEnd + 2;
+  }
+
+  return out;
+}
+
+function _stripSingleLineComments(text) {
+  // Filter out single-line comment styles to avoid false positives
+  return text.split('\n').filter((line) => {
+    const trimmed = line.trim();
+    return !trimmed.startsWith('#') && !trimmed.startsWith('//');
+  }).join('\n');
+}
+
+function detectClaudePathRefs(content, isMarkdown = false) {
+  if (!content) return [];
+
+  const scanContent = isMarkdown ? _extractMarkdownCodeBlocks(content) : content;
+  const withoutBlockComments = _stripBlockComments(scanContent);
+  const codeContent = _stripSingleLineComments(withoutBlockComments);
+  const matches = codeContent.match(/(?:~|\$HOME)\/\.claude\b/g);
+  return matches || [];
+}
+
+/**
  * Emit a PATH-export suggestion if globalBin is not already on PATH AND
  * the user's shell rc files do not already cover it via a HOME-relative
  * entry (#2620).
@@ -7381,6 +7550,7 @@ if (process.env.GSD_TEST_MODE) {
     finishInstall,
     homePathCoveredByRc,
     maybeSuggestPathExport,
+    detectClaudePathRefs,
   };
 } else {
 

--- a/bin/install.js
+++ b/bin/install.js
@@ -7195,12 +7195,36 @@ function _stripBlockComments(text) {
   return out;
 }
 
+function _findSingleLineCommentStart(line) {
+  let first = -1;
+
+  const hashIdx = line.indexOf('#');
+  if (hashIdx === 0 || (hashIdx > 0 && /\s/.test(line[hashIdx - 1]))) {
+    first = hashIdx;
+  }
+
+  let searchFrom = 0;
+  while (searchFrom < line.length) {
+    const slashIdx = line.indexOf('//', searchFrom);
+    if (slashIdx === -1) break;
+    if (slashIdx === 0 || /\s/.test(line[slashIdx - 1])) {
+      first = first === -1 ? slashIdx : Math.min(first, slashIdx);
+      break;
+    }
+    searchFrom = slashIdx + 2;
+  }
+
+  return first;
+}
+
 function _stripSingleLineComments(text) {
-  // Filter out single-line comment styles to avoid false positives
-  return text.split('\n').filter((line) => {
-    const trimmed = line.trim();
-    return !trimmed.startsWith('#') && !trimmed.startsWith('//');
-  }).join('\n');
+  // Strip both full-line and inline # / // comments while preserving code
+  // before the comment marker. Drop now-empty lines after stripping.
+  return text.split('\n').map((line) => {
+    const markerIdx = _findSingleLineCommentStart(line);
+    const stripped = markerIdx === -1 ? line : line.slice(0, markerIdx);
+    return stripped.trimEnd();
+  }).filter((line) => line.trim() !== '').join('\n');
 }
 
 function detectClaudePathRefs(content, isMarkdown = false) {

--- a/tests/bug-2470-update-md-claude-path.test.cjs
+++ b/tests/bug-2470-update-md-claude-path.test.cjs
@@ -4,11 +4,9 @@
  * Regression test for #2470.
  *
  * update.md is installed into every runtime directory including .gemini, .codex,
- * .opencode, etc. The installer's scanForLeakedPaths() uses the regex
- * /(?:~|\$HOME)\/\.claude\b/g to detect unresolved .claude path references after
- * copyWithPathReplacement() runs. The replacer handles "~/.claude/" (trailing slash)
- * but not "~/.claude" (bare, no trailing slash) — so any bare reference in
- * update.md would slip through and trigger the installer warning for non-Claude runtimes.
+ * .opencode, etc. We assert against the installer's exported detector so this
+ * test remains aligned with real leak-scan behavior (Markdown code blocks +
+ * comment filtering + `(?:~|$HOME)/.claude` matching).
  */
 
 const { test, describe } = require('node:test');
@@ -16,21 +14,21 @@ const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
 
+process.env.GSD_TEST_MODE = '1';
+
+const { detectClaudePathRefs } = require('../bin/install.js');
+
 const UPDATE_MD = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'update.md');
 
-describe('update.md — no bare ~.claude path references (#2470)', () => {
+describe('update.md — no leaked .claude refs under installer scan (#2470)', () => {
   const content = fs.readFileSync(UPDATE_MD, 'utf-8');
 
-  test('update.md does not contain bare ~/\\.claude (without trailing slash)', () => {
-    // This is the exact pattern from the installer's scanForLeakedPaths():
-    // /(?:~|\$HOME)\/\.claude\b/g
-    // The replacer handles ~/\.claude\/ (with trailing slash) but misses bare ~/\.claude
-    // so we must not have bare references in the source file.
-    const matches = content.match(/(?:~|\$HOME)\/\.claude(?!\/)/g);
-    assert.strictEqual(
+  test('update.md has no .claude refs detected by installer markdown scan', () => {
+    const matches = detectClaudePathRefs(content, /* isMarkdown */ true);
+    assert.deepStrictEqual(
       matches,
-      null,
-      `update.md must not contain bare ~/\.claude (without trailing slash) — installer scanner flags these as unresolved path refs: ${JSON.stringify(matches)}`
+      [],
+      `update.md contains leaked .claude references under installer scan: ${JSON.stringify(matches)}`
     );
   });
 });

--- a/tests/install-leaked-claude-paths-filter.test.cjs
+++ b/tests/install-leaked-claude-paths-filter.test.cjs
@@ -84,6 +84,13 @@ describe('detectClaudePathRefs', () => {
         expectNoMatches('  # example: ~/.claude\n  // example: $HOME/.claude', false);
       });
 
+      // Ignore inline single-line comments and keep code before markers.
+      test('ignores inline # and // comment text', () => {
+        expectNoMatches('const x = 1; // ~/.claude', false);
+        expectNoMatches('export FLAG=1 # $HOME/.claude', false);
+        expectMatches('export PATH="~/.claude/skills:$PATH" // note: $HOME/.claude', false, ['~/.claude']);
+      });
+
       // Ignore C-style block comments in one-line and multi-line forms.
       test('ignores /* */ block comments (single-line and multi-line)', () => {
         expectNoMatches('/* example: ~/.claude */', false);
@@ -166,6 +173,15 @@ Outside docs mention $HOME/.claude`;
 export PATH="~/.claude/skills:$PATH"
 \`\`\``;
         expectMatches(content, true, ['~/.claude']);
+      });
+
+      // Ignore inline single-line comment tails in code blocks.
+      test('ignores inline # and // comment text', () => {
+        const content = `\`\`\`bash
+const x = 1; // ~/.claude
+export FLAG=1 # $HOME/.claude
+\`\`\``;
+        expectNoMatches(content, true);
       });
 
       // Ignore multi-line C-style comments while preserving valid code below.

--- a/tests/install-leaked-claude-paths-filter.test.cjs
+++ b/tests/install-leaked-claude-paths-filter.test.cjs
@@ -1,0 +1,191 @@
+'use strict';
+
+/**
+ * Regression test for leaked .claude path detection with comment filtering.
+ *
+ * Verifies that detectClaudePathRefs() for Markdown files only scans code blocks,
+ * while for other files scans all content.
+ */
+
+const { test, describe, before } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+
+const INSTALL_PATH = path.join(__dirname, '..', 'bin', 'install.js');
+
+/**
+ * Test goal:
+ * - Lock leak-detection behavior for `detectClaudePathRefs`.
+ * - Ensure scan scope is correct:
+ *   - Markdown scans code blocks only.
+ *   - Non-Markdown scans full content.
+ * - Ensure comment filtering is correct:
+ *   - Ignore hash, slash-slash, and block-comment content.
+ *   - Keep real path refs outside comments.
+ */
+describe('detectClaudePathRefs', () => {
+  let detect;
+
+  // Load installer once and capture the function under test.
+  before(() => {
+    process.env.GSD_TEST_MODE = '1';
+    const installer = require(INSTALL_PATH);
+    detect = installer.detectClaudePathRefs;
+    assert.strictEqual(typeof detect, 'function');
+  });
+
+  // Helper: assert exact ordered matches.
+  const expectMatches = (content, isMarkdown, expected) => {
+    assert.deepStrictEqual(detect(content, isMarkdown), expected);
+  };
+
+  // Helper: assert no leaked path references are detected.
+  const expectNoMatches = (content, isMarkdown) => {
+    expectMatches(content, isMarkdown, []);
+  };
+
+  /**
+   * Section: Non-Markdown Input
+   * Target behavior:
+   * - Full-content scanning is enabled.
+   * - Comment text does not produce false positives.
+   */
+  describe('non-Markdown files (isMarkdown=false)', () => {
+    /**
+     * Section: Scan Scope
+     * Target behavior:
+     * - Plain text/config files are scanned end-to-end.
+     */
+    describe('scan scope', () => {
+      // Positive baseline: both supported path forms are detectable.
+      test('detects ~/.claude and $HOME/.claude in content', () => {
+        expectMatches('export PATH="~/.claude/skills:$PATH"', false, ['~/.claude']);
+        expectMatches('config="$HOME/.claude/config"', false, ['$HOME/.claude']);
+      });
+
+      // Negative baseline: unrelated content and empty input should produce no hits.
+      test('returns empty array for non-matching or empty content', () => {
+        expectNoMatches('export PATH="$HOME/.local/bin:$PATH"', false);
+        expectNoMatches('', false);
+      });
+    });
+
+    /**
+     * Section: Comment Filtering
+     * Target behavior:
+     * - Comment-only content is ignored.
+     * - Inline comments do not erase adjacent valid refs.
+     */
+    describe('comment filtering', () => {
+      // Ignore shell/js single-line comments even if they mention .claude paths.
+      test('ignores # and // comment lines', () => {
+        expectNoMatches('# e.g. ~/.claude, ~/.config/opencode', false);
+        expectNoMatches('// e.g. ~/.claude, ~/.config/opencode', false);
+        expectNoMatches('  # example: ~/.claude\n  // example: $HOME/.claude', false);
+      });
+
+      // Ignore C-style block comments in one-line and multi-line forms.
+      test('ignores /* */ block comments (single-line and multi-line)', () => {
+        expectNoMatches('/* example: ~/.claude */', false);
+        expectNoMatches('/*\n * docs: $HOME/.claude/config\n * docs: ~/.claude/skills\n */', false);
+      });
+
+      // Ensure filtering is selective: valid code on the same line is preserved.
+      test('keeps valid matches when inline block comments are present', () => {
+        expectMatches('const cfg = "$HOME/.claude/config"; /* docs mention ~/.claude */', false, ['$HOME/.claude']);
+        expectMatches('export PATH="~/.claude/skills:$PATH" /* trailing note */', false, ['~/.claude']);
+      });
+    });
+  });
+
+  /**
+   * Section: Markdown Input
+   * Target behavior:
+   * - Only executable-looking regions (code blocks) are scanned.
+   * - Prose/documentation text is ignored.
+   */
+  describe('Markdown files (isMarkdown=true)', () => {
+    /**
+     * Section: Scan Scope
+     * Target behavior:
+     * - Fenced and indented code blocks are scanned.
+     * - Non-code markdown text is not scanned.
+     */
+    describe('scan scope', () => {
+      // Prose mentions are documentation text and must not be treated as leaks.
+      test('ignores content outside code blocks', () => {
+        const content = 'Some docs mentioning ~/.claude here\n\n## Section about $HOME/.claude';
+        expectNoMatches(content, true);
+      });
+
+      // Fenced blocks are executable examples and should be scanned.
+      test('detects paths in fenced code blocks only', () => {
+        const content = `Some docs.
+
+\`\`\`bash
+export PATH="~/.claude/skills:$PATH"
+\`\`\`
+
+More docs.
+
+\`\`\`yaml
+config: $HOME/.claude/config
+\`\`\``;
+        expectMatches(content, true, ['~/.claude', '$HOME/.claude']);
+      });
+
+      // Indented code blocks should behave the same as fenced code blocks.
+      test('detects paths in indented code blocks', () => {
+        const content = `List:
+
+    export PATH="~/.claude/skills:$PATH"
+    # comment: $HOME/.claude
+
+Outside docs mention $HOME/.claude`;
+        expectMatches(content, true, ['~/.claude']);
+      });
+
+      // Empty markdown or markdown without code blocks should return no matches.
+      test('returns empty array for markdown without code blocks or empty content', () => {
+        expectNoMatches('Just plain text with ~/.claude', true);
+        expectNoMatches('', true);
+      });
+    });
+
+    /**
+     * Section: Comment Filtering In Code Blocks
+     * Target behavior:
+     * - Hash and C-style comments inside code blocks are ignored.
+     * - Non-comment refs in the same block are still detected.
+     */
+    describe('comment filtering inside code blocks', () => {
+      // Ignore hash comment lines in fenced shell snippets.
+      test('ignores # comment lines', () => {
+        const content = `\`\`\`bash
+# Example: ~/.claude
+export PATH="~/.claude/skills:$PATH"
+\`\`\``;
+        expectMatches(content, true, ['~/.claude']);
+      });
+
+      // Ignore multi-line C-style comments while preserving valid code below.
+      test('ignores /* */ block comments', () => {
+        const content = `\`\`\`js
+/*
+ * Example: ~/.claude
+ */
+const cfg = "$HOME/.claude/config";
+\`\`\``;
+        expectMatches(content, true, ['$HOME/.claude']);
+      });
+
+      // Keep valid refs when inline block comments share the same line.
+      test('keeps valid matches when inline block comments are present', () => {
+        const content = `\`\`\`js
+const cfg = "$HOME/.claude/config"; /* example: ~/.claude */
+\`\`\``;
+        expectMatches(content, true, ['$HOME/.claude']);
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Restrict leaked `.claude` detection to executable markdown regions by scanning fenced and indented code blocks only.
- Filter `#`, `//`, and `/* ... */` comments before matching so documentation/examples do not trigger false positives while preserving real path hits.
- Add focused regression coverage for scan scope + comment filtering and align `update.md` guard with `detectClaudePathRefs()`.

Fixes #2470

## Test plan
- [x] `node --test tests/install-leaked-claude-paths-filter.test.cjs tests/bug-2470-update-md-claude-path.test.cjs`
- [x] `npm test`

Made with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate detection of unreplaced ".claude" paths: scans only code sections for Markdown, scans full content otherwise, and filters common comment styles to reduce false positives; leak records only when actual matches are found.

* **Tests**
  * Added regression tests validating Markdown vs non‑Markdown scanning, comment filtering, and edge-case path detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->