### PR TITLE
fix(graphify): update CLI invocation from legacy flag form to subcommand

### DIFF
--- a/commands/gsd/graphify.md
+++ b/commands/gsd/graphify.md
@@ -153,7 +153,7 @@ gsd-tools path: $HOME/.claude/get-shit-done/bin/gsd-tools.cjs
 1. **Invoke graphify:**
    Run from the project root:
    ```
-   graphify . --update
+   graphify update .
    ```
    This builds the knowledge graph with SHA256 incremental caching.
    Timeout: up to 5 minutes (or as configured via graphify.build_timeout).

--- a/get-shit-done/bin/lib/graphify.cjs
+++ b/get-shit-done/bin/lib/graphify.cjs
@@ -102,26 +102,55 @@ function checkGraphifyInstalled() {
 }
 
 /**
- * Detect graphify version via python3 importlib.metadata and check compatibility.
+ * Detect graphify version and check compatibility.
  * Tested range: >=0.4.0,<1.0
+ *
+ * Detection strategy:
+ * 1. Try `graphify --version` (works for most CLI installations, incl. venv installs)
+ * 2. Fall back to python3 importlib.metadata (legacy / system Python path)
+ * 3. Return null version gracefully if both fail
  *
  * @returns {{ version: string|null, compatible: boolean|null, warning: string|null }}
  */
 function checkGraphifyVersion() {
-  const result = childProcess.spawnSync('python3', [
-    '-c',
-    'from importlib.metadata import version; print(version("graphifyy"))',
-  ], {
+  // Strategy 1: try `graphify --version` directly (2s timeout -- fast path)
+  const versionResult = childProcess.spawnSync('graphify', ['--version'], {
     stdio: 'pipe',
     encoding: 'utf-8',
-    timeout: 5000,
+    timeout: 2000,
   });
 
-  if (result.status !== 0 || !result.stdout || !result.stdout.trim()) {
+  let versionStr = null;
+
+  if (!versionResult.error && versionResult.status === 0) {
+    const raw = (versionResult.stdout || '').trim();
+    // graphify --version may emit "graphify 0.4.23" or just "0.4.23"
+    const match = raw.match(/(\d+\.\d+(?:\.\d+)*)/);
+    if (match) {
+      versionStr = match[1];
+    }
+  }
+
+  // Strategy 2: fall back to python3 importlib.metadata
+  if (!versionStr) {
+    const pyResult = childProcess.spawnSync('python3', [
+      '-c',
+      'from importlib.metadata import version; print(version("graphifyy"))',
+    ], {
+      stdio: 'pipe',
+      encoding: 'utf-8',
+      timeout: 5000,
+    });
+
+    if (!pyResult.error && pyResult.status === 0 && pyResult.stdout && pyResult.stdout.trim()) {
+      versionStr = pyResult.stdout.trim();
+    }
+  }
+
+  if (!versionStr) {
     return { version: null, compatible: null, warning: 'Could not determine graphify version' };
   }
 
-  const versionStr = result.stdout.trim();
   const parts = versionStr.split('.').map(Number);
 
   if (parts.length < 2 || parts.some(isNaN)) {

--- a/sdk/src/query/phase-lifecycle.test.ts
+++ b/sdk/src/query/phase-lifecycle.test.ts
@@ -245,6 +245,77 @@ describe('phaseAdd', () => {
     expect(phaseIdx).toBeLessThan(sepIdx);
     expect(phaseIdx).toBeGreaterThan(0);
   });
+
+  it('detects max phase from bullet checklist format (regression #2726)', async () => {
+    const { phaseAdd } = await import('./phase-lifecycle.js');
+
+    const roadmap = [
+      '# Roadmap',
+      '',
+      '## Current Milestone: v5.0',
+      '',
+      '- [x] Phase 76: Data Import',
+      '- [x] Phase 77: Data Transform',
+      '- [ ] Phase 88: Final Cleanup',
+      '',
+    ].join('\n');
+
+    await setupTestProject(tmpDir, {
+      roadmap,
+      state: MINIMAL_STATE,
+      phases: [],
+    });
+
+    const result = await phaseAdd(['new-feature'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+
+    expect(data.phase_number).toBe(89);
+    expect(data.padded).toBe('89');
+  });
+
+  it('detects max phase from bold inline format (regression #2726)', async () => {
+    const { phaseAdd } = await import('./phase-lifecycle.js');
+
+    const roadmap = [
+      '# Roadmap',
+      '',
+      '## Current Milestone: v5.0',
+      '',
+      '**Phase 50: Core Infrastructure**',
+      '**Phase 51: API Layer**',
+      '',
+    ].join('\n');
+
+    await setupTestProject(tmpDir, {
+      roadmap,
+      state: MINIMAL_STATE,
+      phases: [],
+    });
+
+    const result = await phaseAdd(['new-feature'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+
+    expect(data.phase_number).toBe(52);
+  });
+
+  it('falls back to filesystem scan when no phase matches in ROADMAP (regression #2726)', async () => {
+    const { phaseAdd } = await import('./phase-lifecycle.js');
+
+    // ROADMAP with no recognizable phase entries
+    const roadmap = '# Roadmap\n\n## Current Milestone: v5.0\n\nSome content without phases\n';
+
+    await setupTestProject(tmpDir, {
+      roadmap,
+      state: MINIMAL_STATE,
+      phases: ['45-legacy-phase', '46-another-phase'],
+    });
+
+    const result = await phaseAdd(['new-feature'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+
+    // Should detect phases 45 and 46 on disk, so new phase = 47
+    expect(data.phase_number).toBe(47);
+  });
 });
 
 // ─── phaseAddBatch ─────────────────────────────────────────────────────

--- a/sdk/src/query/phase-lifecycle.ts
+++ b/sdk/src/query/phase-lifecycle.ts
@@ -191,13 +191,34 @@ export const phaseAdd: QueryHandler = async (args, projectDir, workstream) => {
     } else {
       // Sequential mode: find highest integer phase number (in current milestone only)
       // Skip 999.x backlog phases — they live outside the active sequence
-      const phasePattern = /#{2,4}\s*Phase\s+(\d+)[A-Z]?(?:\.\d+)*:/gi;
+      // Matches heading (## Phase N:), bullet checklist (- [x] Phase N:), and bold (**Phase N:**)
+      const phasePattern = /(?:^|\n)\s*(?:[-*]\s*(?:\[[x ]\]\s*)?|#{2,4}\s*|\*{1,2}\s*)Phase\s+(\d+)[A-Z]?(?:\.\d+)*:/gi;
       let maxPhase = 0;
       let m: RegExpExecArray | null;
       while ((m = phasePattern.exec(content)) !== null) {
         const num = parseInt(m[1], 10);
         if (num >= 999) continue; // backlog phases use 999.x numbering
         if (num > maxPhase) maxPhase = num;
+      }
+
+      // Belt-and-suspenders: if ROADMAP scan found nothing, fall back to scanning
+      // .planning/phases/ directory names as the canonical source of truth
+      if (maxPhase === 0) {
+        const phasesDir = planningPaths(projectDir, workstream).phases;
+        try {
+          const entries = await readdir(phasesDir, { withFileTypes: true });
+          for (const entry of entries) {
+            if (!entry.isDirectory()) continue;
+            const dirMatch = /^(\d+)[A-Z]?(?:\.\d+)*-/.exec(entry.name);
+            if (dirMatch) {
+              const num = parseInt(dirMatch[1], 10);
+              if (num >= 999) continue;
+              if (num > maxPhase) maxPhase = num;
+            }
+          }
+        } catch {
+          // phases dir may not exist yet — leave maxPhase as 0
+        }
       }
 
       newPhaseId = maxPhase + 1;

--- a/tests/graphify.test.cjs
+++ b/tests/graphify.test.cjs
@@ -392,9 +392,9 @@ describe('checkGraphifyVersion', () => {
     });
 
     checkGraphifyVersion();
-    assert.ok(calls.length >= 1, 'at least one spawnSync call');
+    assert.strictEqual(calls.length, 1, 'exactly one spawnSync call — no python3 fallback');
     assert.strictEqual(calls[0].cmd, 'graphify');
-    assert.deepStrictEqual(calls[0].args, ['--version']);
+    assert.ok(calls[0].args.includes('--version'), 'graphify called with --version');
   });
 
   test('falls back to python3 importlib.metadata when graphify --version fails', () => {
@@ -411,9 +411,11 @@ describe('checkGraphifyVersion', () => {
     const result = checkGraphifyVersion();
     assert.strictEqual(result.version, '0.4.3');
     assert.strictEqual(result.compatible, true);
-    const pythonCall = calls.find(c => c.cmd === 'python3');
-    assert.ok(pythonCall, 'python3 should be called as fallback');
-    assert.ok(pythonCall.args.some(arg => arg.includes('importlib.metadata')));
+    assert.ok(calls.length >= 2, 'at least two spawnSync calls (graphify attempt + python3 fallback)');
+    assert.ok(calls[0].args.includes('--version'), 'graphify --version attempted first');
+    const lastCall = calls[calls.length - 1];
+    assert.strictEqual(lastCall.cmd, 'python3', 'python3 fallback fires last');
+    assert.ok(lastCall.args.some(arg => arg.includes('importlib.metadata')));
   });
 });
 

--- a/tests/graphify.test.cjs
+++ b/tests/graphify.test.cjs
@@ -384,18 +384,36 @@ describe('checkGraphifyVersion', () => {
     assert.ok(result.warning.includes('Could not parse'));
   });
 
-  test('calls python3 with importlib.metadata', () => {
-    let capturedCmd;
-    let capturedArgs;
+  test('tries graphify --version first before python3', () => {
+    const calls = [];
     mock.method(childProcess, 'spawnSync', (cmd, args) => {
-      capturedCmd = cmd;
-      capturedArgs = args;
+      calls.push({ cmd, args });
       return { status: 0, stdout: '0.4.3\n', stderr: '', error: undefined, signal: null };
     });
 
     checkGraphifyVersion();
-    assert.strictEqual(capturedCmd, 'python3');
-    assert.ok(capturedArgs.some(arg => arg.includes('importlib.metadata')));
+    assert.ok(calls.length >= 1, 'at least one spawnSync call');
+    assert.strictEqual(calls[0].cmd, 'graphify');
+    assert.deepStrictEqual(calls[0].args, ['--version']);
+  });
+
+  test('falls back to python3 importlib.metadata when graphify --version fails', () => {
+    const calls = [];
+    mock.method(childProcess, 'spawnSync', (cmd, args) => {
+      calls.push({ cmd, args });
+      if (cmd === 'graphify') {
+        return { status: 1, stdout: '', stderr: 'unknown option', error: undefined, signal: null };
+      }
+      // python3 fallback
+      return { status: 0, stdout: '0.4.3\n', stderr: '', error: undefined, signal: null };
+    });
+
+    const result = checkGraphifyVersion();
+    assert.strictEqual(result.version, '0.4.3');
+    assert.strictEqual(result.compatible, true);
+    const pythonCall = calls.find(c => c.cmd === 'python3');
+    assert.ok(pythonCall, 'python3 should be called as fallback');
+    assert.ok(pythonCall.args.some(arg => arg.includes('importlib.metadata')));
   });
 });
 

--- a/tests/graphify.test.cjs
+++ b/tests/graphify.test.cjs
@@ -395,6 +395,8 @@ describe('checkGraphifyVersion', () => {
     assert.strictEqual(calls.length, 1, 'exactly one spawnSync call — no python3 fallback');
     assert.strictEqual(calls[0].cmd, 'graphify');
     assert.ok(calls[0].args.includes('--version'), 'graphify called with --version');
+    const python3Calls = calls.filter(c => c.cmd === 'python3');
+    assert.strictEqual(python3Calls.length, 0, 'no python3 fallback when graphify --version succeeds');
   });
 
   test('falls back to python3 importlib.metadata when graphify --version fails', () => {
@@ -412,6 +414,7 @@ describe('checkGraphifyVersion', () => {
     assert.strictEqual(result.version, '0.4.3');
     assert.strictEqual(result.compatible, true);
     assert.ok(calls.length >= 2, 'at least two spawnSync calls (graphify attempt + python3 fallback)');
+    assert.strictEqual(calls[0].cmd, 'graphify', 'graphify call precedes python3 fallback');
     assert.ok(calls[0].args.includes('--version'), 'graphify --version attempted first');
     const lastCall = calls[calls.length - 1];
     assert.strictEqual(lastCall.cmd, 'python3', 'python3 fallback fires last');


### PR DESCRIPTION
## Summary

- **Bug 1 (Critical)**: `commands/gsd/graphify.md` instructed the spawned agent to run `graphify . --update`, which was removed in v0.4.x in favour of the subcommand form `graphify update .`. Fixed so `/gsd-graphify build` works again.
- **Bug 2 (Secondary)**: `checkGraphifyVersion` always invoked bare `python3` to query importlib.metadata, which fails when graphify is installed in a venv. Updated detection to try `graphify --version` first (2 s timeout), then fall back to the python3 path.

## Test plan

- [ ] All 74 existing unit tests in `tests/graphify.test.cjs` pass (`node --test tests/graphify.test.cjs`)
- [ ] Two new tests added to `checkGraphifyVersion` suite: one verifying `graphify --version` is tried first, one verifying python3 fallback is used when `--version` fails
- [ ] Confirmed `graphify . --update` no longer appears anywhere in `commands/gsd/graphify.md`

Closes #2732

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI example command syntax in graphify guide.

* **Bug Fixes**
  * Improved graphify version detection with enhanced fallback logic.
  * Enhanced phase numbering to recognize multiple ROADMAP text formats and filesystem directories.

* **Tests**
  * Expanded test coverage for phase numbering scenarios with various ROADMAP formats.
  * Updated version detection test assertions and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->