### PR TITLE
fix: validate LM Studio model identity in review workflow

### DIFF
--- a/get-shit-done/workflows/review.md
+++ b/get-shit-done/workflows/review.md
@@ -270,11 +270,16 @@ LM_STUDIO_MODEL=$(gsd-sdk query config-get review.models.lm_studio 2>/dev/null |
 if [ -z "$LM_STUDIO_MODEL" ] || [ "$LM_STUDIO_MODEL" = "null" ]; then
   LM_STUDIO_MODEL=$(curl -s --max-time 2 "${LM_STUDIO_HOST}/v1/models" 2>/dev/null | jq -r '.data[0].id // "local-model"' 2>/dev/null || echo "local-model")
 fi
-jq -n --rawfile content /tmp/gsd-review-prompt-{phase}.md \
+LM_STUDIO_RESPONSE=$(jq -n --rawfile content /tmp/gsd-review-prompt-{phase}.md \
   --arg model "$LM_STUDIO_MODEL" \
   '{model: $model, messages: [{role: "user", content: $content}]}' | \
   curl -s --max-time 120 -X POST "${LM_STUDIO_HOST}/v1/chat/completions" \
-    -H "Content-Type: application/json" -d @- 2>/dev/null | \
+    -H "Content-Type: application/json" -d @- 2>/dev/null)
+LM_STUDIO_ACTUAL_MODEL=$(echo "$LM_STUDIO_RESPONSE" | jq -r '.model // ""' 2>/dev/null || echo "")
+if [ -n "$LM_STUDIO_ACTUAL_MODEL" ] && [ "$LM_STUDIO_ACTUAL_MODEL" != "null" ] && [ "$LM_STUDIO_ACTUAL_MODEL" != "$LM_STUDIO_MODEL" ]; then
+  echo "Warning: LM Studio served model '$LM_STUDIO_ACTUAL_MODEL' but '$LM_STUDIO_MODEL' was requested. Review may be from a different model." >&2
+fi
+echo "$LM_STUDIO_RESPONSE" | \
   jq -r '.choices[0].message.content // "LM Studio review failed or returned empty output."' \
   > /tmp/gsd-review-lm_studio-{phase}.md
 if [ ! -s /tmp/gsd-review-lm_studio-{phase}.md ]; then

--- a/get-shit-done/workflows/review.md
+++ b/get-shit-done/workflows/review.md
@@ -279,11 +279,11 @@ LM_STUDIO_ACTUAL_MODEL=$(echo "$LM_STUDIO_RESPONSE" | jq -r '.model // ""' 2>/de
 if [ -n "$LM_STUDIO_ACTUAL_MODEL" ] && [ "$LM_STUDIO_ACTUAL_MODEL" != "null" ] && [ "$LM_STUDIO_ACTUAL_MODEL" != "$LM_STUDIO_MODEL" ]; then
   echo "Warning: LM Studio served model '$LM_STUDIO_ACTUAL_MODEL' but '$LM_STUDIO_MODEL' was requested. Review may be from a different model." >&2
 fi
-echo "$LM_STUDIO_RESPONSE" | \
-  jq -r '.choices[0].message.content // "LM Studio review failed or returned empty output."' \
-  > /tmp/gsd-review-lm_studio-{phase}.md
-if [ ! -s /tmp/gsd-review-lm_studio-{phase}.md ]; then
-  echo "LM Studio review failed or returned empty output." > /tmp/gsd-review-lm_studio-{phase}.md
+LM_STUDIO_CONTENT=$(echo "$LM_STUDIO_RESPONSE" | jq -r '.choices[0].message.content // ""' 2>/dev/null || echo "")
+if [ -n "$LM_STUDIO_CONTENT" ]; then
+  echo "$LM_STUDIO_CONTENT" > /tmp/gsd-review-lm_studio-{phase}.md
+else
+  echo "Warning: LM Studio returned empty content — skipping review." >&2
 fi
 ```
 
@@ -295,15 +295,16 @@ LLAMA_CPP_MODEL=$(gsd-sdk query config-get review.models.llama_cpp 2>/dev/null |
 if [ -z "$LLAMA_CPP_MODEL" ] || [ "$LLAMA_CPP_MODEL" = "null" ]; then
   LLAMA_CPP_MODEL=$(curl -s --max-time 2 "${LLAMA_CPP_HOST}/v1/models" 2>/dev/null | jq -r '.data[0].id // "local-model"' 2>/dev/null || echo "local-model")
 fi
-jq -n --rawfile content /tmp/gsd-review-prompt-{phase}.md \
+LLAMA_CPP_CONTENT=$(jq -n --rawfile content /tmp/gsd-review-prompt-{phase}.md \
   --arg model "$LLAMA_CPP_MODEL" \
   '{model: $model, messages: [{role: "user", content: $content}]}' | \
   curl -s --max-time 120 -X POST "${LLAMA_CPP_HOST}/v1/chat/completions" \
     -H "Content-Type: application/json" -d @- 2>/dev/null | \
-  jq -r '.choices[0].message.content // "llama.cpp review failed or returned empty output."' \
-  > /tmp/gsd-review-llama_cpp-{phase}.md
-if [ ! -s /tmp/gsd-review-llama_cpp-{phase}.md ]; then
-  echo "llama.cpp review failed or returned empty output." > /tmp/gsd-review-llama_cpp-{phase}.md
+  jq -r '.choices[0].message.content // ""' 2>/dev/null || echo "")
+if [ -n "$LLAMA_CPP_CONTENT" ]; then
+  echo "$LLAMA_CPP_CONTENT" > /tmp/gsd-review-llama_cpp-{phase}.md
+else
+  echo "Warning: llama.cpp returned empty content — skipping review." >&2
 fi
 ```
 


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #2721

---

## What was broken

The LM Studio block in `get-shit-done/workflows/review.md` did not validate that the model returned by the API matched the configured `LM_STUDIO_MODEL`. Additionally, when LM Studio (or llama.cpp) returned an empty response, a literal error string was written into the review temp file, polluting `REVIEWS.md` with error text instead of real review content.

## What this fix does

1. Captures the full curl response into `LM_STUDIO_RESPONSE`, extracts `.model` from it, and compares to `LM_STUDIO_MODEL` — emitting a warning to stderr if they differ (review still proceeds).
2. For LM Studio and llama.cpp: only writes the review temp file when the extracted content is non-empty; otherwise logs a warning to stderr and skips the file, so `REVIEWS.md` cannot be polluted with error strings.

## Root cause

The original implementation piped curl output directly to `jq` with a `// "error string"` fallback, which wrote that fallback into the review file on failure. Model identity was never checked.

## Testing

### How I verified the fix

Reviewed the bash logic — the model-comparison conditional correctly guards against empty/null actual-model fields, and the content-guard only writes when `[ -n "$CONTENT" ]`.

### Regression test added?

- [ ] Yes — added a test that would have caught this bug
- [x] No — this is a shell workflow file (`.md`); unit tests for bash snippets in workflow docs are not part of the test infrastructure

### Platforms tested

- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific — LM Studio is a local inference backend)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] All existing tests pass (`npm test`)
- [x] No unnecessary dependencies added

## Breaking changes

None