### PR TITLE
feat: add review.models.<cli> config key for per-runtime review model selection

### DIFF
--- a/tests/review-model-config.test.cjs
+++ b/tests/review-model-config.test.cjs
@@ -44,6 +44,36 @@ describe('review.models.<cli> config key', () => {
     assert.ok(result.success, `config-set should succeed for review.models.codex: ${result.error}`);
   });
 
+  test('isValidConfigKey accepts review.models.claude (#2688)', () => {
+    const result = runGsdTools(
+      ['config-set', 'review.models.claude', 'claude-opus-4-6'],
+      tmpDir,
+      { HOME: tmpDir, USERPROFILE: tmpDir }
+    );
+    assert.ok(result.success, `config-set should succeed for review.models.claude: ${result.error}`);
+  });
+
+  test('round-trip: review.models.claude config-set then config-get (#2688)', () => {
+    const setResult = runGsdTools(
+      ['config-set', 'review.models.claude', 'claude-opus-4-6'],
+      tmpDir,
+      { HOME: tmpDir, USERPROFILE: tmpDir }
+    );
+    assert.ok(setResult.success, `config-set failed: ${setResult.error}`);
+
+    const getResult = runGsdTools(
+      ['config-get', 'review.models.claude', '--raw'],
+      tmpDir,
+      { HOME: tmpDir, USERPROFILE: tmpDir }
+    );
+    assert.ok(getResult.success, `config-get failed: ${getResult.error}`);
+    assert.strictEqual(
+      getResult.output,
+      'claude-opus-4-6',
+      'config-get should return the model ID set via config-set'
+    );
+  });
+
   test('review.model is rejected and suggests review.models.<cli-name>', () => {
     // The suggestion path goes through validateKnownConfigKeyPath, which is
     // called before isValidConfigKey in cmdConfigSet.


### PR DESCRIPTION
## Summary

- The `review.models.<cli>` dynamic config key pattern was already implemented in the schema, workflow, and docs — this PR completes coverage by adding `review.models.claude`-specific tests to `tests/review-model-config.test.cjs`
- Adds schema validation test: `isValidConfigKey` accepts `review.models.claude`
- Adds round-trip test: `config-set review.models.claude <model-id>` → `config-get review.models.claude --raw` returns the stored model ID

## Test plan

- [x] `node --test tests/review-model-config.test.cjs` — all 7 tests pass (was 5 before this PR)
- [x] New tests cover: key acceptance via CJS `isValidConfigKey`, and full config-set/config-get round-trip for `review.models.claude`

Closes #2688

🤖 Generated with [Claude Code](https://claude.com/claude-code)