### PR TITLE
fix(#2775): verify gsd-sdk on PATH before reporting SDK ready

### DIFF
--- a/bin/gsd-sdk.js
+++ b/bin/gsd-sdk.js
@@ -2,11 +2,16 @@
 /**
  * bin/gsd-sdk.js — back-compat shim for external callers of `gsd-sdk`.
  *
- * When the parent package is installed globally (`npm install -g get-shit-done-cc`
- * or `npx get-shit-done-cc`), npm creates a `gsd-sdk` symlink in the global bin
- * directory pointing at this file. npm correctly chmods bin entries from a tarball,
- * so the execute-bit problem that afflicted the sub-install approach (issue #2453)
- * cannot occur here.
+ * When the parent package is installed globally (`npm install -g get-shit-done-cc`)
+ * npm creates a `gsd-sdk` symlink in the global bin directory pointing at this
+ * file. npm correctly chmods bin entries from a tarball, so the execute-bit
+ * problem that afflicted the sub-install approach (issue #2453) cannot occur here.
+ *
+ * NOTE (#2775): `npx get-shit-done-cc` does NOT link this shim — npx only
+ * exposes the package's primary bin (`get-shit-done-cc`). For npx-based usage,
+ * the installer (`bin/install.js#installSdkIfNeeded`) self-symlinks `gsd-sdk`
+ * into `~/.local/bin` when needed and verifies PATH callability before
+ * reporting `✓ GSD SDK ready`.
  *
  * This shim resolves sdk/dist/cli.js relative to its own location and delegates
  * to it via `node`, so `gsd-sdk <args>` behaves identically to

--- a/bin/install.js
+++ b/bin/install.js
@@ -7518,8 +7518,19 @@ function trySelfLinkGsdSdk(shimSrc) {
       try {
         fs.symlinkSync(shimSrc, target);
       } catch {
-        // Filesystems that don't support symlinks (some FUSE mounts): copy.
-        fs.copyFileSync(shimSrc, target);
+        // Filesystems that don't support symlinks (some FUSE mounts): write a
+        // tiny wrapper that `require()`s the real shim by absolute path. We
+        // cannot copyFileSync(shimSrc, target) — bin/gsd-sdk.js resolves the
+        // CLI via `path.resolve(__dirname, '..', 'sdk', 'dist', 'cli.js')`,
+        // and after a copy `__dirname` would be the link directory (e.g.
+        // ~/.local/bin), causing the resolved CLI path to be broken
+        // (~/.local/sdk/dist/cli.js). Wrapping via require() preserves
+        // __dirname resolution because the require runs against shimSrc's
+        // own location. (#2775 CodeRabbit follow-up)
+        fs.writeFileSync(
+          target,
+          `#!/usr/bin/env node\nrequire(${JSON.stringify(shimSrc)});\n`,
+        );
         try { fs.chmodSync(target, 0o755); } catch {}
       }
       return target;

--- a/bin/install.js
+++ b/bin/install.js
@@ -7395,14 +7395,49 @@ function installSdkIfNeeded(opts) {
     // `node sdkCliPath` invocation in bin/gsd-sdk.js.
   }
 
-  console.log(`  ${green}✓${reset} GSD SDK ready (sdk/dist/cli.js)`);
+  // #2775: do not assert "GSD SDK ready" until `gsd-sdk` actually resolves on
+  // PATH. `npx get-shit-done-cc` only links the package's primary bin; the
+  // secondary `gsd-sdk` shim is left dangling under the npx cache and is NOT
+  // callable as a bare command. The previous file-presence-only check was a
+  // strictly weaker invariant than the one workflows depend on
+  // (`command -v gsd-sdk` resolving), and led to a false ✓ in npx-cache
+  // installs (issue #2775).
+  const shimSrc = path.resolve(__dirname, 'gsd-sdk.js');
+  let onPath = isGsdSdkOnPath();
+
+  if (!onPath) {
+    // Try to materialize the shim into a user-writable PATH location so the
+    // installer can deliver on the success message without requiring the user
+    // to run `npm install -g` separately. Picks the first PATH entry that
+    // looks like a user-owned bin dir; falls back to ~/.local/bin even if
+    // it's not on PATH (then a follow-up suggestion is printed).
+    const linked = trySelfLinkGsdSdk(shimSrc);
+    if (linked) {
+      onPath = isGsdSdkOnPath();
+      if (onPath) {
+        console.log(`  ${dim}↪ linked gsd-sdk → ${linked}${reset}`);
+      }
+    }
+  }
+
+  if (onPath) {
+    console.log(`  ${green}✓${reset} GSD SDK ready (sdk/dist/cli.js)`);
+  } else {
+    console.log('');
+    console.log(`  ${yellow}⚠${reset} GSD SDK files are present but ${bold}gsd-sdk${reset} is not on your PATH.`);
+    console.log(`    Workflows that call ${cyan}gsd-sdk query …${reset} will fail with "command not found".`);
+    console.log(`    Install globally to materialize the bin symlink:`);
+    console.log(`      ${cyan}npm install -g get-shit-done-cc${reset}`);
+    console.log(`    Or add a directory containing the shim to your PATH manually.`);
+    console.log('');
+  }
 
   // #2620: warn if npm's global bin is not on PATH, suppressing the
   // absolute-path suggestion when the user's rc already covers it via
   // a HOME-relative entry (e.g. `export PATH="$HOME/.npm-global/bin:$PATH"`).
   try {
-    const { execSync } = require('child_process');
-    const npmPrefix = execSync('npm prefix -g', { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+    const cp = require('child_process');
+    const npmPrefix = cp.execSync('npm prefix -g', { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
     if (npmPrefix) {
       // On Windows npm prefix IS the bin dir; on POSIX it's `${prefix}/bin`.
       const globalBin = process.platform === 'win32' ? npmPrefix : path.join(npmPrefix, 'bin');
@@ -7411,6 +7446,88 @@ function installSdkIfNeeded(opts) {
   } catch {
     // npm not available / exec failed — silently skip the PATH advice.
   }
+}
+
+/**
+ * #2775 helper: check whether a callable `gsd-sdk` exists on the current PATH.
+ *
+ * Pure PATH walk (no spawn) — we look for a regular file or symlink named
+ * `gsd-sdk` (or `gsd-sdk.cmd`/`.exe` on Windows) in any directory on PATH and
+ * verify it carries the execute bit on POSIX. Avoids paying spawn cost and
+ * avoids the chicken-and-egg of needing to run the not-yet-installed binary.
+ */
+function isGsdSdkOnPath() {
+  const path = require('path');
+  const fs = require('fs');
+  const pathEnv = process.env.PATH || '';
+  const exts = process.platform === 'win32' ? ['.cmd', '.exe', '.bat', ''] : [''];
+  for (const seg of pathEnv.split(path.delimiter)) {
+    if (!seg) continue;
+    for (const ext of exts) {
+      const candidate = path.join(seg, `gsd-sdk${ext}`);
+      try {
+        const st = fs.statSync(candidate);
+        if (st.isFile()) {
+          if (process.platform === 'win32') return true;
+          if ((st.mode & 0o111) !== 0) return true;
+        }
+      } catch {
+        // missing / EACCES on dir — keep scanning.
+      }
+    }
+  }
+  return false;
+}
+
+/**
+ * #2775 helper: attempt to materialize the `gsd-sdk` shim at a user-writable
+ * PATH location. Returns the absolute path created on success, or null if no
+ * suitable location was usable.
+ *
+ * Strategy (POSIX): prefer ~/.local/bin (creating it if absent — many distros
+ * already have it on PATH via .profile). Fall back to the first PATH entry
+ * under HOME we can write to. Skip on Windows (npm install -g is the right
+ * primitive there; we don't try to fabricate a .cmd shim).
+ */
+function trySelfLinkGsdSdk(shimSrc) {
+  if (process.platform === 'win32') return null;
+  const path = require('path');
+  const fs = require('fs');
+  const home = os.homedir();
+  if (!home) return null;
+
+  const candidates = [];
+  const localBin = path.join(home, '.local', 'bin');
+  candidates.push(localBin);
+  const pathEnv = process.env.PATH || '';
+  for (const seg of pathEnv.split(path.delimiter)) {
+    if (!seg) continue;
+    const abs = path.resolve(seg);
+    if (abs.startsWith(home + path.sep) && !candidates.includes(abs)) {
+      candidates.push(abs);
+    }
+  }
+
+  for (const dir of candidates) {
+    try {
+      fs.mkdirSync(dir, { recursive: true });
+      const target = path.join(dir, 'gsd-sdk');
+      // Replace any existing entry — it may be stale (prior install of an
+      // older version pointing at a now-absent shim).
+      try { fs.unlinkSync(target); } catch {}
+      try {
+        fs.symlinkSync(shimSrc, target);
+      } catch {
+        // Filesystems that don't support symlinks (some FUSE mounts): copy.
+        fs.copyFileSync(shimSrc, target);
+        try { fs.chmodSync(target, 0o755); } catch {}
+      }
+      return target;
+    } catch {
+      // permission / EROFS — try next candidate.
+    }
+  }
+  return null;
 }
 
 /**

--- a/bin/install.js
+++ b/bin/install.js
@@ -7496,17 +7496,23 @@ function trySelfLinkGsdSdk(shimSrc) {
   const home = os.homedir();
   if (!home) return null;
 
-  const candidates = [];
   const localBin = path.join(home, '.local', 'bin');
-  candidates.push(localBin);
+  const pathCandidates = [];
   const pathEnv = process.env.PATH || '';
   for (const seg of pathEnv.split(path.delimiter)) {
     if (!seg) continue;
     const abs = path.resolve(seg);
-    if (abs.startsWith(home + path.sep) && !candidates.includes(abs)) {
-      candidates.push(abs);
+    if (abs.startsWith(home + path.sep) && !pathCandidates.includes(abs)) {
+      pathCandidates.push(abs);
     }
   }
+  // If ~/.local/bin is already on PATH, keep it first (preserves existing UX
+  // for the common case). Otherwise prefer PATH-backed HOME dirs first so we
+  // self-link somewhere actually on PATH, falling back to ~/.local/bin only
+  // when no on-PATH HOME dir is writable. (#2775 CodeRabbit follow-up)
+  const candidates = pathCandidates.includes(localBin)
+    ? [localBin, ...pathCandidates.filter((dir) => dir !== localBin)]
+    : [...pathCandidates, localBin];
 
   for (const dir of candidates) {
     try {

--- a/tests/bug-2775-sdk-shim-path-verify.test.cjs
+++ b/tests/bug-2775-sdk-shim-path-verify.test.cjs
@@ -29,14 +29,10 @@ const { describe, test, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
-const os = require('os');
 
 const installModule = require('../bin/install.js');
 const { installSdkIfNeeded } = installModule;
-
-function makeTempDir(prefix) {
-  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
-}
+const { createTempDir, cleanup } = require('./helpers.cjs');
 
 function captureConsole(fn) {
   const stdout = [];
@@ -74,7 +70,7 @@ describe('bug #2775: installSdkIfNeeded must verify gsd-sdk on PATH before repor
   let savedEnv;
 
   beforeEach(() => {
-    tmpRoot = makeTempDir('gsd-2775-');
+    tmpRoot = createTempDir('gsd-2775-');
     sdkDir = path.join(tmpRoot, 'sdk');
     fs.mkdirSync(path.join(sdkDir, 'dist'), { recursive: true });
     fs.writeFileSync(
@@ -96,7 +92,7 @@ describe('bug #2775: installSdkIfNeeded must verify gsd-sdk on PATH before repor
     process.env.PATH = savedEnv.PATH;
     if (savedEnv.HOME == null) delete process.env.HOME;
     else process.env.HOME = savedEnv.HOME;
-    try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch {}
+    cleanup(tmpRoot);
   });
 
   test('does NOT print "GSD SDK ready" when gsd-sdk is not callable on PATH and cannot be linked', () => {

--- a/tests/bug-2775-sdk-shim-path-verify.test.cjs
+++ b/tests/bug-2775-sdk-shim-path-verify.test.cjs
@@ -89,7 +89,8 @@ describe('bug #2775: installSdkIfNeeded must verify gsd-sdk on PATH before repor
   });
 
   afterEach(() => {
-    process.env.PATH = savedEnv.PATH;
+    if (savedEnv.PATH == null) delete process.env.PATH;
+    else process.env.PATH = savedEnv.PATH;
     if (savedEnv.HOME == null) delete process.env.HOME;
     else process.env.HOME = savedEnv.HOME;
     cleanup(tmpRoot);
@@ -134,6 +135,66 @@ describe('bug #2775: installSdkIfNeeded must verify gsd-sdk on PATH before repor
     // And the link must actually exist + resolve back to the shim.
     const linkPath = path.join(localBin, 'gsd-sdk');
     assert.ok(fs.existsSync(linkPath), `installer must materialize ${linkPath}`);
+  });
+
+  test('symlink-fallback writes a wrapper that require()s the real shim by absolute path (preserves __dirname)', () => {
+    // Simulate a symlink-hostile filesystem by forcing fs.symlinkSync to throw.
+    // The fallback must NOT copy bin/gsd-sdk.js into ~/.local/bin (which would
+    // break the shim's `path.resolve(__dirname, '..', 'sdk', 'dist', 'cli.js')`
+    // resolution). Instead it must write a tiny wrapper script that
+    // require()s the real shim by absolute path so __dirname stays correct.
+    const localBin = path.join(homeDir, '.local', 'bin');
+    fs.mkdirSync(localBin, { recursive: true });
+    process.env.PATH = `${localBin}${path.delimiter}${pathDir}`;
+
+    const realShimSrc = path.resolve(__dirname, '..', 'bin', 'gsd-sdk.js');
+    const origSymlink = fs.symlinkSync;
+    fs.symlinkSync = () => {
+      const err = new Error('EPERM: simulated symlink-hostile filesystem');
+      err.code = 'EPERM';
+      throw err;
+    };
+    try {
+      captureConsole(() => {
+        installSdkIfNeeded({ sdkDir });
+      });
+    } finally {
+      fs.symlinkSync = origSymlink;
+    }
+
+    const target = path.join(localBin, 'gsd-sdk');
+    assert.ok(fs.existsSync(target), `fallback must materialize ${target}`);
+    // Critical: it must NOT be a verbatim copy of bin/gsd-sdk.js.
+    const targetContent = fs.readFileSync(target, 'utf8');
+    const realShimContent = fs.readFileSync(realShimSrc, 'utf8');
+    assert.notStrictEqual(
+      targetContent,
+      realShimContent,
+      'fallback must not copyFileSync bin/gsd-sdk.js — that breaks __dirname-based CLI resolution',
+    );
+    // It must be a wrapper that require()s the real shim by absolute path.
+    assert.ok(
+      targetContent.includes('require(') && targetContent.includes(realShimSrc),
+      `fallback wrapper must require() the real shim by absolute path. Got:\n${targetContent}`,
+    );
+    // And it must be executable.
+    const st = fs.statSync(target);
+    assert.ok(
+      (st.mode & 0o111) !== 0,
+      `fallback wrapper must have execute bit set (mode=${st.mode.toString(8)})`,
+    );
+    // Behavioral check: require()ing the wrapper from a fresh Node child must
+    // resolve the CLI correctly (i.e. __dirname inside the real shim points
+    // at <pkg>/bin, not at ~/.local/bin). We don't actually want to spawn the
+    // CLI (the test sdk dir has only a stub), so we override the spawnSync
+    // module path via an env probe: assert that the wrapper, when read by
+    // Node, references the real shim location whose sibling is sdk/dist.
+    const realShimDir = path.dirname(realShimSrc);
+    const expectedCliDir = path.resolve(realShimDir, '..', 'sdk', 'dist');
+    assert.ok(
+      fs.existsSync(expectedCliDir) || fs.existsSync(path.dirname(expectedCliDir)),
+      `real shim's resolved CLI dir must exist relative to the package, not the link dir. Expected near: ${expectedCliDir}`,
+    );
   });
 
   test('DOES print "GSD SDK ready" when gsd-sdk is already resolvable on PATH', () => {

--- a/tests/bug-2775-sdk-shim-path-verify.test.cjs
+++ b/tests/bug-2775-sdk-shim-path-verify.test.cjs
@@ -1,0 +1,155 @@
+/**
+ * Regression test for bug #2775
+ *
+ * `npx get-shit-done-cc@latest --global` runs the installer, which prints
+ * `✓ GSD SDK ready` even though the secondary `gsd-sdk` bin is not on the
+ * user's PATH. Root cause: `npx` only links the package's primary bin into
+ * the ephemeral cache; secondary bins are not symlinked. The installer's
+ * `installSdkIfNeeded` only verified that `sdk/dist/cli.js` exists on disk
+ * — a strictly weaker invariant than `command -v gsd-sdk` resolving.
+ *
+ * The fix tightens the success gate: after confirming the dist is present,
+ * the installer must verify `gsd-sdk` resolves on PATH. If it does not, the
+ * installer attempts to materialize the shim into a user-writable PATH
+ * location (`~/.local/bin/gsd-sdk`) and re-checks. Only when the PATH probe
+ * succeeds does it print `✓ GSD SDK ready`. Otherwise it emits a clear
+ * warning + remediation and does NOT lie about readiness.
+ *
+ * This test exercises `installSdkIfNeeded` against a synthetic npx-cache
+ * shape: sdk/dist/cli.js present, but PATH does not contain any directory
+ * with a `gsd-sdk` shim. The legacy code printed the success line in this
+ * shape; the fixed code must not.
+ */
+
+'use strict';
+
+process.env.GSD_TEST_MODE = '1';
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const installModule = require('../bin/install.js');
+const { installSdkIfNeeded } = installModule;
+
+function makeTempDir(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function captureConsole(fn) {
+  const stdout = [];
+  const stderr = [];
+  const origLog = console.log;
+  const origWarn = console.warn;
+  const origError = console.error;
+  console.log = (...a) => stdout.push(a.join(' '));
+  console.warn = (...a) => stderr.push(a.join(' '));
+  console.error = (...a) => stderr.push(a.join(' '));
+  let threw = null;
+  try {
+    fn();
+  } catch (e) {
+    threw = e;
+  } finally {
+    console.log = origLog;
+    console.warn = origWarn;
+    console.error = origError;
+  }
+  // strip ANSI for matching
+  const strip = (s) => s.replace(/\x1b\[[0-9;]*m/g, '');
+  return {
+    stdout: stdout.map(strip).join('\n'),
+    stderr: stderr.map(strip).join('\n'),
+    threw,
+  };
+}
+
+describe('bug #2775: installSdkIfNeeded must verify gsd-sdk on PATH before reporting ready', () => {
+  let tmpRoot;
+  let sdkDir;
+  let pathDir;
+  let homeDir;
+  let savedEnv;
+
+  beforeEach(() => {
+    tmpRoot = makeTempDir('gsd-2775-');
+    sdkDir = path.join(tmpRoot, 'sdk');
+    fs.mkdirSync(path.join(sdkDir, 'dist'), { recursive: true });
+    fs.writeFileSync(
+      path.join(sdkDir, 'dist', 'cli.js'),
+      '#!/usr/bin/env node\nconsole.log("0.0.0-test");\n',
+      { mode: 0o755 },
+    );
+    pathDir = path.join(tmpRoot, 'somebin');
+    fs.mkdirSync(pathDir, { recursive: true });
+    homeDir = path.join(tmpRoot, 'home');
+    fs.mkdirSync(homeDir, { recursive: true });
+    savedEnv = { PATH: process.env.PATH, HOME: process.env.HOME };
+    // PATH does NOT contain anything with a gsd-sdk shim — simulates npx-cache.
+    process.env.PATH = pathDir;
+    process.env.HOME = homeDir;
+  });
+
+  afterEach(() => {
+    process.env.PATH = savedEnv.PATH;
+    if (savedEnv.HOME == null) delete process.env.HOME;
+    else process.env.HOME = savedEnv.HOME;
+    try { fs.rmSync(tmpRoot, { recursive: true, force: true }); } catch {}
+  });
+
+  test('does NOT print "GSD SDK ready" when gsd-sdk is not callable on PATH and cannot be linked', () => {
+    // Make ~/.local/bin not on PATH and not creatable-friendly: PATH stays
+    // as a single dir with no gsd-sdk. The installer may attempt to create
+    // ~/.local/bin/gsd-sdk, but that location isn't on PATH either, so the
+    // post-link probe should still fail and the success line must be withheld.
+    const { stdout, stderr } = captureConsole(() => {
+      installSdkIfNeeded({ sdkDir });
+    });
+    const combined = `${stdout}\n${stderr}`;
+    const hasReady = /GSD SDK ready/.test(combined);
+    const mentionsPath = /not on (your )?PATH|gsd-sdk.*PATH|PATH.*gsd-sdk/i.test(combined);
+    assert.ok(
+      !hasReady,
+      `installer must not print "GSD SDK ready" when gsd-sdk is not on PATH. Output:\n${combined}`,
+    );
+    assert.ok(
+      mentionsPath,
+      `installer must surface a PATH-related warning when gsd-sdk is not callable. Output:\n${combined}`,
+    );
+  });
+
+  test('DOES print "GSD SDK ready" after self-linking into a directory that IS on PATH', () => {
+    // Put ~/.local/bin on PATH; the installer should create the shim there
+    // and the post-link callability probe should succeed.
+    const localBin = path.join(homeDir, '.local', 'bin');
+    fs.mkdirSync(localBin, { recursive: true });
+    process.env.PATH = `${localBin}${path.delimiter}${pathDir}`;
+
+    const { stdout, stderr } = captureConsole(() => {
+      installSdkIfNeeded({ sdkDir });
+    });
+    const combined = `${stdout}\n${stderr}`;
+    assert.ok(
+      /GSD SDK ready/.test(combined),
+      `installer must print "GSD SDK ready" after self-linking to a dir on PATH. Output:\n${combined}`,
+    );
+    // And the link must actually exist + resolve back to the shim.
+    const linkPath = path.join(localBin, 'gsd-sdk');
+    assert.ok(fs.existsSync(linkPath), `installer must materialize ${linkPath}`);
+  });
+
+  test('DOES print "GSD SDK ready" when gsd-sdk is already resolvable on PATH', () => {
+    // Pre-populate PATH with a `gsd-sdk` shim so the probe finds one.
+    const preexisting = path.join(pathDir, 'gsd-sdk');
+    fs.writeFileSync(preexisting, '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+    const { stdout } = captureConsole(() => {
+      installSdkIfNeeded({ sdkDir });
+    });
+    assert.ok(
+      /GSD SDK ready/.test(stdout),
+      `installer must print "GSD SDK ready" when gsd-sdk is already on PATH. Output:\n${stdout}`,
+    );
+  });
+});

--- a/tests/bug-2775-sdk-shim-path-verify.test.cjs
+++ b/tests/bug-2775-sdk-shim-path-verify.test.cjs
@@ -53,12 +53,16 @@ function captureConsole(fn) {
     console.warn = origWarn;
     console.error = origError;
   }
+  // Re-throw any captured exception AFTER restoring console so callers don't
+  // have to destructure-and-assert on `threw` (and a future regression that
+  // crashes before printing won't falsely pass `!hasReady`). (#2775
+  // CodeRabbit follow-up)
+  if (threw) throw threw;
   // strip ANSI for matching
   const strip = (s) => s.replace(/\x1b\[[0-9;]*m/g, '');
   return {
     stdout: stdout.map(strip).join('\n'),
     stderr: stderr.map(strip).join('\n'),
-    threw,
   };
 }
 
@@ -183,17 +187,34 @@ describe('bug #2775: installSdkIfNeeded must verify gsd-sdk on PATH before repor
       (st.mode & 0o111) !== 0,
       `fallback wrapper must have execute bit set (mode=${st.mode.toString(8)})`,
     );
-    // Behavioral check: require()ing the wrapper from a fresh Node child must
-    // resolve the CLI correctly (i.e. __dirname inside the real shim points
-    // at <pkg>/bin, not at ~/.local/bin). We don't actually want to spawn the
-    // CLI (the test sdk dir has only a stub), so we override the spawnSync
-    // module path via an env probe: assert that the wrapper, when read by
-    // Node, references the real shim location whose sibling is sdk/dist.
-    const realShimDir = path.dirname(realShimSrc);
-    const expectedCliDir = path.resolve(realShimDir, '..', 'sdk', 'dist');
+    // (Earlier assertions on targetContent already verify the wrapper points
+    // at the real shim by absolute path, which is what guarantees __dirname
+    // resolves correctly. A separate "does <pkg>/sdk/dist exist?" check would
+    // be tautological — that path is true regardless of what the wrapper
+    // wrote.) (#2775 CodeRabbit follow-up)
+  });
+
+  test('self-link prefers a PATH-backed HOME dir over ~/.local/bin when ~/.local/bin is off-PATH', () => {
+    // Regression for #2775 CodeRabbit follow-up: the candidate ordering must
+    // try PATH-backed HOME dirs FIRST, falling back to ~/.local/bin only when
+    // it's not on PATH. Otherwise we self-link to ~/.local/bin (off-PATH) and
+    // warn — when we could have linked to ~/bin (on-PATH) and printed success.
+    const homeBin = path.join(homeDir, 'bin');
+    fs.mkdirSync(homeBin, { recursive: true });
+    // PATH contains ~/bin (a HOME dir) but NOT ~/.local/bin.
+    process.env.PATH = `${homeBin}${path.delimiter}${pathDir}`;
+
+    const { stdout, stderr } = captureConsole(() => {
+      installSdkIfNeeded({ sdkDir });
+    });
+    const combined = `${stdout}\n${stderr}`;
     assert.ok(
-      fs.existsSync(expectedCliDir) || fs.existsSync(path.dirname(expectedCliDir)),
-      `real shim's resolved CLI dir must exist relative to the package, not the link dir. Expected near: ${expectedCliDir}`,
+      /GSD SDK ready/.test(combined),
+      `installer must self-link into the on-PATH HOME dir and print success. Output:\n${combined}`,
+    );
+    assert.ok(
+      fs.existsSync(path.join(homeBin, 'gsd-sdk')),
+      `installer must materialize the link in the on-PATH HOME dir (~/bin), not ~/.local/bin`,
     );
   });
 


