### PR TITLE
fix(phase-lifecycle): detect phases in bullet/bold ROADMAP formats for phase.add

### DIFF
--- a/sdk/src/query/phase-lifecycle.test.ts
+++ b/sdk/src/query/phase-lifecycle.test.ts
@@ -245,6 +245,77 @@ describe('phaseAdd', () => {
     expect(phaseIdx).toBeLessThan(sepIdx);
     expect(phaseIdx).toBeGreaterThan(0);
   });
+
+  it('detects max phase from bullet checklist format (regression #2726)', async () => {
+    const { phaseAdd } = await import('./phase-lifecycle.js');
+
+    const roadmap = [
+      '# Roadmap',
+      '',
+      '## Current Milestone: v5.0',
+      '',
+      '- [x] Phase 76: Data Import',
+      '- [x] Phase 77: Data Transform',
+      '- [ ] Phase 88: Final Cleanup',
+      '',
+    ].join('\n');
+
+    await setupTestProject(tmpDir, {
+      roadmap,
+      state: MINIMAL_STATE,
+      phases: [],
+    });
+
+    const result = await phaseAdd(['new-feature'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+
+    expect(data.phase_number).toBe(89);
+    expect(data.padded).toBe('89');
+  });
+
+  it('detects max phase from bold inline format (regression #2726)', async () => {
+    const { phaseAdd } = await import('./phase-lifecycle.js');
+
+    const roadmap = [
+      '# Roadmap',
+      '',
+      '## Current Milestone: v5.0',
+      '',
+      '**Phase 50: Core Infrastructure**',
+      '**Phase 51: API Layer**',
+      '',
+    ].join('\n');
+
+    await setupTestProject(tmpDir, {
+      roadmap,
+      state: MINIMAL_STATE,
+      phases: [],
+    });
+
+    const result = await phaseAdd(['new-feature'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+
+    expect(data.phase_number).toBe(52);
+  });
+
+  it('falls back to filesystem scan when no phase matches in ROADMAP (regression #2726)', async () => {
+    const { phaseAdd } = await import('./phase-lifecycle.js');
+
+    // ROADMAP with no recognizable phase entries
+    const roadmap = '# Roadmap\n\n## Current Milestone: v5.0\n\nSome content without phases\n';
+
+    await setupTestProject(tmpDir, {
+      roadmap,
+      state: MINIMAL_STATE,
+      phases: ['45-legacy-phase', '46-another-phase'],
+    });
+
+    const result = await phaseAdd(['new-feature'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+
+    // Should detect phases 45 and 46 on disk, so new phase = 47
+    expect(data.phase_number).toBe(47);
+  });
 });
 
 // ─── phaseAddBatch ─────────────────────────────────────────────────────

--- a/sdk/src/query/phase-lifecycle.test.ts
+++ b/sdk/src/query/phase-lifecycle.test.ts
@@ -316,6 +316,29 @@ describe('phaseAdd', () => {
     // Should detect phases 45 and 46 on disk, so new phase = 47
     expect(data.phase_number).toBe(47);
   });
+
+  it('filesystem fallback handles project-code-prefixed phase directories (regression coderabbit)', async () => {
+    const { phaseAdd } = await import('./phase-lifecycle.js');
+
+    const roadmap = '# Roadmap\n\n## Current Milestone: v5.0\n\nSome content\n';
+
+    await setupTestProject(tmpDir, {
+      roadmap,
+      state: MINIMAL_STATE,
+      phases: [],
+    });
+
+    // Create prefixed directories manually (project_code = "CK" scenario)
+    const phasesDir = join(tmpDir, '.planning', 'phases');
+    await mkdir(join(phasesDir, 'CK-45-legacy-phase'), { recursive: true });
+    await mkdir(join(phasesDir, 'CK-46-another-phase'), { recursive: true });
+
+    const result = await phaseAdd(['new-feature'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+
+    // Should detect CK-45 and CK-46, so new phase = 47
+    expect(data.phase_number).toBe(47);
+  });
 });
 
 // ─── phaseAddBatch ─────────────────────────────────────────────────────

--- a/sdk/src/query/phase-lifecycle.ts
+++ b/sdk/src/query/phase-lifecycle.ts
@@ -191,13 +191,34 @@ export const phaseAdd: QueryHandler = async (args, projectDir, workstream) => {
     } else {
       // Sequential mode: find highest integer phase number (in current milestone only)
       // Skip 999.x backlog phases — they live outside the active sequence
-      const phasePattern = /#{2,4}\s*Phase\s+(\d+)[A-Z]?(?:\.\d+)*:/gi;
+      // Matches heading (## Phase N:), bullet checklist (- [x] Phase N:), and bold (**Phase N:**)
+      const phasePattern = /(?:^|\n)\s*(?:[-*]\s*(?:\[[x ]\]\s*)?|#{2,4}\s*|\*{1,2}\s*)Phase\s+(\d+)[A-Z]?(?:\.\d+)*:/gi;
       let maxPhase = 0;
       let m: RegExpExecArray | null;
       while ((m = phasePattern.exec(content)) !== null) {
         const num = parseInt(m[1], 10);
         if (num >= 999) continue; // backlog phases use 999.x numbering
         if (num > maxPhase) maxPhase = num;
+      }
+
+      // Belt-and-suspenders: if ROADMAP scan found nothing, fall back to scanning
+      // .planning/phases/ directory names as the canonical source of truth
+      if (maxPhase === 0) {
+        const phasesDir = planningPaths(projectDir, workstream).phases;
+        try {
+          const entries = await readdir(phasesDir, { withFileTypes: true });
+          for (const entry of entries) {
+            if (!entry.isDirectory()) continue;
+            const dirMatch = /^(\d+)[A-Z]?(?:\.\d+)*-/.exec(entry.name);
+            if (dirMatch) {
+              const num = parseInt(dirMatch[1], 10);
+              if (num >= 999) continue;
+              if (num > maxPhase) maxPhase = num;
+            }
+          }
+        } catch {
+          // phases dir may not exist yet — leave maxPhase as 0
+        }
       }
 
       newPhaseId = maxPhase + 1;

--- a/sdk/src/query/phase-lifecycle.ts
+++ b/sdk/src/query/phase-lifecycle.ts
@@ -209,7 +209,7 @@ export const phaseAdd: QueryHandler = async (args, projectDir, workstream) => {
           const entries = await readdir(phasesDir, { withFileTypes: true });
           for (const entry of entries) {
             if (!entry.isDirectory()) continue;
-            const dirMatch = /^(\d+)[A-Z]?(?:\.\d+)*-/.exec(entry.name);
+            const dirMatch = /^(?:[A-Z][A-Z0-9]*-)?(\d+)[A-Z]?(?:\.\d+)*-/i.exec(entry.name);
             if (dirMatch) {
               const num = parseInt(dirMatch[1], 10);
               if (num >= 999) continue;


### PR DESCRIPTION
## Summary

- Broadens `phasePattern` regex in `phaseAdd` to match bullet checklist (`- [x] Phase N:`), bold inline (`**Phase N:**`), and heading formats
- Adds filesystem fallback: when ROADMAP scan finds zero phases, reads `.planning/phases/` directory names as source of truth
- Adds 3 regression tests covering each new format

## Root cause

The existing regex `/#{2,4}\s*Phase\s+(\d+)/gi` only matches markdown headings. ROADMAPs using checklist or bold formats returned `maxPhase = 0`, producing `newPhaseId = 1` regardless of actual phase count.

## Adversarial notes

- The filesystem fallback is the stronger fix — ROADMAP text is user-editable and format varies; on-disk phase directories are the canonical source of truth
- Both fixes are independent; either alone solves the reported bug, together they provide defense-in-depth
- No breaking changes: heading-format ROADMAPs continue to work

## Test plan
- [x] Bullet checklist detection test passes
- [x] Bold inline detection test passes
- [x] Filesystem fallback test passes
- [x] All existing phaseAdd tests pass
- [x] Full SDK test suite green

Closes #2726

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced phase number detection to recognize additional markdown formats (checklist items and bold entries) when determining the next phase number, with improved fallback logic to scan existing phase directories when needed.

* **Tests**
  * Added comprehensive tests for phase detection regression, covering checklist-based phases, bold-formatted entries, and directory-based fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->