### PR TITLE
fix(#2774): inclusion-based worktree cleanup to protect workspace .git

### DIFF
--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -636,8 +636,14 @@ increases monotonically across waves. `{status}` is `complete` (success),
    When executor agents ran in worktree isolation, their commits land on temporary branches in separate working trees. After the wave completes, merge these changes back and clean up:
 
    ```bash
-   # List worktrees created by this wave's agents
-   WORKTREES=$(git worktree list --porcelain | grep "^worktree " | grep -v "$(pwd)$" | sed 's/^worktree //')
+   # List worktrees created by this wave's agents.
+   # Inclusion-based filter (#2774): match ONLY agent-spawned worktrees under
+   # `.claude/worktrees/agent-` (the namespace Claude Code's `isolation="worktree"`
+   # uses). The previous exclusion filter (`grep -v "$(pwd)$"`) destroyed the parent
+   # workspace's `.git` whenever the workspace itself was a worktree (multi-workspace
+   # setups, and the cross-drive Windows case where `git worktree list` reports the
+   # registry path on a different drive than `$(pwd)`).
+   WORKTREES=$(git worktree list --porcelain | grep "^worktree " | grep "\.claude/worktrees/agent-" | sed 's/^worktree //')
 
    for WT in $WORKTREES; do
      # Get the branch name for this worktree

--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -643,9 +643,9 @@ increases monotonically across waves. `{status}` is `complete` (success),
    # workspace's `.git` whenever the workspace itself was a worktree (multi-workspace
    # setups, and the cross-drive Windows case where `git worktree list` reports the
    # registry path on a different drive than `$(pwd)`).
-   WORKTREES=$(git worktree list --porcelain | grep "^worktree " | grep "\.claude/worktrees/agent-" | sed 's/^worktree //')
-
-   for WT in $WORKTREES; do
+   # Read line-by-line so worktree paths containing whitespace are preserved (#2774).
+   while IFS= read -r WT; do
+     [ -z "$WT" ] && continue
      # Get the branch name for this worktree
      WT_BRANCH=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null)
      if [ -n "$WT_BRANCH" ] && [ "$WT_BRANCH" != "HEAD" ]; then
@@ -760,7 +760,7 @@ increases monotonically across waves. `{status}` is `complete` (success),
        # Delete the temporary branch
        git branch -D "$WT_BRANCH" 2>/dev/null || true
      fi
-   done
+   done < <(git worktree list --porcelain | grep "^worktree " | grep "\.claude/worktrees/agent-" | sed 's/^worktree //')
    ```
 
    **If `workflow.use_worktrees` is `false`:** Agents ran on the main working tree — skip this step entirely.

--- a/get-shit-done/workflows/quick.md
+++ b/get-shit-done/workflows/quick.md
@@ -647,8 +647,14 @@ ${AGENT_SKILLS_EXECUTOR}
 After executor returns:
 1. **Worktree cleanup:** If the executor ran with `isolation="worktree"`, merge the worktree branch back and clean up:
    ```bash
-   # Find worktrees created by the executor
-   WORKTREES=$(git worktree list --porcelain | grep "^worktree " | grep -v "$(pwd)$" | sed 's/^worktree //')
+   # Find worktrees created by the executor.
+   # Inclusion-based filter (#2774): match ONLY agent-spawned worktrees under
+   # `.claude/worktrees/agent-` (the namespace Claude Code's `isolation="worktree"`
+   # uses). The previous exclusion filter (`grep -v "$(pwd)$"`) destroyed the parent
+   # workspace's `.git` whenever the workspace itself was a worktree (multi-workspace
+   # setups, and the cross-drive Windows case where `git worktree list` reports the
+   # registry path on a different drive than `$(pwd)`).
+   WORKTREES=$(git worktree list --porcelain | grep "^worktree " | grep "\.claude/worktrees/agent-" | sed 's/^worktree //')
    for WT in $WORKTREES; do
      WT_BRANCH=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null)
      if [ -n "$WT_BRANCH" ] && [ "$WT_BRANCH" != "HEAD" ]; then

--- a/get-shit-done/workflows/quick.md
+++ b/get-shit-done/workflows/quick.md
@@ -654,8 +654,9 @@ After executor returns:
    # workspace's `.git` whenever the workspace itself was a worktree (multi-workspace
    # setups, and the cross-drive Windows case where `git worktree list` reports the
    # registry path on a different drive than `$(pwd)`).
-   WORKTREES=$(git worktree list --porcelain | grep "^worktree " | grep "\.claude/worktrees/agent-" | sed 's/^worktree //')
-   for WT in $WORKTREES; do
+   # Read line-by-line so worktree paths containing whitespace are preserved (#2774).
+   while IFS= read -r WT; do
+     [ -z "$WT" ] && continue
      WT_BRANCH=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null)
      if [ -n "$WT_BRANCH" ] && [ "$WT_BRANCH" != "HEAD" ]; then
        # --- Orchestrator file protection (#1756) ---
@@ -731,7 +732,7 @@ After executor returns:
        fi
        git branch -D "$WT_BRANCH" 2>/dev/null || true
      fi
-   done
+   done < <(git worktree list --porcelain | grep "^worktree " | grep "\.claude/worktrees/agent-" | sed 's/^worktree //')
    ```
    If `workflow.use_worktrees` is `false`, skip this step.
 2. Verify summary exists at `${QUICK_DIR}/${quick_id}-SUMMARY.md`

--- a/tests/bug-2774-worktree-cleanup-workspace-safety.test.cjs
+++ b/tests/bug-2774-worktree-cleanup-workspace-safety.test.cjs
@@ -24,106 +24,249 @@
 
 'use strict';
 
-const { describe, test } = require('node:test');
+const { describe, test, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert/strict');
+const { execSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const os = require('os');
 
-const QUICK_PATH = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'quick.md');
-const EXECUTE_PHASE_PATH = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'execute-phase.md');
+const { cleanup } = require('./helpers.cjs');
 
-/**
- * Extract the WORKTREES=... discovery line from a workflow file.
- * Returns the first matching line of shell that assigns the WORKTREES variable
- * via `git worktree list`.
- */
-function extractWorktreeDiscoveryLine(content) {
-  const lines = content.split('\n');
-  for (const line of lines) {
-    if (line.includes('WORKTREES=') && line.includes('git worktree list')) {
-      return line;
-    }
-  }
-  return null;
+// The exact discovery pipeline from get-shit-done/workflows/quick.md and
+// get-shit-done/workflows/execute-phase.md (line: `WORKTREES=$(git worktree
+// list --porcelain | grep "^worktree " | grep "\.claude/worktrees/agent-" |
+// sed 's/^worktree //')`). We invoke it as a standalone shell pipeline
+// against either real `git worktree list --porcelain` output (in the
+// end-to-end case) or piped-in fixture text (in the unit case).
+// Note: execSync runs with `shell: '/bin/sh'` by default, which interprets the
+// command string directly — no extra `bash -c '...'` wrapper needed. The
+// pipeline string below is the verbatim shell from quick.md / execute-phase.md
+// (the RHS of the `WORKTREES=$(...)` substitution).
+const DISCOVERY_PIPELINE =
+  'grep "^worktree " | grep "\\.claude/worktrees/agent-" | sed \'s/^worktree //\'';
+
+function runDiscoveryAgainstFixture(porcelain) {
+  const out = execSync(DISCOVERY_PIPELINE, {
+    input: porcelain,
+    encoding: 'utf-8',
+  });
+  return out.split('\n').filter((l) => l.length > 0);
 }
 
-describe('bug #2774 — worktree cleanup must not target the parent workspace', () => {
-  test('quick.md uses inclusion-based agent worktree filter', () => {
-    const content = fs.readFileSync(QUICK_PATH, 'utf8');
-    const line = extractWorktreeDiscoveryLine(content);
+function runDiscoveryAgainstRepo(repoCwd) {
+  const out = execSync(
+    `git worktree list --porcelain | ${DISCOVERY_PIPELINE}`,
+    { cwd: repoCwd, encoding: 'utf-8' }
+  );
+  return out.split('\n').filter((l) => l.length > 0);
+}
 
-    assert.ok(line, 'quick.md must contain a WORKTREES discovery line backed by git worktree list');
+function makeBareTempGitRepo(prefix) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  execSync('git init -b main', { cwd: tmpDir, stdio: 'pipe' });
+  execSync('git config user.email "test@test.com"', { cwd: tmpDir, stdio: 'pipe' });
+  execSync('git config user.name "Test"', { cwd: tmpDir, stdio: 'pipe' });
+  execSync('git config commit.gpgsign false', { cwd: tmpDir, stdio: 'pipe' });
+  fs.writeFileSync(path.join(tmpDir, 'README.md'), '# upstream\n');
+  execSync('git add -A', { cwd: tmpDir, stdio: 'pipe' });
+  execSync('git commit -m "initial"', { cwd: tmpDir, stdio: 'pipe' });
+  return tmpDir;
+}
 
-    assert.ok(
-      line.includes('.claude/worktrees/agent-'),
-      `quick.md WORKTREES discovery must include only agent-spawned worktrees ` +
-        `(matching '.claude/worktrees/agent-' prefix), got: ${line}`
-    );
+describe('bug #2774 — worktree cleanup pipeline must not target the parent workspace', () => {
+  describe('discovery pipeline (unit)', () => {
+    test('selects only the agent worktree when workspace itself is a worktree', () => {
+      // Fixture mirrors the multi-workspace setup: upstream main + sibling
+      // workspace worktree + agent worktree under workspace's
+      // `.claude/worktrees/agent-` namespace.
+      const porcelain = [
+        'worktree /Users/dev/upstream/get-shit-done',
+        'HEAD abc123',
+        'branch refs/heads/main',
+        '',
+        'worktree /Users/dev/workspaces/feature-x',
+        'HEAD def456',
+        'branch refs/heads/workspace/feature-x',
+        '',
+        'worktree /Users/dev/workspaces/feature-x/.claude/worktrees/agent-deadbeef',
+        'HEAD 789abc',
+        'branch refs/heads/worktree-agent-deadbeef',
+        '',
+      ].join('\n');
 
-    assert.ok(
-      !/grep\s+-v\s+["']?\$\(pwd\)\$/.test(line),
-      `quick.md WORKTREES discovery must not rely on 'grep -v "$(pwd)$"' as the ` +
-        `sole guard — that exclusion fails when the workspace itself is a worktree, ` +
-        `got: ${line}`
-    );
+      const discovered = runDiscoveryAgainstFixture(porcelain);
+
+      assert.deepEqual(
+        discovered,
+        ['/Users/dev/workspaces/feature-x/.claude/worktrees/agent-deadbeef'],
+        'pipeline must select only the agent-spawned worktree, never the ' +
+          'workspace or upstream main repo'
+      );
+    });
+
+    test('selects nothing when no agent worktrees exist', () => {
+      const porcelain = [
+        'worktree /Users/dev/upstream/get-shit-done',
+        'HEAD abc123',
+        'branch refs/heads/main',
+        '',
+        'worktree /Users/dev/workspaces/feature-x',
+        'HEAD def456',
+        'branch refs/heads/workspace/feature-x',
+        '',
+      ].join('\n');
+
+      const discovered = runDiscoveryAgainstFixture(porcelain);
+
+      assert.deepEqual(discovered, []);
+    });
+
+    test('selects multiple agent worktrees and excludes non-agent paths', () => {
+      const porcelain = [
+        'worktree /repo/main',
+        'HEAD a',
+        'branch refs/heads/main',
+        '',
+        'worktree /repo/main/.claude/worktrees/agent-aaa',
+        'HEAD b',
+        'branch refs/heads/agent-aaa',
+        '',
+        'worktree /repo/main/.claude/worktrees/agent-bbb',
+        'HEAD c',
+        'branch refs/heads/agent-bbb',
+        '',
+        'worktree /repo/main/some-other-dir',
+        'HEAD d',
+        'branch refs/heads/feature',
+        '',
+      ].join('\n');
+
+      const discovered = runDiscoveryAgainstFixture(porcelain);
+
+      assert.deepEqual(discovered.sort(), [
+        '/repo/main/.claude/worktrees/agent-aaa',
+        '/repo/main/.claude/worktrees/agent-bbb',
+      ]);
+    });
   });
 
-  test('execute-phase.md uses inclusion-based agent worktree filter', () => {
-    const content = fs.readFileSync(EXECUTE_PHASE_PATH, 'utf8');
-    const line = extractWorktreeDiscoveryLine(content);
+  describe('end-to-end against real git worktrees', () => {
+    let upstream;
+    let workspace;
+    let agentWorktree;
+    let workspacesParent;
 
-    assert.ok(line, 'execute-phase.md must contain a WORKTREES discovery line backed by git worktree list');
+    beforeEach(() => {
+      // Build the multi-worktree scenario from #2774:
+      //   upstream/         <- main repo
+      //   workspace/        <- worktree of upstream (the "workspace")
+      //   workspace/.claude/worktrees/agent-XXXX/  <- agent worktree
+      upstream = makeBareTempGitRepo('gsd-2774-upstream-');
 
-    assert.ok(
-      line.includes('.claude/worktrees/agent-'),
-      `execute-phase.md WORKTREES discovery must include only agent-spawned worktrees ` +
-        `(matching '.claude/worktrees/agent-' prefix), got: ${line}`
-    );
+      workspacesParent = fs.mkdtempSync(
+        path.join(os.tmpdir(), 'gsd-2774-workspaces-')
+      );
+      workspace = path.join(workspacesParent, 'feature-x');
+      execSync(`git worktree add -b workspace/feature-x "${workspace}"`, {
+        cwd: upstream,
+        stdio: 'pipe',
+      });
 
-    assert.ok(
-      !/grep\s+-v\s+["']?\$\(pwd\)\$/.test(line),
-      `execute-phase.md WORKTREES discovery must not rely on 'grep -v "$(pwd)$"' as ` +
-        `the sole guard — that exclusion fails when the workspace itself is a worktree, ` +
-        `got: ${line}`
-    );
-  });
+      const agentDir = path.join(workspace, '.claude', 'worktrees');
+      fs.mkdirSync(agentDir, { recursive: true });
+      agentWorktree = path.join(agentDir, 'agent-deadbeef');
+      execSync(
+        `git worktree add -b worktree-agent-deadbeef "${agentWorktree}"`,
+        { cwd: upstream, stdio: 'pipe' }
+      );
+    });
 
-  test('end-to-end: simulated git worktree list output yields only agent worktrees', () => {
-    // Simulate `git worktree list --porcelain` output where the *current* worktree
-    // is itself a workspace (a worktree of a main repo at a DIFFERENT path), and
-    // an agent worktree exists alongside it.
-    //
-    // Exclusion-based filter ("grep -v '$(pwd)$'") would keep BOTH the upstream main
-    // repo path AND the agent worktree, deleting the upstream main on cleanup.
-    // Inclusion-based filter must keep ONLY the agent worktree.
-    const porcelain = [
-      'worktree /Users/dev/upstream/get-shit-done',
-      'HEAD abc123',
-      'branch refs/heads/main',
-      '',
-      'worktree /Users/dev/workspaces/feature-x',
-      'HEAD def456',
-      'branch refs/heads/workspace/feature-x',
-      '',
-      'worktree /Users/dev/workspaces/feature-x/.claude/worktrees/agent-deadbeef',
-      'HEAD 789abc',
-      'branch refs/heads/worktree-agent-deadbeef',
-      '',
-    ].join('\n');
+    afterEach(() => {
+      try {
+        execSync('git worktree prune', { cwd: upstream, stdio: 'pipe' });
+      } catch (_) {
+        /* ignore */
+      }
+      cleanup(upstream);
+      cleanup(workspacesParent);
+    });
 
-    // The discovery filter, applied as text:
-    //   grep "^worktree " | grep ".claude/worktrees/agent-" | sed 's/^worktree //'
-    const discovered = porcelain
-      .split('\n')
-      .filter((l) => l.startsWith('worktree '))
-      .filter((l) => l.includes('.claude/worktrees/agent-'))
-      .map((l) => l.replace(/^worktree /, ''));
+    test('discovery from inside workspace returns only the agent worktree', () => {
+      const discovered = runDiscoveryAgainstRepo(workspace);
 
-    assert.deepEqual(
-      discovered,
-      ['/Users/dev/workspaces/feature-x/.claude/worktrees/agent-deadbeef'],
-      'inclusion-based filter must select only the agent-spawned worktree, ' +
-        'never the workspace or upstream main repo'
-    );
+      // Resolve symlinks (macOS /var → /private/var) for stable comparison.
+      const expected = fs.realpathSync(agentWorktree);
+      const actual = discovered.map((p) => fs.realpathSync(p));
+
+      assert.deepEqual(
+        actual,
+        [expected],
+        'pipeline must list only the agent worktree, not the workspace or upstream'
+      );
+    });
+
+    test('running cleanup loop on discovered paths preserves workspace .git', () => {
+      const workspaceGitBefore = fs.readFileSync(
+        path.join(workspace, '.git'),
+        'utf-8'
+      );
+      assert.ok(
+        fs.existsSync(path.join(upstream, '.git')),
+        'precondition: upstream .git must exist'
+      );
+
+      const discovered = runDiscoveryAgainstRepo(workspace);
+      assert.equal(
+        discovered.length,
+        1,
+        'precondition: exactly one agent worktree should be discovered'
+      );
+
+      // Execute the cleanup behavior end-to-end: `git worktree remove --force`
+      // each discovered path. This mirrors the workflow's cleanup loop.
+      for (const wt of discovered) {
+        execSync(`git worktree remove --force "${wt}"`, {
+          cwd: workspace,
+          stdio: 'pipe',
+        });
+      }
+
+      // Agent worktree dir must be gone.
+      assert.equal(
+        fs.existsSync(agentWorktree),
+        false,
+        'agent worktree dir should be removed by cleanup'
+      );
+
+      // Workspace `.git` pointer file must still exist and be unchanged —
+      // the regression we are guarding against.
+      assert.ok(
+        fs.existsSync(path.join(workspace, '.git')),
+        'workspace .git pointer must survive cleanup (regression #2774)'
+      );
+      assert.equal(
+        fs.readFileSync(path.join(workspace, '.git'), 'utf-8'),
+        workspaceGitBefore,
+        'workspace .git pointer contents must be unchanged'
+      );
+
+      // Upstream repo's .git directory must also be intact.
+      assert.ok(
+        fs.existsSync(path.join(upstream, '.git')),
+        'upstream .git must survive cleanup'
+      );
+
+      // Workspace must still be a functional git worktree.
+      const branch = execSync('git rev-parse --abbrev-ref HEAD', {
+        cwd: workspace,
+        encoding: 'utf-8',
+      }).trim();
+      assert.equal(
+        branch,
+        'workspace/feature-x',
+        'workspace must still be a functional worktree on its branch'
+      );
+    });
   });
 });

--- a/tests/bug-2774-worktree-cleanup-workspace-safety.test.cjs
+++ b/tests/bug-2774-worktree-cleanup-workspace-safety.test.cjs
@@ -1,0 +1,129 @@
+/**
+ * Bug #2774 — Worktree cleanup destroys parent workspace .git
+ *
+ * The cleanup blocks in execute-phase.md and quick.md previously used an
+ * EXCLUSION-based filter:
+ *
+ *   git worktree list --porcelain | grep "^worktree " | grep -v "$(pwd)$" | sed ...
+ *
+ * That filter only excludes the literal `$(pwd)`. When a GSD project is itself
+ * a git worktree of an upstream main repo (the multi-workspace case, including
+ * the cross-drive Windows case where `git worktree list` reports the registry
+ * path as e.g. `E:/...` while `$(pwd)` resolves to `C:/...`), every other
+ * worktree — including the workspace itself — is wiped, taking the
+ * workspace's `.git` pointer file with it.
+ *
+ * The fix is INCLUSION-based: only target paths matching the agent worktree
+ * convention (`.claude/worktrees/agent-`), the namespace under which Claude
+ * Code's `isolation="worktree"` always creates executor worktrees.
+ *
+ * These tests assert the cleanup block in BOTH workflow files:
+ *   1. Includes only paths matching `.claude/worktrees/agent-` (positive filter)
+ *   2. Does NOT rely on `grep -v "$(pwd)$"` as the sole guard (negative filter)
+ */
+
+'use strict';
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const QUICK_PATH = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'quick.md');
+const EXECUTE_PHASE_PATH = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'execute-phase.md');
+
+/**
+ * Extract the WORKTREES=... discovery line from a workflow file.
+ * Returns the first matching line of shell that assigns the WORKTREES variable
+ * via `git worktree list`.
+ */
+function extractWorktreeDiscoveryLine(content) {
+  const lines = content.split('\n');
+  for (const line of lines) {
+    if (line.includes('WORKTREES=') && line.includes('git worktree list')) {
+      return line;
+    }
+  }
+  return null;
+}
+
+describe('bug #2774 — worktree cleanup must not target the parent workspace', () => {
+  test('quick.md uses inclusion-based agent worktree filter', () => {
+    const content = fs.readFileSync(QUICK_PATH, 'utf8');
+    const line = extractWorktreeDiscoveryLine(content);
+
+    assert.ok(line, 'quick.md must contain a WORKTREES discovery line backed by git worktree list');
+
+    assert.ok(
+      line.includes('.claude/worktrees/agent-'),
+      `quick.md WORKTREES discovery must include only agent-spawned worktrees ` +
+        `(matching '.claude/worktrees/agent-' prefix), got: ${line}`
+    );
+
+    assert.ok(
+      !/grep\s+-v\s+["']?\$\(pwd\)\$/.test(line),
+      `quick.md WORKTREES discovery must not rely on 'grep -v "$(pwd)$"' as the ` +
+        `sole guard — that exclusion fails when the workspace itself is a worktree, ` +
+        `got: ${line}`
+    );
+  });
+
+  test('execute-phase.md uses inclusion-based agent worktree filter', () => {
+    const content = fs.readFileSync(EXECUTE_PHASE_PATH, 'utf8');
+    const line = extractWorktreeDiscoveryLine(content);
+
+    assert.ok(line, 'execute-phase.md must contain a WORKTREES discovery line backed by git worktree list');
+
+    assert.ok(
+      line.includes('.claude/worktrees/agent-'),
+      `execute-phase.md WORKTREES discovery must include only agent-spawned worktrees ` +
+        `(matching '.claude/worktrees/agent-' prefix), got: ${line}`
+    );
+
+    assert.ok(
+      !/grep\s+-v\s+["']?\$\(pwd\)\$/.test(line),
+      `execute-phase.md WORKTREES discovery must not rely on 'grep -v "$(pwd)$"' as ` +
+        `the sole guard — that exclusion fails when the workspace itself is a worktree, ` +
+        `got: ${line}`
+    );
+  });
+
+  test('end-to-end: simulated git worktree list output yields only agent worktrees', () => {
+    // Simulate `git worktree list --porcelain` output where the *current* worktree
+    // is itself a workspace (a worktree of a main repo at a DIFFERENT path), and
+    // an agent worktree exists alongside it.
+    //
+    // Exclusion-based filter ("grep -v '$(pwd)$'") would keep BOTH the upstream main
+    // repo path AND the agent worktree, deleting the upstream main on cleanup.
+    // Inclusion-based filter must keep ONLY the agent worktree.
+    const porcelain = [
+      'worktree /Users/dev/upstream/get-shit-done',
+      'HEAD abc123',
+      'branch refs/heads/main',
+      '',
+      'worktree /Users/dev/workspaces/feature-x',
+      'HEAD def456',
+      'branch refs/heads/workspace/feature-x',
+      '',
+      'worktree /Users/dev/workspaces/feature-x/.claude/worktrees/agent-deadbeef',
+      'HEAD 789abc',
+      'branch refs/heads/worktree-agent-deadbeef',
+      '',
+    ].join('\n');
+
+    // The discovery filter, applied as text:
+    //   grep "^worktree " | grep ".claude/worktrees/agent-" | sed 's/^worktree //'
+    const discovered = porcelain
+      .split('\n')
+      .filter((l) => l.startsWith('worktree '))
+      .filter((l) => l.includes('.claude/worktrees/agent-'))
+      .map((l) => l.replace(/^worktree /, ''));
+
+    assert.deepEqual(
+      discovered,
+      ['/Users/dev/workspaces/feature-x/.claude/worktrees/agent-deadbeef'],
+      'inclusion-based filter must select only the agent-spawned worktree, ' +
+        'never the workspace or upstream main repo'
+    );
+  });
+});

--- a/tests/bug-2774-worktree-cleanup-workspace-safety.test.cjs
+++ b/tests/bug-2774-worktree-cleanup-workspace-safety.test.cjs
@@ -62,7 +62,7 @@ function runDiscoveryAgainstRepo(repoCwd) {
   return out.split('\n').filter((l) => l.length > 0);
 }
 
-function makeBareTempGitRepo(prefix) {
+function makeTempUpstreamRepo(prefix) {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
   execSync('git init -b main', { cwd: tmpDir, stdio: 'pipe' });
   execSync('git config user.email "test@test.com"', { cwd: tmpDir, stdio: 'pipe' });
@@ -149,6 +149,77 @@ describe('bug #2774 — worktree cleanup pipeline must not target the parent wor
         '/repo/main/.claude/worktrees/agent-bbb',
       ]);
     });
+
+    test('selects agent worktree even when path contains whitespace', () => {
+      // Regression for CodeRabbit feedback on PR #2778: `for WT in $WORKTREES`
+      // splits on whitespace and would emit broken half-paths like
+      // "/Users/dev/My" and "Workspace/.claude/worktrees/agent-xyz". The
+      // pipeline output itself is line-delimited and preserves the full path —
+      // the workflow's loop must consume it line-by-line via `while IFS= read`.
+      const porcelain = [
+        'worktree /Users/dev/My Workspace',
+        'HEAD def456',
+        'branch refs/heads/workspace/feature-x',
+        '',
+        'worktree /Users/dev/My Workspace/.claude/worktrees/agent-deadbeef',
+        'HEAD 789abc',
+        'branch refs/heads/worktree-agent-deadbeef',
+        '',
+      ].join('\n');
+
+      const discovered = runDiscoveryAgainstFixture(porcelain);
+
+      assert.deepEqual(
+        discovered,
+        ['/Users/dev/My Workspace/.claude/worktrees/agent-deadbeef'],
+        'pipeline output must preserve whitespace-bearing agent worktree path on a single line'
+      );
+    });
+
+    test('while/read loop iterates each whitespace-bearing path exactly once', () => {
+      // Verify the actual consumer pattern from quick.md / execute-phase.md:
+      //   while IFS= read -r WT; do ...; done < <(<pipeline>)
+      // Counts the lines yielded to the loop body. With the previous
+      // `for WT in $WORKTREES` form, a path containing one space would yield
+      // 2 iterations (broken halves). The `while/read` form yields exactly 1.
+      const porcelain = [
+        'worktree /tmp/has space/.claude/worktrees/agent-aaa',
+        'HEAD a',
+        'branch refs/heads/agent-aaa',
+        '',
+        'worktree /tmp/two  spaces/.claude/worktrees/agent-bbb',
+        'HEAD b',
+        'branch refs/heads/agent-bbb',
+        '',
+      ].join('\n');
+
+      // Mirror the workflow's loop verbatim. Print one line per iteration with
+      // a sentinel so we can count and inspect what the loop actually saw.
+      const script = `
+while IFS= read -r WT; do
+  [ -z "$WT" ] && continue
+  printf 'ITER:%s\\n' "$WT"
+done < <(${DISCOVERY_PIPELINE})
+`;
+      // bash needed for process substitution `< <(...)`.
+      const out = execSync(`bash -c '${script.replace(/'/g, `'\\''`)}'`, {
+        input: porcelain,
+        encoding: 'utf-8',
+      });
+      const iterations = out
+        .split('\n')
+        .filter((l) => l.startsWith('ITER:'))
+        .map((l) => l.slice('ITER:'.length));
+
+      assert.deepEqual(
+        iterations,
+        [
+          '/tmp/has space/.claude/worktrees/agent-aaa',
+          '/tmp/two  spaces/.claude/worktrees/agent-bbb',
+        ],
+        'while/read loop must yield exactly one iteration per worktree, with whitespace preserved'
+      );
+    });
   });
 
   describe('end-to-end against real git worktrees', () => {
@@ -162,7 +233,7 @@ describe('bug #2774 — worktree cleanup pipeline must not target the parent wor
       //   upstream/         <- main repo
       //   workspace/        <- worktree of upstream (the "workspace")
       //   workspace/.claude/worktrees/agent-XXXX/  <- agent worktree
-      upstream = makeBareTempGitRepo('gsd-2774-upstream-');
+      upstream = makeTempUpstreamRepo('gsd-2774-upstream-');
 
       workspacesParent = fs.mkdtempSync(
         path.join(os.tmpdir(), 'gsd-2774-workspaces-')


### PR DESCRIPTION
## TL;DR

Switches the worktree cleanup blocks in `quick.md` and `execute-phase.md` from an exclusion filter (`grep -v "$(pwd)$"`) to an inclusion filter matching only agent-spawned worktrees under `.claude/worktrees/agent-`. The exclusion approach destroyed the parent workspace's `.git` whenever the workspace was itself a worktree of an upstream repo (multi-workspace setups; cross-drive Windows case).

Closes #2774

## What

- `get-shit-done/workflows/quick.md:651` — replace `grep -v "$(pwd)$"` with `grep "\.claude/worktrees/agent-"`
- `get-shit-done/workflows/execute-phase.md:640` — same replacement
- Add `tests/bug-2774-worktree-cleanup-workspace-safety.test.cjs` (3 cases) — asserts the inclusion filter on both files and simulates porcelain output to prove the workspace is preserved.

## Why

The exclusion filter assumes `$(pwd)` matches the path that `git worktree list --porcelain` prints for the current worktree. That assumption holds when the workspace is the main repo; it fails when the workspace is itself a linked worktree of an upstream repo (the `gsd-new-workspace` worktree strategy, or any external worktree-based workflow). In that case the equality check never holds, every other worktree gets `git worktree remove --force`'d, and the workspace's `.git` pointer file is removed — wiping the workspace.

The cross-drive Windows variant (`E:/...` reported by the registry vs. `C:/...` from `$(pwd)`) is the original reproducer in the issue.

The inclusion filter cannot collide with any workspace path: Claude Code's `isolation="worktree"` always creates executor worktrees at `<repo>/.claude/worktrees/agent-<id>`, a namespace that workspaces and the main repo never use.

## How

Inclusion-based filter (single-line shell change in two files):

```diff
- WORKTREES=$(git worktree list --porcelain | grep "^worktree " | grep -v "$(pwd)$" | sed 's/^worktree //')
+ WORKTREES=$(git worktree list --porcelain | grep "^worktree " | grep "\.claude/worktrees/agent-" | sed 's/^worktree //')
```

Comments above each cleanup block explain the choice and reference #2774 so future readers do not regress to the exclusion approach.

## Knock-on check

- `grep -rn 'grep -v "\$(pwd)\$"'` — no remaining occurrences in the source tree (only in the new test's docstring/assertions).
- `grep -rn "git worktree list --porcelain"` — the only other production caller is `get-shit-done/bin/lib/core.cjs::pruneOrphanedWorktrees`, which has independent guards (skips index 0 / main; skips `process.cwd()`; only removes ancestor-merged branches). Not affected.
- `bin/install.js` and `bin/lib/` — no worktree-cleanup code that uses the broken filter.

## Test plan

- [x] New tests RED before the fix, GREEN after (3/3 pass).
- [x] Existing worktree test files all pass: `worktree-cleanup`, `worktree-safety`, `worktree-merge-protection`, `execute-phase-worktree-artifacts`, `bug-2075-worktree-deletion-safeguards` (34/34).
- [x] Full suite: `npm test` — 5677/5677 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Safer worktree cleanup: now only targets executor-created agent worktrees, avoiding accidental removal of parent workspace worktrees in multi-workspace or cross-drive setups.

* **Tests**
  * Added automated tests validating discovery/removal affect only agent worktrees, preserve workspace and upstream integrity, and handle paths with whitespace.

* **Documentation**
  * Updated workflow docs to explain the improved cleanup discovery behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->