### PR DESCRIPTION
Closes #2775

## Root cause

`npx get-shit-done-cc@latest` printed `✓ GSD SDK ready` even though `gsd-sdk` was not callable as a bare command. `npx` only links the package's primary bin (`get-shit-done-cc`); secondary bins (`gsd-sdk`) are not materialized into a PATH directory. The installer's `installSdkIfNeeded` only verified `sdk/dist/cli.js` existed on disk — strictly weaker than the invariant workflows depend on (`command -v gsd-sdk` resolving), so the success line was a false positive on every npx-cache install.

## Fix

Tightens the success gate in `installSdkIfNeeded` (`bin/install.js`):

1. After confirming the dist is present, walk PATH for an executable `gsd-sdk` shim (`isGsdSdkOnPath` — pure stat-walk, no spawn).
2. If absent, attempt to self-link the shim into `~/.local/bin/gsd-sdk` (or the first HOME-rooted PATH dir we can write to), falling back to a copy on filesystems that reject symlinks (`trySelfLinkGsdSdk`).
3. Re-probe PATH after linking. Only print `✓ GSD SDK ready` when the probe succeeds; otherwise emit a clear ⚠ with remediation (`npm install -g get-shit-done-cc`).
4. Strips the misleading "or `npx get-shit-done-cc`" clause from `bin/gsd-sdk.js` header — npx never linked the secondary bin.

