### PR TITLE
test(query): Vitest regression guard for milestone.complete version arg (fix #2644)

### DIFF
--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -22,7 +22,7 @@
         "vitest": "^3.1.1"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {

--- a/sdk/src/query/decomposed-handlers.test.ts
+++ b/sdk/src/query/decomposed-handlers.test.ts
@@ -170,6 +170,74 @@ describe('progressBar', () => {
   });
 });
 
+// ─── phase-lifecycle.ts — milestoneComplete ──────────────────────────────
+
+/**
+ * Regression tests for bug #2644: milestone.complete handler drops version arg.
+ *
+ * Original defect (first introduced in 6f79b1d): the handler called
+ * `phasesArchive([], projectDir)` instead of forwarding the version positional
+ * arg. phasesArchive read args[0] and threw GSDError('version required for
+ * phases archive'); the surrounding try/catch swallowed the throw into
+ * { completed: false, reason: String(err) }, masking it as a legitimate
+ * negative answer.
+ *
+ * Fixed in c5b1445: handler now validates version upfront and uses inline
+ * archive logic instead of delegating to phasesArchive.
+ */
+describe('milestoneComplete', () => {
+  it('accepts version as first positional arg and returns it in data', async () => {
+    const result = await milestoneComplete(['v1.19', '--name', 'Test Milestone'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+
+    // Must NOT return the error shape from the old bug
+    expect(data.completed).not.toBe(false);
+    expect((data as Record<string, unknown>).reason).toBeUndefined();
+
+    // Must return version echoed in data
+    expect(data.version).toBe('v1.19');
+  });
+
+  it('does not call phasesArchive with empty args (regression: bug #2644)', async () => {
+    // If the old bug were present, this would return { completed: false, reason: 'GSDError: version required for phases archive' }
+    // The fix ensures version is extracted from args[0] before any archive operation
+    const result = await milestoneComplete(['v1.0'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+
+    // Should return the success shape with version, never the error shape
+    expect(data.version).toBe('v1.0');
+    expect(typeof data.date).toBe('string');
+    expect(typeof data.phases).toBe('number');
+    expect(data.milestones_updated).toBe(true);
+  });
+
+  it('throws GSDError when version arg is missing (not masked as completed: false)', async () => {
+    // The old bug swallowed ALL errors into { completed: false, reason: String(err) }
+    // The fix explicitly throws so callers can distinguish validation failure from "not complete"
+    await expect(milestoneComplete([], tmpDir)).rejects.toThrow('version required for milestone complete');
+  });
+
+  it('archives with --archive-phases when flag is present', async () => {
+    const result = await milestoneComplete(['v1.0', '--archive-phases'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+
+    expect(data.version).toBe('v1.0');
+    const archived = data.archived as Record<string, unknown>;
+    // --archive-phases was passed; phases dir should have been scoped but
+    // may result in 0 if the milestone filter finds no matching dirs.
+    // The important assertion: no error, version is correctly forwarded.
+    expect(typeof archived.phases).toBe('boolean');
+  });
+
+  it('returns name from --name flag', async () => {
+    const result = await milestoneComplete(['v2.0', '--name', 'My Release'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+
+    expect(data.version).toBe('v2.0');
+    expect(data.name).toBe('My Release');
+  });
+});
+
 // ─── summary.ts ──────────────────────────────────────────────────────────
 
 describe('summaryExtract', () => {

--- a/sdk/src/query/decomposed-handlers.test.ts
+++ b/sdk/src/query/decomposed-handlers.test.ts
@@ -186,6 +186,15 @@ describe('progressBar', () => {
  * archive logic instead of delegating to phasesArchive.
  */
 describe('milestoneComplete', () => {
+  const assertMilestoneSuccess = (result: Awaited<ReturnType<typeof milestoneComplete>>, version: string) => {
+    const data = result.data as Record<string, unknown>;
+    expect(data.version).toBe(version);
+    expect(typeof data.date).toBe('string');
+    expect(typeof data.phases).toBe('number');
+    expect(data.milestones_updated).toBe(true);
+    return data;
+  };
+
   it('accepts version as first positional arg and returns it in data', async () => {
     const result = await milestoneComplete(['v1.19', '--name', 'Test Milestone'], tmpDir);
     const data = result.data as Record<string, unknown>;
@@ -202,13 +211,7 @@ describe('milestoneComplete', () => {
     // If the old bug were present, this would return { completed: false, reason: 'GSDError: version required for phases archive' }
     // The fix ensures version is extracted from args[0] before any archive operation
     const result = await milestoneComplete(['v1.0'], tmpDir);
-    const data = result.data as Record<string, unknown>;
-
-    // Should return the success shape with version, never the error shape
-    expect(data.version).toBe('v1.0');
-    expect(typeof data.date).toBe('string');
-    expect(typeof data.phases).toBe('number');
-    expect(data.milestones_updated).toBe(true);
+    assertMilestoneSuccess(result, 'v1.0');
   });
 
   it('throws GSDError when version arg is missing (not masked as completed: false)', async () => {
@@ -219,9 +222,8 @@ describe('milestoneComplete', () => {
 
   it('archives with --archive-phases when flag is present', async () => {
     const result = await milestoneComplete(['v1.0', '--archive-phases'], tmpDir);
-    const data = result.data as Record<string, unknown>;
+    const data = assertMilestoneSuccess(result, 'v1.0');
 
-    expect(data.version).toBe('v1.0');
     const archived = data.archived as Record<string, unknown>;
     // --archive-phases was passed; phases dir should have been scoped but
     // may result in 0 if the milestone filter finds no matching dirs.
@@ -231,9 +233,8 @@ describe('milestoneComplete', () => {
 
   it('returns name from --name flag', async () => {
     const result = await milestoneComplete(['v2.0', '--name', 'My Release'], tmpDir);
-    const data = result.data as Record<string, unknown>;
+    const data = assertMilestoneSuccess(result, 'v2.0');
 
-    expect(data.version).toBe('v2.0');
     expect(data.name).toBe('My Release');
   });
 });


### PR DESCRIPTION
## Summary

- Adds five Vitest unit tests for `milestoneComplete` in `decomposed-handlers.test.ts` — the handler was imported but had zero test coverage
- Tests lock in the correct contract that was broken in the original implementation and fixed in c5b1445
- Regression guard ensures the `{ completed: false, reason: "GSDError: version required for phases archive" }` error shape cannot resurface silently

## Root cause (for record)

The original defect (introduced in `6f79b1d`, `feat(sdk): Phase 1 typed query foundation`):

```js
export const milestoneComplete = async (args, projectDir) => {
    const version = args[0] || 'current';
    try {
        const archiveResult = await phasesArchive([], projectDir);  // empty args — bug
        return { data: { completed: true, version, archive: archiveResult.data } };
    } catch (err) {
        return { data: { completed: false, reason: String(err) } };  // swallowed
    }
};
```

`phasesArchive([], ...)` read `args[0]` → `undefined` → threw `GSDError('version required for phases archive')`. The catch swallowed it into `{ completed: false, reason: "GSDError: version required for phases archive" }`, making a programming error look like a legitimate "milestone not complete" answer.

Fixed in `c5b1445` (golden parity harness): handler now validates version upfront with an explicit throw and uses inline archive logic, never delegating to `phasesArchive`.

## What the fix does

The source code was already corrected in `c5b1445`. This PR adds the missing test coverage that would have:
1. Caught the original bug before merge
2. Prevented regression if the inline logic is ever refactored to call `phasesArchive` again

## Test plan

- [ ] `cd sdk && npm run test:unit` — all milestoneComplete tests green
- [ ] `node --test tests/bug-2684-milestone-complete-version.test.cjs` — existing node:test regression suite still passes
- [ ] `gsd-sdk query milestone.complete "v1.0"` against a project with `.planning/` — returns `{ version: "v1.0", date: "...", phases: N, milestones_updated: true }`, not `{ completed: false, reason: "..." }`

Closes #2644

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression test suite for milestone completion functionality, including validation of version argument handling, successful result structure verification, and option propagation testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->