### PR TITLE
fix(#2784): clear shared ~/.cache/gsd/ update-check cache in update workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   values, and unsupported value types. Both pre-write helper failures and write-time
   failures restore the pre-install snapshot and abort with a clear error rather than
   warn-and-continue. (#2760)
-- **Codex hooks migrator correctness hardening** — five edge-cases in the
+- **Codex hooks migrator correctness hardening** — four edge-cases in the
   `[[hooks.<Event>]]` → `[[hooks.<Event>.hooks]]` migration path fixed: (1) the TOML
   key parser in hook-body classification now uses `parseTomlKey()` instead of a bare
   regex, so hyphenated keys (e.g. `status-message`) and quoted keys are no longer

--- a/docs/RELEASE-v1.39.0-rc.5.md
+++ b/docs/RELEASE-v1.39.0-rc.5.md
@@ -2,7 +2,7 @@
 
 Pre-release candidate. Published to npm under the `next` tag.
 
-```
+```bash
 npx get-shit-done-cc@next
 ```
 

--- a/get-shit-done/workflows/update.md
+++ b/get-shit-done/workflows/update.md
@@ -539,6 +539,11 @@ for dir in .claude .config/opencode .opencode .gemini .config/kilo .kilo .codex;
   rm -f "./$dir/cache/gsd-update-check.json"
   rm -f "$HOME/$dir/cache/gsd-update-check.json"
 done
+
+# Clear the shared tool-agnostic cache written by gsd-check-update.js hook (#2784).
+# The hook uses ~/.cache/gsd/gsd-update-check.json regardless of runtime; clear it
+# so the statusline stops showing the stale "⬆ /gsd-update" indicator after update.
+rm -f "$HOME/.cache/gsd/gsd-update-check.json"
 ```
 
 The SessionStart hook (`gsd-check-update.js`) writes to the detected runtime's cache directory, so preferred/env-derived paths and default paths must all be cleared to prevent stale update indicators.

--- a/tests/bug-2784-update-cache-clear-path.test.cjs
+++ b/tests/bug-2784-update-cache-clear-path.test.cjs
@@ -1,0 +1,86 @@
+/**
+ * Regression test for bug #2784
+ *
+ * /gsd-update cache-clear step only cleared per-runtime cache paths
+ * (e.g. ~/.claude/cache/gsd-update-check.json) but the SessionStart hook
+ * (hooks/gsd-check-update.js) writes to the shared tool-agnostic path
+ * ~/.cache/gsd/gsd-update-check.json. After a successful update, the statusline
+ * kept showing the stale "⬆ /gsd-update" indicator because the actual cache
+ * file was never deleted.
+ *
+ * Fix: add `rm -f "$HOME/.cache/gsd/gsd-update-check.json"` to the
+ * run_update step's cache-clear block in get-shit-done/workflows/update.md.
+ */
+
+'use strict';
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const UPDATE_WORKFLOW = path.join(
+  REPO_ROOT,
+  'get-shit-done',
+  'workflows',
+  'update.md'
+);
+const CHECK_UPDATE_HOOK = path.join(REPO_ROOT, 'hooks', 'gsd-check-update.js');
+
+describe('bug-2784: update.md cache-clear covers shared cache path', () => {
+  test('gsd-check-update.js hook writes to ~/.cache/gsd/ path', () => {
+    const hookContent = fs.readFileSync(CHECK_UPDATE_HOOK, 'utf-8');
+    // Verify the hook writes to the shared path (the one being missed).
+    // The hook uses path.join(homeDir, '.cache', 'gsd') so check for the
+    // constituent parts rather than a collapsed path string.
+    const referencesSharedCache =
+      hookContent.includes('.cache/gsd') ||
+      hookContent.includes("'.cache'") ||
+      hookContent.includes('".cache"') ||
+      (hookContent.includes("'.cache'") && hookContent.includes("'gsd'")) ||
+      (hookContent.includes('".cache"') && hookContent.includes('"gsd"')) ||
+      hookContent.includes("path.join(homeDir, '.cache', 'gsd')");
+    assert.ok(
+      referencesSharedCache,
+      'hook should write to ~/.cache/gsd/ shared path (via path.join or direct string)'
+    );
+  });
+
+  test('update.md run_update step clears ~/.cache/gsd/gsd-update-check.json', () => {
+    const workflowContent = fs.readFileSync(UPDATE_WORKFLOW, 'utf-8');
+
+    // The workflow must explicitly clear the shared cache path the hook writes to.
+    // Accept either literal $HOME or tilde expansion pattern.
+    const clearsSharedPath =
+      workflowContent.includes('"$HOME/.cache/gsd/gsd-update-check.json"') ||
+      workflowContent.includes("'$HOME/.cache/gsd/gsd-update-check.json'") ||
+      workflowContent.includes('~/.cache/gsd/gsd-update-check.json') ||
+      workflowContent.includes('$HOME/.cache/gsd/gsd-update-check.json');
+
+    assert.ok(
+      clearsSharedPath,
+      'update.md must clear $HOME/.cache/gsd/gsd-update-check.json — the path written by gsd-check-update.js'
+    );
+  });
+
+  test('update.md run_update step places shared cache clear in the same block as per-runtime clears', () => {
+    const workflowContent = fs.readFileSync(UPDATE_WORKFLOW, 'utf-8');
+
+    // The run_update step should have a bash block that clears the cache.
+    // The shared path clear must appear in the same run_update step block.
+    const runUpdateStepMatch = workflowContent.match(
+      /<step name="run_update">([\s\S]*?)<\/step>/
+    );
+    assert.ok(
+      runUpdateStepMatch,
+      'update.md must have a <step name="run_update"> block'
+    );
+
+    const stepContent = runUpdateStepMatch[1];
+    assert.ok(
+      stepContent.includes('.cache/gsd/gsd-update-check.json'),
+      'run_update step must clear .cache/gsd/gsd-update-check.json'
+    );
+  });
+});

--- a/tests/bug-2784-update-cache-clear-path.test.cjs
+++ b/tests/bug-2784-update-cache-clear-path.test.cjs
@@ -29,58 +29,58 @@ const UPDATE_WORKFLOW = path.join(
 const CHECK_UPDATE_HOOK = path.join(REPO_ROOT, 'hooks', 'gsd-check-update.js');
 
 describe('bug-2784: update.md cache-clear covers shared cache path', () => {
-  test('gsd-check-update.js hook writes to ~/.cache/gsd/ path', () => {
+  test('gsd-check-update.js hook constructs cache dir from .cache and gsd path segments', () => {
     const hookContent = fs.readFileSync(CHECK_UPDATE_HOOK, 'utf-8');
-    // Verify the hook writes to the shared path (the one being missed).
-    // The hook uses path.join(homeDir, '.cache', 'gsd') so check for the
-    // constituent parts rather than a collapsed path string.
-    const referencesSharedCache =
-      hookContent.includes('.cache/gsd') ||
-      hookContent.includes("'.cache'") ||
-      hookContent.includes('".cache"') ||
-      (hookContent.includes("'.cache'") && hookContent.includes("'gsd'")) ||
-      (hookContent.includes('".cache"') && hookContent.includes('"gsd"')) ||
-      hookContent.includes("path.join(homeDir, '.cache', 'gsd')");
+    // Parse the path.join() call structurally rather than text-grepping.
+    const m = hookContent.match(/const cacheDir\s*=\s*path\.join\(([^)]+)\)/);
     assert.ok(
-      referencesSharedCache,
-      'hook should write to ~/.cache/gsd/ shared path (via path.join or direct string)'
+      m !== null,
+      'hook must assign cacheDir via path.join() with explicit path segments'
+    );
+    const segments = m[1].split(',').map((a) => a.trim().replace(/^['"]|['"]$/g, ''));
+    assert.ok(
+      segments.includes('.cache'),
+      `hook cacheDir path.join() must include '.cache' segment; got: ${JSON.stringify(segments)}`
+    );
+    assert.ok(
+      segments.includes('gsd'),
+      `hook cacheDir path.join() must include 'gsd' segment; got: ${JSON.stringify(segments)}`
     );
   });
 
-  test('update.md run_update step clears ~/.cache/gsd/gsd-update-check.json', () => {
+  test('update.md run_update bash commands include rm for shared gsd cache file', () => {
     const workflowContent = fs.readFileSync(UPDATE_WORKFLOW, 'utf-8');
+    // Parse the step block structurally, then extract only bash fenced code lines.
+    const stepMatch = workflowContent.match(/<step name="run_update">[\s\S]*?<\/step>/);
+    assert.ok(stepMatch, 'update.md must have a <step name="run_update"> block');
+    const stepContent = stepMatch[0];
 
-    // The workflow must explicitly clear the shared cache path the hook writes to.
-    // Accept either literal $HOME or tilde expansion pattern.
-    const clearsSharedPath =
-      workflowContent.includes('"$HOME/.cache/gsd/gsd-update-check.json"') ||
-      workflowContent.includes("'$HOME/.cache/gsd/gsd-update-check.json'") ||
-      workflowContent.includes('~/.cache/gsd/gsd-update-check.json') ||
-      workflowContent.includes('$HOME/.cache/gsd/gsd-update-check.json');
+    const bashLines = [];
+    const fenceRe = /```(?:bash|sh)\n([\s\S]*?)```/g;
+    let m;
+    while ((m = fenceRe.exec(stepContent)) !== null) {
+      for (const line of m[1].split('\n')) {
+        const trimmed = line.trim();
+        if (trimmed) bashLines.push(trimmed);
+      }
+    }
 
-    assert.ok(
-      clearsSharedPath,
-      'update.md must clear $HOME/.cache/gsd/gsd-update-check.json — the path written by gsd-check-update.js'
-    );
-  });
-
-  test('update.md run_update step places shared cache clear in the same block as per-runtime clears', () => {
-    const workflowContent = fs.readFileSync(UPDATE_WORKFLOW, 'utf-8');
-
-    // The run_update step should have a bash block that clears the cache.
-    // The shared path clear must appear in the same run_update step block.
-    const runUpdateStepMatch = workflowContent.match(
-      /<step name="run_update">([\s\S]*?)<\/step>/
+    const sharedCacheClearCmds = bashLines.filter(
+      (line) => /^rm\b/.test(line) && line.includes('.cache/gsd/gsd-update-check.json')
     );
     assert.ok(
-      runUpdateStepMatch,
-      'update.md must have a <step name="run_update"> block'
+      sharedCacheClearCmds.length > 0,
+      [
+        'run_update step bash blocks must include an `rm` command targeting .cache/gsd/gsd-update-check.json.',
+        `Bash lines found: ${JSON.stringify(bashLines)}`,
+      ].join('\n')
     );
-
-    const stepContent = runUpdateStepMatch[1];
+    const hasHomeExpansion = sharedCacheClearCmds.some(
+      (line) => line.includes('$HOME') || line.includes('~/')
+    );
     assert.ok(
-      stepContent.includes('.cache/gsd/gsd-update-check.json'),
-      'run_update step must clear .cache/gsd/gsd-update-check.json'
+      hasHomeExpansion,
+      `shared cache rm command must use $HOME or ~/ expansion; found: ${JSON.stringify(sharedCacheClearCmds)}`
     );
   });
 });


### PR DESCRIPTION
## What

The `/gsd-update` workflow's cache-clear step only cleared runtime-specific cache paths but omitted the shared `~/.cache/gsd/gsd-update-check.json` file written by the update-check hook.

## Why

The update-check hook writes to `$HOME/.cache/gsd/gsd-update-check.json`. After running an update, the workflow cleared per-runtime paths but left this file intact — causing the hook to continue reporting "update available" based on stale cached data until the TTL expired.

## How

- Added `rm -f "$HOME/.cache/gsd/gsd-update-check.json"` to the `run_update` step cache-clear block in `get-shit-done/workflows/update.md`
- Regression test: `tests/bug-2784-update-cache-clear-path.test.cjs`

Closes #2784

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected Unreleased changelog count for migrator hardening and improved release notes code block syntax for better highlighting.

* **Bug Fixes**
  * Extended cache invalidation so update status indicators are reliably cleared after updates.

* **Tests**
  * Added a regression test to verify the update-cache clearing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->