### PR TITLE
fix: bump opus alias from claude-opus-4-6 to claude-opus-4-7

### DIFF
--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -1488,7 +1488,7 @@ function checkAgentsInstalled() {
  * Users can override with model_overrides in config.json for custom/latest models.
  */
 const MODEL_ALIAS_MAP = {
-  'opus': 'claude-opus-4-6',
+  'opus': 'claude-opus-4-7',
   'sonnet': 'claude-sonnet-4-6',
   'haiku': 'claude-haiku-4-5',
 };
@@ -1507,7 +1507,7 @@ const MODEL_ALIAS_MAP = {
  */
 const RUNTIME_PROFILE_MAP = {
   claude: {
-    opus:   { model: 'claude-opus-4-6' },
+    opus:   { model: 'claude-opus-4-7' },
     sonnet: { model: 'claude-sonnet-4-6' },
     haiku:  { model: 'claude-haiku-4-5' },
   },


### PR DESCRIPTION
## Summary

`MODEL_ALIAS_MAP` and `RUNTIME_PROFILE_MAP` in `bin/lib/core.cjs` both pinned the `opus` alias to `claude-opus-4-6` even though Anthropic shipped Opus 4.7 in Q1 2026 and it's the current default in Claude Code.

## Impact

When `resolve_model_ids: true` is set in `.planning/config.json`, agents receive the stale model ID instead of the latest. No runtime error (Claude resolves the alias platform-side), but full IDs in commits, logs, and exports drift from the runtime's actual model — confusing for users inspecting `gsd-tools resolve-model --raw`.

## Diff

\`\`\`diff
 const MODEL_ALIAS_MAP = {
-  'opus': 'claude-opus-4-6',
+  'opus': 'claude-opus-4-7',
   'sonnet': 'claude-sonnet-4-6',
   'haiku': 'claude-haiku-4-5',
 };

 const RUNTIME_PROFILE_MAP = {
   claude: {
-    opus:   { model: 'claude-opus-4-6' },
+    opus:   { model: 'claude-opus-4-7' },
     sonnet: { model: 'claude-sonnet-4-6' },
     haiku:  { model: 'claude-haiku-4-5' },
   },
\`\`\`

## Verification

- Anthropic SDK \`@anthropic-ai/sdk@0.90.0\` \`Model\` type literal includes \`'claude-opus-4-7'\` (currently first in the union, indicating most-recent).
- Bare aliases (\`opus\`, \`sonnet\`, \`haiku\`) at the platform level remain auto-routing — this PR only updates the explicit-ID expansion path used when \`resolve_model_ids: true\`.

## Closes

Closes #2712

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Upgraded Claude Opus AI model to the latest available version for enhanced performance and capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->