### PR TITLE
fix(#2770): coerce non-string depends_on YAML values to preserve dependencies

### DIFF
--- a/get-shit-done/bin/lib/roadmap.cjs
+++ b/get-shit-done/bin/lib/roadmap.cjs
@@ -456,10 +456,11 @@ function cmdRoadmapAnnotateDependencies(cwd, phaseNum, raw) {
     for (const t of truths) {
       const text = coerceTruthToString(t);
       if (!text) continue;
-      const key = text.trim().toLowerCase();
+      const trimmed = text.trim();
+      const key = trimmed.toLowerCase();
       if (!key || seen.has(key)) continue;
       seen.add(key);
-      truthCounts.set(key, (truthCounts.get(key) || { count: 0, text: text.trim() }));
+      if (!truthCounts.has(key)) truthCounts.set(key, { count: 0, text: trimmed });
       truthCounts.get(key).count++;
     }
   }

--- a/get-shit-done/bin/lib/roadmap.cjs
+++ b/get-shit-done/bin/lib/roadmap.cjs
@@ -7,6 +7,35 @@ const path = require('path');
 const { escapeRegex, normalizePhaseName, planningPaths, withPlanningLock, output, error, findPhaseInternal, stripShippedMilestones, extractCurrentMilestone, replaceInCurrentMilestone, phaseTokenMatches, atomicWriteFileSync } = require('./core.cjs');
 
 /**
+ * Coerce an arbitrary YAML scalar/object into a string for cross-cutting
+ * truth aggregation. Handles:
+ *   - strings (passthrough)
+ *   - numbers / booleans (String() coercion — issue #2770: bare YAML ints
+ *     like `- 3` must be surfaced, not silently skipped)
+ *   - kv-shaped objects from parseMustHavesBlock continuation kv (issue
+ *     #2757) — extract the first meaningful string field
+ *
+ * Returns the empty string when no usable text can be derived; callers should
+ * skip empty results.
+ */
+function coerceTruthToString(t) {
+  if (t === null || t === undefined) return '';
+  if (typeof t === 'string') return t;
+  if (typeof t === 'number' || typeof t === 'boolean' || typeof t === 'bigint') {
+    return String(t);
+  }
+  if (typeof t === 'object') {
+    // Prefer common title-bearing keys produced by parseMustHavesBlock
+    for (const k of ['title', 'text', 'name', 'rule', 'path', 'provides']) {
+      const v = t[k];
+      if (typeof v === 'string' && v.trim()) return v;
+      if (typeof v === 'number' || typeof v === 'boolean') return String(v);
+    }
+  }
+  return '';
+}
+
+/**
  * Search for a phase header (and its section) within the given content string.
  * Returns a result object if found (either a full match or a malformed_roadmap
  * checklist-only match), or null if the phase is not present at all.
@@ -412,16 +441,25 @@ function cmdRoadmapAnnotateDependencies(cwd, phaseNum, raw) {
   }
   const waves = [...waveGroups.keys()].sort((a, b) => a - b);
 
-  // Find cross-cutting truths: appear in 2+ plans (de-duplicated, case-insensitive)
+  // Find cross-cutting truths: appear in 2+ plans (de-duplicated, case-insensitive).
+  //
+  // Issue #2770: must **coerce, not skip**. A previous guard
+  // `if (typeof t !== 'string') continue` silently dropped numeric scalars
+  // (YAML ints like `- 3`) and kv-shaped truths (`- title: X`), so the
+  // cross-cutting analysis lost real constraints rather than crashing on
+  // `t.trim()`. We coerce primitives via `String(t)` and extract a sensible
+  // string field from object-shaped items produced by parseMustHavesBlock's
+  // continuation-kv path (issue #2757 produces those shapes for nested keys).
   const truthCounts = new Map();
   for (const { truths } of planData) {
     const seen = new Set();
     for (const t of truths) {
-      if (typeof t !== 'string') continue;
-      const key = t.trim().toLowerCase();
+      const text = coerceTruthToString(t);
+      if (!text) continue;
+      const key = text.trim().toLowerCase();
       if (!key || seen.has(key)) continue;
       seen.add(key);
-      truthCounts.set(key, (truthCounts.get(key) || { count: 0, text: t.trim() }));
+      truthCounts.set(key, (truthCounts.get(key) || { count: 0, text: text.trim() }));
       truthCounts.get(key).count++;
     }
   }

--- a/tests/bug-2770-annotate-deps-int-coerce.test.cjs
+++ b/tests/bug-2770-annotate-deps-int-coerce.test.cjs
@@ -38,39 +38,43 @@ function makePlanProject(files = {}) {
   return dir;
 }
 
-const ROADMAP = `# Roadmap
-
-### Phase 1: Foundation
-**Goal:** Set up project
-**Plans:** 2 plans
-
-Plans:
-- [ ] 01-01-PLAN.md — Set up DB
-- [ ] 01-02-PLAN.md — Build API
-`;
+const ROADMAP = [
+  '# Roadmap',
+  '',
+  '### Phase 1: Foundation',
+  '**Goal:** Set up project',
+  '**Plans:** 2 plans',
+  '',
+  'Plans:',
+  '- [ ] 01-01-PLAN.md — Set up DB',
+  '- [ ] 01-02-PLAN.md — Build API',
+  '',
+].join('\n');
 
 // PLAN where must_haves.truths includes a bare numeric scalar AND a kv-shaped
 // item whose value is numeric — both must be surfaced as cross-cutting
 // constraints when shared across plans, not silently dropped.
-const PLAN_NUMERIC_TRUTH = (wave, sharedTitle) => `---
-phase: "1"
-plan: "01-0${wave}"
-type: standard
-wave: ${wave}
-depends_on: []
-files_modified: []
-autonomous: true
-must_haves:
-  truths:
-    - title: ${sharedTitle}
-      count: 3
-    - 42
-  artifacts: []
-  key_links: []
----
-
-<objective>Plan ${wave}</objective>
-`;
+const PLAN_NUMERIC_TRUTH = (wave, sharedTitle) => [
+  '---',
+  'phase: "1"',
+  `plan: "01-0${wave}"`,
+  'type: standard',
+  `wave: ${wave}`,
+  'depends_on: []',
+  'files_modified: []',
+  'autonomous: true',
+  'must_haves:',
+  '  truths:',
+  `    - title: ${sharedTitle}`,
+  '      count: 3',
+  '    - 42',
+  '  artifacts: []',
+  '  key_links: []',
+  '---',
+  '',
+  `<objective>Plan ${wave}</objective>`,
+  '',
+].join('\n');
 
 describe('bug #2770 — non-string truths must be coerced, not dropped', () => {
   let tmpDir;
@@ -80,23 +84,25 @@ describe('bug #2770 — non-string truths must be coerced, not dropped', () => {
     // Both plans share the numeric truth `42`. Pre-fix: silently dropped by
     // `typeof t !== 'string' continue`, so cross_cutting_constraints == 0.
     // Post-fix: coerced to "42" and surfaced as a constraint.
-    const PLAN_BARE_INT_TRUTH = (wave) => `---
-phase: "1"
-plan: "01-0${wave}"
-type: standard
-wave: ${wave}
-depends_on: []
-files_modified: []
-autonomous: true
-must_haves:
-  truths:
-    - 42
-  artifacts: []
-  key_links: []
----
-
-<objective>Plan ${wave}</objective>
-`;
+    const PLAN_BARE_INT_TRUTH = (wave) => [
+      '---',
+      'phase: "1"',
+      `plan: "01-0${wave}"`,
+      'type: standard',
+      `wave: ${wave}`,
+      'depends_on: []',
+      'files_modified: []',
+      'autonomous: true',
+      'must_haves:',
+      '  truths:',
+      '    - 42',
+      '  artifacts: []',
+      '  key_links: []',
+      '---',
+      '',
+      `<objective>Plan ${wave}</objective>`,
+      '',
+    ].join('\n');
     tmpDir = makePlanProject({
       '.planning/ROADMAP.md': ROADMAP,
       '.planning/phases/01-foundation/01-01-PLAN.md': PLAN_BARE_INT_TRUTH(1),
@@ -157,13 +163,15 @@ describe('bug #2770 — bare-int depends_on values parse as preserved strings', 
     // string "3". The frontmatter parser already returns strings here; this
     // test pins the behaviour so a future "convert YAML scalars to numbers"
     // optimization cannot silently regress dependency tracking.
-    const fm = extractFrontmatter(`---
-phase: "1"
-plan: "01"
-depends_on: 3
----
-body
-`);
+    const fm = extractFrontmatter([
+      '---',
+      'phase: "1"',
+      'plan: "01"',
+      'depends_on: 3',
+      '---',
+      'body',
+      '',
+    ].join('\n'));
     assert.strictEqual(typeof fm.depends_on, 'string',
       'scalar depends_on must remain a string after parse');
     assert.strictEqual(fm.depends_on, '3',
@@ -171,13 +179,15 @@ body
   });
 
   test('inline-array bare-int depends_on parses to ["3","4"] (preserved as strings)', () => {
-    const fm = extractFrontmatter(`---
-phase: "1"
-plan: "01"
-depends_on: [3, 4]
----
-body
-`);
+    const fm = extractFrontmatter([
+      '---',
+      'phase: "1"',
+      'plan: "01"',
+      'depends_on: [3, 4]',
+      '---',
+      'body',
+      '',
+    ].join('\n'));
     assert.ok(Array.isArray(fm.depends_on),
       'inline array depends_on must be an array');
     assert.deepStrictEqual(fm.depends_on, ['3', '4'],

--- a/tests/bug-2770-annotate-deps-int-coerce.test.cjs
+++ b/tests/bug-2770-annotate-deps-int-coerce.test.cjs
@@ -1,0 +1,190 @@
+'use strict';
+
+/**
+ * Regression — issue #2770
+ *
+ * `roadmap.annotate-dependencies` crashes with
+ * `TypeError: t.trim is not a function` when must_haves.truths contains a
+ * non-string scalar (e.g., a YAML int like `- 3` interpreted by an upstream
+ * parser as a number, or a kv-shaped item whose value is numeric).
+ *
+ * The original guard `if (typeof t !== 'string') continue` skipped silently —
+ * which avoids the crash but **drops the constraint from cross-cutting
+ * analysis**. The required behaviour is to **coerce, not skip**: a numeric
+ * scalar `3` must be surfaced as the string "3", and a kv-shaped truth like
+ * `{ title: "X", count: 3 }` must contribute its title to the analysis.
+ *
+ * The two literal cases called out in the issue title (bare-int `depends_on`
+ * values) are also exercised here as regression guards on the frontmatter
+ * parser to prove the dependency is preserved as a string and never dropped.
+ */
+
+const { test, describe, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
+const { extractFrontmatter } = require('../get-shit-done/bin/lib/frontmatter.cjs');
+
+function makePlanProject(files = {}) {
+  const dir = createTempProject();
+  fs.writeFileSync(path.join(dir, '.planning', 'ROADMAP.md'), '');
+  fs.mkdirSync(path.join(dir, '.planning', 'phases', '01-foundation'), { recursive: true });
+  for (const [rel, content] of Object.entries(files)) {
+    const abs = path.join(dir, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, content, 'utf-8');
+  }
+  return dir;
+}
+
+const ROADMAP = `# Roadmap
+
+### Phase 1: Foundation
+**Goal:** Set up project
+**Plans:** 2 plans
+
+Plans:
+- [ ] 01-01-PLAN.md — Set up DB
+- [ ] 01-02-PLAN.md — Build API
+`;
+
+// PLAN where must_haves.truths includes a bare numeric scalar AND a kv-shaped
+// item whose value is numeric — both must be surfaced as cross-cutting
+// constraints when shared across plans, not silently dropped.
+const PLAN_NUMERIC_TRUTH = (wave, sharedTitle) => `---
+phase: "1"
+plan: "01-0${wave}"
+type: standard
+wave: ${wave}
+depends_on: []
+files_modified: []
+autonomous: true
+must_haves:
+  truths:
+    - title: ${sharedTitle}
+      count: 3
+    - 42
+  artifacts: []
+  key_links: []
+---
+
+<objective>Plan ${wave}</objective>
+`;
+
+describe('bug #2770 — non-string truths must be coerced, not dropped', () => {
+  let tmpDir;
+  afterEach(() => cleanup(tmpDir));
+
+  test('numeric scalar truth shared across 2+ plans is surfaced as cross-cutting constraint', () => {
+    // Both plans share the numeric truth `42`. Pre-fix: silently dropped by
+    // `typeof t !== 'string' continue`, so cross_cutting_constraints == 0.
+    // Post-fix: coerced to "42" and surfaced as a constraint.
+    const PLAN_BARE_INT_TRUTH = (wave) => `---
+phase: "1"
+plan: "01-0${wave}"
+type: standard
+wave: ${wave}
+depends_on: []
+files_modified: []
+autonomous: true
+must_haves:
+  truths:
+    - 42
+  artifacts: []
+  key_links: []
+---
+
+<objective>Plan ${wave}</objective>
+`;
+    tmpDir = makePlanProject({
+      '.planning/ROADMAP.md': ROADMAP,
+      '.planning/phases/01-foundation/01-01-PLAN.md': PLAN_BARE_INT_TRUTH(1),
+      '.planning/phases/01-foundation/01-02-PLAN.md': PLAN_BARE_INT_TRUTH(2),
+    });
+
+    const result = runGsdTools('roadmap annotate-dependencies 1', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const out = JSON.parse(result.output);
+    assert.strictEqual(
+      out.cross_cutting_constraints,
+      1,
+      'numeric truth shared across plans must be surfaced (coerced), not dropped'
+    );
+
+    const roadmap = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+    assert.ok(roadmap.includes('Cross-cutting constraints:'),
+      'cross-cutting subsection present');
+    assert.ok(/-\s*42\b/.test(roadmap),
+      'numeric truth "42" surfaced as a string in the roadmap');
+  });
+
+  test('kv-shaped truth with numeric value uses title and contributes to cross-cutting analysis', () => {
+    // Both plans share `{ title: 'shared-rule', count: 3 }`. Pre-fix:
+    // typeof === 'object' so silently skipped → constraint dropped.
+    // Post-fix: title extracted, surfaced in cross-cutting subsection.
+    tmpDir = makePlanProject({
+      '.planning/ROADMAP.md': ROADMAP,
+      '.planning/phases/01-foundation/01-01-PLAN.md': PLAN_NUMERIC_TRUTH(1, 'shared-rule'),
+      '.planning/phases/01-foundation/01-02-PLAN.md': PLAN_NUMERIC_TRUTH(2, 'shared-rule'),
+    });
+
+    const result = runGsdTools('roadmap annotate-dependencies 1', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const out = JSON.parse(result.output);
+    // Both plans share two truths: the kv-shaped { title: 'shared-rule', ... }
+    // and the bare numeric 42. Pre-fix neither would survive the typeof guard;
+    // post-fix both are coerced and surfaced.
+    assert.strictEqual(
+      out.cross_cutting_constraints,
+      2,
+      'kv-shaped truth and numeric truth both surface, not dropped'
+    );
+
+    const roadmap = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+    assert.ok(roadmap.includes('shared-rule'),
+      'title from kv-shaped truth surfaced in cross-cutting list');
+    assert.ok(/-\s*42\b/.test(roadmap),
+      'numeric truth surfaced as a string');
+  });
+});
+
+describe('bug #2770 — bare-int depends_on values parse as preserved strings', () => {
+  test('scalar bare-int depends_on parses as string "3" (not dropped, not numeric)', () => {
+    // Per issue title: a YAML scalar `depends_on: 3` must be preserved as the
+    // string "3". The frontmatter parser already returns strings here; this
+    // test pins the behaviour so a future "convert YAML scalars to numbers"
+    // optimization cannot silently regress dependency tracking.
+    const fm = extractFrontmatter(`---
+phase: "1"
+plan: "01"
+depends_on: 3
+---
+body
+`);
+    assert.strictEqual(typeof fm.depends_on, 'string',
+      'scalar depends_on must remain a string after parse');
+    assert.strictEqual(fm.depends_on, '3',
+      'bare int 3 must be preserved as the string "3"');
+  });
+
+  test('inline-array bare-int depends_on parses to ["3","4"] (preserved as strings)', () => {
+    const fm = extractFrontmatter(`---
+phase: "1"
+plan: "01"
+depends_on: [3, 4]
+---
+body
+`);
+    assert.ok(Array.isArray(fm.depends_on),
+      'inline array depends_on must be an array');
+    assert.deepStrictEqual(fm.depends_on, ['3', '4'],
+      'bare ints in inline array must be preserved as strings — never dropped');
+    // Critical: assert *length* matches input. A naive `if (typeof !== string) continue`
+    // would silently drop entries; we must coerce, not skip.
+    assert.strictEqual(fm.depends_on.length, 2,
+      'no dependency may be silently dropped during coercion');
+  });
+});


### PR DESCRIPTION
## TL;DR

`roadmap.annotate-dependencies` was silently dropping constraints whose
must_haves.truths entries weren't strings — numeric YAML scalars and
kv-shaped objects from the parser's continuation-kv path. Replace the
skip-guard with a coercion helper so every legitimate constraint
contributes to the cross-cutting analysis.

## What

- `get-shit-done/bin/lib/roadmap.cjs` — replace
  `if (typeof t !== 'string') continue` with a new `coerceTruthToString`
  helper that handles primitives via `String()` and extracts the first
  meaningful string field (`title`, `text`, `name`, `rule`, `path`,
  `provides`) from object-shaped truths.
- `tests/bug-2770-annotate-deps-int-coerce.test.cjs` — new regression suite:
  - numeric scalar truth shared across plans now surfaces as a
    cross-cutting constraint instead of being dropped
  - kv-shaped truth (`{ title: 'X', count: 3 }`) surfaces via its title
  - two regression guards on `extractFrontmatter` pin scalar and
    inline-array bare-int `depends_on` parsing as preserved strings

## Why

The reporter saw `TypeError: t.trim is not a function` from `roadmap.cjs`
and the obvious "fix" — a `typeof !== 'string' continue` — was already in
place. But that guard converted a crash into silent data loss: numeric
truths and the object shapes produced by the #2757 fix path were skipped
entirely, leaving the cross-cutting constraints subsection under-populated.
The triage RCA on the issue called this out explicitly: "**coerce, not
skip**." This PR does that.

## Composition with prior fixes

- `ab5ad6c8 fix(#2757): unquoted truths with colons crash annotate-dependencies`
  produced the kv-shaped object truths in the first place. The new helper
  treats those objects as first-class inputs by extracting a title rather
  than dropping them — the two fixes now compose: #2757 doesn't crash on
  colons, and #2770 doesn't drop the resulting objects.

## Knock-on check

Grepped `bin/lib/` for similar `for (const t of …)` loops over YAML scalar
collections. Only the two sites in `roadmap.cjs` exist (line 456 — fixed;
line 532 iterates the already-coerced output strings). No other parser
(REQUIREMENTS.md, PLAN.md, ROADMAP.md, init.cjs) reaches a `.trim()` on a
raw YAML scalar that could be numeric — those paths read from regex
captures on markdown text, which are always strings by construction.

## Tests

- New: `tests/bug-2770-annotate-deps-int-coerce.test.cjs` (4 tests, RED→GREEN)
- Full suite: **5678 pass / 0 fail / 0 skip** (`npm test`)
- Existing #2757 regression test still passes (no conflict with prior fix)
- Existing #2447 wave-deps suite still passes (idempotency, single-wave,
  cross-cutting all green)

Closes #2770

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Non-string values (numbers, booleans, and object-shaped entries) in roadmap truths and dependencies are now coerced to strings and preserved in cross-cutting constraints and generated roadmap output instead of being skipped.
* **Tests**
  * Added regression tests to ensure numeric and structured truths are retained and that dependency parsing preserves numeric values (including array elements) as strings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->