### PR TITLE
docs: CHANGELOG and rc.5 release notes for #2809 Codex hooks migrator fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   values, and unsupported value types. Both pre-write helper failures and write-time
   failures restore the pre-install snapshot and abort with a clear error rather than
   warn-and-continue. (#2760)
+- **Codex hooks migrator correctness hardening** — five edge-cases in the
+  `[[hooks.<Event>]]` → `[[hooks.<Event>.hooks]]` migration path fixed: (1) the TOML
+  key parser in hook-body classification now uses `parseTomlKey()` instead of a bare
+  regex, so hyphenated keys (e.g. `status-message`) and quoted keys are no longer
+  silently dropped; (2) `buildNestedBlock` no longer synthesises an empty
+  `[[hooks.TYPE.hooks]]` sub-table for matcher-only sections that carry no handler
+  fields — previously produced a broken entry with `type = "command"` but no
+  `command`; (3) the `legacyMapSections` filter now uses the parsed segment count
+  instead of dot-splitting the path string, preventing three-segment tables such as
+  `[hooks.SessionStart.hooks]` from being misclassified as event entries (same class
+  of bug fixed for `staleNamespacedAotSections` in the previous round); (4) regression
+  test added: `[[hooks."before.tool"]]` (a quoted key containing a dot) is correctly
+  treated as a two-segment namespace and not split on the inner dot. (#2809)
 - **Codex `[[agents]]` reverted to `[agents.<name>]` struct format** — the sequence
   format introduced in #2645 is rejected by codex-cli 0.124.0 with "invalid type:
   sequence, expected struct AgentsToml". Reverted to struct format which is correct for

--- a/docs/RELEASE-v1.39.0-rc.5.md
+++ b/docs/RELEASE-v1.39.0-rc.5.md
@@ -1,0 +1,99 @@
+# v1.39.0-rc.5 Release Notes
+
+Pre-release candidate. Published to npm under the `next` tag.
+
+```
+npx get-shit-done-cc@next
+```
+
+---
+
+## What's in this release
+
+All fixes from rc.4, plus:
+
+### Fixed
+
+**Codex hooks migrator correctness hardening** (#2809)
+
+Five edge-cases in the `[[hooks.<Event>]]` → `[[hooks.<Event>.hooks]]` two-level nested
+schema migration path, discovered across five rounds of code review:
+
+| Finding | Fix |
+|---------|-----|
+| `parseHooksBody` used a bare regex (`/^([\w.]+)\s*=/`) that silently dropped hyphenated keys such as `status-message` and any quoted TOML key | Replaced with `parseTomlKey()`, the existing full TOML key parser |
+| `buildNestedBlock` unconditionally emitted `[[hooks.TYPE.hooks]]` even when no handler fields were present, producing an entry with `type = "command"` but no `command` | Added guard: matcher-only / handler-field-free sections emit only the event-entry block |
+| `legacyMapSections` filter used `section.path.startsWith('hooks.')` without checking the segment count, so three-segment tables like `[hooks.SessionStart.hooks]` were misclassified as event entries and re-emitted as bogus nested events | Now uses `section.segments.length === 2` (same fix previously applied to `staleNamespacedAotSections`) |
+| No regression test for quoted event names containing dots — `[[hooks."before.tool"]]` has a 2-segment path but 3 dot-parts, and a `split('.')` check would misclassify it | Regression test added; quoted-dot names are correctly treated as a single two-segment namespace |
+| Handler command path assertion in install tests used a regex (`/gsd-check-update\.js/`) rather than the exact absolute path | Strengthened to `assert.strictEqual` with `path.join(codexHome, 'hooks', 'gsd-check-update.js')` |
+
+---
+
+## What was in rc.4
+
+### Added
+
+**`--minimal` install flag** (alias `--core-only`) (#2762)
+
+Writes only the six core skills needed to run the main workflow loop:
+`new-project`, `discuss-phase`, `plan-phase`, `execute-phase`, `help`, `update`.
+No `gsd-*` subagents are installed.
+
+| Mode | Cold-start system-prompt overhead |
+|------|-----------------------------------|
+| full (default) | ~12k tokens |
+| minimal | ~700 tokens |
+
+Useful for local LLMs with 32K–128K context windows. Sonnet 4.6 / Opus 4.7 users
+don't need it — the full surface is the right default for cloud models.
+
+The install manifest records `mode: "minimal" | "full"`. Run `gsd update` without
+`--minimal` at any time to expand to the full skill set.
+
+### Fixed (rc.4)
+
+**Codex install no longer corrupts `~/.codex/config.toml`** (#2760)
+
+The installer now:
+
+- Strips legacy `[agents]` (single-bracket) and `[[agents]]` (sequence) blocks
+  unconditionally — both are invalid in the current Codex TOML schema, regardless of
+  whether a GSD marker is present.
+- Emits the GSD-managed hook in the shape the user's config already uses:
+  `[[hooks.<Event>]]` namespaced AoT if any existing hook uses that form, otherwise
+  top-level `[[hooks]]`.
+- Migrates any legacy `[hooks.<Event>]` (map format) to `[[hooks.<Event>]]` (array
+  format) during write.
+- Writes atomically via a temp file + `renameSync` — no partial writes.
+- Validates the post-write bytes with a strict TOML parser that rejects duplicate
+  keys, repeated table headers, trailing bytes after values, and unsupported value
+  types.
+- On any pre-write or write-time failure, restores the pre-install snapshot and aborts
+  with a clear error instead of warn-and-continue.
+
+---
+
+## Installing the pre-release
+
+```bash
+# npm
+npm install -g get-shit-done-cc@next
+
+# npx (one-shot)
+npx get-shit-done-cc@next
+```
+
+To pin to this exact RC:
+
+```bash
+npm install -g get-shit-done-cc@1.39.0-rc.5
+```
+
+---
+
+## What's next
+
+- Run `rc` again on the release branch to publish rc.6 if further fixes land before
+  finalization.
+- Run `finalize` on the release workflow to promote `1.39.0` to `latest` when the RC
+  is stable.


### PR DESCRIPTION
## Linked Issue

Closes #2810

## What this changes

- **`CHANGELOG.md`** — adds a `Fixed` bullet in `[Unreleased]` for PR #2809, covering the five edge-cases corrected in the Codex hooks migrator (hyphenated-key parser, empty-handler guard, segment-count filter, quoted-dot regression test, exact path assertion)
- **`docs/RELEASE-v1.39.0-rc.5.md`** — new file following the rc.4 format; documents the round-5 findings as a table and includes the full rc.4 "what was in rc.4" section so each release file is self-contained

## Checklist

- [x] `CHANGELOG.md` updated
- [x] Release notes match what actually shipped in `1.39.0-rc.5` (npm `next` tag)
- [x] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved correctness of hook migration, including proper handling of TOML keys with hyphens and quotes to prevent data loss.
  * Fixed hook table classification to prevent invalid nested entries.

* **Tests**
  * Added regression test for quoted hook event names.

* **Documentation**
  * Published v1.39.0-rc.5 release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->