### PR TITLE
feat: workstream config inherits from root .planning/config.json

### DIFF
--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -269,12 +269,50 @@ const CONFIG_DEFAULTS = {
   post_planning_gaps: true, // workflow.post_planning_gaps — unified post-planning gap report (#2493): scan REQUIREMENTS.md + CONTEXT.md decisions vs all PLAN.md files
 };
 
+/**
+ * Deep-merge two config objects. `overlay` wins on key conflict; nested
+ * objects are merged recursively. Arrays and primitives in `overlay`
+ * replace the corresponding value in `base` entirely (no array merge).
+ *
+ * Used by loadConfig to inherit root .planning/config.json into a
+ * workstream config when GSD_WORKSTREAM is set (#2714).
+ */
+function _deepMergeConfig(base, overlay) {
+  if (overlay === null || overlay === undefined) return base;
+  if (base === null || base === undefined) return overlay;
+  if (typeof base !== 'object' || typeof overlay !== 'object') return overlay;
+  if (Array.isArray(base) || Array.isArray(overlay)) return overlay;
+  const out = { ...base };
+  for (const k of Object.keys(overlay)) {
+    out[k] = _deepMergeConfig(base[k], overlay[k]);
+  }
+  return out;
+}
+
 function loadConfig(cwd) {
   const configPath = path.join(planningDir(cwd), 'config.json');
+  const rootConfigPath = path.join(planningRoot(cwd), 'config.json');
   const defaults = CONFIG_DEFAULTS;
 
+  // Inherit-from-root (#2714): when GSD_WORKSTREAM is active, read the root
+  // config and the workstream config, deep-merge with workstream-wins. If the
+  // workstream config is missing, fall back to root entirely. Workstream
+  // settings override root for shared keys; unset keys inherit from root.
+  let inheritedRaw = null;
+  if (configPath !== rootConfigPath && process.env.GSD_WORKSTREAM) {
+    let rootObj = null;
+    let wsObj = null;
+    try { rootObj = JSON.parse(fs.readFileSync(rootConfigPath, 'utf-8')); } catch { /* no root config */ }
+    try { wsObj = JSON.parse(fs.readFileSync(configPath, 'utf-8')); } catch { /* no ws config */ }
+    if (rootObj && wsObj) {
+      inheritedRaw = JSON.stringify(_deepMergeConfig(rootObj, wsObj));
+    } else if (rootObj && !wsObj) {
+      inheritedRaw = JSON.stringify(rootObj);
+    }
+  }
+
   try {
-    const raw = fs.readFileSync(configPath, 'utf-8');
+    const raw = inheritedRaw || fs.readFileSync(configPath, 'utf-8');
     const parsed = JSON.parse(raw);
 
     // Migrate deprecated "depth" key to "granularity" with value mapping


### PR DESCRIPTION
## Summary

When \`GSD_WORKSTREAM\` is set, \`loadConfig()\` previously read only \`.planning/workstreams/<ws>/config.json\`. If that file was missing (or didn't define a key), the resolver fell back to \`CONFIG_DEFAULTS\` — never to root \`.planning/config.json\`. This forced users with multiple workstreams to duplicate every setting (\`model_overrides\`, \`workflow.*\`, \`context_window\`, \`features.*\`, \`manager.*\`) across every workstream config.

This PR makes workstream configs deep-merge over root config:

- **Root \`.planning/config.json\`** = project-wide defaults (single source)
- **Workstream \`config.json\`** = per-workstream overrides (overlay)
- **Workstream wins** on key conflict; unset keys **inherit from root**
- **Missing workstream config** falls back to root entirely

## Pain point this fixes

Real-world example: a team of 4-5 devs each running 2-3 parallel workstreams ends up with 10-15 copies of the same config drifting slowly out of sync. Adding a new workstream means a new copy. Updating \`model_overrides\` to add a new agent means editing every workstream copy by hand.

After this PR: set \`model_overrides\` once at root → every workstream picks it up automatically. Workstream-specific overrides remain (e.g., a workstream that wants a different \`code_review_depth\`).

## Diff

\`\`\`diff
+function _deepMergeConfig(base, overlay) {
+  if (overlay === null || overlay === undefined) return base;
+  if (base === null || base === undefined) return overlay;
+  if (typeof base !== 'object' || typeof overlay !== 'object') return overlay;
+  if (Array.isArray(base) || Array.isArray(overlay)) return overlay;
+  const out = { ...base };
+  for (const k of Object.keys(overlay)) {
+    out[k] = _deepMergeConfig(base[k], overlay[k]);
+  }
+  return out;
+}

 function loadConfig(cwd) {
   const configPath = path.join(planningDir(cwd), 'config.json');
+  const rootConfigPath = path.join(planningRoot(cwd), 'config.json');
   const defaults = CONFIG_DEFAULTS;

+  // Inherit-from-root (#2714): when GSD_WORKSTREAM is active, read root
+  // and workstream configs, deep-merge with workstream-wins.
+  let inheritedRaw = null;
+  if (configPath !== rootConfigPath && process.env.GSD_WORKSTREAM) {
+    let rootObj = null;
+    let wsObj = null;
+    try { rootObj = JSON.parse(fs.readFileSync(rootConfigPath, 'utf-8')); } catch {}
+    try { wsObj = JSON.parse(fs.readFileSync(configPath, 'utf-8')); } catch {}
+    if (rootObj && wsObj) {
+      inheritedRaw = JSON.stringify(_deepMergeConfig(rootObj, wsObj));
+    } else if (rootObj && !wsObj) {
+      inheritedRaw = JSON.stringify(rootObj);
+    }
+  }

   try {
-    const raw = fs.readFileSync(configPath, 'utf-8');
+    const raw = inheritedRaw || fs.readFileSync(configPath, 'utf-8');
     const parsed = JSON.parse(raw);
\`\`\`

## Verification

Tested locally with 4 workstreams (\`junny\`, \`henry\`, \`junny-p2\`, \`junny-p3\`):

\`\`\`
ws=junny    profile: quality, model_overrides count: 32
ws=henry    profile: quality, model_overrides count: 32
ws=junny-p2 profile: quality, model_overrides count: 32
ws=junny-p3 profile: quality, model_overrides count: 32
\`\`\`

Before this PR: each workstream returned \`balanced\` profile + 0 overrides because their workstream-local config either didn't exist or was a stripped-down copy.

## Backwards compatibility

- Workstreams with full standalone configs keep working — they just stop falling through to \`CONFIG_DEFAULTS\` for unset keys, and instead fall through to root. Concrete keys still set in workstream config still win.
- Workstreams with no config now correctly inherit root settings instead of defaulting to \`balanced\` model_profile, no \`model_overrides\`, etc.
- No new files. No new dependencies. Pure read-merge — no on-disk mutation.

## Closes

Closes #2714

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workstream-specific configuration overrides now supported. When workstreams are enabled, per-workstream settings automatically take precedence over global settings with intelligent fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->