### PR TITLE
refactor(state): drop unused args + lift currentPhase in cmdStateCompletePhase

### DIFF
--- a/get-shit-done/bin/gsd-tools.cjs
+++ b/get-shit-done/bin/gsd-tools.cjs
@@ -484,7 +484,7 @@ async function runCommand(command, args, cwd, raw, defaultValue) {
         const { 'keep-recent': keepRecent, 'dry-run': dryRun } = parseNamedArgs(args, ['keep-recent'], ['dry-run']);
         state.cmdStatePrune(cwd, { keepRecent: keepRecent || '3', dryRun: !!dryRun }, raw);
       } else if (subcommand === 'complete-phase') {
-        state.cmdStateCompletePhase(cwd, args, raw);
+        state.cmdStateCompletePhase(cwd, raw);
       } else if (subcommand === 'milestone-switch') {
         // Bug #2630: reset STATE.md frontmatter + Current Position for new milestone.
         // NB: the flag is `--milestone`, not `--version` — gsd-tools reserves

--- a/get-shit-done/bin/lib/state.cjs
+++ b/get-shit-done/bin/lib/state.cjs
@@ -1701,10 +1701,19 @@ function cmdStateCompletePhase(cwd, raw) {
   let resolvedPhase = '?';
 
   readModifyWriteStateMd(statePath, (content) => {
-    // Read the current phase number for descriptive messages
-    const currentPhase = stateExtractField(content, 'Current Phase') ||
-                         stateExtractField(content, 'Phase') ||
-                         '?';
+    // Read the current phase number for descriptive messages.
+    //
+    // The 'Phase' fallback can match the decorated body line under
+    // `## Current Position` (e.g. `Phase: 01 (Foo) — EXECUTING`), which would
+    // flow downstream into messy `Status: Phase 01 (Foo) — EXECUTING complete`
+    // output. Strip everything past the leading numeric/decimal token so the
+    // fallback path produces a clean phase identifier matching the canonical
+    // `Current Phase` field. CodeRabbit nitpick on PR #2761.
+    const rawPhase = stateExtractField(content, 'Current Phase') ||
+                     stateExtractField(content, 'Phase') ||
+                     '';
+    const phaseToken = rawPhase.match(/^\s*([\w.-]+)/);
+    const currentPhase = phaseToken ? phaseToken[1] : '?';
     resolvedPhase = currentPhase;
 
     // Update Status field

--- a/get-shit-done/bin/lib/state.cjs
+++ b/get-shit-done/bin/lib/state.cjs
@@ -1689,7 +1689,7 @@ function cmdStatePrune(cwd, options, raw) {
  * that the phase execution is finished and the project is ready for the next phase.
  * Implements the `gsd state complete-phase` subcommand (issue #2735).
  */
-function cmdStateCompletePhase(cwd, args, raw) {
+function cmdStateCompletePhase(cwd, raw) {
   const statePath = planningPaths(cwd).state;
   if (!fs.existsSync(statePath)) {
     output({ error: 'STATE.md not found' }, raw);
@@ -1698,12 +1698,14 @@ function cmdStateCompletePhase(cwd, args, raw) {
 
   const today = new Date().toISOString().split('T')[0];
   const updated = [];
+  let resolvedPhase = '?';
 
   readModifyWriteStateMd(statePath, (content) => {
     // Read the current phase number for descriptive messages
     const currentPhase = stateExtractField(content, 'Current Phase') ||
                          stateExtractField(content, 'Phase') ||
                          '?';
+    resolvedPhase = currentPhase;
 
     // Update Status field
     const statusValue = `Phase ${currentPhase} complete`;
@@ -1752,7 +1754,7 @@ function cmdStateCompletePhase(cwd, args, raw) {
   }, cwd);
 
   output(
-    { updated, phase: stateExtractField(fs.readFileSync(planningPaths(cwd).state, 'utf-8'), 'Current Phase') || '?' },
+    { updated, phase: resolvedPhase },
     raw,
     updated.length > 0 ? 'true' : 'false',
   );

--- a/tests/dispatcher.test.cjs
+++ b/tests/dispatcher.test.cjs
@@ -71,6 +71,14 @@ describe('dispatcher error paths', () => {
     const result = runGsdTools('state bogus', tmpDir);
     assert.strictEqual(result.success, false, 'Should exit non-zero');
     assert.ok(result.error.includes('Unknown state subcommand'), `Expected "Unknown state subcommand" in stderr, got: ${result.error}`);
+    // Pin the enumerated subcommand list. If a future refactor reformats the
+    // error string and silently drops 'complete-phase' from the available list,
+    // this test fails loudly rather than passing on the substring above.
+    // CodeRabbit nitpick on PR #2761.
+    assert.ok(
+      result.error.includes('complete-phase'),
+      `Expected enumerated subcommands to include "complete-phase", got: ${result.error}`,
+    );
   });
 
   // Unknown subcommand: template

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -2371,5 +2371,104 @@ describe('stale phase dirs do not corrupt phase counts (bug #2445)', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// state complete-phase: Phase-fallback decoration handling (PR #2761 nitpick)
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// When STATE.md is missing the canonical `**Current Phase:**` field but
+// includes a decorated `## Current Position` body line, the fallback path used
+// to leak the decoration into downstream Status/Phase strings — producing
+// `**Status:** Phase 01 (Foo) — EXECUTING complete` instead of the expected
+// `**Status:** Phase 01 complete`. CodeRabbit flagged this on PR #2761 and the
+// Phase fallback now strips everything past the leading numeric/decimal token.
+describe('state complete-phase: decorated Phase fallback (#2761 nitpick)', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('writes clean Phase identifier when only Current Position decoration is present', () => {
+    // STATE.md without the canonical `**Current Phase:**` field — the only
+    // phase signal lives inside the `## Current Position` block as a decorated
+    // line. This is the regression fixture.
+    const stateMd = [
+      '---',
+      'milestone: v1.0',
+      '---',
+      '',
+      '# State',
+      '',
+      '**Status:** Executing',
+      '**Last Activity:** 2024-01-15',
+      '',
+      '## Current Position',
+      '',
+      'Phase: 01 (Foo) — EXECUTING',
+      'Plan: bootstrap',
+      '',
+    ].join('\n');
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), stateMd);
+
+    const result = runGsdTools('state complete-phase', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const updated = fs.readFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      'utf-8',
+    );
+
+    // Status should reference the bare phase identifier (`01`), not the
+    // decorated string. The negative assertion catches the regression
+    // shape directly.
+    assert.ok(
+      updated.includes('**Status:** Phase 01 complete'),
+      `Status should be "Phase 01 complete", got STATE.md:\n${updated}`,
+    );
+    assert.ok(
+      !updated.includes('Phase 01 (Foo) — EXECUTING complete'),
+      `Status must not embed Current Position decoration: ${updated}`,
+    );
+  });
+
+  test('canonical Current Phase field is preferred over Current Position decoration', () => {
+    // When both are present, Current Phase wins — same outcome as before, but
+    // pinned here so a future refactor that flips precedence is caught.
+    const stateMd = [
+      '---',
+      'milestone: v1.0',
+      '---',
+      '',
+      '# State',
+      '',
+      '**Status:** Executing',
+      '**Current Phase:** 03',
+      '**Last Activity:** 2024-01-15',
+      '',
+      '## Current Position',
+      '',
+      'Phase: 01 (Foo) — EXECUTING',
+      '',
+    ].join('\n');
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), stateMd);
+
+    const result = runGsdTools('state complete-phase', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const updated = fs.readFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      'utf-8',
+    );
+    assert.ok(
+      updated.includes('**Status:** Phase 03 complete'),
+      `Status should reference canonical Current Phase (03), got: ${updated}`,
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // summary-extract command
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Fix PR

## Linked Issue

Closes #2759

> Source: CodeRabbit nitpicks raised during review of #2759. The nitpicks pointed at code that landed via #2744 (which closed the underlying #2734 / #2735 bugs) rather than at #2759's diff itself. After main caught up, two of this PR's three original commits were already-upstream duplicates of #2744 and were dropped during rebase. The remaining content is the refactor + the regression tests for both nitpicks.

---

## What was broken

Two latent issues in `cmdStateCompletePhase` and the dispatcher's regression coverage:

1. **`cmdStateCompletePhase(cwd, args, raw)`** — the `args` parameter was never read. Every sibling state subcommand (`cmdStateLoad`, `cmdStateAdvancePlan`, `cmdStateUpdateProgress`, …) uses the leaner `(cwd, raw)` shape, so this was a stale API surface that would mislead future callers.

2. **`output()` re-read STATE.md after the lock was released** — `readModifyWriteStateMd` had already given the closure the `currentPhase` value at L1704, but `output()` then called `fs.readFileSync(statePath)` post-lock to re-extract it. That's an unnecessary fs round-trip plus a tiny race window between lock release and the read.

3. **Decorated `Phase` fallback leak** — when `STATE.md` is missing the canonical `**Current Phase:**` field, the fallback `stateExtractField(content, 'Phase')` matched the decorated body line under `## Current Position` (e.g. `Phase: 01 (Foo) — EXECUTING`) and returned the entire decorated string, producing messy output:
   - `**Status:** Phase 01 (Foo) — EXECUTING complete`
   - `**Phase:** 01 (Foo) — EXECUTING — COMPLETE`

4. **Dispatcher test passed too easily** — `result.error.includes('Unknown state subcommand')` only checked the error preamble. Future reformat that drops `complete-phase` (or any other entry) from the enumerated list of available subcommands would still pass.

## What this fix does

1. Drop `args` from `cmdStateCompletePhase`; update the lone caller in `gsd-tools.cjs:487`.
2. Lift `resolvedPhase` into outer scope and capture `currentPhase` inside the `readModifyWriteStateMd` callback. Eliminate the post-lock `fs.readFileSync`.
3. Tighten the `Phase` fallback: extract only the leading numeric/decimal token via `/^\s*([\w.-]+)/` so degraded inputs render the same clean phase identifier the canonical path produces.
4. Pin the enumerated subcommand list in `dispatcher.test.cjs` — additionally assert the error includes `'complete-phase'`.

## Root cause

Items 1–2 were structural drift on a fresh function (`cmdStateCompletePhase` was added in #2744 and the cleanup chance hadn't been taken). Item 3 was a copy-paste of the canonical-then-fallback pattern without considering the body-line shape produced by `## Current Position`. Item 4 was test thinness.

## Testing

### How I verified the fix

```bash
node --test tests/state.test.cjs           # 99 pass — includes 2 new regression tests
node --test tests/dispatcher.test.cjs      # 27 pass — pinned enumeration assertion
node --test tests/frontmatter.test.cjs     # 41 pass — unchanged
```

### Regression test added?

- [x] Yes — three new tests landed with this PR:
  - `tests/state.test.cjs` — `decorated Phase line writes clean Phase identifier`
  - `tests/state.test.cjs` — `canonical Current Phase wins over Current Position decoration`
  - `tests/dispatcher.test.cjs` — pinned `complete-phase` enumeration in the error message

### Platforms tested

- [x] macOS (Darwin 25.4.0, Node v25.9.0)
- [ ] Windows — N/A: pure string/regex on already-decoded content; CI matrix exercises Windows path handling separately.
- [ ] Linux — same as Windows; CI matrix covers.

### Runtimes tested

- [x] N/A — `state` command is runtime-agnostic; behavior is verified via `runGsdTools()` against synthetic STATE.md fixtures.

---

## Note on rebase

This branch was originally `[ahead 2, behind 3]` of main with `mergeStateStatus: DIRTY`. Two of the three commits (`3ca3f7b8`, `63e5e752`) duplicated content that landed via #2744. After `git rebase origin/main` they were dropped (one auto-detected as "patch contents already upstream"; the other was a hard conflict where the patch had already shipped — skipped manually). The remaining `d62c5668` (the refactor) was preserved as commit `20281113`. The CodeRabbit nitpick fixes + regression tests landed as commit `fd97a7b9`.

Final shape: 2 clean commits, 3 files changed, +120/−4.