### PR TITLE
fix(#2722): forensics gh commands pin --repo gsd-build/get-shit-done

### DIFF
--- a/get-shit-done/workflows/forensics.md
+++ b/get-shit-done/workflows/forensics.md
@@ -244,13 +244,14 @@ If actionable anomalies were found (HIGH or MEDIUM confidence):
 If confirmed:
 ```bash
 # Check if "bug" label exists before using it
-BUG_LABEL=$(gh label list --search "bug" --json name -q '.[0].name' 2>/dev/null)
+BUG_LABEL=$(gh label list --repo gsd-build/get-shit-done --search "bug" --json name -q '.[0].name' 2>/dev/null)
 LABEL_FLAG=""
 if [ -n "$BUG_LABEL" ]; then
   LABEL_FLAG="--label bug"
 fi
 
 gh issue create \
+  --repo gsd-build/get-shit-done \
   --title "bug: {concise description from anomaly}" \
   $LABEL_FLAG \
   --body "{formatted findings from report}"

--- a/tests/forensics.test.cjs
+++ b/tests/forensics.test.cjs
@@ -140,22 +140,22 @@ describe('forensics workflow', () => {
 
   test('workflow submits issues to gsd-build/get-shit-done, not the current repo', () => {
     const content = fs.readFileSync(workflowPath, 'utf-8');
-    // gh resolves the target repo from $PWD's git remote by default.
-    // Forensics always reports GSD bugs, so every gh call must pin the repo explicitly.
-    assert.ok(
-      content.includes('--repo gsd-build/get-shit-done'),
+    // Scope check to the gh issue create invocation — a whole-file search would
+    // pass even if gh issue create lacked --repo, because gh label list also
+    // contains the repo string.
+    assert.match(
+      content,
+      /gh issue create[\s\S]{0,250}--repo\s+gsd-build\/get-shit-done/,
       'gh issue create must use --repo gsd-build/get-shit-done to avoid submitting to the user\'s current project repo'
     );
   });
 
   test('workflow checks bug label in gsd-build/get-shit-done, not the current repo', () => {
     const content = fs.readFileSync(workflowPath, 'utf-8');
-    // gh label list also defaults to $PWD repo — must pin the same target repo
-    const labelListIdx = content.indexOf('gh label list');
-    assert.notStrictEqual(labelListIdx, -1, 'should have gh label list command');
-    const labelListSection = content.slice(labelListIdx, labelListIdx + 200);
-    assert.ok(
-      labelListSection.includes('gsd-build/get-shit-done'),
+    // Regex is more robust than a fixed-length slice to formatting changes
+    assert.match(
+      content,
+      /gh label list[\s\S]{0,250}--repo\s+gsd-build\/get-shit-done/,
       'gh label list must target gsd-build/get-shit-done'
     );
   });

--- a/tests/forensics.test.cjs
+++ b/tests/forensics.test.cjs
@@ -138,6 +138,28 @@ describe('forensics workflow', () => {
     );
   });
 
+  test('workflow submits issues to gsd-build/get-shit-done, not the current repo', () => {
+    const content = fs.readFileSync(workflowPath, 'utf-8');
+    // gh resolves the target repo from $PWD's git remote by default.
+    // Forensics always reports GSD bugs, so every gh call must pin the repo explicitly.
+    assert.ok(
+      content.includes('--repo gsd-build/get-shit-done'),
+      'gh issue create must use --repo gsd-build/get-shit-done to avoid submitting to the user\'s current project repo'
+    );
+  });
+
+  test('workflow checks bug label in gsd-build/get-shit-done, not the current repo', () => {
+    const content = fs.readFileSync(workflowPath, 'utf-8');
+    // gh label list also defaults to $PWD repo — must pin the same target repo
+    const labelListIdx = content.indexOf('gh label list');
+    assert.notStrictEqual(labelListIdx, -1, 'should have gh label list command');
+    const labelListSection = content.slice(labelListIdx, labelListIdx + 200);
+    assert.ok(
+      labelListSection.includes('gsd-build/get-shit-done'),
+      'gh label list must target gsd-build/get-shit-done'
+    );
+  });
+
   test('workflow updates STATE.md', () => {
     const content = fs.readFileSync(workflowPath, 'utf-8');
     assert.ok(


### PR DESCRIPTION
## Summary

- `gh issue create` in the forensics workflow had no `--repo` flag, causing issues to be submitted to whatever repo `gh` inferred from the user's current working directory
- `gh label list` had the same problem — it checked for a "bug" label in the wrong repo
- Added `--repo gsd-build/get-shit-done` to both commands
- Added two regression tests that will catch any future regressions on either command

## Test plan

- [ ] `node --test tests/forensics.test.cjs` — all 23 tests pass (was 21 before this PR)
- [ ] The two new tests fail on the unfixed workflow and pass after the fix (verified via TDD red→green cycle)

Closes #2722

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the forensics workflow to explicitly target the correct repository for all GitHub operations, including label discovery and issue creation, improving reliability and preventing operations from being executed in unintended contexts.

* **Tests**
  * Added automated tests that validate the workflow scopes all GitHub CLI operations to the designated repository, reducing the risk of misrouted labels or issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->