### PR TITLE
fix(codex): use current agent config schema and hooks.json

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -2066,10 +2066,10 @@ function generateCodexConfigBlock(agents, targetDir) {
   ];
 
   for (const { name, description } of agents) {
-    // #2645 — Codex schema requires [[agents]] array-of-tables, not [agents.<name>] maps.
-    // Emitting [agents.<name>] produces `invalid type: map, expected a sequence` on load.
-    lines.push(`[[agents]]`);
-    lines.push(`name = ${JSON.stringify(name)}`);
+    // Live Codex parser validation on 26.422.3464.0 accepts [agents.<name>]
+    // subtables and rejects [[agents]] with:
+    // `invalid type: sequence, expected struct AgentsToml`.
+    lines.push(`[agents.${name}]`);
     lines.push(`description = ${JSON.stringify(description)}`);
     lines.push(`config_file = "${agentsPrefix}/${name}.toml"`);
     lines.push('');
@@ -2082,8 +2082,8 @@ function generateCodexConfigBlock(agents, targetDir) {
  * Strip any managed GSD agent sections from a TOML string.
  *
  * Handles BOTH shapes so reinstall self-heals broken legacy configs:
- *   - Legacy: `[agents.gsd-*]` single-keyed map tables (pre-#2645).
- *   - Current: `[[agents]]` array-of-tables whose `name = "gsd-*"`.
+ *   - Current: `[agents.gsd-*]` subtables.
+ *   - Broken v1.38.5: `[[agents]]` array-of-tables whose `name = "gsd-*"`.
  *
  * A section runs from its header to the next `[` header or EOF.
  */
@@ -2091,12 +2091,12 @@ function stripCodexGsdAgentSections(content) {
   // Use the TOML-aware section parser so we never absorb adjacent user-authored
   // tables — even if their headers are indented or otherwise oddly placed.
   const sections = getTomlTableSections(content).filter((section) => {
-    // Legacy `[agents.gsd-<name>]` map tables (pre-#2645).
+    // Current `[agents.gsd-<name>]` subtables.
     if (!section.array && /^agents\.gsd-/.test(section.path)) {
       return true;
     }
 
-    // Current `[[agents]]` array-of-tables — only strip blocks whose
+    // Broken v1.38.5 `[[agents]]` array-of-tables — only strip blocks whose
     // `name = "gsd-..."`, preserving user-authored [[agents]] entries.
     if (section.array && section.path === 'agents') {
       const body = content.slice(section.headerEnd, section.end);
@@ -2118,6 +2118,7 @@ function stripCodexGsdAgentSections(content) {
  * Returns cleaned content, or null if file would be empty.
  */
 function stripGsdFromCodexConfig(content) {
+  content = stripLegacyCodexHookBlockFromConfig(content);
   const eol = detectLineEnding(content);
   const markerIndex = content.indexOf(GSD_CODEX_MARKER);
   const codexHooksOwnership = getManagedCodexHooksOwnership(content);
@@ -2809,7 +2810,7 @@ function isLegacyGsdAgentsSection(body) {
 function stripLeakedGsdCodexSections(content) {
   const leakedSections = getTomlTableSections(content)
     .filter((section) => {
-      // Legacy [agents.gsd-<name>] map tables (pre-#2645).
+      // Current [agents.gsd-<name>] subtables.
       if (!section.array && section.path.startsWith('agents.gsd-')) return true;
 
       // Legacy bare [agents] table with only the old max_threads/max_depth keys.
@@ -2819,7 +2820,7 @@ function stripLeakedGsdCodexSections(content) {
         isLegacyGsdAgentsSection(content.slice(section.headerEnd, section.end))
       ) return true;
 
-      // Current [[agents]] array-of-tables whose name is gsd-*. Preserve
+      // Broken v1.38.5 [[agents]] array-of-tables whose name is gsd-*. Preserve
       // user-authored [[agents]] entries (other names) untouched.
       if (section.array && section.path === 'agents') {
         const body = content.slice(section.headerEnd, section.end);
@@ -4862,6 +4863,36 @@ function uninstall(isGlobal, runtime = 'claude') {
           console.log(`  ${green}✓${reset} Cleaned GSD sections from config.toml`);
         }
       }
+
+      const hooksPath = path.join(targetDir, 'hooks.json');
+      if (fs.existsSync(hooksPath)) {
+        let hooksSettings = readSettings(hooksPath);
+        if (hooksSettings === null) {
+          console.log(`  ${yellow}i${reset} Skipping hooks.json cleanup — file could not be parsed`);
+        } else {
+          let hooksModified = false;
+          for (const eventName of ['SessionStart', 'PostToolUse', 'AfterTool', 'PreToolUse', 'BeforeTool']) {
+            if (hooksSettings.hooks && hooksSettings.hooks[eventName]) {
+              const before = JSON.stringify(hooksSettings.hooks[eventName]);
+              hooksSettings.hooks[eventName] = filterGsdHooks(hooksSettings.hooks[eventName]);
+              if (JSON.stringify(hooksSettings.hooks[eventName]) !== before) {
+                hooksModified = true;
+              }
+              if (hooksSettings.hooks[eventName].length === 0) {
+                delete hooksSettings.hooks[eventName];
+              }
+            }
+          }
+          if (hooksSettings.hooks && Object.keys(hooksSettings.hooks).length === 0) {
+            delete hooksSettings.hooks;
+          }
+          if (hooksModified) {
+            writeSettings(hooksPath, hooksSettings);
+            removedCount++;
+            console.log(`  ${green}✓${reset} Removed GSD hooks from hooks.json`);
+          }
+        }
+      }
     }
   } else if (isCopilot) {
     // Copilot: remove skills/gsd-*/ directories (same layout as Codex skills)
@@ -5118,26 +5149,10 @@ function uninstall(isGlobal, runtime = 'claude') {
       console.log(`  ${green}✓${reset} Removed GSD statusline from settings`);
     }
 
-    // Remove GSD hooks from settings — per-hook granularity to preserve
-    // user hooks that share an entry with a GSD hook (#1755 followup)
-    const isGsdHookCommand = (cmd) =>
-      cmd && (cmd.includes('gsd-check-update') || cmd.includes('gsd-statusline') ||
-        cmd.includes('gsd-session-state') || cmd.includes('gsd-context-monitor') ||
-        cmd.includes('gsd-phase-boundary') || cmd.includes('gsd-prompt-guard') ||
-        cmd.includes('gsd-read-guard') || cmd.includes('gsd-read-injection-scanner') ||
-        cmd.includes('gsd-validate-commit') || cmd.includes('gsd-workflow-guard'));
-
     for (const eventName of ['SessionStart', 'PostToolUse', 'AfterTool', 'PreToolUse', 'BeforeTool']) {
       if (settings.hooks && settings.hooks[eventName]) {
         const before = JSON.stringify(settings.hooks[eventName]);
-        settings.hooks[eventName] = settings.hooks[eventName]
-          .map(entry => {
-            if (!entry.hooks || !Array.isArray(entry.hooks)) return entry;
-            // Filter out individual GSD hooks, keep user hooks
-            entry.hooks = entry.hooks.filter(h => !isGsdHookCommand(h.command));
-            return entry.hooks.length > 0 ? entry : null;
-          })
-          .filter(Boolean);
+        settings.hooks[eventName] = filterGsdHooks(settings.hooks[eventName]);
         if (JSON.stringify(settings.hooks[eventName]) !== before) {
           settingsModified = true;
         }
@@ -6277,40 +6292,27 @@ function install(isGlobal, runtime = 'claude') {
       console.log(`  ${green}✓${reset} Installed hooks`);
     }
 
-    // Add Codex hooks (SessionStart for update checking) — requires codex_hooks feature flag
+    // Enable Codex hooks feature in config.toml; actual hook registrations live
+    // in hooks.json for current Codex builds.
     const configPath = path.join(targetDir, 'config.toml');
     try {
       let configContent = fs.existsSync(configPath) ? fs.readFileSync(configPath, 'utf-8') : '';
-      const eol = detectLineEnding(configContent);
       const codexHooksFeature = ensureCodexHooksFeature(configContent);
       configContent = setManagedCodexHooksOwnership(codexHooksFeature.content, codexHooksFeature.ownership);
-
-      // Add SessionStart hook for update checking
-      const updateCheckScript = path.resolve(targetDir, 'hooks', 'gsd-check-update.js').replace(/\\/g, '/');
-      const hookBlock =
-        `${eol}# GSD Hooks${eol}` +
-        `[[hooks]]${eol}` +
-        `event = "SessionStart"${eol}` +
-        `command = "node ${updateCheckScript}"${eol}`;
-
-      // Migrate legacy gsd-update-check entries from prior installs (#1755 followup)
-      // Remove stale hook blocks that used the inverted filename or wrong path.
-      // Single \r?\n-aware regex handles LF, CRLF, and block-at-file-start (#2698).
-      if (configContent.includes('gsd-update-check')) {
-        configContent = configContent.replace(
-          /(?:\r?\n|^)# GSD Hooks\r?\n\[\[hooks\]\]\r?\nevent = "SessionStart"\r?\ncommand = "node [^\r\n]*gsd-update-check\.js"\r?\n/gm,
-          (match) => (match.startsWith('\r\n') ? '\r\n' : match.startsWith('\n') ? '\n' : ''),
-        );
-      }
-
-      if (hasEnabledCodexHooksFeature(configContent) && !configContent.includes('gsd-check-update')) {
-        configContent += hookBlock;
-      }
+      configContent = stripLegacyCodexHookBlockFromConfig(configContent);
 
       fs.writeFileSync(configPath, configContent, 'utf-8');
-      console.log(`  ${green}✓${reset} Configured Codex hooks (SessionStart)`);
+      console.log(`  ${green}✓${reset} Enabled Codex hook feature`);
+
+      const updateCheckFile = path.join(targetDir, 'hooks', 'gsd-check-update.js');
+      if (hasEnabledCodexHooksFeature(configContent) && fs.existsSync(updateCheckFile)) {
+        const updateCheckCommand = `node ${path.resolve(updateCheckFile).replace(/\\/g, '/')}`;
+        configureCodexHooksJson(targetDir, updateCheckCommand);
+      } else if (!fs.existsSync(updateCheckFile)) {
+        console.warn(`  ${yellow}⚠${reset}  Skipped hooks.json update — gsd-check-update.js not found at target`);
+      }
     } catch (e) {
-      console.warn(`  ${yellow}⚠${reset}  Could not configure Codex hooks: ${e.message}`);
+      console.warn(`  ${yellow}⚠${reset}  Could not configure Codex hook settings: ${e.message}`);
     }
 
     return { settingsPath: null, settings: null, statuslineCommand: null, runtime, configDir: targetDir };
@@ -7042,6 +7044,80 @@ function homePathCoveredByRc(globalBin, homeDir, rcFileNames) {
   }
 
   return false;
+}
+
+function isGsdHookCommand(cmd) {
+  return cmd && (
+    cmd.includes('gsd-check-update') ||
+    cmd.includes('gsd-update-check') ||
+    cmd.includes('gsd-statusline') ||
+    cmd.includes('gsd-session-state') ||
+    cmd.includes('gsd-context-monitor') ||
+    cmd.includes('gsd-phase-boundary') ||
+    cmd.includes('gsd-prompt-guard') ||
+    cmd.includes('gsd-read-guard') ||
+    cmd.includes('gsd-read-injection-scanner') ||
+    cmd.includes('gsd-validate-commit') ||
+    cmd.includes('gsd-workflow-guard')
+  );
+}
+
+function filterGsdHooks(entries, predicate = isGsdHookCommand) {
+  if (!Array.isArray(entries)) return entries;
+  return entries
+    .map((entry) => {
+      if (!entry || !entry.hooks || !Array.isArray(entry.hooks)) return entry;
+      const hooks = entry.hooks.filter((hook) => !predicate(hook.command));
+      return hooks.length > 0 ? { ...entry, hooks } : null;
+    })
+    .filter(Boolean);
+}
+
+function stripLegacyCodexHookBlockFromConfig(content) {
+  return content.replace(
+    /(?:\r?\n|^)# GSD Hooks\r?\n\[\[hooks\]\]\r?\nevent = "SessionStart"\r?\ncommand = "node [^\r\n]*gsd-(?:update-check|check-update)\.js"\r?\n/gm,
+    (match) => (match.startsWith('\r\n') ? '\r\n' : match.startsWith('\n') ? '\n' : '')
+  );
+}
+
+function configureCodexHooksJson(targetDir, updateCheckCommand) {
+  const hooksPath = path.join(targetDir, 'hooks.json');
+  let settings = readSettings(hooksPath);
+  if (settings === null) {
+    console.log(`  ${yellow}i${reset} Skipping hooks.json configuration — file could not be parsed (comments or malformed JSON). Your existing hooks are preserved.`);
+    return;
+  }
+
+  settings = cleanupOrphanedHooks(settings);
+  settings = validateHookFields(settings);
+
+  if (!settings.hooks) {
+    settings.hooks = {};
+  }
+  if (!settings.hooks.SessionStart) {
+    settings.hooks.SessionStart = [];
+  }
+
+  const before = JSON.stringify(settings.hooks.SessionStart);
+  settings.hooks.SessionStart = filterGsdHooks(
+    settings.hooks.SessionStart,
+    (cmd) => cmd && (cmd.includes('gsd-check-update') || cmd.includes('gsd-update-check'))
+  );
+
+  settings.hooks.SessionStart.push({
+    hooks: [
+      {
+        type: 'command',
+        command: updateCheckCommand,
+      }
+    ]
+  });
+
+  if (JSON.stringify(settings.hooks.SessionStart) !== before || !fs.existsSync(hooksPath)) {
+    writeSettings(hooksPath, settings);
+  }
+
+  console.log(`  ${green}✓${reset} Configured Codex hooks in hooks.json (SessionStart)`);
 }
 
 /**

--- a/tests/codex-config.test.cjs
+++ b/tests/codex-config.test.cjs
@@ -23,6 +23,7 @@ const {
   stripGsdFromCodexConfig,
   mergeCodexConfig,
   install,
+  uninstall,
   GSD_CODEX_MARKER,
   CODEX_AGENT_SANDBOX,
 } = require('../bin/install.js');
@@ -45,6 +46,24 @@ function runCodexInstall(codexHome, cwd = path.join(__dirname, '..')) {
   }
 }
 
+function runCodexUninstall(codexHome, cwd = path.join(__dirname, '..')) {
+  const previousCodeHome = process.env.CODEX_HOME;
+  const previousCwd = process.cwd();
+  process.env.CODEX_HOME = codexHome;
+
+  try {
+    process.chdir(cwd);
+    return uninstall(true, 'codex');
+  } finally {
+    process.chdir(previousCwd);
+    if (previousCodeHome === undefined) {
+      delete process.env.CODEX_HOME;
+    } else {
+      process.env.CODEX_HOME = previousCodeHome;
+    }
+  }
+}
+
 function readCodexConfig(codexHome) {
   return fs.readFileSync(path.join(codexHome, 'config.toml'), 'utf8');
 }
@@ -52,6 +71,15 @@ function readCodexConfig(codexHome) {
 function writeCodexConfig(codexHome, content) {
   fs.mkdirSync(codexHome, { recursive: true });
   fs.writeFileSync(path.join(codexHome, 'config.toml'), content, 'utf8');
+}
+
+function readCodexHooks(codexHome) {
+  return JSON.parse(fs.readFileSync(path.join(codexHome, 'hooks.json'), 'utf8'));
+}
+
+function writeCodexHooks(codexHome, content) {
+  fs.mkdirSync(codexHome, { recursive: true });
+  fs.writeFileSync(path.join(codexHome, 'hooks.json'), content, 'utf8');
 }
 
 function countMatches(content, pattern) {
@@ -391,43 +419,35 @@ describe('generateCodexConfigBlock', () => {
     assert.ok(result.startsWith(GSD_CODEX_MARKER), 'starts with marker');
   });
 
-  test('does not include feature flags or agents table header', () => {
+  test('does not include feature flags or the broken [[agents]] shape', () => {
     const result = generateCodexConfigBlock(agents);
     assert.ok(!result.includes('[features]'), 'no features table');
     assert.ok(!result.includes('multi_agent'), 'no multi_agent');
     assert.ok(!result.includes('default_mode_request_user_input'), 'no request_user_input');
-    // #2645 — must NOT use the legacy `[agents.<name>]` map shape (causes
-    // `invalid type: map, expected a sequence` when Codex loads config).
-    assert.ok(!result.match(/^\[agents\.gsd-/m), 'no legacy [agents.gsd-*] map sections');
+    assert.ok(result.match(/^\[agents\.gsd-/m), 'uses [agents.gsd-*] sections');
     // Should not have bare [agents] table header either.
     assert.ok(!result.match(/^\[agents\]\s*$/m), 'no bare [agents] table');
+    assert.ok(!result.match(/^\[\[agents\]\]\s*$/m), 'no broken [[agents]] headers');
     assert.ok(!result.includes('max_threads'), 'no max_threads');
     assert.ok(!result.includes('max_depth'), 'no max_depth');
   });
 
-  test('#2645: emits [[agents]] array-of-tables with name field', () => {
+  test('emits [agents.gsd-*] subtables for current Codex schema', () => {
     const result = generateCodexConfigBlock(agents);
-    // One [[agents]] header per agent.
-    const headerCount = (result.match(/^\[\[agents\]\]\s*$/gm) || []).length;
-    assert.strictEqual(headerCount, 2, 'one [[agents]] header per agent');
-    // Each agent has a name field matching the input name.
-    assert.ok(result.includes('name = "gsd-executor"'), 'executor has name field');
-    assert.ok(result.includes('name = "gsd-planner"'), 'planner has name field');
+    assert.strictEqual((result.match(/^\[agents\.gsd-/gm) || []).length, 2, 'one [agents.gsd-*] header per agent');
+    assert.ok(result.includes('[agents.gsd-executor]'), 'executor uses subtable header');
+    assert.ok(result.includes('[agents.gsd-planner]'), 'planner uses subtable header');
   });
 
-  test('#2645: block is a valid TOML array-of-tables shape (no stray map headers)', () => {
+  test('block contains no broken [[agents]] tables', () => {
     const result = generateCodexConfigBlock(agents);
-    // Strip comment/marker lines and count structural headers. There must be
-    // no `[agents.X]` or `[agents]` tables mixed in with `[[agents]]`, which
-    // would trigger the Codex parse error from #2645.
-    const stray = result.match(/^\[agents(\.[^\]]+)?\]\s*$/gm);
-    assert.strictEqual(stray, null, 'no map-shaped [agents] or [agents.X] headers present');
+    assert.strictEqual((result.match(/^\[\[agents\]\]\s*$/gm) || []).length, 0, 'no [[agents]] headers remain');
   });
 
   test('includes per-agent sections with relative paths (no targetDir)', () => {
     const result = generateCodexConfigBlock(agents);
-    assert.ok(result.includes('name = "gsd-executor"'), 'has executor entry');
-    assert.ok(result.includes('name = "gsd-planner"'), 'has planner entry');
+    assert.ok(result.includes('[agents.gsd-executor]'), 'has executor entry');
+    assert.ok(result.includes('[agents.gsd-planner]'), 'has planner entry');
     assert.ok(result.includes('config_file = "agents/gsd-executor.toml"'), 'relative config_file without targetDir');
     assert.ok(result.includes('"Executes plans"'), 'has executor description');
   });
@@ -491,7 +511,7 @@ describe('stripGsdFromCodexConfig', () => {
     assert.ok(result.includes('[agents.custom-agent]'), 'preserves user agent section');
   });
 
-  test('#2645: removes [[agents]] array-of-tables entries whose name is gsd-*', () => {
+  test('removes broken [[agents]] array-of-tables entries whose name is gsd-*', () => {
     const content = `[[agents]]\nname = "gsd-executor"\ndescription = "test"\nconfig_file = "agents/gsd-executor.toml"\n\n[[agents]]\nname = "custom-agent"\ndescription = "user agent"\n`;
     const result = stripGsdFromCodexConfig(content);
     assert.ok(!/name = "gsd-executor"/.test(result), 'removes managed GSD [[agents]] entry');
@@ -499,9 +519,9 @@ describe('stripGsdFromCodexConfig', () => {
   });
 
   test('#2645: handles mixed legacy + new shapes and multiple user/gsd entries in one file', () => {
-    // Multiple GSD entries (both legacy map and new array-of-tables) interleaved
-    // with multiple user-authored agents in both shapes — none of the user
-    // entries may be removed and all GSD entries must be stripped.
+      // Multiple GSD entries (current subtable + broken array-of-tables) interleaved
+      // with multiple user-authored agents in both shapes — none of the user
+      // entries may be removed and all GSD entries must be stripped.
     const content = [
       '[agents.gsd-executor]',
       'description = "legacy gsd"',
@@ -535,8 +555,8 @@ describe('stripGsdFromCodexConfig', () => {
     // All user-authored entries preserved.
     assert.ok(result.includes('[agents.custom-legacy]'), 'preserves user legacy [agents.custom-legacy]');
     assert.ok(result.includes('user legacy'), 'preserves user legacy body');
-    assert.ok(result.includes('name = "my-helper"'), 'preserves user new [[agents]]');
-    assert.ok(result.includes('name = "another-user"'), 'preserves second user [[agents]]');
+      assert.ok(result.includes('name = "my-helper"'), 'preserves user broken-form [[agents]]');
+      assert.ok(result.includes('name = "another-user"'), 'preserves second user broken-form [[agents]]');
     assert.ok(result.includes('second user agent'), 'preserves second user body');
   });
 });
@@ -565,7 +585,7 @@ describe('mergeCodexConfig', () => {
     assert.ok(fs.existsSync(configPath), 'file created');
     const content = fs.readFileSync(configPath, 'utf8');
     assert.ok(content.includes(GSD_CODEX_MARKER), 'has marker');
-    assert.ok(content.includes('name = "gsd-executor"'), 'has agent');
+    assert.ok(content.includes('[agents.gsd-executor]'), 'has agent');
     assert.ok(!content.includes('[features]'), 'no features section');
     assert.ok(!content.includes('multi_agent'), 'no multi_agent');
   });
@@ -585,7 +605,7 @@ describe('mergeCodexConfig', () => {
     const content = fs.readFileSync(configPath, 'utf8');
     assert.ok(content.includes('[model]'), 'preserves user content');
     assert.ok(content.includes('Updated description'), 'has new description');
-    assert.ok(content.includes('name = "gsd-planner"'), 'has new agent');
+    assert.ok(content.includes('[agents.gsd-planner]'), 'has new agent');
     // Verify no duplicate markers
     const markerCount = (content.match(new RegExp(GSD_CODEX_MARKER.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g')) || []).length;
     assert.strictEqual(markerCount, 1, 'exactly one marker');
@@ -600,7 +620,7 @@ describe('mergeCodexConfig', () => {
     const content = fs.readFileSync(configPath, 'utf8');
     assert.ok(content.includes('[model]'), 'preserves user content');
     assert.ok(content.includes(GSD_CODEX_MARKER), 'adds marker');
-    assert.ok(content.includes('name = "gsd-executor"'), 'has agent');
+    assert.ok(content.includes('[agents.gsd-executor]'), 'has agent');
   });
 
   test('case 3 with existing [features]: preserves user features, does not inject GSD keys', () => {
@@ -614,7 +634,7 @@ describe('mergeCodexConfig', () => {
     assert.ok(!content.includes('multi_agent'), 'does not inject multi_agent');
     assert.ok(!content.includes('default_mode_request_user_input'), 'does not inject request_user_input');
     assert.ok(content.includes(GSD_CODEX_MARKER), 'adds marker for agents block');
-    assert.ok(content.includes('name = "gsd-executor"'), 'has agent');
+    assert.ok(content.includes('[agents.gsd-executor]'), 'has agent');
   });
 
   test('case 3 strips existing [agents.gsd-*] sections before appending fresh block', () => {
@@ -637,14 +657,16 @@ describe('mergeCodexConfig', () => {
     mergeCodexConfig(configPath, sampleBlock);
 
     const content = fs.readFileSync(configPath, 'utf8');
-    const legacyGsdAgentCount = (content.match(/^\[agents\.gsd-executor\]\s*$/gm) || []).length;
-    const managedAgentCount = (content.match(/name = "gsd-executor"/g) || []).length;
+    const markerIndex = content.indexOf(GSD_CODEX_MARKER);
+    const beforeMarker = markerIndex === -1 ? content : content.slice(0, markerIndex);
+    const legacyGsdAgentCount = (beforeMarker.match(/^\[agents\.gsd-executor\]\s*$/gm) || []).length;
+    const managedAgentCount = (content.match(/^\[agents\.gsd-executor\]\s*$/gm) || []).length;
     const markerCount = (content.match(new RegExp(GSD_CODEX_MARKER.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g')) || []).length;
 
     assert.ok(content.includes('[model]'), 'preserves user content');
     assert.ok(content.includes('[agents.custom-agent]'), 'preserves non-GSD agent section');
     assert.strictEqual(legacyGsdAgentCount, 0, 'strips legacy map-shape GSD agent sections');
-    assert.strictEqual(managedAgentCount, 1, 'keeps exactly one managed GSD [[agents]] entry');
+    assert.strictEqual(managedAgentCount, 1, 'keeps exactly one managed GSD [agents.gsd-*] entry');
     assert.strictEqual(markerCount, 1, 'adds exactly one marker block');
     assert.ok(!/\n{3,}# GSD Agent Configuration/.test(content), 'does not leave extra blank lines before marker block');
   });
@@ -671,7 +693,7 @@ describe('mergeCodexConfig', () => {
     const featuresCount = (content.match(/^\[features\]\s*$/gm) || []).length;
     assert.strictEqual(featuresCount, 1, 'exactly one [features] section');
     assert.ok(content.includes('other_feature = true'), 'preserves user feature keys');
-    assert.ok(content.includes('name = "gsd-executor"'), 'has agent');
+    assert.ok(content.includes('[agents.gsd-executor]'), 'has agent');
     // Verify no duplicate markers
     const markerCount = (content.match(new RegExp(GSD_CODEX_MARKER.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g')) || []).length;
     assert.strictEqual(markerCount, 1, 'exactly one marker');
@@ -688,7 +710,7 @@ describe('mergeCodexConfig', () => {
     assert.ok(!content.includes('multi_agent'), 'does not inject multi_agent');
     assert.ok(!content.includes('default_mode_request_user_input'), 'does not inject request_user_input');
     assert.ok(content.includes('other_feature = true'), 'preserves user feature');
-    assert.ok(content.includes('name = "gsd-executor"'), 'has agent from fresh block');
+    assert.ok(content.includes('[agents.gsd-executor]'), 'has agent from fresh block');
   });
 
   test('case 2 strips leaked [agents] and [agents.gsd-*] from before content', () => {
@@ -718,7 +740,7 @@ describe('mergeCodexConfig', () => {
 
     const content = fs.readFileSync(configPath, 'utf8');
     assert.ok(content.includes('child_agents_md = false'), 'preserves user feature keys');
-    assert.ok(content.includes('name = "gsd-executor"'), 'has agent from fresh block');
+    assert.ok(content.includes('[agents.gsd-executor]'), 'has agent from fresh block');
     // Verify the leaked [agents] table header above marker was stripped
     const markerIndex = content.indexOf(GSD_CODEX_MARKER);
     const beforeMarker = content.substring(0, markerIndex);
@@ -758,8 +780,8 @@ describe('mergeCodexConfig', () => {
     assert.ok(content.includes('child_agents_md = false'), 'preserves user feature keys');
     assert.strictEqual(countMatches(beforeMarker, /^\[agents\]\s*$/gm), 0, 'removes leaked [agents] above marker');
     assert.strictEqual(countMatches(beforeMarker, /^\[agents\.gsd-executor\]\s*$/gm), 0, 'removes leaked GSD agent section above marker');
-    assert.strictEqual(countMatches(content, /^\[agents\.gsd-executor\]\s*$/gm), 0, 'no legacy map-shape sections remain (all replaced by new [[agents]] block)');
-    assert.strictEqual(countMatches(content, /name = "gsd-executor"/g), 1, 'keeps one managed agent entry');
+    assert.strictEqual(countMatches(content, /^\[agents\.gsd-executor\]\s*$/gm), 1, 'keeps one managed [agents.gsd-*] section');
+    assert.strictEqual(countMatches(content, /^\[\[agents\]\]\s*$/gm), 0, 'removes broken [[agents]] sections');
     assertUsesOnlyEol(content, '\r\n');
   });
 
@@ -794,8 +816,8 @@ describe('mergeCodexConfig', () => {
 
     assert.ok(beforeMarker.includes('[agents]\r\ndefault = "custom-agent"\r\n'), 'preserves user-authored [agents] table');
     assert.strictEqual(countMatches(beforeMarker, /^\[agents\.gsd-executor\]\s*$/gm), 0, 'removes leaked GSD agent section above marker');
-    assert.strictEqual(countMatches(content, /^\[agents\.gsd-executor\]\s*$/gm), 0, 'no legacy map-shape sections remain');
-    assert.strictEqual(countMatches(content, /name = "gsd-executor"/g), 1, 'keeps one managed agent entry in the GSD block');
+    assert.strictEqual(countMatches(content, /^\[\[agents\]\]\s*$/gm), 0, 'no broken [[agents]] sections remain');
+    assert.strictEqual(countMatches(content, /^\[agents\.gsd-executor\]\s*$/gm), 1, 'keeps one managed agent entry in the GSD block');
     assertUsesOnlyEol(content, '\r\n');
   });
 
@@ -867,7 +889,7 @@ describe('installCodexConfig (integration)', () => {
     assert.ok(fs.existsSync(configPath), 'config.toml exists');
     const config = fs.readFileSync(configPath, 'utf8');
     assert.ok(config.includes(GSD_CODEX_MARKER), 'has GSD marker');
-    assert.ok(config.includes('name = "gsd-executor"'), 'has executor agent');
+    assert.ok(config.includes('[agents.gsd-executor]'), 'has executor agent');
     assert.ok(!config.includes('multi_agent'), 'no feature flags');
 
     // Verify per-agent .toml files
@@ -963,18 +985,19 @@ describe('Codex install hook configuration (e2e)', () => {
   });
 
   test('Codex install copies hook file that is referenced in config.toml (#2153)', () => {
-    // Regression test: Codex install writes gsd-check-update hook reference into
-    // config.toml but must also copy the hook file to ~/$CODEX_HOME/hooks/
+    // Regression test: Codex install writes the update hook registration into
+    // hooks.json and must also copy the hook file to ~/$CODEX_HOME/hooks/
     runCodexInstall(codexHome);
 
-    const configContent = readCodexConfig(codexHome);
-    // config.toml must reference the hook
-    assert.ok(configContent.includes('gsd-check-update.js'), 'config.toml references gsd-check-update.js');
+    const hooks = readCodexHooks(codexHome);
+    assert.ok(hooks.hooks.SessionStart, 'hooks.json contains SessionStart hooks');
+    const commands = hooks.hooks.SessionStart.flatMap(entry => (entry.hooks || []).map(h => h.command));
+    assert.ok(commands.some(cmd => cmd.includes('gsd-check-update.js')), 'hooks.json references gsd-check-update.js');
     // The hook file must physically exist at the referenced path
     const hookFile = path.join(codexHome, 'hooks', 'gsd-check-update.js');
     assert.ok(
       fs.existsSync(hookFile),
-      `gsd-check-update.js must exist at ${hookFile} — config.toml references it but file was not installed`
+      `gsd-check-update.js must exist at ${hookFile} — hooks.json references it but file was not installed`
     );
   });
 
@@ -982,10 +1005,12 @@ describe('Codex install hook configuration (e2e)', () => {
     runCodexInstall(codexHome);
 
     const content = readCodexConfig(codexHome);
+    const hooks = readCodexHooks(codexHome);
     assert.ok(content.includes('[features]\ncodex_hooks = true\n'), 'writes codex_hooks feature');
-    assert.ok(content.includes('# GSD Hooks\n[[hooks]]\nevent = "SessionStart"\n'), 'writes GSD SessionStart hook block');
+    assert.ok(!content.includes('[[hooks]]'), 'does not write invalid [[hooks]] block');
     assert.strictEqual(countMatches(content, /^codex_hooks = true$/gm), 1, 'writes one codex_hooks key');
-    assert.strictEqual(countMatches(content, /gsd-check-update\.js/g), 1, 'writes one GSD update hook');
+    const commands = hooks.hooks.SessionStart.flatMap(entry => (entry.hooks || []).map(h => h.command));
+    assert.strictEqual(commands.filter(cmd => cmd.includes('gsd-check-update.js')).length, 1, 'writes one GSD update hook to hooks.json');
     assertNoDraftRootKeys(content);
     assertUsesOnlyEol(content, '\n');
   });
@@ -1053,21 +1078,23 @@ describe('Codex install hook configuration (e2e)', () => {
       '[model]',
       'name = "o3"',
       '',
-      '[[hooks]]',
-      'event = "SessionStart"',
-      'command = "echo custom"',
+      '[hooks]',
+      'SessionStart = [{ type = "command", command = "echo custom" }]',
       '',
     ].join('\n'));
 
     runCodexInstall(codexHome);
 
     const content = readCodexConfig(codexHome);
+    const hooks = readCodexHooks(codexHome);
     assert.strictEqual(countMatches(content, /^\[features\]\s*$/gm), 1, 'creates one [features] section');
     assert.strictEqual(countMatches(content, /^codex_hooks = true$/gm), 1, 'creates one codex_hooks key');
     assert.ok(content.includes('# user comment'), 'preserves user comment');
     assert.ok(content.includes('[model]\nname = "o3"'), 'preserves model section');
-    assert.ok(content.includes('command = "echo custom"'), 'preserves custom hook');
-    assert.strictEqual(countMatches(content, /gsd-check-update\.js/g), 1, 'adds one GSD update hook');
+    assert.ok(content.includes('SessionStart = [{ type = "command", command = "echo custom" }]'), 'preserves user config.toml hook syntax');
+    const commands = hooks.hooks.SessionStart.flatMap(entry => (entry.hooks || []).map(h => h.command));
+    assert.strictEqual(commands.filter(cmd => cmd === 'echo custom').length, 0, 'does not mirror config.toml hooks into hooks.json');
+    assert.strictEqual(commands.filter(cmd => cmd.includes('gsd-check-update.js')).length, 1, 'adds one GSD update hook to hooks.json');
     assertNoDraftRootKeys(content);
   });
 
@@ -1178,7 +1205,7 @@ describe('Codex install hook configuration (e2e)', () => {
     assert.strictEqual(countMatches(content, /^\[features\]\s*$/gm), 1, 'keeps one [features] section');
     assert.strictEqual(countMatches(content, /^codex_hooks = true$/gm), 1, 'adds one codex_hooks key');
     assert.ok(content.indexOf('codex_hooks = true') > content.indexOf('[features]'), 'adds codex_hooks after the existing EOF features header');
-    assert.ok(content.indexOf('codex_hooks = true') < content.indexOf('[[agents]]'), 'keeps codex_hooks before the first managed [[agents]] entry');
+    assert.ok(content.indexOf('codex_hooks = true') < content.indexOf('[agents.gsd-executor]'), 'keeps codex_hooks before the first managed [agents.gsd-*] entry');
     assertNoDraftRootKeys(content);
   });
 
@@ -1188,23 +1215,32 @@ describe('Codex install hook configuration (e2e)', () => {
       'codex_hooks = false',
       'other_feature = true',
       '',
-      '[[hooks]]',
-      'event = "SessionStart"',
-      'command = "echo custom"',
-      '',
     ].join('\n'));
+    writeCodexHooks(codexHome, JSON.stringify({
+      hooks: {
+        SessionStart: [
+          {
+            hooks: [
+              { type: 'command', command: 'echo custom' }
+            ]
+          }
+        ]
+      }
+    }, null, 2) + '\n');
 
     runCodexInstall(codexHome);
     runCodexInstall(codexHome);
     runCodexInstall(codexHome);
 
     const content = readCodexConfig(codexHome);
+    const hooks = readCodexHooks(codexHome);
     assert.strictEqual(countMatches(content, /^\[features\]\s*$/gm), 1, 'keeps one [features] section');
     assert.strictEqual(countMatches(content, /^codex_hooks = true$/gm), 1, 'normalizes to one codex_hooks = true');
     assert.ok(!content.includes('codex_hooks = false'), 'removes false codex_hooks value');
     assert.ok(content.includes('other_feature = true'), 'preserves other feature keys');
-    assert.ok(content.includes('command = "echo custom"'), 'preserves custom hook');
-    assert.strictEqual(countMatches(content, /gsd-check-update\.js/g), 1, 'does not duplicate GSD update hook');
+    const commands = hooks.hooks.SessionStart.flatMap(entry => (entry.hooks || []).map(h => h.command));
+    assert.ok(commands.includes('echo custom'), 'preserves custom hook in hooks.json');
+    assert.strictEqual(commands.filter(cmd => cmd.includes('gsd-check-update.js')).length, 1, 'does not duplicate GSD update hook');
     assertNoDraftRootKeys(content);
   });
 
@@ -1242,11 +1278,13 @@ describe('Codex install hook configuration (e2e)', () => {
     runCodexInstall(codexHome);
 
     const content = readCodexConfig(codexHome);
+    const hooks = readCodexHooks(codexHome);
     assert.strictEqual(countMatches(content, /^\[(?:"features"|'features'|features)\]\s*$/gm), 1, 'keeps one features table');
     assert.strictEqual(countMatches(content, /^"codex_hooks" = true$/gm), 1, 'normalizes the quoted codex_hooks key to true');
     assert.strictEqual(countMatches(content, /^\[features\]\s*$/gm), 0, 'does not prepend a second bare features table');
     assert.ok(content.includes('other_feature = true'), 'preserves existing feature keys');
-    assert.strictEqual(countMatches(content, /gsd-check-update\.js/g), 1, 'keeps one GSD update hook');
+    const commands = hooks.hooks.SessionStart.flatMap(entry => (entry.hooks || []).map(h => h.command));
+    assert.strictEqual(commands.filter(cmd => cmd.includes('gsd-check-update.js')).length, 1, 'keeps one GSD update hook');
     assertNoDraftRootKeys(content);
   });
 
@@ -1264,10 +1302,12 @@ describe('Codex install hook configuration (e2e)', () => {
     runCodexInstall(codexHome);
 
     const content = readCodexConfig(codexHome);
+    const hooks = readCodexHooks(codexHome);
     assert.ok(content.includes('[features."a#b"]\nenabled = true'), 'preserves the quoted nested features table');
     assert.strictEqual(countMatches(content, /^\[features\]\s*$/gm), 1, 'adds one real top-level features table');
     assert.strictEqual(countMatches(content, /^codex_hooks = true$/gm), 1, 'adds one codex_hooks key');
-    assert.strictEqual(countMatches(content, /gsd-check-update\.js/g), 1, 'remains idempotent for the GSD hook block');
+    const commands = hooks.hooks.SessionStart.flatMap(entry => (entry.hooks || []).map(h => h.command));
+    assert.strictEqual(commands.filter(cmd => cmd.includes('gsd-check-update.js')).length, 1, 'remains idempotent for the GSD hook entry');
     assertNoDraftRootKeys(content);
   });
 
@@ -1284,10 +1324,12 @@ describe('Codex install hook configuration (e2e)', () => {
     runCodexInstall(codexHome);
 
     const content = readCodexConfig(codexHome);
+    const hooks = readCodexHooks(codexHome);
     assert.strictEqual(countMatches(content, /^\[features\]\s*$/gm), 0, 'does not add a [features] table');
     assert.strictEqual(countMatches(content, /^features\.codex_hooks = true$/gm), 1, 'adds one dotted codex_hooks key');
     assert.ok(content.includes('features.other_feature = true'), 'preserves existing dotted features key');
-    assert.strictEqual(countMatches(content, /gsd-check-update\.js/g), 1, 'adds one GSD update hook for dotted codex_hooks and remains idempotent');
+    const commands = hooks.hooks.SessionStart.flatMap(entry => (entry.hooks || []).map(h => h.command));
+    assert.strictEqual(commands.filter(cmd => cmd.includes('gsd-check-update.js')).length, 1, 'adds one GSD update hook for dotted codex_hooks and remains idempotent');
     assertNoDraftRootKeys(content);
   });
 
@@ -1307,8 +1349,8 @@ describe('Codex install hook configuration (e2e)', () => {
     assert.ok(content.includes('features = { other_feature = true }'), 'preserves the root inline-table assignment');
     assert.strictEqual(countMatches(content, /^features\.codex_hooks = true$/gm), 0, 'does not append an invalid dotted codex_hooks key');
     assert.strictEqual(countMatches(content, /^\[features\]\s*$/gm), 0, 'does not prepend a features table');
-    assert.strictEqual(countMatches(content, /gsd-check-update\.js/g), 0, 'does not add the GSD hook block when codex_hooks cannot be enabled safely');
-    assert.ok(content.includes('name = "gsd-executor"'), 'still installs the managed agent block');
+    assert.ok(!fs.existsSync(path.join(codexHome, 'hooks.json')), 'does not add hooks.json when codex_hooks cannot be enabled safely');
+    assert.ok(content.includes('[agents.gsd-executor]'), 'still installs the managed agent block');
     assertNoDraftRootKeys(content);
   });
 
@@ -1328,8 +1370,8 @@ describe('Codex install hook configuration (e2e)', () => {
     assert.ok(content.includes('features = "disabled"'), 'preserves the root scalar assignment');
     assert.strictEqual(countMatches(content, /^features\.codex_hooks = true$/gm), 0, 'does not append an invalid dotted codex_hooks key');
     assert.strictEqual(countMatches(content, /^\[features\]\s*$/gm), 0, 'does not prepend a features table');
-    assert.strictEqual(countMatches(content, /gsd-check-update\.js/g), 0, 'does not add the GSD hook block when codex_hooks cannot be enabled safely');
-    assert.ok(content.includes('name = "gsd-executor"'), 'still installs the managed agent block');
+    assert.ok(!fs.existsSync(path.join(codexHome, 'hooks.json')), 'does not add hooks.json when codex_hooks cannot be enabled safely');
+    assert.ok(content.includes('[agents.gsd-executor]'), 'still installs the managed agent block');
     assertNoDraftRootKeys(content);
   });
 
@@ -1347,11 +1389,13 @@ describe('Codex install hook configuration (e2e)', () => {
     runCodexInstall(codexHome);
 
     const content = readCodexConfig(codexHome);
+    const hooks = readCodexHooks(codexHome);
     assert.strictEqual(countMatches(content, /^\[features\]\s*$/gm), 0, 'does not add a [features] table');
     assert.strictEqual(countMatches(content, /^features\."codex_hooks" = true$/gm), 1, 'normalizes the quoted dotted key to true');
     assert.strictEqual(countMatches(content, /^features\.codex_hooks = true$/gm), 0, 'does not append a bare dotted duplicate');
     assert.ok(content.includes('features.other_feature = true'), 'preserves other dotted features keys');
-    assert.strictEqual(countMatches(content, /gsd-check-update\.js/g), 1, 'adds one GSD update hook for quoted dotted codex_hooks and remains idempotent');
+    const commands = hooks.hooks.SessionStart.flatMap(entry => (entry.hooks || []).map(h => h.command));
+    assert.strictEqual(commands.filter(cmd => cmd.includes('gsd-check-update.js')).length, 1, 'adds one GSD update hook for quoted dotted codex_hooks and remains idempotent');
     assertNoDraftRootKeys(content);
   });
 
@@ -1399,9 +1443,8 @@ describe('Codex install hook configuration (e2e)', () => {
       '\'\'\'',
       'other_feature = true',
       '',
-      '[[hooks]]',
-      'event = "AfterCommand"',
-      'command = "echo custom-after-command"',
+      '[hooks]',
+      'AfterCommand = [{ type = "command", command = "echo custom-after-command" }]',
       '',
     ].join('\n'));
 
@@ -1413,7 +1456,7 @@ describe('Codex install hook configuration (e2e)', () => {
     assert.ok(content.includes('notes = \'\'\'\n[model]\ncodex_hooks = false\n\'\'\''), 'preserves multiline string content');
     assert.strictEqual(countMatches(content, /^codex_hooks = false$/gm), 1, 'does not rewrite codex_hooks text inside multiline string');
     assert.ok(content.indexOf('codex_hooks = true') > content.indexOf('other_feature = true'), 'does not stop the features section at multiline string content');
-    assert.ok(content.indexOf('codex_hooks = true') < content.indexOf('[[hooks]]'), 'inserts the real codex_hooks key before the next table');
+    assert.ok(content.indexOf('codex_hooks = true') < content.indexOf('[hooks]'), 'inserts the real codex_hooks key before the next table');
     assertNoDraftRootKeys(content);
   });
 
@@ -1456,10 +1499,12 @@ describe('Codex install hook configuration (e2e)', () => {
     runCodexInstall(codexHome);
 
     const content = readCodexConfig(codexHome);
+    const hooks = readCodexHooks(codexHome);
     assert.strictEqual(countMatches(content, /^codex_hooks = true$/gm), 1, 'replaces the multiline basic-string assignment with one true value');
     assert.ok(!content.includes('multiline-basic-sentinel'), 'removes multiline basic-string continuation lines');
     assert.ok(content.includes('other_feature = true'), 'preserves following feature keys');
-    assert.strictEqual(countMatches(content, /gsd-check-update\.js/g), 1, 'remains idempotent for the GSD hook block');
+    const commands = hooks.hooks.SessionStart.flatMap(entry => (entry.hooks || []).map(h => h.command));
+    assert.strictEqual(commands.filter(cmd => cmd.includes('gsd-check-update.js')).length, 1, 'remains idempotent for the GSD hook entry');
     assertNoDraftRootKeys(content);
   });
 
@@ -1481,10 +1526,12 @@ describe('Codex install hook configuration (e2e)', () => {
     runCodexInstall(codexHome);
 
     const content = readCodexConfig(codexHome);
+    const hooks = readCodexHooks(codexHome);
     assert.strictEqual(countMatches(content, /^codex_hooks = true$/gm), 1, 'replaces the multiline literal-string assignment with one true value');
     assert.ok(!content.includes('multiline-literal-sentinel'), 'removes multiline literal-string continuation lines');
     assert.ok(content.includes('other_feature = true'), 'preserves following feature keys');
-    assert.strictEqual(countMatches(content, /gsd-check-update\.js/g), 1, 'remains idempotent for the GSD hook block');
+    const commands = hooks.hooks.SessionStart.flatMap(entry => (entry.hooks || []).map(h => h.command));
+    assert.strictEqual(commands.filter(cmd => cmd.includes('gsd-check-update.js')).length, 1, 'remains idempotent for the GSD hook entry');
     assertNoDraftRootKeys(content);
   });
 
@@ -1506,11 +1553,13 @@ describe('Codex install hook configuration (e2e)', () => {
     runCodexInstall(codexHome);
 
     const content = readCodexConfig(codexHome);
+    const hooks = readCodexHooks(codexHome);
     assert.strictEqual(countMatches(content, /^codex_hooks = true$/gm), 1, 'replaces the multiline array assignment with one true value');
     assert.ok(!content.includes('array-sentinel-1'), 'removes multiline array continuation lines');
     assert.ok(!content.includes('array-sentinel-2'), 'removes multiline array continuation lines');
     assert.ok(content.includes('other_feature = true'), 'preserves following feature keys');
-    assert.strictEqual(countMatches(content, /gsd-check-update\.js/g), 1, 'remains idempotent for the GSD hook block');
+    const commands = hooks.hooks.SessionStart.flatMap(entry => (entry.hooks || []).map(h => h.command));
+    assert.strictEqual(commands.filter(cmd => cmd.includes('gsd-check-update.js')).length, 1, 'remains idempotent for the GSD hook entry');
     assertNoDraftRootKeys(content);
   });
 
@@ -1541,9 +1590,8 @@ describe('Codex install hook configuration (e2e)', () => {
       'codex_hooks = true',
       'other_feature = true',
       '',
-      '[[hooks]]',
-      'event = "AfterCommand"',
-      'command = "echo custom-after-command"',
+      '[hooks]',
+      'AfterCommand = [{ type = "command", command = "echo custom-after-command" }]',
       '',
     ].join('\r\n'));
 
@@ -1551,11 +1599,13 @@ describe('Codex install hook configuration (e2e)', () => {
     runCodexInstall(codexHome);
 
     const content = readCodexConfig(codexHome);
+    const hooks = readCodexHooks(codexHome);
     assert.strictEqual(countMatches(content, /^\[features\]\s*$/gm), 1, 'keeps one [features] section');
     assert.strictEqual(countMatches(content, /^codex_hooks = true$/gm), 1, 'keeps one codex_hooks = true');
     assert.ok(content.includes('other_feature = true'), 'preserves other feature keys');
-    assert.strictEqual(countMatches(content, /echo custom-after-command/g), 1, 'preserves non-GSD hook exactly once');
-    assert.strictEqual(countMatches(content, /gsd-check-update\.js/g), 1, 'keeps one GSD update hook');
+    assert.strictEqual(countMatches(content, /echo custom-after-command/g), 1, 'preserves non-GSD config hook exactly once');
+    const commands = hooks.hooks.SessionStart.flatMap(entry => (entry.hooks || []).map(h => h.command));
+    assert.strictEqual(commands.filter(cmd => cmd.includes('gsd-check-update.js')).length, 1, 'keeps one GSD update hook');
     assertUsesOnlyEol(content, '\r\n');
     assertNoDraftRootKeys(content);
   });
@@ -1575,10 +1625,12 @@ describe('Codex install hook configuration (e2e)', () => {
     runCodexInstall(codexHome);
 
     const content = readCodexConfig(codexHome);
+    const hooks = readCodexHooks(codexHome);
     assert.strictEqual(countMatches(content, /^\[features\]\s*$/gm), 1, 'keeps one [features] section');
     assert.strictEqual(countMatches(content, /^codex_hooks = true # keep me$/gm), 1, 'preserves the commented true value');
     assert.ok(content.includes('other_feature = true'), 'preserves other feature keys');
-    assert.strictEqual(countMatches(content, /gsd-check-update\.js/g), 1, 'adds the GSD update hook once');
+    const commands = hooks.hooks.SessionStart.flatMap(entry => (entry.hooks || []).map(h => h.command));
+    assert.strictEqual(commands.filter(cmd => cmd.includes('gsd-check-update.js')).length, 1, 'adds the GSD update hook once');
     assertNoDraftRootKeys(content);
   });
 
@@ -1589,13 +1641,14 @@ describe('Codex install hook configuration (e2e)', () => {
     runCodexInstall(codexHome);
 
     const content = readCodexConfig(codexHome);
+    const hooks = readCodexHooks(codexHome);
     // [features] is inserted after top-level lines, before [model] — not prepended
     assert.ok(content.includes('# first line wins\n\n[features]\ncodex_hooks = true\n'), 'inserts features after top-level lines using first newline style');
     assert.ok(content.includes(`# GSD Agent Configuration — managed by get-shit-done installer\n`), 'writes the managed agent block using the first newline style');
-    assert.ok(content.includes('# GSD Hooks\n[[hooks]]\nevent = "SessionStart"\n'), 'writes the GSD hook block using the first newline style');
+    const commands = hooks.hooks.SessionStart.flatMap(entry => (entry.hooks || []).map(h => h.command));
+    assert.strictEqual(commands.filter(cmd => cmd.includes('gsd-check-update.js')).length, 1, 'writes the GSD hook entry to hooks.json');
     assert.ok(content.includes('[model]\r\nname = "o3"'), 'preserves the existing CRLF model lines');
     assert.strictEqual(countMatches(content, /^codex_hooks = true$/gm), 1, 'remains idempotent on repeated installs');
-    assert.strictEqual(countMatches(content, /gsd-check-update\.js/g), 1, 'does not duplicate the GSD hook block');
     assertNoDraftRootKeys(content);
   });
 });
@@ -1626,9 +1679,8 @@ describe('Codex uninstall symmetry for hook-enabled configs', () => {
       '# keep me',
       'other_feature = true',
       '',
-      '[[hooks]]',
-      'event = "AfterCommand"',
-      'command = "echo custom-after-command"',
+      '[hooks]',
+      'AfterCommand = [{ type = "command", command = "echo custom-after-command" }]',
       '',
       '[model]',
       'name = "o3"',
@@ -1643,8 +1695,8 @@ describe('Codex uninstall symmetry for hook-enabled configs', () => {
     assert.strictEqual(countMatches(cleaned, /^codex_hooks = true$/gm), 0, 'removes the GSD-added codex_hooks key');
     assert.ok(cleaned.includes('# keep me'), 'preserves user comments in [features]');
     assert.ok(cleaned.includes('other_feature = true'), 'preserves other feature keys');
-    assert.strictEqual(countMatches(cleaned, /echo custom-after-command/g), 1, 'preserves non-GSD hooks');
-    assert.strictEqual(countMatches(cleaned, /gsd-check-update\.js/g), 0, 'removes only the GSD update hook');
+    assert.strictEqual(countMatches(cleaned, /echo custom-after-command/g), 1, 'preserves non-GSD config hooks');
+    assert.strictEqual(countMatches(cleaned, /gsd-check-update\.js/g), 0, 'config.toml no longer contains the GSD update hook');
     assert.strictEqual(countMatches(cleaned, /\[agents\.gsd-/g), 0, 'removes managed GSD agent sections');
     assertUsesOnlyEol(cleaned, '\r\n');
   });
@@ -1653,9 +1705,8 @@ describe('Codex uninstall symmetry for hook-enabled configs', () => {
     writeCodexConfig(codexHome, [
       'features.other_feature = true',
       '',
-      '[[hooks]]',
-      'event = "AfterCommand"',
-      'command = "echo custom-after-command"',
+      '[hooks]',
+      'AfterCommand = [{ type = "command", command = "echo custom-after-command" }]',
       '',
       '[model]',
       'name = "o3"',
@@ -1768,5 +1819,41 @@ describe('Codex uninstall symmetry for hook-enabled configs', () => {
     assert.strictEqual(countMatches(cleaned, /^codex_hooks = true$/gm), 0, 'removes the injected codex_hooks key');
     assert.strictEqual(countMatches(cleaned, /gsd-check-update\.js/g), 0, 'removes the GSD update hook');
     assert.strictEqual(countMatches(cleaned, /\[agents\.gsd-/g), 0, 'removes managed GSD agent sections');
+  });
+
+  test('install then uninstall removes only GSD hooks from hooks.json', () => {
+    runCodexInstall(codexHome);
+
+    writeCodexHooks(codexHome, JSON.stringify({
+      hooks: {
+        SessionStart: [
+          {
+            hooks: [
+              { type: 'command', command: 'node /tmp/gsd-check-update.js' },
+              { type: 'command', command: 'echo keep-me' }
+            ]
+          }
+        ],
+        PostToolUse: [
+          {
+            hooks: [
+              { type: 'command', command: 'node /tmp/gsd-context-monitor.js' },
+              { type: 'command', command: 'echo keep-post' }
+            ]
+          }
+        ]
+      }
+    }, null, 2) + '\n');
+
+    runCodexUninstall(codexHome);
+
+    const hooks = readCodexHooks(codexHome);
+    const sessionCommands = hooks.hooks.SessionStart.flatMap(entry => (entry.hooks || []).map(h => h.command));
+    const postCommands = hooks.hooks.PostToolUse.flatMap(entry => (entry.hooks || []).map(h => h.command));
+
+    assert.ok(!sessionCommands.some(cmd => cmd.includes('gsd-check-update')), 'removes GSD SessionStart hook');
+    assert.ok(!postCommands.some(cmd => cmd.includes('gsd-context-monitor')), 'removes GSD PostToolUse hook');
+    assert.ok(sessionCommands.includes('echo keep-me'), 'preserves user SessionStart hook');
+    assert.ok(postCommands.includes('echo keep-post'), 'preserves user PostToolUse hook');
   });
 });


### PR DESCRIPTION
# Title

fix(codex): use current agent config schema and move update hook to hooks.json

# Summary

- switch Codex agent registry generation from broken `[[agents]]` array-of-tables to current `[agents.gsd-*]` subtables
- stop writing the invalid Codex `[[hooks]]` SessionStart block into `config.toml`
- register the Codex update hook in `hooks.json` instead, while preserving user hook entries
- keep cleanup/self-heal logic for previously shipped broken `[[agents]]` / `[[hooks]]` installs

# Root Cause

Current GSD Codex installs generate:

- `[[agents]]` entries in `config.toml`
- `[[hooks]]` SessionStart entries in `config.toml`

On current Codex builds, this breaks parsing:

- `[[agents]]` triggers `invalid type: sequence, expected struct AgentsToml`
- `[[hooks]]` triggers `invalid type: map, expected a sequence`

I reproduced this against a live local Codex install by pointing `CODEX_HOME` at isolated test configs and running `codex features list`.

# What Changed

## Agents

Generated Codex config now uses:

```toml
[agents.gsd-executor]
description = "..."
config_file = "/absolute/path/to/agents/gsd-executor.toml"
```

The installer still strips previously shipped broken `[[agents]]` entries on reinstall/uninstall.

## Hooks

The installer now:

- keeps enabling `codex_hooks = true`
- removes previously shipped legacy `[[hooks]]` GSD update blocks from `config.toml`
- writes the GSD SessionStart update hook to `hooks.json`

This preserves user hooks while avoiding invalid Codex TOML hook syntax.

## Tests

Updated Codex tests to cover:

- `[agents.gsd-*]` generation
- self-healing of shipped broken `[[agents]]`
- `hooks.json` install behavior
- `hooks.json` uninstall cleanup that removes only GSD hooks and preserves user hooks

# Verification

- `node --test tests/codex-config.test.cjs tests/install-hooks-copy.test.cjs`
- live parser smoke with isolated `CODEX_HOME` and `codex features list`

# Notes

- A smoke install from the git clone still exits non-zero if `sdk/dist/cli.js` has not been built locally. That pre-existing SDK build issue is separate from this Codex config schema fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured hook management system for improved configuration handling.
  * Improved agent configuration storage format.

* **Bug Fixes**
  * Enhanced uninstall cleanup to selectively remove only relevant managed hooks while preserving user-defined configurations.
  * Fixed reinstall behavior to reliably restore configurations.

* **Tests**
  * Updated test suite to validate new configuration structures and hook management behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->