### PR TITLE
perf: convert discuss-phase SKILL.md @file imports to lazy per-branch reads

### DIFF
--- a/commands/gsd/discuss-phase.md
+++ b/commands/gsd/discuss-phase.md
@@ -50,16 +50,10 @@ DISCUSS_MODE=$(gsd-sdk query config-get workflow.discuss_mode 2>/dev/null || ech
 ```
 
 If `DISCUSS_MODE` is `"assumptions"`:
-```
-Read(~/.claude/get-shit-done/workflows/discuss-phase-assumptions.md)
-```
-Then execute that workflow end-to-end.
+Read and execute `~/.claude/get-shit-done/workflows/discuss-phase-assumptions.md` end-to-end.
 
 If `DISCUSS_MODE` is `"discuss"` (or unset, or any other value):
-```
-Read(~/.claude/get-shit-done/workflows/discuss-phase.md)
-```
-Then execute that workflow end-to-end.
+Read and execute `~/.claude/get-shit-done/workflows/discuss-phase.md` end-to-end.
 
 **MANDATORY:** Read the appropriate workflow file BEFORE taking any action. The objective and success_criteria sections in this command file are summaries — the workflow file contains the complete step-by-step process with all required behaviors, config checks, and interaction patterns. Do not improvise from the summary.
 

--- a/commands/gsd/discuss-phase.md
+++ b/commands/gsd/discuss-phase.md
@@ -29,10 +29,8 @@ Extract implementation decisions that downstream agents need — researcher and 
 </objective>
 
 <execution_context>
-@~/.claude/get-shit-done/workflows/discuss-phase.md
-@~/.claude/get-shit-done/workflows/discuss-phase-assumptions.md
-@~/.claude/get-shit-done/workflows/discuss-phase-power.md
-@~/.claude/get-shit-done/templates/context.md
+Workflow files are loaded on-demand in the <process> section below — not upfront.
+Do not pre-load any workflow files before reading the mode routing instructions.
 </execution_context>
 
 <runtime_note>
@@ -51,11 +49,21 @@ Context files are resolved in-workflow using `init phase-op` and roadmap/state t
 DISCUSS_MODE=$(gsd-sdk query config-get workflow.discuss_mode 2>/dev/null || echo "discuss")
 ```
 
-If `DISCUSS_MODE` is `"assumptions"`: Read and execute @~/.claude/get-shit-done/workflows/discuss-phase-assumptions.md end-to-end.
+If `DISCUSS_MODE` is `"assumptions"`:
+```
+Read(~/.claude/get-shit-done/workflows/discuss-phase-assumptions.md)
+```
+Then execute that workflow end-to-end.
 
-If `DISCUSS_MODE` is `"discuss"` (or unset, or any other value): Read and execute @~/.claude/get-shit-done/workflows/discuss-phase.md end-to-end.
+If `DISCUSS_MODE` is `"discuss"` (or unset, or any other value):
+```
+Read(~/.claude/get-shit-done/workflows/discuss-phase.md)
+```
+Then execute that workflow end-to-end.
 
-**MANDATORY:** The execution_context files listed above ARE the instructions. Read the workflow file BEFORE taking any action. The objective and success_criteria sections in this command file are summaries — the workflow file contains the complete step-by-step process with all required behaviors, config checks, and interaction patterns. Do not improvise from the summary.
+**MANDATORY:** Read the appropriate workflow file BEFORE taking any action. The objective and success_criteria sections in this command file are summaries — the workflow file contains the complete step-by-step process with all required behaviors, config checks, and interaction patterns. Do not improvise from the summary.
+
+**Lazy loading:** `templates/context.md` is loaded inside the `write_context` step of the active workflow. Do not load it here.
 </process>
 
 <success_criteria>

--- a/commands/gsd/discuss-phase.md
+++ b/commands/gsd/discuss-phase.md
@@ -57,7 +57,7 @@ Read and execute `~/.claude/get-shit-done/workflows/discuss-phase.md` end-to-end
 
 **MANDATORY:** Read the appropriate workflow file BEFORE taking any action. The objective and success_criteria sections in this command file are summaries — the workflow file contains the complete step-by-step process with all required behaviors, config checks, and interaction patterns. Do not improvise from the summary.
 
-**Lazy loading:** `templates/context.md` is loaded inside the `write_context` step of the active workflow. Do not load it here.
+**Lazy loading:** `templates/context.md` is loaded inside the `write_context` step of the active workflow. `discuss-phase-power.md` is loaded inside `discuss-phase.md` when `--power` is detected. Do not load either here.
 </process>
 
 <success_criteria>


### PR DESCRIPTION
## Enhancement PR

---

## Linked Issue

Closes #2606

---

## What this enhancement improves

`commands/gsd/discuss-phase.md` — the entry point for the `/gsd:discuss-phase` slash command.

## Before / After

**Before:**
The `<execution_context>` block used 4 `@file` directives that eagerly loaded `discuss-phase-assumptions.md`, `discuss-phase.md`, `discuss-phase-power.md`, and `templates/context.md` on every skill invocation regardless of which mode the user selected — adding ~13k tokens before any work began.

**After:**
No workflow files are loaded at skill entry. The `<process>` block reads the mode from config, then `Read and execute`s only the relevant workflow file for the chosen mode (`discuss-phase-assumptions.md` for assumptions mode, `discuss-phase.md` for discuss/default mode). `discuss-phase-power.md` is loaded lazily inside `discuss-phase.md` when `--power` is detected. `templates/context.md` is loaded inside the `write_context` step of the active workflow.

## How it was implemented

Replaced the `<execution_context>` `@file` directives with an instruction to load on demand. Updated `<process>` to use explicit `Read and execute` calls gated behind the `DISCUSS_MODE` config check. Only `commands/gsd/discuss-phase.md` changed — no workflow file content was modified.

## Testing

### How I verified the enhancement works

- All 14 tests in `tests/discuss-mode.test.cjs` pass
- All tests in `tests/discuss-phase-power.test.cjs` pass
- Full test suite passes

### Platforms tested

- [x] macOS
- [x] Linux
- [ ] Windows

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals

---

## Checklist

- [x] Issue linked above with `Closes #NNN`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement
- [x] All existing tests pass (`npm test`)
- [x] No unnecessary dependencies added

## Breaking changes

None — only the timing of file loads changes, not what gets loaded or the workflow behavior.