### PR TITLE
fix(#2773): emit correct Codex 0.124.0+ two-level nested hooks schema

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -2905,7 +2905,27 @@ function migrateCodexHooksMapFormat(content) {
     (section) => section.array && section.path === 'hooks'
   );
 
-  if (legacyMapSections.length === 0 && flatAotSections.length === 0) {
+  // Find [[hooks.TYPE]] namespaced AoT entries that carry handler fields
+  // (command, type, timeout, statusMessage) at event-entry level but have no
+  // [[hooks.TYPE.hooks]] sub-table. This is the pre-#2773 single-block shape
+  // that Codex 0.124.0+ rejects. Promote them to the two-level nested form.
+  // Entries that already have a [[hooks.TYPE.hooks]] sub-table are left untouched.
+  // Matcher-only entries (no handler fields) are intentionally valid and skipped.
+  const STALE_HANDLER_FIELD_PATTERN = /^\s*(?:command|type|timeout|statusMessage)\s*=/m;
+  const staleNamespacedAotSections = sections.filter((section) => {
+    if (!section.array) return false;
+    if (!section.path.startsWith('hooks.')) return false;
+    // [[hooks.TYPE.hooks]] sub-tables have 3 path segments — skip them.
+    if (section.path.split('.').length > 2) return false;
+    // Must carry at least one handler field at event-entry level.
+    const body = content.slice(section.headerEnd, section.end);
+    if (!STALE_HANDLER_FIELD_PATTERN.test(body)) return false;
+    // Don't migrate when the nested [[hooks.TYPE.hooks]] sub-table already exists.
+    const subPath = section.path + '.hooks';
+    return !sections.some((s) => s.array && s.path === subPath);
+  });
+
+  if (legacyMapSections.length === 0 && flatAotSections.length === 0 && staleNamespacedAotSections.length === 0) {
     return content;
   }
 
@@ -2941,12 +2961,23 @@ function migrateCodexHooksMapFormat(content) {
     return { eventEntries, handlerEntries, hasExplicitType };
   }
 
+  // TOML key quoting: bare keys may only contain [A-Za-z0-9_-]. Event names
+  // containing spaces, dots, or other punctuation must be wrapped in double-
+  // quoted TOML strings with backslash and double-quote characters escaped.
+  // Using raw event names in [[hooks.${type}]] headers produces invalid TOML
+  // for any non-bare-key character (e.g. "Before Tool" → [[hooks.Before Tool]]).
+  function tomlBareKey(key) {
+    if (/^[A-Za-z0-9_-]+$/.test(key)) return key;
+    return '"' + key.replace(/\\/g, '\\\\').replace(/"/g, '\\"') + '"';
+  }
+
   function buildNestedBlock(type, body, skipKeys = new Set()) {
+    const quotedType = tomlBareKey(type);
     const { eventEntries, handlerEntries, hasExplicitType } = parseHooksBody(body, skipKeys);
     if (!hasExplicitType) handlerEntries.unshift('type = "command"');
     const eventBody = eventEntries.length > 0 ? eventEntries.join(eol) + eol : '';
     const handlerBody = handlerEntries.join(eol) + eol;
-    return `[[hooks.${type}]]${eol}${eventBody}${eol}[[hooks.${type}.hooks]]${eol}${handlerBody}`;
+    return `[[hooks.${quotedType}]]${eol}${eventBody}${eol}[[hooks.${quotedType}.hooks]]${eol}${handlerBody}`;
   }
 
   // Extract the event name from a flat [[hooks]] section body.
@@ -2967,7 +2998,7 @@ function migrateCodexHooksMapFormat(content) {
     return extractFlatHookEventName(body) !== null;
   });
 
-  const legacyHooksSections = [...legacyMapSections, ...migratedFlatAotSections];
+  const legacyHooksSections = [...legacyMapSections, ...migratedFlatAotSections, ...staleNamespacedAotSections];
 
   // Remove all legacy hooks sections from the content
   let result = removeContentRanges(
@@ -2990,6 +3021,15 @@ function migrateCodexHooksMapFormat(content) {
       return buildNestedBlock(type, body);
     });
 
+  // Stale namespaced AoT blocks: [[hooks.TYPE]] entries with handler fields at
+  // event-entry level (no .hooks sub-table). Treated like map-format blocks —
+  // inserted before the first remaining table section.
+  const staleNamespacedAotBlocks = staleNamespacedAotSections.map((s) => {
+    const type = s.path.slice('hooks.'.length);
+    const body = content.slice(s.headerEnd, s.end);
+    return buildNestedBlock(type, body);
+  });
+
   const flatAotBlocks = migratedFlatAotSections.map((s) => {
     const body = content.slice(s.headerEnd, s.end);
     const eventName = extractFlatHookEventName(body);
@@ -2997,9 +3037,11 @@ function migrateCodexHooksMapFormat(content) {
     return buildNestedBlock(eventName, body, new Set(['event']));
   }).filter(Boolean);
 
-  // Insert map-format conversions before the first remaining table section.
-  if (mapOnlyBlocks.length > 0) {
-    const insertionText = mapOnlyBlocks.join('');
+  // Insert map-format and stale-namespaced-AoT conversions before the first
+  // remaining table section (both share the same placement strategy).
+  const allMapStyleBlocks = [...mapOnlyBlocks, ...staleNamespacedAotBlocks];
+  if (allMapStyleBlocks.length > 0) {
+    const insertionText = allMapStyleBlocks.join('');
     const remainingSections = getTomlTableSections(result);
     if (remainingSections.length > 0) {
       const firstTable = remainingSections[0];
@@ -3482,26 +3524,40 @@ function validateCodexConfigSchema(content) {
             reason: `hooks.${event} must be an array of tables, got ${typeof value}`,
           };
         }
-        // Each entry in hooks.<Event> must have a .hooks sub-array of handlers.
-        // An entry without any .hooks is structurally valid (matcher-only event
-        // filter) but warn rather than hard-fail to avoid blocking user configs
-        // that haven't been migrated yet. GSD-managed blocks always emit .hooks.
+        // Each entry in hooks.<Event> must either be a matcher-only filter (no
+        // handler fields) or carry a .hooks sub-array of handler tables.
+        // Entries with handler fields (command, type, timeout, statusMessage) at
+        // event-entry level but without a .hooks sub-table are the pre-#2773
+        // single-block shape that Codex 0.124.0+ rejects. migrateCodexHooksMapFormat
+        // converts these before validation runs; their presence here means migration
+        // failed to cover this entry — fail loudly rather than pass a broken config.
+        const HANDLER_FIELD_NAMES = new Set(['command', 'type', 'timeout', 'statusMessage']);
         for (const entry of value) {
-          if (entry && typeof entry === 'object' && entry.hooks !== undefined) {
-            if (!Array.isArray(entry.hooks)) {
+          if (!entry || typeof entry !== 'object') continue;
+          if (entry.hooks === undefined) {
+            const strayKey = Object.keys(entry).find((k) => HANDLER_FIELD_NAMES.has(k));
+            if (strayKey) {
               return {
                 ok: false,
-                reason: `hooks.${event}[].hooks must be an array of handler tables, got ${typeof entry.hooks}`,
+                reason: `hooks.${event}[] entry has handler field "${strayKey}" at event-entry level; ` +
+                  `Codex 0.124.0+ requires handler fields nested under [[hooks.${event}.hooks]]`,
               };
             }
-            for (const handler of entry.hooks) {
-              if (handler && typeof handler === 'object' && handler.type !== undefined) {
-                if (handler.type !== 'command') {
-                  return {
-                    ok: false,
-                    reason: `hooks.${event}[].hooks[].type must be "command", got "${handler.type}"`,
-                  };
-                }
+            continue;
+          }
+          if (!Array.isArray(entry.hooks)) {
+            return {
+              ok: false,
+              reason: `hooks.${event}[].hooks must be an array of handler tables, got ${typeof entry.hooks}`,
+            };
+          }
+          for (const handler of entry.hooks) {
+            if (handler && typeof handler === 'object' && handler.type !== undefined) {
+              if (handler.type !== 'command') {
+                return {
+                  ok: false,
+                  reason: `hooks.${event}[].hooks[].type must be "command", got "${handler.type}"`,
+                };
               }
             }
           }

--- a/bin/install.js
+++ b/bin/install.js
@@ -2951,9 +2951,12 @@ function migrateCodexHooksMapFormat(content) {
 
   // Collect which flat AoT sections are migratable (have an `event` key).
   // Sections without an `event` key cannot be migrated and are left untouched.
+  // TOML allows both double-quoted ("SessionStart") and single-quoted ('SessionStart')
+  // string values, so the filter accepts both forms.
+  const TOML_QUOTED_STRING = /^\s*event\s*=\s*(?:"(?:[^"\\]|\\.)*"|'[^']*')/m;
   const migratedFlatAotSections = flatAotSections.filter((section) => {
     const body = content.slice(section.headerEnd, section.end);
-    return /^\s*event\s*=\s*"[^"]+"/m.test(body);
+    return TOML_QUOTED_STRING.test(body);
   });
 
   const legacyHooksSections = [...legacyMapSections, ...migratedFlatAotSections];
@@ -2979,11 +2982,15 @@ function migrateCodexHooksMapFormat(content) {
       return buildNestedBlock(type, body);
     });
 
+  // Extract the event name from a flat [[hooks]] body, handling both quote styles.
+  const TOML_EVENT_CAPTURE = /^\s*event\s*=\s*(?:"((?:[^"\\]|\\.)*)"|'([^']*)')/m;
   const flatAotBlocks = migratedFlatAotSections.map((s) => {
     const body = content.slice(s.headerEnd, s.end);
-    const eventMatch = body.match(/^\s*event\s*=\s*"([^"]+)"/m);
-    return buildNestedBlock(eventMatch[1], body, new Set(['event']));
-  });
+    const eventMatch = body.match(TOML_EVENT_CAPTURE);
+    const eventName = eventMatch ? (eventMatch[1] ?? eventMatch[2]) : null;
+    if (!eventName) return '';
+    return buildNestedBlock(eventName, body, new Set(['event']));
+  }).filter(Boolean);
 
   // Insert map-format conversions before the first remaining table section.
   if (mapOnlyBlocks.length > 0) {
@@ -7059,41 +7066,15 @@ function install(isGlobal, runtime = 'claude') {
       let configContent = fs.existsSync(configPath) ? fs.readFileSync(configPath, 'utf-8') : '';
       const eol = detectLineEnding(configContent);
 
-      // Migrate legacy [hooks] map format to [[hooks]] array-of-tables (#2637).
-      // Codex 0.124.0 requires [[hooks]] array-of-tables; old GSD installs wrote
-      // [hooks.shell] map tables which now cause a startup parse error.
-      const migratedContent = migrateCodexHooksMapFormat(configContent);
-      if (migratedContent !== configContent) {
-        configContent = migratedContent;
-        console.log(`  ${green}✓${reset} Migrated legacy Codex [hooks] map format to [[hooks]] array-of-tables`);
-      }
-
-      const codexHooksFeature = ensureCodexHooksFeature(configContent);
-      configContent = setManagedCodexHooksOwnership(codexHooksFeature.content, codexHooksFeature.ownership);
-
-      // Add SessionStart hook for update checking. Codex 0.124.0+ requires the
-      // two-level nested AoT schema: [[hooks.SessionStart]] for the event entry
-      // (holds optional matcher) and [[hooks.SessionStart.hooks]] for the handler
-      // (holds type, command, statusMessage, timeout). The flat [[hooks]] form
-      // with a synthetic `event` field and the single-block [[hooks.SessionStart]]
-      // form were pre-release approximations that Codex 0.124.0 stable does not
-      // accept. (#2637, #2760, #2773)
-      const updateCheckScript = path.resolve(targetDir, 'hooks', 'gsd-check-update.js').replace(/\\/g, '/');
-      const hookBlock = `${eol}# GSD Hooks${eol}` +
-        `[[hooks.SessionStart]]${eol}` +
-        `${eol}` +
-        `[[hooks.SessionStart.hooks]]${eol}` +
-        `type = "command"${eol}` +
-        `command = "node ${updateCheckScript}"${eol}`;
-
-      // Strip ALL prior GSD-managed hook blocks before re-emitting so every
-      // install converges on the correct nested schema regardless of what a
-      // previous GSD version wrote. Handles four historical shapes in order:
+      // Strip ALL prior GSD-managed hook blocks BEFORE migration so the migration
+      // only touches user-authored hooks, not GSD-owned stale entries. Running
+      // strip after migration causes Shape 1 (legacy gsd-update-check filename)
+      // to be converted by migration before the strip regex can match it (#2698).
       //
+      // Historical shapes stripped, in order:
       //   Shape 1 — legacy gsd-update-check filename (pre-#1755): flat [[hooks]] + event
       //   Shape 2 — flat [[hooks]] + event = "SessionStart" (#2637 era, never correct)
-      //   Shape 4 — correct two-block nested schema (must strip before shape 3 to
-      //             avoid leaving an orphaned [[hooks.SessionStart]] header behind)
+      //   Shape 4 — correct two-block nested (strip before shape 3 to avoid orphaned header)
       //   Shape 3 — single-block [[hooks.SessionStart]] without nested .hooks (#2760 era)
       if (configContent.includes('gsd-update-check') || configContent.includes('gsd-check-update')) {
         // Shape 1
@@ -7108,15 +7089,41 @@ function install(isGlobal, runtime = 'claude') {
         );
         // Shape 4 — strip before shape 3 to avoid orphaned header
         configContent = configContent.replace(
-          /(?:\r?\n|^)# GSD Hooks\r?\n\[\[hooks\.SessionStart\]\]\r?\n\r?\n\[\[hooks\.SessionStart\.hooks\]\]\r?\ntype = "command"\r?\ncommand = "node [^\r\n]*gsd-check-update\.js"\r?\n/gm,
+          /(?:\r?\n|^)# GSD Hooks\r?\n\[\[hooks\.SessionStart\]\]\r?\n\r?\n\[\[hooks\.SessionStart\.hooks\]\]\r?\ntype = "command"\r?\ncommand = "node [^\r\n]*(?:gsd-check-update|gsd-update-check)\.js"\r?\n/gm,
           (match) => (match.startsWith('\r\n') ? '\r\n' : match.startsWith('\n') ? '\n' : ''),
         );
         // Shape 3
         configContent = configContent.replace(
-          /(?:\r?\n|^)# GSD Hooks\r?\n\[\[hooks\.SessionStart\]\]\r?\ncommand = "node [^\r\n]*gsd-check-update\.js"\r?\n/gm,
+          /(?:\r?\n|^)# GSD Hooks\r?\n\[\[hooks\.SessionStart\]\]\r?\ncommand = "node [^\r\n]*(?:gsd-check-update|gsd-update-check)\.js"\r?\n/gm,
           (match) => (match.startsWith('\r\n') ? '\r\n' : match.startsWith('\n') ? '\n' : ''),
         );
       }
+
+      // Migrate legacy [hooks] map format and flat [[hooks]] AoT entries to the
+      // namespaced [[hooks.<EVENT>]] form after stripping GSD-managed stale blocks.
+      // Running migration after strip ensures only user-authored hooks are migrated
+      // (#2698 regression: migration before strip converts stale GSD blocks before
+      // the strip regexes can match their original shape).
+      const migratedContent = migrateCodexHooksMapFormat(configContent);
+      if (migratedContent !== configContent) {
+        configContent = migratedContent;
+        console.log(`  ${green}✓${reset} Migrated legacy Codex [hooks] format to two-level nested AoT`);
+      }
+
+      const codexHooksFeature = ensureCodexHooksFeature(configContent);
+      configContent = setManagedCodexHooksOwnership(codexHooksFeature.content, codexHooksFeature.ownership);
+
+      // Add SessionStart hook for update checking. Codex 0.124.0+ requires the
+      // two-level nested AoT schema: [[hooks.SessionStart]] for the event entry
+      // (holds optional matcher) and [[hooks.SessionStart.hooks]] for the handler
+      // (holds type, command, statusMessage, timeout). (#2637, #2760, #2773)
+      const updateCheckScript = path.resolve(targetDir, 'hooks', 'gsd-check-update.js').replace(/\\/g, '/');
+      const hookBlock = `${eol}# GSD Hooks${eol}` +
+        `[[hooks.SessionStart]]${eol}` +
+        `${eol}` +
+        `[[hooks.SessionStart.hooks]]${eol}` +
+        `type = "command"${eol}` +
+        `command = "node ${updateCheckScript}"${eol}`;
 
       if (hasEnabledCodexHooksFeature(configContent) && !configContent.includes('gsd-check-update')) {
         configContent += hookBlock;

--- a/bin/install.js
+++ b/bin/install.js
@@ -2896,9 +2896,15 @@ function stripLeakedGsdCodexSections(content) {
 function migrateCodexHooksMapFormat(content) {
   const sections = getTomlTableSections(content);
 
-  // Find all non-array hooks sections: [hooks] or [hooks.TYPE]
+  // Find all non-array hooks sections: bare [hooks] container or [hooks.TYPE] event tables.
+  // Use section.segments (parsed key count) rather than section.path.startsWith() so that
+  // nested handler tables like [hooks.SessionStart.hooks] (3 segments) are not mistakenly
+  // included and re-emitted as an event named "SessionStart.hooks".
   const legacyMapSections = sections.filter(
-    (section) => !section.array && (section.path === 'hooks' || section.path.startsWith('hooks.'))
+    (section) => !section.array && (
+      section.path === 'hooks' ||
+      (section.path.startsWith('hooks.') && section.segments.length === 2)
+    )
   );
 
   // Find flat [[hooks]] array-of-tables entries (path === 'hooks', array === true).
@@ -2954,9 +2960,12 @@ function migrateCodexHooksMapFormat(content) {
     for (const line of bodyLines) {
       const trimmed = line.trim();
       if (!trimmed || trimmed.startsWith('#')) continue;
-      const keyMatch = trimmed.match(/^([\w.]+)\s*=/);
-      if (!keyMatch) continue;
-      const key = keyMatch[1];
+      // Use parseTomlKey so hyphenated keys (e.g. status-message) and quoted
+      // keys are recognised — the old /^([\w.]+)\s*=/ regex silently dropped them.
+      const parsed = parseTomlKey(trimmed);
+      if (!parsed) continue;
+      // Hook body keys are always single-segment; use segments[0] for the name.
+      const key = parsed.segments[0];
       if (skipKeys.has(key)) continue;
       if (key === 'type') {
         hasExplicitType = true;
@@ -2983,8 +2992,14 @@ function migrateCodexHooksMapFormat(content) {
   function buildNestedBlock(type, body, skipKeys = new Set()) {
     const quotedType = tomlBareKey(type);
     const { eventEntries, handlerEntries, hasExplicitType } = parseHooksBody(body, skipKeys);
-    if (!hasExplicitType) handlerEntries.unshift('type = "command"');
     const eventBody = eventEntries.length > 0 ? eventEntries.join(eol) + eol : '';
+    // If no handler fields were found (e.g. matcher-only entry), do not synthesise
+    // an empty [[hooks.TYPE.hooks]] block — that would produce structurally valid
+    // TOML but semantically broken output (a handler entry with no command).
+    if (handlerEntries.length === 0) {
+      return `[[hooks.${quotedType}]]${eol}${eventBody}`;
+    }
+    if (!hasExplicitType) handlerEntries.unshift('type = "command"');
     const handlerBody = handlerEntries.join(eol) + eol;
     return `[[hooks.${quotedType}]]${eol}${eventBody}${eol}[[hooks.${quotedType}.hooks]]${eol}${handlerBody}`;
   }

--- a/bin/install.js
+++ b/bin/install.js
@@ -2628,6 +2628,11 @@ function getTomlTableSections(content) {
 
   return headerLines.map((record, index) => ({
     path: record.tableHeader.path,
+    // segments preserves the true parsed key count so callers that need to
+    // distinguish a 2-segment path like hooks."before.tool" from a 3-segment
+    // path like hooks.SessionStart.hooks can do so without splitting on dots
+    // (which misclassifies quoted key names that contain dot characters).
+    segments: record.tableHeader.segments,
     array: record.tableHeader.array,
     start: record.start,
     headerEnd: record.end + record.eol.length,
@@ -2915,8 +2920,12 @@ function migrateCodexHooksMapFormat(content) {
   const staleNamespacedAotSections = sections.filter((section) => {
     if (!section.array) return false;
     if (!section.path.startsWith('hooks.')) return false;
-    // [[hooks.TYPE.hooks]] sub-tables have 3 path segments — skip them.
-    if (section.path.split('.').length > 2) return false;
+    // [[hooks.TYPE.hooks]] sub-tables have 3 parsed segments — skip them.
+    // Use section.segments (true parsed key count) rather than splitting
+    // section.path on '.', which misclassifies quoted event names that contain
+    // dots (e.g. [[hooks."before.tool"]] has segments ['hooks','before.tool']
+    // but path 'hooks.before.tool' would split into 3 parts).
+    if (section.segments.length !== 2) return false;
     // Must carry at least one handler field at event-entry level.
     const body = content.slice(section.headerEnd, section.end);
     if (!STALE_HANDLER_FIELD_PATTERN.test(body)) return false;

--- a/bin/install.js
+++ b/bin/install.js
@@ -2949,14 +2949,22 @@ function migrateCodexHooksMapFormat(content) {
     return `[[hooks.${type}]]${eol}${eventBody}${eol}[[hooks.${type}.hooks]]${eol}${handlerBody}`;
   }
 
-  // Collect which flat AoT sections are migratable (have an `event` key).
-  // Sections without an `event` key cannot be migrated and are left untouched.
-  // TOML allows both double-quoted ("SessionStart") and single-quoted ('SessionStart')
-  // string values, so the filter accepts both forms.
-  const TOML_QUOTED_STRING = /^\s*event\s*=\s*(?:"(?:[^"\\]|\\.)*"|'[^']*')/m;
+  // Extract the event name from a flat [[hooks]] section body.
+  // Returns null if no `event` key is found, if the value is an empty string, or if
+  // the quoting is unrecognised. Both TOML double-quoted ("...") and single-quoted
+  // ('...') strings are accepted. An empty event string (event = "" or event = '')
+  // is explicitly rejected — it cannot be meaningfully namespaced and is left untouched.
+  function extractFlatHookEventName(body) {
+    const TOML_EVENT_CAPTURE = /^\s*event\s*=\s*(?:"((?:[^"\\]|\\.)*)"|'([^']*)')/m;
+    const m = body.match(TOML_EVENT_CAPTURE);
+    if (!m) return null;
+    const name = (m[1] ?? m[2] ?? '').trim();
+    return name || null;
+  }
+
   const migratedFlatAotSections = flatAotSections.filter((section) => {
     const body = content.slice(section.headerEnd, section.end);
-    return TOML_QUOTED_STRING.test(body);
+    return extractFlatHookEventName(body) !== null;
   });
 
   const legacyHooksSections = [...legacyMapSections, ...migratedFlatAotSections];
@@ -2982,12 +2990,9 @@ function migrateCodexHooksMapFormat(content) {
       return buildNestedBlock(type, body);
     });
 
-  // Extract the event name from a flat [[hooks]] body, handling both quote styles.
-  const TOML_EVENT_CAPTURE = /^\s*event\s*=\s*(?:"((?:[^"\\]|\\.)*)"|'([^']*)')/m;
   const flatAotBlocks = migratedFlatAotSections.map((s) => {
     const body = content.slice(s.headerEnd, s.end);
-    const eventMatch = body.match(TOML_EVENT_CAPTURE);
-    const eventName = eventMatch ? (eventMatch[1] ?? eventMatch[2]) : null;
+    const eventName = extractFlatHookEventName(body);
     if (!eventName) return '';
     return buildNestedBlock(eventName, body, new Set(['event']));
   }).filter(Boolean);

--- a/bin/install.js
+++ b/bin/install.js
@@ -2892,39 +2892,71 @@ function migrateCodexHooksMapFormat(content) {
   const sections = getTomlTableSections(content);
 
   // Find all non-array hooks sections: [hooks] or [hooks.TYPE]
-  const legacyHooksSections = sections.filter(
+  const legacyMapSections = sections.filter(
     (section) => !section.array && (section.path === 'hooks' || section.path.startsWith('hooks.'))
   );
 
-  if (legacyHooksSections.length === 0) {
+  // Find flat [[hooks]] array-of-tables entries (path === 'hooks', array === true).
+  // These are incompatible with [[hooks.<EVENT>]] namespaced form — both cannot
+  // coexist in the same TOML file because `hooks` cannot be simultaneously an
+  // array and a table. Migrate each flat entry to [[hooks.<EVENT>]] form using
+  // the `event` key as the event name.
+  const flatAotSections = sections.filter(
+    (section) => section.array && section.path === 'hooks'
+  );
+
+  if (legacyMapSections.length === 0 && flatAotSections.length === 0) {
     return content;
   }
 
   const eol = detectLineEnding(content);
 
-  // Build [[hooks]] blocks for each [hooks.TYPE] section (skipping bare [hooks])
-  const newHooksBlocks = [];
-  for (const section of legacyHooksSections) {
-    if (section.path === 'hooks') {
-      // Bare [hooks] container — drop it (no key-value content to convert)
-      continue;
+  // Helper: parse a hooks body into event-level and handler-level entries,
+  // returning { eventEntries, handlerEntries, hasExplicitType }.
+  // Event-level keys: matcher. Everything else is handler-level.
+  // The `event` key (used in flat [[hooks]] blocks) is consumed as the type
+  // name and excluded from both levels.
+  const EVENT_LEVEL_KEYS = new Set(['matcher']);
+  function parseHooksBody(body, skipKeys = new Set()) {
+    const bodyLines = body.split(/\r?\n/);
+    const eventEntries = [];
+    const handlerEntries = [];
+    let hasExplicitType = false;
+    for (const line of bodyLines) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith('#')) continue;
+      const keyMatch = trimmed.match(/^([\w.]+)\s*=/);
+      if (!keyMatch) continue;
+      const key = keyMatch[1];
+      if (skipKeys.has(key)) continue;
+      if (key === 'type') {
+        hasExplicitType = true;
+        handlerEntries.push(trimmed);
+      } else if (EVENT_LEVEL_KEYS.has(key)) {
+        eventEntries.push(trimmed);
+      } else {
+        handlerEntries.push(trimmed);
+      }
     }
-
-    // Extract the type from the path: "hooks.shell" → "shell"
-    const type = section.path.slice('hooks.'.length);
-    const body = content.slice(section.headerEnd, section.end);
-
-    // #2760 CR5 finding 3 — emit the namespaced AoT form directly:
-    // `[[hooks.<TYPE>]]` (no synthetic `event` field — the namespace IS the
-    // event). Previously we emitted flat `[[hooks]]\nevent = "<TYPE>"`,
-    // which produced mixed flat + namespaced layouts when the user already
-    // had `[[hooks.<OTHER>]]` entries. With every migration emit using the
-    // namespaced shape, the managed-emit detector
-    // (`hasUserNamespacedAotHooks`) fires correctly and the install
-    // converges on a single hook layout.
-    const block = `[[hooks.${type}]]${eol}${body}`;
-    newHooksBlocks.push(block);
+    return { eventEntries, handlerEntries, hasExplicitType };
   }
+
+  function buildNestedBlock(type, body, skipKeys = new Set()) {
+    const { eventEntries, handlerEntries, hasExplicitType } = parseHooksBody(body, skipKeys);
+    if (!hasExplicitType) handlerEntries.unshift('type = "command"');
+    const eventBody = eventEntries.length > 0 ? eventEntries.join(eol) + eol : '';
+    const handlerBody = handlerEntries.join(eol) + eol;
+    return `[[hooks.${type}]]${eol}${eventBody}${eol}[[hooks.${type}.hooks]]${eol}${handlerBody}`;
+  }
+
+  // Collect which flat AoT sections are migratable (have an `event` key).
+  // Sections without an `event` key cannot be migrated and are left untouched.
+  const migratedFlatAotSections = flatAotSections.filter((section) => {
+    const body = content.slice(section.headerEnd, section.end);
+    return /^\s*event\s*=\s*"[^"]+"/m.test(body);
+  });
+
+  const legacyHooksSections = [...legacyMapSections, ...migratedFlatAotSections];
 
   // Remove all legacy hooks sections from the content
   let result = removeContentRanges(
@@ -2933,28 +2965,31 @@ function migrateCodexHooksMapFormat(content) {
   );
   result = collapseTomlBlankLines(result);
 
-  // Insert new [[hooks]] blocks at the position of the first legacy section
-  // (adjusted for removed content), or append if nothing remains before EOF.
-  if (newHooksBlocks.length > 0) {
-    const insertionText = newHooksBlocks.join('');
-    // Find a good insertion point: before the first remaining table section
-    // that came after our removed hooks, or just append.
-    const remainingSections = getTomlTableSections(result);
-    const firstHooksSection = legacyHooksSections[0];
-
-    // Find the first remaining section whose original start was after the legacy hooks block
-    const anchorSection = remainingSections.find((s) => {
-      // Use content position in the result string as a heuristic
-      // We insert before the first non-hooks section if any exists
-      return s.start > 0;
+  // Map-format blocks ([hooks.TYPE]) are inserted at the position of the first
+  // remaining table section (preserving their relative placement in the file).
+  // Flat AoT blocks ([[hooks]] with event = "...") are always APPENDED because
+  // flat [[hooks]] entries only appear at the END of a TOML file (AoT cannot
+  // precede a regular table), and inserting before the first table would push
+  // them above [features] / [model] etc., corrupting relative ordering.
+  const mapOnlyBlocks = legacyMapSections
+    .filter((s) => s.path !== 'hooks')   // skip bare [hooks] container
+    .map((s) => {
+      const type = s.path.slice('hooks.'.length);
+      const body = content.slice(s.headerEnd, s.end);
+      return buildNestedBlock(type, body);
     });
 
-    // Prefer to insert the new blocks right before the first remaining table
-    // that was originally positioned after the legacy hooks area, but since
-    // positions shift after removal, we simply append before the first table
-    // header or at end-of-file.
+  const flatAotBlocks = migratedFlatAotSections.map((s) => {
+    const body = content.slice(s.headerEnd, s.end);
+    const eventMatch = body.match(/^\s*event\s*=\s*"([^"]+)"/m);
+    return buildNestedBlock(eventMatch[1], body, new Set(['event']));
+  });
+
+  // Insert map-format conversions before the first remaining table section.
+  if (mapOnlyBlocks.length > 0) {
+    const insertionText = mapOnlyBlocks.join('');
+    const remainingSections = getTomlTableSections(result);
     if (remainingSections.length > 0) {
-      // Find where to insert: after any leading top-level keys, before first table
       const firstTable = remainingSections[0];
       const before = result.slice(0, firstTable.start);
       const after = result.slice(firstTable.start);
@@ -2966,7 +3001,23 @@ function migrateCodexHooksMapFormat(content) {
         (needsTrailingGap ? eol : '') +
         after;
     } else {
-      // No remaining sections — append
+      const needsGap = result.length > 0 && !result.endsWith(eol + eol);
+      result = result + (needsGap ? eol : '') + insertionText;
+    }
+  }
+
+  // Insert flat-AoT conversions before the GSD managed marker (if present) so
+  // the migrated user hooks stay in the "user" portion of the file and are not
+  // swept away when stripGsdFromCodexConfig strips from the marker to EOF.
+  // If no marker exists, append at the end of the file.
+  if (flatAotBlocks.length > 0) {
+    const insertionText = flatAotBlocks.join('');
+    const markerIdx = result.indexOf(GSD_CODEX_MARKER);
+    if (markerIdx !== -1) {
+      const before = result.slice(0, markerIdx).trimEnd();
+      const after = result.slice(markerIdx);
+      result = before + eol + eol + insertionText + eol + after;
+    } else {
       const needsGap = result.length > 0 && !result.endsWith(eol + eol);
       result = result + (needsGap ? eol : '') + insertionText;
     }
@@ -3400,14 +3451,49 @@ function validateCodexConfigSchema(content) {
   }
 
   // Structural confirmation against parsed object: any present hooks.<Event>
-  // must be an array.
-  if (parsed.hooks && typeof parsed.hooks === 'object' && !Array.isArray(parsed.hooks)) {
-    for (const [event, value] of Object.entries(parsed.hooks)) {
-      if (!Array.isArray(value)) {
-        return {
-          ok: false,
-          reason: `hooks.${event} must be an array of tables, got ${typeof value}`,
-        };
+  // must be an array, and flat top-level [[hooks]] (parsed as Array on root)
+  // is rejected — Codex 0.124.0+ requires [[hooks.<Event>]] namespaced form.
+  if (parsed.hooks !== undefined) {
+    if (Array.isArray(parsed.hooks)) {
+      return {
+        ok: false,
+        reason: 'flat [[hooks]] array-of-tables is invalid in Codex 0.124.0+ (expected [[hooks.<Event>]] namespaced form)',
+      };
+    }
+    if (typeof parsed.hooks === 'object' && parsed.hooks !== null) {
+      for (const [event, value] of Object.entries(parsed.hooks)) {
+        // Skip the nested .hooks sub-array — it lives under hooks.<Event>[n].hooks
+        // and is validated separately below.
+        if (!Array.isArray(value)) {
+          return {
+            ok: false,
+            reason: `hooks.${event} must be an array of tables, got ${typeof value}`,
+          };
+        }
+        // Each entry in hooks.<Event> must have a .hooks sub-array of handlers.
+        // An entry without any .hooks is structurally valid (matcher-only event
+        // filter) but warn rather than hard-fail to avoid blocking user configs
+        // that haven't been migrated yet. GSD-managed blocks always emit .hooks.
+        for (const entry of value) {
+          if (entry && typeof entry === 'object' && entry.hooks !== undefined) {
+            if (!Array.isArray(entry.hooks)) {
+              return {
+                ok: false,
+                reason: `hooks.${event}[].hooks must be an array of handler tables, got ${typeof entry.hooks}`,
+              };
+            }
+            for (const handler of entry.hooks) {
+              if (handler && typeof handler === 'object' && handler.type !== undefined) {
+                if (handler.type !== 'command') {
+                  return {
+                    ok: false,
+                    reason: `hooks.${event}[].hooks[].type must be "command", got "${handler.type}"`,
+                  };
+                }
+              }
+            }
+          }
+        }
       }
     }
   }
@@ -6985,45 +7071,47 @@ function install(isGlobal, runtime = 'claude') {
       const codexHooksFeature = ensureCodexHooksFeature(configContent);
       configContent = setManagedCodexHooksOwnership(codexHooksFeature.content, codexHooksFeature.ownership);
 
-      // Add SessionStart hook for update checking. Default to top-level
-      // `[[hooks]]` AoT with `event` field — the form GSD has emitted since
-      // the Codex 0.124 migration (#2637). When the user already uses the
-      // namespaced AoT form `[[hooks.SessionStart]]` for their own hooks,
-      // emit our managed entry in that same shape so the two forms don't
-      // collide on round-trip (#2760, defect 3).
+      // Add SessionStart hook for update checking. Codex 0.124.0+ requires the
+      // two-level nested AoT schema: [[hooks.SessionStart]] for the event entry
+      // (holds optional matcher) and [[hooks.SessionStart.hooks]] for the handler
+      // (holds type, command, statusMessage, timeout). The flat [[hooks]] form
+      // with a synthetic `event` field and the single-block [[hooks.SessionStart]]
+      // form were pre-release approximations that Codex 0.124.0 stable does not
+      // accept. (#2637, #2760, #2773)
       const updateCheckScript = path.resolve(targetDir, 'hooks', 'gsd-check-update.js').replace(/\\/g, '/');
-      const useNamespacedAot = hasUserNamespacedAotHooks(configContent, 'SessionStart');
-      const hookBlock = useNamespacedAot
-        ? `${eol}# GSD Hooks${eol}` +
-          `[[hooks.SessionStart]]${eol}` +
-          `command = "node ${updateCheckScript}"${eol}`
-        : `${eol}# GSD Hooks${eol}` +
-          `[[hooks]]${eol}` +
-          `event = "SessionStart"${eol}` +
-          `command = "node ${updateCheckScript}"${eol}`;
+      const hookBlock = `${eol}# GSD Hooks${eol}` +
+        `[[hooks.SessionStart]]${eol}` +
+        `${eol}` +
+        `[[hooks.SessionStart.hooks]]${eol}` +
+        `type = "command"${eol}` +
+        `command = "node ${updateCheckScript}"${eol}`;
 
-      // Migrate legacy gsd-update-check entries from prior installs (#1755 followup)
-      // Remove stale hook blocks that used the inverted filename or wrong path.
-      // Single \r?\n-aware regex handles LF, CRLF, and block-at-file-start (#2698).
-      if (configContent.includes('gsd-update-check')) {
+      // Strip ALL prior GSD-managed hook blocks before re-emitting so every
+      // install converges on the correct nested schema regardless of what a
+      // previous GSD version wrote. Handles four historical shapes in order:
+      //
+      //   Shape 1 — legacy gsd-update-check filename (pre-#1755): flat [[hooks]] + event
+      //   Shape 2 — flat [[hooks]] + event = "SessionStart" (#2637 era, never correct)
+      //   Shape 4 — correct two-block nested schema (must strip before shape 3 to
+      //             avoid leaving an orphaned [[hooks.SessionStart]] header behind)
+      //   Shape 3 — single-block [[hooks.SessionStart]] without nested .hooks (#2760 era)
+      if (configContent.includes('gsd-update-check') || configContent.includes('gsd-check-update')) {
+        // Shape 1
         configContent = configContent.replace(
           /(?:\r?\n|^)# GSD Hooks\r?\n\[\[hooks\]\]\r?\nevent = "SessionStart"\r?\ncommand = "node [^\r\n]*gsd-update-check\.js"\r?\n/gm,
           (match) => (match.startsWith('\r\n') ? '\r\n' : match.startsWith('\n') ? '\n' : ''),
         );
-      }
-
-      // #2760 CR4 finding 2 — Strip ALL existing managed gsd-check-update
-      // hook blocks (top-level [[hooks]] AND namespaced [[hooks.SessionStart]])
-      // BEFORE evaluating the includes guard. Without this, an install that
-      // already has a legacy flat [[hooks]] block short-circuits the new
-      // namespaced AoT emit and stays stuck in the mixed layout this fix is
-      // designed to eliminate. Stripping first means every install converges
-      // on the right shape regardless of prior state.
-      if (configContent.includes('gsd-check-update')) {
+        // Shape 2
         configContent = configContent.replace(
           /(?:\r?\n|^)# GSD Hooks\r?\n\[\[hooks\]\]\r?\nevent = "SessionStart"\r?\ncommand = "node [^\r\n]*gsd-check-update\.js"\r?\n/gm,
           (match) => (match.startsWith('\r\n') ? '\r\n' : match.startsWith('\n') ? '\n' : ''),
         );
+        // Shape 4 — strip before shape 3 to avoid orphaned header
+        configContent = configContent.replace(
+          /(?:\r?\n|^)# GSD Hooks\r?\n\[\[hooks\.SessionStart\]\]\r?\n\r?\n\[\[hooks\.SessionStart\.hooks\]\]\r?\ntype = "command"\r?\ncommand = "node [^\r\n]*gsd-check-update\.js"\r?\n/gm,
+          (match) => (match.startsWith('\r\n') ? '\r\n' : match.startsWith('\n') ? '\n' : ''),
+        );
+        // Shape 3
         configContent = configContent.replace(
           /(?:\r?\n|^)# GSD Hooks\r?\n\[\[hooks\.SessionStart\]\]\r?\ncommand = "node [^\r\n]*gsd-check-update\.js"\r?\n/gm,
           (match) => (match.startsWith('\r\n') ? '\r\n' : match.startsWith('\n') ? '\n' : ''),

--- a/tests/bug-2760-codex-install-defensive.test.cjs
+++ b/tests/bug-2760-codex-install-defensive.test.cjs
@@ -671,8 +671,11 @@ describe('#2760 CR4 finding 2 — Legacy flat [[hooks]] block migrates to namesp
         + (parsed.hooks ? typeof parsed.hooks.SessionStart : 'no hooks table')
     );
 
-    // Collect commands from both event-level (old user schema) and nested
-    // .hooks sub-tables (new GSD schema) so the test covers both shapes.
+    // Collect commands from both event-entry level (user-authored [[hooks.SessionStart]]
+    // entries are preserved as-is, with command at event level) and nested .hooks
+    // sub-tables (the GSD-managed entry uses the Codex 0.124.0+ nested schema).
+    // Migration only upgrades [hooks.TYPE] map-format sections, not existing
+    // namespaced AoT entries, so both shapes can coexist in this test.
     const allSessionStartCommands = parsed.hooks.SessionStart.flatMap((entry) => {
       const cmds = [];
       if (entry.command) cmds.push(entry.command);
@@ -1042,7 +1045,10 @@ describe('#2760 CR5 finding 3 — migration emits namespaced AoT (no flat/namesp
       parsed.hooks && Array.isArray(parsed.hooks.AfterTool),
       'pre-existing [[hooks.AfterTool]] must remain a namespaced AoT array'
     );
-    // AfterTool was authored in old single-level form; command may be at event level.
+    // AfterTool was authored in [[hooks.AfterTool]] namespaced AoT form (not a legacy
+    // map-format section), so migration leaves it untouched. Collect commands from
+    // both event-entry level (the shape it was authored in) and any nested .hooks
+    // sub-tables (for future-proofing) so the assertion covers the preserved entry.
     const afterToolCommands = parsed.hooks.AfterTool.flatMap((e) => {
       const cmds = [];
       if (e.command) cmds.push(e.command);
@@ -1059,13 +1065,15 @@ describe('#2760 CR5 finding 3 — migration emits namespaced AoT (no flat/namesp
       parsed.hooks && Array.isArray(parsed.hooks.SessionStart),
       'migrated SessionStart must be namespaced AoT (not flat [[hooks]])'
     );
-    // After migration, command lives in .hooks[0].command (nested schema).
-    const ssCommands = parsed.hooks.SessionStart.flatMap((e) => {
-      const cmds = [];
-      if (e.command) cmds.push(e.command);
-      if (Array.isArray(e.hooks)) cmds.push(...e.hooks.map((h) => h.command).filter(Boolean));
-      return cmds;
-    });
+    // After migration, [hooks.SessionStart] map-format is promoted to nested AoT.
+    // Command lives in [[hooks.SessionStart.hooks]][0].command (nested schema).
+    assert.ok(
+      parsed.hooks.SessionStart.every((e) => Array.isArray(e.hooks)),
+      'every SessionStart entry must use nested [[hooks.SessionStart.hooks]] handlers after migration'
+    );
+    const ssCommands = parsed.hooks.SessionStart.flatMap((e) =>
+      e.hooks.map((h) => h.command).filter(Boolean)
+    );
     assert.ok(
       ssCommands.includes('y'),
       'user SessionStart command "y" must be preserved in namespaced array: ' +

--- a/tests/bug-2760-codex-install-defensive.test.cjs
+++ b/tests/bug-2760-codex-install-defensive.test.cjs
@@ -90,12 +90,59 @@ describe('#2760 defect 3 — Hooks AoT preservation across install/uninstall/rei
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  test('preserves both pre-existing [[hooks.SessionStart]] entries and adds GSD entry in namespaced form', () => {
+  test('fresh install emits the two-level nested AoT schema (#2773)', () => {
+    // Codex 0.124.0+ requires [[hooks.SessionStart]] + [[hooks.SessionStart.hooks]]
+    // with type = "command". Neither the flat [[hooks]] + event field form nor
+    // the single-block [[hooks.SessionStart]] form without .hooks is accepted.
+    writeCodexConfig(codexHome, '');
+    runCodexInstall(codexHome);
+    const content = readCodexConfig(codexHome);
+    const parsed = parseTomlToObject(content);
+
+    // hooks must be an object (namespaced), NOT a flat array.
+    assert.ok(
+      parsed.hooks && !Array.isArray(parsed.hooks) && typeof parsed.hooks === 'object',
+      'hooks must be a namespaced object, not a flat array: got ' + JSON.stringify(parsed.hooks)
+    );
+    // hooks.SessionStart must be an array-of-tables.
+    assert.ok(
+      Array.isArray(parsed.hooks.SessionStart),
+      'hooks.SessionStart must be array-of-tables: got ' + typeof parsed.hooks.SessionStart
+    );
+    // Each event entry must have a .hooks sub-array.
+    const eventEntry = parsed.hooks.SessionStart[0];
+    assert.ok(
+      eventEntry && Array.isArray(eventEntry.hooks),
+      'hooks.SessionStart[0].hooks must be an array of handlers: got ' + JSON.stringify(eventEntry)
+    );
+    // The handler must have type = "command" and reference gsd-check-update.js.
+    const handler = eventEntry.hooks[0];
+    assert.strictEqual(handler.type, 'command', 'handler type must be "command"');
+    assert.ok(
+      typeof handler.command === 'string' && /gsd-check-update\.js/.test(handler.command),
+      'handler command must reference gsd-check-update.js: got ' + handler.command
+    );
+    // No flat [[hooks]] entries must exist alongside the namespaced form.
+    assert.ok(
+      !Array.isArray(parsed.hooks),
+      'flat [[hooks]] AoT must not coexist with namespaced [[hooks.SessionStart]]'
+    );
+  });
+
+  test('preserves user [[hooks.SessionStart]] entries and adds GSD nested handler', () => {
+    // Users may have their own [[hooks.SessionStart]] entries using the new schema.
+    // GSD must append its own two-level block without disturbing theirs.
     const userConfig = [
       '[[hooks.SessionStart]]',
+      '',
+      '[[hooks.SessionStart.hooks]]',
+      'type = "command"',
       'command = "echo first user hook"',
       '',
       '[[hooks.SessionStart]]',
+      '',
+      '[[hooks.SessionStart.hooks]]',
+      'type = "command"',
       'command = "echo second user hook"',
       '',
     ].join('\n');
@@ -105,57 +152,115 @@ describe('#2760 defect 3 — Hooks AoT preservation across install/uninstall/rei
     const afterInstall = readCodexConfig(codexHome);
     const parsed = parseTomlToObject(afterInstall);
 
-    // hooks.SessionStart must be an array-of-tables (namespaced AoT form).
     assert.ok(
       parsed.hooks && Array.isArray(parsed.hooks.SessionStart),
-      'hooks.SessionStart must be an array-of-tables, got: '
-        + (parsed.hooks ? typeof parsed.hooks.SessionStart : 'no hooks table')
+      'hooks.SessionStart must remain an array-of-tables after install'
     );
 
-    const commands = parsed.hooks.SessionStart.map((entry) => entry.command);
-
-    // Both pre-existing user hook entries survive in the parsed structure.
-    assert.ok(
-      commands.includes('echo first user hook'),
-      'first user [[hooks.SessionStart]] entry preserved in parsed structure: ' + JSON.stringify(commands)
-    );
-    assert.ok(
-      commands.includes('echo second user hook'),
-      'second user [[hooks.SessionStart]] entry preserved in parsed structure: ' + JSON.stringify(commands)
+    // Collect all handler commands across all event entries.
+    const allCommands = parsed.hooks.SessionStart.flatMap((entry) =>
+      Array.isArray(entry.hooks) ? entry.hooks.map((h) => h.command) : []
     );
 
-    // GSD's managed entry is emitted in the same namespaced AoT shape so it
-    // does not collide with the user's preferred form.
     assert.ok(
-      commands.some((cmd) => typeof cmd === 'string' && /gsd-check-update\.js/.test(cmd)),
-      'GSD entry must appear in hooks.SessionStart array (not top-level [[hooks]]): '
-        + JSON.stringify(commands)
+      allCommands.includes('echo first user hook'),
+      'first user hook preserved: ' + JSON.stringify(allCommands)
     );
-
-    // Top-level [[hooks]] AoT must not coexist when namespaced form is in use —
-    // mixing forms is what produces the round-trip break this fix prevents.
     assert.ok(
-      !Array.isArray(parsed.hooks) || parsed.hooks.length === 0,
-      'no top-level [[hooks]] AoT entries when namespaced form is in use'
+      allCommands.includes('echo second user hook'),
+      'second user hook preserved: ' + JSON.stringify(allCommands)
     );
+    assert.ok(
+      allCommands.some((cmd) => typeof cmd === 'string' && /gsd-check-update\.js/.test(cmd)),
+      'GSD handler must appear in hooks.SessionStart[].hooks: ' + JSON.stringify(allCommands)
+    );
+    assert.ok(!Array.isArray(parsed.hooks), 'no flat [[hooks]] entries');
   });
 
-  test('selects top-level [[hooks]] form when user has no namespaced hooks (status-quo behavior)', () => {
-    writeCodexConfig(codexHome, '');
+  test('reinstall replaces flat [[hooks]] + event form with nested schema', () => {
+    // Upgrade path: user has a config written by GSD 1.38.x (flat [[hooks]] form).
+    const legacyConfig = [
+      '[features]',
+      'codex_hooks = true',
+      '',
+      '# GSD Hooks',
+      '[[hooks]]',
+      'event = "SessionStart"',
+      'command = "node /old/path/to/gsd-check-update.js"',
+      '',
+    ].join('\n');
+    writeCodexConfig(codexHome, legacyConfig);
+
     runCodexInstall(codexHome);
     const content = readCodexConfig(codexHome);
     const parsed = parseTomlToObject(content);
 
-    // Top-level hooks must be an array-of-tables; the GSD entry must be one
-    // of those tables and carry event = "SessionStart".
-    assert.ok(
-      Array.isArray(parsed.hooks),
-      'fresh install must produce top-level [[hooks]] AoT, got: ' + typeof parsed.hooks
+    // Old flat form must be gone.
+    assert.ok(!Array.isArray(parsed.hooks), 'flat [[hooks]] must be stripped on upgrade');
+    // New nested form must be present.
+    assert.ok(Array.isArray(parsed.hooks && parsed.hooks.SessionStart), 'new [[hooks.SessionStart]] must be present');
+    const handler = parsed.hooks.SessionStart[0].hooks[0];
+    assert.strictEqual(handler.type, 'command');
+    assert.ok(/gsd-check-update\.js/.test(handler.command));
+    // Only one GSD hook entry must exist (no duplication).
+    assert.strictEqual(
+      (content.match(/gsd-check-update\.js/g) || []).length,
+      1,
+      'exactly one gsd-check-update.js reference after upgrade'
     );
-    assert.ok(
-      parsed.hooks.some((h) => h && h.event === 'SessionStart'),
-      'top-level [[hooks]] AoT must contain an entry with event = "SessionStart": '
-        + JSON.stringify(parsed.hooks)
+  });
+
+  test('reinstall replaces single-block [[hooks.SessionStart]] (no .hooks sub-table) with nested schema', () => {
+    // Upgrade path: user has a config written by the PR #2802 shape —
+    // [[hooks.SessionStart]] without a nested [[hooks.SessionStart.hooks]] sub-table.
+    const prBranchConfig = [
+      '[features]',
+      'codex_hooks = true',
+      '',
+      '# GSD Hooks',
+      '[[hooks.SessionStart]]',
+      'command = "node /old/path/to/gsd-check-update.js"',
+      '',
+    ].join('\n');
+    writeCodexConfig(codexHome, prBranchConfig);
+
+    runCodexInstall(codexHome);
+    const content = readCodexConfig(codexHome);
+    const parsed = parseTomlToObject(content);
+
+    assert.ok(Array.isArray(parsed.hooks && parsed.hooks.SessionStart), '[[hooks.SessionStart]] must be present');
+    const eventEntry = parsed.hooks.SessionStart[0];
+    assert.ok(Array.isArray(eventEntry.hooks), '[[hooks.SessionStart.hooks]] sub-table must be present');
+    const handler = eventEntry.hooks[0];
+    assert.strictEqual(handler.type, 'command');
+    assert.ok(/gsd-check-update\.js/.test(handler.command));
+    assert.strictEqual(
+      (content.match(/gsd-check-update\.js/g) || []).length,
+      1,
+      'exactly one gsd-check-update.js reference after upgrade from PR-#2802-shape'
+    );
+  });
+
+  test('reinstall is idempotent: correct nested schema is stripped and re-emitted cleanly', () => {
+    writeCodexConfig(codexHome, '');
+    runCodexInstall(codexHome);
+    runCodexInstall(codexHome); // second install
+    const content = readCodexConfig(codexHome);
+
+    assert.strictEqual(
+      (content.match(/gsd-check-update\.js/g) || []).length,
+      1,
+      'exactly one gsd-check-update.js reference after double install'
+    );
+    assert.strictEqual(
+      (content.match(/\[\[hooks\.SessionStart\]\]/g) || []).length,
+      1,
+      'exactly one [[hooks.SessionStart]] header after double install'
+    );
+    assert.strictEqual(
+      (content.match(/\[\[hooks\.SessionStart\.hooks\]\]/g) || []).length,
+      1,
+      'exactly one [[hooks.SessionStart.hooks]] header after double install'
     );
   });
 });
@@ -572,15 +677,22 @@ describe('#2760 CR4 finding 2 — Legacy flat [[hooks]] block migrates to namesp
         + (parsed.hooks ? typeof parsed.hooks.SessionStart : 'no hooks table')
     );
 
-    const namespacedCommands = parsed.hooks.SessionStart.map((entry) => entry.command);
+    // Collect commands from both event-level (old user schema) and nested
+    // .hooks sub-tables (new GSD schema) so the test covers both shapes.
+    const allSessionStartCommands = parsed.hooks.SessionStart.flatMap((entry) => {
+      const cmds = [];
+      if (entry.command) cmds.push(entry.command);
+      if (Array.isArray(entry.hooks)) cmds.push(...entry.hooks.map((h) => h.command).filter(Boolean));
+      return cmds;
+    });
     assert.ok(
-      namespacedCommands.includes('echo user hook'),
-      'user [[hooks.SessionStart]] entry preserved: ' + JSON.stringify(namespacedCommands)
+      allSessionStartCommands.includes('echo user hook'),
+      'user [[hooks.SessionStart]] entry preserved: ' + JSON.stringify(allSessionStartCommands)
     );
     assert.ok(
-      namespacedCommands.some((cmd) => typeof cmd === 'string' && /gsd-check-update\.js/.test(cmd)),
+      allSessionStartCommands.some((cmd) => typeof cmd === 'string' && /gsd-check-update\.js/.test(cmd)),
       'GSD entry must appear in hooks.SessionStart array (namespaced AoT form): '
-        + JSON.stringify(namespacedCommands)
+        + JSON.stringify(allSessionStartCommands)
     );
 
     // The legacy top-level [[hooks]] AoT must NOT coexist with the namespaced
@@ -592,7 +704,7 @@ describe('#2760 CR4 finding 2 — Legacy flat [[hooks]] block migrates to namesp
     );
 
     // No duplicate gsd-check-update entries — exactly one managed entry.
-    const gsdEntries = namespacedCommands.filter(
+    const gsdEntries = allSessionStartCommands.filter(
       (cmd) => typeof cmd === 'string' && /gsd-check-update\.js/.test(cmd)
     );
     assert.equal(gsdEntries.length, 1,
@@ -936,18 +1048,30 @@ describe('#2760 CR5 finding 3 — migration emits namespaced AoT (no flat/namesp
       parsed.hooks && Array.isArray(parsed.hooks.AfterTool),
       'pre-existing [[hooks.AfterTool]] must remain a namespaced AoT array'
     );
+    // AfterTool was authored in old single-level form; command may be at event level.
+    const afterToolCommands = parsed.hooks.AfterTool.flatMap((e) => {
+      const cmds = [];
+      if (e.command) cmds.push(e.command);
+      if (Array.isArray(e.hooks)) cmds.push(...e.hooks.map((h) => h.command).filter(Boolean));
+      return cmds;
+    });
     assert.ok(
-      parsed.hooks.AfterTool.some((entry) => entry.command === 'x'),
-      'user AfterTool entry must be preserved: ' + JSON.stringify(parsed.hooks.AfterTool)
+      afterToolCommands.includes('x'),
+      'user AfterTool entry must be preserved: ' + JSON.stringify(afterToolCommands)
     );
 
-    // The migrated SessionStart entry is now namespaced AoT, not flat
-    // [[hooks]] with event="SessionStart".
+    // The migrated SessionStart entry is now namespaced AoT with nested .hooks sub-table.
     assert.ok(
       parsed.hooks && Array.isArray(parsed.hooks.SessionStart),
       'migrated SessionStart must be namespaced AoT (not flat [[hooks]])'
     );
-    const ssCommands = parsed.hooks.SessionStart.map((e) => e.command);
+    // After migration, command lives in .hooks[0].command (nested schema).
+    const ssCommands = parsed.hooks.SessionStart.flatMap((e) => {
+      const cmds = [];
+      if (e.command) cmds.push(e.command);
+      if (Array.isArray(e.hooks)) cmds.push(...e.hooks.map((h) => h.command).filter(Boolean));
+      return cmds;
+    });
     assert.ok(
       ssCommands.includes('y'),
       'user SessionStart command "y" must be preserved in namespaced array: ' +

--- a/tests/bug-2760-codex-install-defensive.test.cjs
+++ b/tests/bug-2760-codex-install-defensive.test.cjs
@@ -671,17 +671,17 @@ describe('#2760 CR4 finding 2 — Legacy flat [[hooks]] block migrates to namesp
         + (parsed.hooks ? typeof parsed.hooks.SessionStart : 'no hooks table')
     );
 
-    // Collect commands from both event-entry level (user-authored [[hooks.SessionStart]]
-    // entries are preserved as-is, with command at event level) and nested .hooks
-    // sub-tables (the GSD-managed entry uses the Codex 0.124.0+ nested schema).
-    // Migration only upgrades [hooks.TYPE] map-format sections, not existing
-    // namespaced AoT entries, so both shapes can coexist in this test.
-    const allSessionStartCommands = parsed.hooks.SessionStart.flatMap((entry) => {
-      const cmds = [];
-      if (entry.command) cmds.push(entry.command);
-      if (Array.isArray(entry.hooks)) cmds.push(...entry.hooks.map((h) => h.command).filter(Boolean));
-      return cmds;
-    });
+    // Migration now handles stale [[hooks.SessionStart]] entries with handler
+    // fields at event-entry level (pre-#2773 shape), promoting them to the
+    // two-level nested form. Every entry must carry a .hooks sub-array after
+    // migration, so collect from nested handlers only.
+    assert.ok(
+      parsed.hooks.SessionStart.every((entry) => Array.isArray(entry.hooks)),
+      'every hooks.SessionStart entry must use nested [[hooks.SessionStart.hooks]] handlers after migration'
+    );
+    const allSessionStartCommands = parsed.hooks.SessionStart.flatMap((entry) =>
+      entry.hooks.map((h) => h.command).filter(Boolean)
+    );
     assert.ok(
       allSessionStartCommands.includes('echo user hook'),
       'user [[hooks.SessionStart]] entry preserved: ' + JSON.stringify(allSessionStartCommands)
@@ -1045,16 +1045,16 @@ describe('#2760 CR5 finding 3 — migration emits namespaced AoT (no flat/namesp
       parsed.hooks && Array.isArray(parsed.hooks.AfterTool),
       'pre-existing [[hooks.AfterTool]] must remain a namespaced AoT array'
     );
-    // AfterTool was authored in [[hooks.AfterTool]] namespaced AoT form (not a legacy
-    // map-format section), so migration leaves it untouched. Collect commands from
-    // both event-entry level (the shape it was authored in) and any nested .hooks
-    // sub-tables (for future-proofing) so the assertion covers the preserved entry.
-    const afterToolCommands = parsed.hooks.AfterTool.flatMap((e) => {
-      const cmds = [];
-      if (e.command) cmds.push(e.command);
-      if (Array.isArray(e.hooks)) cmds.push(...e.hooks.map((h) => h.command).filter(Boolean));
-      return cmds;
-    });
+    // AfterTool was in [[hooks.AfterTool]] with command at event-entry level
+    // (pre-#2773 stale namespaced AoT shape). Migration now promotes these to
+    // the two-level nested form, so every entry must have a .hooks sub-array.
+    assert.ok(
+      parsed.hooks.AfterTool.every((e) => Array.isArray(e.hooks)),
+      'every AfterTool entry must use nested [[hooks.AfterTool.hooks]] handlers after migration'
+    );
+    const afterToolCommands = parsed.hooks.AfterTool.flatMap((e) =>
+      e.hooks.map((h) => h.command).filter(Boolean)
+    );
     assert.ok(
       afterToolCommands.includes('x'),
       'user AfterTool entry must be preserved: ' + JSON.stringify(afterToolCommands)

--- a/tests/bug-2760-codex-install-defensive.test.cjs
+++ b/tests/bug-2760-codex-install-defensive.test.cjs
@@ -203,11 +203,11 @@ describe('#2760 defect 3 — Hooks AoT preservation across install/uninstall/rei
     assert.strictEqual(handler.type, 'command');
     assert.ok(/gsd-check-update\.js/.test(handler.command));
     // Only one GSD hook entry must exist (no duplication).
-    assert.strictEqual(
-      (content.match(/gsd-check-update\.js/g) || []).length,
-      1,
-      'exactly one gsd-check-update.js reference after upgrade'
-    );
+    const sessionStart = parsed.hooks?.SessionStart ?? [];
+    const gsdHandlers = sessionStart.flatMap((entry) =>
+      Array.isArray(entry.hooks) ? entry.hooks : []
+    ).filter((h) => typeof h?.command === 'string' && /gsd-check-update\.js/.test(h.command));
+    assert.strictEqual(gsdHandlers.length, 1, 'exactly one managed handler after upgrade');
   });
 
   test('reinstall replaces single-block [[hooks.SessionStart]] (no .hooks sub-table) with nested schema', () => {
@@ -234,10 +234,13 @@ describe('#2760 defect 3 — Hooks AoT preservation across install/uninstall/rei
     const handler = eventEntry.hooks[0];
     assert.strictEqual(handler.type, 'command');
     assert.ok(/gsd-check-update\.js/.test(handler.command));
+    const handlers = (parsed.hooks?.SessionStart ?? []).flatMap((entry) =>
+      Array.isArray(entry.hooks) ? entry.hooks : []
+    );
     assert.strictEqual(
-      (content.match(/gsd-check-update\.js/g) || []).length,
+      handlers.filter((h) => typeof h?.command === 'string' && /gsd-check-update\.js/.test(h.command)).length,
       1,
-      'exactly one gsd-check-update.js reference after upgrade from PR-#2802-shape'
+      'exactly one managed handler after upgrade from PR-#2802-shape'
     );
   });
 
@@ -247,21 +250,12 @@ describe('#2760 defect 3 — Hooks AoT preservation across install/uninstall/rei
     runCodexInstall(codexHome); // second install
     const content = readCodexConfig(codexHome);
 
-    assert.strictEqual(
-      (content.match(/gsd-check-update\.js/g) || []).length,
-      1,
-      'exactly one gsd-check-update.js reference after double install'
-    );
-    assert.strictEqual(
-      (content.match(/\[\[hooks\.SessionStart\]\]/g) || []).length,
-      1,
-      'exactly one [[hooks.SessionStart]] header after double install'
-    );
-    assert.strictEqual(
-      (content.match(/\[\[hooks\.SessionStart\.hooks\]\]/g) || []).length,
-      1,
-      'exactly one [[hooks.SessionStart.hooks]] header after double install'
-    );
+    const parsed = parseTomlToObject(content);
+    const sessionStart = parsed.hooks?.SessionStart ?? [];
+    assert.strictEqual(sessionStart.length, 1, 'exactly one SessionStart event entry after double install');
+    assert.ok(Array.isArray(sessionStart[0].hooks), 'SessionStart event has nested handlers array');
+    assert.strictEqual(sessionStart[0].hooks.length, 1, 'exactly one handler in SessionStart after double install');
+    assert.ok(/gsd-check-update\.js/.test(sessionStart[0].hooks[0].command), 'managed handler command preserved');
   });
 });
 

--- a/tests/codex-config.test.cjs
+++ b/tests/codex-config.test.cjs
@@ -795,8 +795,19 @@ describe('migrateCodexHooksMapFormat', () => {
       '',
     ].join('\n');
     const result = migrateCodexHooksMapFormat(content);
-    // Content unchanged — migration finds nothing to migrate.
-    assert.strictEqual(result, content);
+    const parsed = parseTomlToObject(result);
+    assert.ok(Array.isArray(parsed.hooks?.SessionStart),
+      'SessionStart must remain a namespaced AoT after no-op migration');
+    assert.strictEqual(parsed.hooks.SessionStart.length, 1,
+      'must not duplicate the event entry');
+    assert.ok(Array.isArray(parsed.hooks.SessionStart[0].hooks),
+      'nested [[hooks.SessionStart.hooks]] sub-table must still be present');
+    assert.strictEqual(parsed.hooks.SessionStart[0].hooks.length, 1,
+      'must not create a double-wrapped [[hooks.SessionStart.hooks.hooks]]');
+    assert.strictEqual(parsed.hooks.SessionStart[0].hooks[0].type, 'command');
+    assert.strictEqual(parsed.hooks.SessionStart[0].hooks[0].command, 'echo already-nested');
+    assert.equal(parsed.hooks.SessionStart[0].command, undefined,
+      'command must not appear at event-entry level');
   });
 
   test('promotes multiple stale [[hooks.TYPE]] entries from different event types', () => {
@@ -829,8 +840,16 @@ describe('migrateCodexHooksMapFormat', () => {
       '',
     ].join('\n');
     const result = migrateCodexHooksMapFormat(content);
-    // Nothing to migrate — content must be unchanged.
-    assert.strictEqual(result, content);
+    const parsed = parseTomlToObject(result);
+    assert.ok(Array.isArray(parsed.hooks?.SessionStart),
+      'matcher-only SessionStart must remain a namespaced AoT');
+    assert.strictEqual(parsed.hooks.SessionStart.length, 1);
+    assert.strictEqual(parsed.hooks.SessionStart[0].matcher, 'some-tool',
+      'matcher key must be preserved');
+    assert.equal(parsed.hooks.SessionStart[0].hooks, undefined,
+      'matcher-only entry must not gain a .hooks sub-array');
+    assert.equal(parsed.hooks.SessionStart[0].command, undefined,
+      'no spurious command key must appear');
   });
 
   test('CRLF line endings are preserved through migration (#2760 CR5: namespaced AoT)', () => {

--- a/tests/codex-config.test.cjs
+++ b/tests/codex-config.test.cjs
@@ -1723,8 +1723,14 @@ describe('Codex install hook configuration (e2e)', () => {
     assert.ok(content.includes('notes = \'\'\'\n[model]\ncodex_hooks = false\n\'\'\''), 'preserves multiline string content');
     assert.strictEqual(countMatches(content, /^codex_hooks = false$/gm), 1, 'does not rewrite codex_hooks text inside multiline string');
     assert.ok(content.indexOf('codex_hooks = true') > content.indexOf('other_feature = true'), 'does not stop the features section at multiline string content');
-    // After migration flat [[hooks]]+event="AfterCommand" becomes [[hooks.AfterCommand]]
-    assert.ok(content.indexOf('codex_hooks = true') < content.indexOf('[[hooks.AfterCommand]]'), 'inserts the real codex_hooks key before the next table');
+    // Parse structurally — verify codex_hooks and migrated AfterCommand hook via parsed object
+    const parsed = parseTomlToObject(content);
+    assert.equal(parsed.features?.codex_hooks, true, 'writes a real codex_hooks boolean key');
+    assert.ok(Array.isArray(parsed.hooks?.AfterCommand), 'AfterCommand flat [[hooks]] migrated to namespaced AoT');
+    const afterCmds = parsed.hooks.AfterCommand.flatMap((entry) =>
+      Array.isArray(entry.hooks) ? entry.hooks.map((h) => h.command).filter(Boolean) : []
+    );
+    assert.ok(afterCmds.includes('echo custom-after-command'), 'preserves AfterCommand user hook command');
     assertNoDraftRootKeys(content);
   });
 

--- a/tests/codex-config.test.cjs
+++ b/tests/codex-config.test.cjs
@@ -756,6 +756,83 @@ describe('migrateCodexHooksMapFormat', () => {
     assert.ok(result.includes('[model]'), 'preserves [model]');
   });
 
+  test('upgrades stale [[hooks.SessionStart]] with event-level command to nested schema (#2773 CR6)', () => {
+    // Pre-#2773 single-block format: handler fields live directly under
+    // [[hooks.SessionStart]] rather than under [[hooks.SessionStart.hooks]].
+    // Codex 0.124.0+ rejects this shape. Migration must promote it.
+    const content = [
+      '[features]',
+      'codex_hooks = true',
+      '',
+      '[[hooks.SessionStart]]',
+      'command = "echo stale-user-hook"',
+      '',
+    ].join('\n');
+    const result = migrateCodexHooksMapFormat(content);
+    const parsed = parseTomlToObject(result);
+    assert.ok(parsed.hooks && Array.isArray(parsed.hooks.SessionStart),
+      'stale [[hooks.SessionStart]] must remain a namespaced AoT');
+    assert.strictEqual(parsed.hooks.SessionStart.length, 1);
+    assert.ok(Array.isArray(parsed.hooks.SessionStart[0].hooks),
+      'must emit [[hooks.SessionStart.hooks]] sub-table');
+    assert.strictEqual(parsed.hooks.SessionStart[0].hooks[0].command, 'echo stale-user-hook');
+    assert.strictEqual(parsed.hooks.SessionStart[0].hooks[0].type, 'command',
+      'must inject type = "command" when source body has no explicit type');
+    assert.equal(parsed.hooks.SessionStart[0].command, undefined,
+      'command must not remain at event-entry level after promotion');
+    assert.equal(parsed.features && parsed.features.codex_hooks, true);
+  });
+
+  test('leaves [[hooks.SessionStart]] + [[hooks.SessionStart.hooks]] untouched (already nested)', () => {
+    // Properly-nested schema: handler lives under [[hooks.SessionStart.hooks]].
+    // Migration must NOT create a double-wrapped [[hooks.SessionStart.hooks.hooks]] shape.
+    const content = [
+      '[[hooks.SessionStart]]',
+      '',
+      '[[hooks.SessionStart.hooks]]',
+      'type = "command"',
+      'command = "echo already-nested"',
+      '',
+    ].join('\n');
+    const result = migrateCodexHooksMapFormat(content);
+    // Content unchanged — migration finds nothing to migrate.
+    assert.strictEqual(result, content);
+  });
+
+  test('promotes multiple stale [[hooks.TYPE]] entries from different event types', () => {
+    const content = [
+      '[[hooks.SessionStart]]',
+      'command = "echo session"',
+      '',
+      '[[hooks.AfterCommand]]',
+      'command = "echo after-cmd"',
+      '',
+    ].join('\n');
+    const result = migrateCodexHooksMapFormat(content);
+    const parsed = parseTomlToObject(result);
+    assert.ok(parsed.hooks && Array.isArray(parsed.hooks.SessionStart));
+    assert.ok(parsed.hooks && Array.isArray(parsed.hooks.AfterCommand));
+    assert.strictEqual(parsed.hooks.SessionStart[0].hooks[0].command, 'echo session');
+    assert.strictEqual(parsed.hooks.SessionStart[0].hooks[0].type, 'command');
+    assert.strictEqual(parsed.hooks.AfterCommand[0].hooks[0].command, 'echo after-cmd');
+    assert.strictEqual(parsed.hooks.AfterCommand[0].hooks[0].type, 'command');
+    assert.equal(parsed.hooks.SessionStart[0].command, undefined);
+    assert.equal(parsed.hooks.AfterCommand[0].command, undefined);
+  });
+
+  test('matcher-only [[hooks.SessionStart]] (no handler fields) is left untouched', () => {
+    // A [[hooks.SessionStart]] entry with only a `matcher` key is a valid
+    // event filter — no handler fields → not a stale single-block entry.
+    const content = [
+      '[[hooks.SessionStart]]',
+      'matcher = "some-tool"',
+      '',
+    ].join('\n');
+    const result = migrateCodexHooksMapFormat(content);
+    // Nothing to migrate — content must be unchanged.
+    assert.strictEqual(result, content);
+  });
+
   test('CRLF line endings are preserved through migration (#2760 CR5: namespaced AoT)', () => {
     const content = [
       '[features]',
@@ -775,6 +852,8 @@ describe('migrateCodexHooksMapFormat', () => {
     assert.ok(Array.isArray(parsed.hooks.shell[0].hooks), 'must emit [[hooks.shell.hooks]] sub-table');
     assert.strictEqual(parsed.hooks.shell[0].hooks[0].command,
       'node /home/.codex/hooks/gsd-check-update.js');
+    assert.strictEqual(parsed.hooks.shell[0].hooks[0].type, 'command',
+      'migrated shell handler must carry type = "command" per Codex 0.124.0+ schema');
   });
 });
 

--- a/tests/codex-config.test.cjs
+++ b/tests/codex-config.test.cjs
@@ -578,7 +578,9 @@ describe('stripGsdFromCodexConfig', () => {
 // ─── migrateCodexHooksMapFormat ─────────────────────────────────────────────────
 
 describe('migrateCodexHooksMapFormat', () => {
-  test('returns content unchanged when no legacy [hooks] map sections present', () => {
+  test('migrates flat [[hooks]] with event key to namespaced [[hooks.<EVENT>]] form', () => {
+    // Flat [[hooks]] + event = "..." is TOML-incompatible with [[hooks.SessionStart]],
+    // so migrateCodexHooksMapFormat now converts it to the nested namespaced form.
     const content = [
       '[features]',
       'codex_hooks = true',
@@ -588,7 +590,19 @@ describe('migrateCodexHooksMapFormat', () => {
       'command = "node /home/.codex/hooks/gsd-check-update.js"',
       '',
     ].join('\n');
-    assert.strictEqual(migrateCodexHooksMapFormat(content), content);
+    const result = migrateCodexHooksMapFormat(content);
+    const parsed = parseTomlToObject(result);
+    assert.ok(parsed.hooks && Array.isArray(parsed.hooks.SessionStart),
+      'flat [[hooks]] event=SessionStart must be promoted to [[hooks.SessionStart]] AoT');
+    assert.strictEqual(parsed.hooks.SessionStart.length, 1);
+    assert.ok(Array.isArray(parsed.hooks.SessionStart[0].hooks),
+      'must emit [[hooks.SessionStart.hooks]] sub-table');
+    assert.strictEqual(parsed.hooks.SessionStart[0].hooks[0].command,
+      'node /home/.codex/hooks/gsd-check-update.js');
+    assert.equal(parsed.hooks.SessionStart[0].event, undefined,
+      'event key consumed as namespace — must not appear in emitted block');
+    assert.ok(!Array.isArray(parsed.hooks), 'hooks must be a table, not a flat array');
+    assert.equal(parsed.features && parsed.features.codex_hooks, true);
   });
 
   test('returns content unchanged for empty string', () => {
@@ -612,7 +626,10 @@ describe('migrateCodexHooksMapFormat', () => {
     assert.ok(parsed.hooks && Array.isArray(parsed.hooks.shell),
       'hooks.shell must be an array of tables, got: ' + (parsed.hooks ? typeof parsed.hooks.shell : 'no hooks table'));
     assert.strictEqual(parsed.hooks.shell.length, 1);
-    assert.strictEqual(parsed.hooks.shell[0].command, 'node /home/.codex/hooks/gsd-check-update.js');
+    // #2773: command now lives in [[hooks.shell.hooks]] sub-table, not at event-entry level
+    assert.ok(Array.isArray(parsed.hooks.shell[0].hooks), 'must emit [[hooks.shell.hooks]] sub-table');
+    assert.strictEqual(parsed.hooks.shell[0].hooks[0].command, 'node /home/.codex/hooks/gsd-check-update.js');
+    assert.strictEqual(parsed.hooks.shell[0].hooks[0].type, 'command');
     // No flat top-level [[hooks]] AoT and no synthetic event field.
     assert.ok(!Array.isArray(parsed.hooks),
       'no top-level [[hooks]] AoT — namespace IS the event in CR5 form');
@@ -633,8 +650,10 @@ describe('migrateCodexHooksMapFormat', () => {
     const parsed = parseTomlToObject(result);
     assert.ok(parsed.hooks && Array.isArray(parsed.hooks.exec));
     assert.strictEqual(parsed.hooks.exec.length, 1);
-    assert.strictEqual(parsed.hooks.exec[0].command, 'echo hello');
-    assert.strictEqual(parsed.hooks.exec[0].extra_key, 'preserved');
+    // #2773: command and extra keys now live in [[hooks.exec.hooks]] sub-table
+    assert.ok(Array.isArray(parsed.hooks.exec[0].hooks), 'must emit [[hooks.exec.hooks]] sub-table');
+    assert.strictEqual(parsed.hooks.exec[0].hooks[0].command, 'echo hello');
+    assert.strictEqual(parsed.hooks.exec[0].hooks[0].extra_key, 'preserved');
     assert.equal(parsed.hooks.exec[0].event, undefined);
   });
 
@@ -653,18 +672,31 @@ describe('migrateCodexHooksMapFormat', () => {
     assert.ok(parsed.hooks && Array.isArray(parsed.hooks.exec));
     assert.strictEqual(parsed.hooks.shell.length, 1);
     assert.strictEqual(parsed.hooks.exec.length, 1);
-    assert.strictEqual(parsed.hooks.shell[0].command, 'node /home/.codex/hooks/gsd-check-update.js');
-    assert.strictEqual(parsed.hooks.exec[0].command, 'echo done');
+    // #2773: commands now live in the [[hooks.<TYPE>.hooks]] sub-table
+    assert.strictEqual(parsed.hooks.shell[0].hooks[0].command, 'node /home/.codex/hooks/gsd-check-update.js');
+    assert.strictEqual(parsed.hooks.exec[0].hooks[0].command, 'echo done');
   });
 
-  test('leaves user-authored [[hooks]] array entries untouched when no legacy [hooks] map present', () => {
+  test('migrates flat [[hooks]] with event=AfterCommand to [[hooks.AfterCommand]] namespaced form', () => {
+    // Flat [[hooks]] + event = "..." is incompatible with [[hooks.<EVENT>]] AoT in the same
+    // file — TOML cannot have hooks be both an array and a table. Migration promotes it.
     const content = [
       '[[hooks]]',
       'event = "AfterCommand"',
       'command = "echo custom"',
       '',
     ].join('\n');
-    assert.strictEqual(migrateCodexHooksMapFormat(content), content);
+    const result = migrateCodexHooksMapFormat(content);
+    const parsed = parseTomlToObject(result);
+    assert.ok(parsed.hooks && Array.isArray(parsed.hooks.AfterCommand),
+      'flat [[hooks]] event=AfterCommand must become [[hooks.AfterCommand]] AoT');
+    assert.strictEqual(parsed.hooks.AfterCommand.length, 1);
+    assert.ok(Array.isArray(parsed.hooks.AfterCommand[0].hooks),
+      'must emit [[hooks.AfterCommand.hooks]] sub-table');
+    assert.strictEqual(parsed.hooks.AfterCommand[0].hooks[0].command, 'echo custom');
+    assert.equal(parsed.hooks.AfterCommand[0].event, undefined,
+      'event key consumed as namespace — must not appear in emitted block');
+    assert.ok(!Array.isArray(parsed.hooks), 'hooks must be a table, not a flat array');
   });
 
   test('end-to-end: install on config with old [hooks] map format produces namespaced AoT (#2637, #2760 CR5)', () => {
@@ -686,7 +718,9 @@ describe('migrateCodexHooksMapFormat', () => {
     assert.ok(parsed.hooks && Array.isArray(parsed.hooks.shell),
       'hooks.shell must be array-of-tables in namespaced form');
     assert.strictEqual(parsed.hooks.shell.length, 1);
-    assert.strictEqual(parsed.hooks.shell[0].command,
+    // #2773: command lives in [[hooks.shell.hooks]] sub-table
+    assert.ok(Array.isArray(parsed.hooks.shell[0].hooks), 'must emit [[hooks.shell.hooks]] sub-table');
+    assert.strictEqual(parsed.hooks.shell[0].hooks[0].command,
       'node /home/.codex/hooks/gsd-check-update.js');
     assert.equal(parsed.features && parsed.features.codex_hooks, true);
   });
@@ -725,7 +759,9 @@ describe('migrateCodexHooksMapFormat', () => {
     // Round-trip parse confirms the structural shape independent of EOL.
     const parsed = parseTomlToObject(result);
     assert.ok(parsed.hooks && Array.isArray(parsed.hooks.shell));
-    assert.strictEqual(parsed.hooks.shell[0].command,
+    // #2773: command lives in [[hooks.shell.hooks]] sub-table
+    assert.ok(Array.isArray(parsed.hooks.shell[0].hooks), 'must emit [[hooks.shell.hooks]] sub-table');
+    assert.strictEqual(parsed.hooks.shell[0].hooks[0].command,
       'node /home/.codex/hooks/gsd-check-update.js');
   });
 });
@@ -750,7 +786,7 @@ describe('Codex hooks emit: migration produces namespaced AoT so managed-emit co
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  test('migration of legacy [hooks.SessionStart] produces namespaced AoT', () => {
+  test('migration of legacy [hooks.SessionStart] produces two-level nested AoT (#2773)', () => {
     const legacyContent = [
       '[features]',
       'codex_hooks = true',
@@ -761,16 +797,27 @@ describe('Codex hooks emit: migration produces namespaced AoT so managed-emit co
     ].join('\n');
     const migrated = migrateCodexHooksMapFormat(legacyContent);
     const parsed = parseTomlToObject(migrated);
+    // Outer event entry
     assert.ok(
       parsed.hooks && Array.isArray(parsed.hooks.SessionStart),
       'migration must emit [[hooks.SessionStart]] namespaced AoT'
     );
     assert.equal(parsed.hooks.SessionStart[0].event, undefined,
       'migration must NOT emit a synthetic event field — namespace IS the event');
-    assert.equal(
-      Array.isArray(parsed.hooks),
-      false,
-      'migration must NOT emit a flat top-level [[hooks]] AoT'
+    assert.equal(Array.isArray(parsed.hooks), false,
+      'migration must NOT emit a flat top-level [[hooks]] AoT');
+    // Inner handler sub-table
+    assert.ok(
+      Array.isArray(parsed.hooks.SessionStart[0].hooks),
+      'migration must emit [[hooks.SessionStart.hooks]] sub-table'
+    );
+    const handler = parsed.hooks.SessionStart[0].hooks[0];
+    assert.strictEqual(handler.type, 'command',
+      'migration must inject type = "command" in handler sub-table');
+    assert.strictEqual(
+      handler.command,
+      'node /home/.codex/hooks/gsd-check-update.js',
+      'migration must preserve original command value in handler sub-table'
     );
   });
 });
@@ -1237,7 +1284,16 @@ describe('Codex install hook configuration (e2e)', () => {
 
     const content = readCodexConfig(codexHome);
     assert.ok(content.includes('[features]\ncodex_hooks = true\n'), 'writes codex_hooks feature');
-    assert.ok(content.includes('# GSD Hooks\n[[hooks]]\nevent = "SessionStart"\n'), 'writes GSD SessionStart hook block');
+    // Codex 0.124.0+ nested schema: [[hooks.SessionStart]] + [[hooks.SessionStart.hooks]]
+    const parsed = parseTomlToObject(content);
+    assert.ok(parsed.hooks && Array.isArray(parsed.hooks.SessionStart), 'writes [[hooks.SessionStart]] AoT');
+    assert.ok(Array.isArray(parsed.hooks.SessionStart[0].hooks), 'writes [[hooks.SessionStart.hooks]] sub-table');
+    assert.strictEqual(parsed.hooks.SessionStart[0].hooks[0].type, 'command', 'handler type is "command"');
+    assert.ok(
+      /gsd-check-update\.js/.test(parsed.hooks.SessionStart[0].hooks[0].command),
+      'handler command references gsd-check-update.js'
+    );
+    assert.ok(!Array.isArray(parsed.hooks), 'no flat [[hooks]] AoT emitted');
     assert.strictEqual(countMatches(content, /^codex_hooks = true$/gm), 1, 'writes one codex_hooks key');
     assert.strictEqual(countMatches(content, /gsd-check-update\.js/g), 1, 'writes one GSD update hook');
     assertNoDraftRootKeys(content);
@@ -1667,7 +1723,8 @@ describe('Codex install hook configuration (e2e)', () => {
     assert.ok(content.includes('notes = \'\'\'\n[model]\ncodex_hooks = false\n\'\'\''), 'preserves multiline string content');
     assert.strictEqual(countMatches(content, /^codex_hooks = false$/gm), 1, 'does not rewrite codex_hooks text inside multiline string');
     assert.ok(content.indexOf('codex_hooks = true') > content.indexOf('other_feature = true'), 'does not stop the features section at multiline string content');
-    assert.ok(content.indexOf('codex_hooks = true') < content.indexOf('[[hooks]]'), 'inserts the real codex_hooks key before the next table');
+    // After migration flat [[hooks]]+event="AfterCommand" becomes [[hooks.AfterCommand]]
+    assert.ok(content.indexOf('codex_hooks = true') < content.indexOf('[[hooks.AfterCommand]]'), 'inserts the real codex_hooks key before the next table');
     assertNoDraftRootKeys(content);
   });
 
@@ -1846,7 +1903,10 @@ describe('Codex install hook configuration (e2e)', () => {
     // [features] is inserted after top-level lines, before [model] — not prepended
     assert.ok(content.includes('# first line wins\n\n[features]\ncodex_hooks = true\n'), 'inserts features after top-level lines using first newline style');
     assert.ok(content.includes(`# GSD Agent Configuration — managed by get-shit-done installer\n`), 'writes the managed agent block using the first newline style');
-    assert.ok(content.includes('# GSD Hooks\n[[hooks]]\nevent = "SessionStart"\n'), 'writes the GSD hook block using the first newline style');
+    // Structural check: nested schema must be present regardless of mixed EOL
+    const parsedMixed = parseTomlToObject(content);
+    assert.ok(parsedMixed.hooks && Array.isArray(parsedMixed.hooks.SessionStart), 'writes [[hooks.SessionStart]] AoT with first-newline style');
+    assert.ok(Array.isArray(parsedMixed.hooks.SessionStart[0].hooks), 'writes [[hooks.SessionStart.hooks]] sub-table');
     assert.ok(content.includes('[model]\r\nname = "o3"'), 'preserves the existing CRLF model lines');
     assert.strictEqual(countMatches(content, /^codex_hooks = true$/gm), 1, 'remains idempotent on repeated installs');
     assert.strictEqual(countMatches(content, /gsd-check-update\.js/g), 1, 'does not duplicate the GSD hook block');

--- a/tests/codex-config.test.cjs
+++ b/tests/codex-config.test.cjs
@@ -852,6 +852,36 @@ describe('migrateCodexHooksMapFormat', () => {
       'no spurious command key must appear');
   });
 
+  test('quoted event name with dot ([[hooks."before.tool"]]) is treated as single 2-segment namespace', () => {
+    // Regression for the split('.') bug: "before.tool" contains a dot, but the
+    // key is quoted so it is ONE segment — [[hooks."before.tool"]] has exactly
+    // two path segments and must be classified the same as [[hooks.SessionStart]].
+    // It should NOT be treated as a 3-level path (hooks / before / tool).
+    const content = [
+      '[[hooks."before.tool"]]',
+      'command = "echo hi"',
+      '',
+    ].join('\n');
+    const result = migrateCodexHooksMapFormat(content);
+    const parsed = parseTomlToObject(result);
+    // The key in the parsed object is the unquoted event name "before.tool".
+    assert.ok(
+      parsed.hooks && Array.isArray(parsed.hooks['before.tool']),
+      '[[hooks."before.tool"]] must be a namespaced AoT — not split on the inner dot'
+    );
+    assert.ok(
+      Array.isArray(parsed.hooks['before.tool'][0].hooks),
+      'must emit [[hooks."before.tool".hooks]] sub-table'
+    );
+    assert.strictEqual(
+      parsed.hooks['before.tool'][0].hooks[0].command,
+      'echo hi',
+      'command must be preserved in the nested handler sub-table'
+    );
+    // Ensure no spurious "before" or "tool" top-level hook keys appeared.
+    assert.equal(parsed.hooks?.before, undefined, 'must not split quoted key on dot');
+  });
+
   test('CRLF line endings are preserved through migration (#2760 CR5: namespaced AoT)', () => {
     const content = [
       '[features]',
@@ -1399,9 +1429,10 @@ describe('Codex install hook configuration (e2e)', () => {
     assert.ok(parsed.hooks && Array.isArray(parsed.hooks.SessionStart), 'writes [[hooks.SessionStart]] AoT');
     assert.ok(Array.isArray(parsed.hooks.SessionStart[0].hooks), 'writes [[hooks.SessionStart.hooks]] sub-table');
     assert.strictEqual(parsed.hooks.SessionStart[0].hooks[0].type, 'command', 'handler type is "command"');
-    assert.ok(
-      /gsd-check-update\.js/.test(parsed.hooks.SessionStart[0].hooks[0].command),
-      'handler command references gsd-check-update.js'
+    assert.strictEqual(
+      parsed.hooks.SessionStart[0].hooks[0].command,
+      'node ' + path.join(codexHome, 'hooks', 'gsd-check-update.js').replace(/\\/g, '/'),
+      'handler command must be the exact absolute path to gsd-check-update.js'
     );
     assert.ok(!Array.isArray(parsed.hooks), 'no flat [[hooks]] AoT emitted');
     assert.strictEqual(countMatches(content, /^codex_hooks = true$/gm), 1, 'writes one codex_hooks key');

--- a/tests/codex-config.test.cjs
+++ b/tests/codex-config.test.cjs
@@ -599,6 +599,8 @@ describe('migrateCodexHooksMapFormat', () => {
       'must emit [[hooks.SessionStart.hooks]] sub-table');
     assert.strictEqual(parsed.hooks.SessionStart[0].hooks[0].command,
       'node /home/.codex/hooks/gsd-check-update.js');
+    assert.strictEqual(parsed.hooks.SessionStart[0].hooks[0].type, 'command',
+      'migrated handler must carry type = "command" per Codex 0.124.0+ schema');
     assert.equal(parsed.hooks.SessionStart[0].event, undefined,
       'event key consumed as namespace — must not appear in emitted block');
     assert.ok(!Array.isArray(parsed.hooks), 'hooks must be a table, not a flat array');
@@ -653,6 +655,8 @@ describe('migrateCodexHooksMapFormat', () => {
     // #2773: command and extra keys now live in [[hooks.exec.hooks]] sub-table
     assert.ok(Array.isArray(parsed.hooks.exec[0].hooks), 'must emit [[hooks.exec.hooks]] sub-table');
     assert.strictEqual(parsed.hooks.exec[0].hooks[0].command, 'echo hello');
+    assert.strictEqual(parsed.hooks.exec[0].hooks[0].type, 'command',
+      'migrated handler must carry type = "command" per Codex 0.124.0+ schema');
     assert.strictEqual(parsed.hooks.exec[0].hooks[0].extra_key, 'preserved');
     assert.equal(parsed.hooks.exec[0].event, undefined);
   });
@@ -674,7 +678,11 @@ describe('migrateCodexHooksMapFormat', () => {
     assert.strictEqual(parsed.hooks.exec.length, 1);
     // #2773: commands now live in the [[hooks.<TYPE>.hooks]] sub-table
     assert.strictEqual(parsed.hooks.shell[0].hooks[0].command, 'node /home/.codex/hooks/gsd-check-update.js');
+    assert.strictEqual(parsed.hooks.shell[0].hooks[0].type, 'command',
+      'migrated shell handler must carry type = "command"');
     assert.strictEqual(parsed.hooks.exec[0].hooks[0].command, 'echo done');
+    assert.strictEqual(parsed.hooks.exec[0].hooks[0].type, 'command',
+      'migrated exec handler must carry type = "command"');
   });
 
   test('migrates flat [[hooks]] with event=AfterCommand to [[hooks.AfterCommand]] namespaced form', () => {
@@ -694,6 +702,8 @@ describe('migrateCodexHooksMapFormat', () => {
     assert.ok(Array.isArray(parsed.hooks.AfterCommand[0].hooks),
       'must emit [[hooks.AfterCommand.hooks]] sub-table');
     assert.strictEqual(parsed.hooks.AfterCommand[0].hooks[0].command, 'echo custom');
+    assert.strictEqual(parsed.hooks.AfterCommand[0].hooks[0].type, 'command',
+      'migrated AfterCommand handler must carry type = "command" per Codex 0.124.0+ schema');
     assert.equal(parsed.hooks.AfterCommand[0].event, undefined,
       'event key consumed as namespace — must not appear in emitted block');
     assert.ok(!Array.isArray(parsed.hooks), 'hooks must be a table, not a flat array');
@@ -722,6 +732,8 @@ describe('migrateCodexHooksMapFormat', () => {
     assert.ok(Array.isArray(parsed.hooks.shell[0].hooks), 'must emit [[hooks.shell.hooks]] sub-table');
     assert.strictEqual(parsed.hooks.shell[0].hooks[0].command,
       'node /home/.codex/hooks/gsd-check-update.js');
+    assert.strictEqual(parsed.hooks.shell[0].hooks[0].type, 'command',
+      'migrated shell handler must carry type = "command" per Codex 0.124.0+ schema');
     assert.equal(parsed.features && parsed.features.codex_hooks, true);
   });
 


### PR DESCRIPTION
## Summary

- Codex 0.124.0's stable `[[hooks.SessionStart]]` spec requires a **two-level nested AoT**: an outer event-entry table and an inner `[[hooks.SessionStart.hooks]]` handler sub-table with `type = "command"`. Previous GSD versions never emitted this correctly — either writing flat `[[hooks]] + event = "SessionStart"` (#2637) or a single-block `[[hooks.SessionStart]]` without the nested `.hooks` sub-table (#2760).
- `migrateCodexHooksMapFormat` now also migrates pre-existing flat `[[hooks]]` AoT entries (the `event = "..."` form). Flat `[[hooks]]` and `[[hooks.<EVENT>]]` are **mutually exclusive TOML types** — the key cannot be both an array and a table, so any pre-existing user flat entries must be promoted before GSD appends its own namespaced hooks.
- Migrated flat AoT blocks are inserted **before the GSD marker** so they survive `stripGsdFromCodexConfig` (which sweeps from marker to EOF). Previously they were appended at the very end, past the marker, and were lost on uninstall.

## What changed

**`bin/install.js`**
- Hook block emission: always emits `[[hooks.SessionStart]]` + `[[hooks.SessionStart.hooks]]` two-level nested form
- `migrateCodexHooksMapFormat`: extended to migrate `[[hooks]] + event = "..."` flat AoT entries to `[[hooks.<EVENT>]]` namespaced form; inserts before GSD marker when present
- Strip regexes: cover all four historical block shapes (legacy filename, flat+event, single-block namespaced, correct two-level nested)
- `validateCodexConfigSchema`: no longer rejects flat `[[hooks]]` at root level to avoid false-positives when users have their own non-GSD hooks in that form

**Tests**
- `bug-2760-codex-install-defensive.test.cjs`: 29/29 ✅ — 5 new regression cases for fresh install, upgrade from each legacy shape, idempotent reinstall, user hook preservation
- `codex-config.test.cjs`: 106/106 ✅ — all migration tests updated to assert the nested `[[hooks.<TYPE>.hooks]]` sub-table structure; new tests for flat `[[hooks]]` migration and install+uninstall preservation of non-GSD hooks

## Test plan

- [x] `node --test tests/bug-2760-codex-install-defensive.test.cjs` — 29/29 pass
- [x] `node --test tests/codex-config.test.cjs` — 106/106 pass
- [x] Fresh install emits two-level nested AoT
- [x] Upgrade from flat `[[hooks]] + event` → nested (shape 2)
- [x] Upgrade from single-block `[[hooks.SessionStart]]` → nested (shape 3, PR #2802 shape)
- [x] User's pre-existing `[[hooks]]\nevent = "AfterCommand"` hook is migrated and preserved through install+uninstall
- [x] Idempotent: double install produces exactly one GSD hook entry

Closes #2773

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened install/migration: detects and converts additional legacy hook shapes (flat and stale single-block forms), strips managed SessionStart shapes before migration, always emits a two-level event→handlers structure, properly quotes event names, rejects flat root hook arrays, requires handler entries to be typed "command", and prevents duplicated handlers on reinstall.

* **Tests**
  * Expanded structural tests cover multiple legacy migrations, install/upgrade emissions, idempotency, and preservation/validation of nested handler commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->