### Why `~/.local/bin` (not npm's globalBin)

`~/.local/bin` is user-writable on every distro we ship to (no sudo) and is on PATH out-of-the-box on most. Writing to npm's globalBin under `npx` would EACCES on system Node installs (#2513). The chosen approach delivers a callable `gsd-sdk` for the `npx` path without inheriting the sudo failure modes; the fallback ⚠ message still points users at `npm install -g` when even `~/.local/bin` is not on PATH.

## Tests

`tests/bug-2775-sdk-shim-path-verify.test.cjs` (3 cases, all node:test + node:assert per repo convention):

- Negative: `gsd-sdk` not on PATH and no writable HOME bin dir on PATH → success line withheld, PATH warning surfaced.
- Self-link: `~/.local/bin` on PATH but empty → installer materializes the shim, post-link probe succeeds, ready line printed.
- Pre-existing: `gsd-sdk` already on PATH → ready line printed, no link attempted.

Verified `bug-2678` (--local guard), `bug-2649` (npx-cache fail-fast), `sdk-no-sdk-guard`, and `bug-2441-sdk-decouple` still pass — 24/24 SDK-related tests green.

## Knock-on findings

- No downstream consumer parses the `✓ GSD SDK ready` literal (grep across `*.js`, `*.cjs`, `*.md` returns only the producer + new test). Wording change is safe.
- `gsd-sdk.js` shim header had encoded the same wrong assumption ("or `npx`") — corrected so future readers don't propagate it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Installer now verifies the CLI is actually callable via PATH, reports accurate success or failure, and will attempt to place a runnable shim in a user-local bin when missing.

* **Tests**
  * Added regression tests covering PATH detection, shim self-install behavior, fallback directory preference, error paths, and readiness messaging.

* **Documentation**
  * Clarified header/usage notes about npx and shim availability and added remediation guidance when the CLI is not found.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->