### PR TITLE
fix(ci): remove stale SDK-variant tests for files deleted in 377a6d2

### DIFF
--- a/tests/enh-2427-sycophancy-hardening.test.cjs
+++ b/tests/enh-2427-sycophancy-hardening.test.cjs
@@ -15,7 +15,6 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const AGENTS_DIR = path.join(__dirname, '../agents');
-const SDK_AGENTS_DIR = path.join(__dirname, '../sdk/prompts/agents');
 
 const AUDIT_AGENTS = [
   'gsd-plan-checker.md',
@@ -27,11 +26,6 @@ const AUDIT_AGENTS = [
   'gsd-ui-auditor.md',
   'gsd-integration-checker.md',
   'gsd-doc-verifier.md',
-];
-
-const SDK_AUDIT_AGENTS = [
-  'gsd-plan-checker.md',
-  'gsd-verifier.md',
 ];
 
 function readAgent(agentsDir, filename) {
@@ -102,26 +96,5 @@ describe('enh-2427 — sycophancy hardening: audit-class agents', () => {
     });
   }
 
-  describe('sdk/prompts/agents variants', () => {
-    for (const filename of SDK_AUDIT_AGENTS) {
-      const label = `sdk/${filename.replace('.md', '')}`;
-
-      describe(label, () => {
-        test('third-person framing and adversarial_stance block present', () => {
-          const content = readAgent(SDK_AGENTS_DIR, filename);
-          const role = extractRole(content);
-          const firstSentence = role.trim().slice(0, 80);
-
-          assert.ok(
-            !firstSentence.startsWith('You are a GSD'),
-            `${filename}: SDK variant must not open <role> with "You are a GSD"`
-          );
-          assert.ok(
-            content.includes('<adversarial_stance>'),
-            `${filename}: SDK variant must contain <adversarial_stance> block`
-          );
-        });
-      });
-    }
-  });
 });
+// sdk/prompts/agents/ was removed in 377a6d2 — SDK now loads installed agents directly.

--- a/tests/post-planning-gaps-2493.test.cjs
+++ b/tests/post-planning-gaps-2493.test.cjs
@@ -30,7 +30,6 @@ const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
 
 const REPO_ROOT = path.join(__dirname, '..');
 const PLAN_PHASE_PATH = path.join(REPO_ROOT, 'get-shit-done', 'workflows', 'plan-phase.md');
-const PLAN_PHASE_SDK_PATH = path.join(REPO_ROOT, 'sdk', 'prompts', 'workflows', 'plan-phase.md');
 
 // ─── Workflow file structure ──────────────────────────────────────────────────
 
@@ -77,10 +76,7 @@ describe('plan-phase.md Step 13e insertion (#2493)', () => {
     assert.match(content, /## 13\.\s*Requirements Coverage Gate/);
   });
 
-  test('Headless plan-phase variant has post_planning_gaps step', () => {
-    const content = fs.readFileSync(PLAN_PHASE_SDK_PATH, 'utf-8');
-    assert.match(content, /post_planning_gaps/);
-  });
+  // sdk/prompts/workflows/plan-phase.md removed in 377a6d2 — SDK loads installed workflow directly.
 });
 
 // ─── Decisions parser ────────────────────────────────────────────────────────

--- a/tests/verifier-deferred-items.test.cjs
+++ b/tests/verifier-deferred-items.test.cjs
@@ -150,34 +150,7 @@ describe('verifier deferred-items filtering (#1624)', () => {
     });
   });
 
-  // ── verify-phase.md (SDK variant) ──────────────────────────────────────────
-
-  describe('sdk/prompts/workflows/verify-phase.md', () => {
-    const sdkPath = path.join(ROOT, 'sdk', 'prompts', 'workflows', 'verify-phase.md');
-    let sdkContent;
-
-    test('file exists', () => {
-      assert.ok(fs.existsSync(sdkPath), 'SDK verify-phase.md should exist');
-      sdkContent = fs.readFileSync(sdkPath, 'utf-8');
-    });
-
-    test('loads roadmap analyze in context step', () => {
-      sdkContent = sdkContent || fs.readFileSync(sdkPath, 'utf-8');
-      assert.ok(
-        sdkContent.includes('roadmap analyze'),
-        'SDK verify-phase.md should reference roadmap analyze for deferred-item filtering'
-      );
-    });
-
-    test('contains deferred-item filtering step', () => {
-      sdkContent = sdkContent || fs.readFileSync(sdkPath, 'utf-8');
-      assert.ok(
-        sdkContent.includes('filter_deferred_items') ||
-        sdkContent.includes('deferred'),
-        'SDK verify-phase.md should contain deferred-item filtering logic'
-      );
-    });
-  });
+  // sdk/prompts/workflows/verify-phase.md removed in 377a6d2 — SDK loads installed workflow directly.
 
   // ── planner-gap-closure.md ─────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- `377a6d2` deleted `sdk/prompts/agents/` and `sdk/prompts/workflows/` (13 files) when the SDK was refactored to load installed GSD agents directly instead of bundled stripped-down copies
- 3 test files that referenced those deleted files were not updated, causing ENOENT failures on every CI run (main and all PRs) since that commit
- Removed the stale SDK-variant describe blocks / constants from all 3 affected test files

Closes #2724

## Test plan

- [ ] `node --test tests/enh-2427-sycophancy-hardening.test.cjs tests/post-planning-gaps-2493.test.cjs tests/verifier-deferred-items.test.cjs` — 96 tests pass, 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Simplified test infrastructure by removing SDK-specific scaffolding for agents and workflows; validation now uses direct system loading instead of file-based assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->