### PR TITLE
fix(#2803): config-get supports --default <value> fallback for missing keys

### DIFF
--- a/docs/RELEASE-v1.39.0-rc.5.md
+++ b/docs/RELEASE-v1.39.0-rc.5.md
@@ -2,7 +2,7 @@
 
 Pre-release candidate. Published to npm under the `next` tag.
 
-```
+```bash
 npx get-shit-done-cc@next
 ```
 

--- a/sdk/src/query/config-query.ts
+++ b/sdk/src/query/config-query.ts
@@ -86,7 +86,10 @@ export const configGet: QueryHandler = async (args, projectDir, workstream) => {
   let defaultValue: string | undefined;
   let filteredArgs = args;
   if (defaultIdx !== -1) {
-    defaultValue = args[defaultIdx + 1] !== undefined ? String(args[defaultIdx + 1]) : '';
+    if (defaultIdx + 1 >= args.length) {
+      throw new GSDError('Usage: config-get <key.path> [--default <value>]', ErrorClassification.Validation);
+    }
+    defaultValue = String(args[defaultIdx + 1]);
     filteredArgs = [...args.slice(0, defaultIdx), ...args.slice(defaultIdx + 2)];
   }
 
@@ -100,7 +103,6 @@ export const configGet: QueryHandler = async (args, projectDir, workstream) => {
   try {
     raw = await readFile(paths.config, 'utf-8');
   } catch {
-    if (defaultValue !== undefined) return { data: defaultValue };
     throw new GSDError(`No config.json found at ${paths.config}`, ErrorClassification.Validation);
   }
 

--- a/sdk/src/query/config-query.ts
+++ b/sdk/src/query/config-query.ts
@@ -80,9 +80,19 @@ export function getAgentToModelMapForProfile(normalizedProfile: string): Record<
  * @throws GSDError with Validation classification if key missing or not found
  */
 export const configGet: QueryHandler = async (args, projectDir, workstream) => {
-  const keyPath = args[0];
+  // Support --default <value> flag (#2803): return this value (exit 0) when the
+  // key is absent, mirroring gsd-tools.cjs config-get behavior from #1893.
+  const defaultIdx = args.indexOf('--default');
+  let defaultValue: string | undefined;
+  let filteredArgs = args;
+  if (defaultIdx !== -1) {
+    defaultValue = args[defaultIdx + 1] !== undefined ? String(args[defaultIdx + 1]) : '';
+    filteredArgs = [...args.slice(0, defaultIdx), ...args.slice(defaultIdx + 2)];
+  }
+
+  const keyPath = filteredArgs[0];
   if (!keyPath) {
-    throw new GSDError('Usage: config-get <key.path>', ErrorClassification.Validation);
+    throw new GSDError('Usage: config-get <key.path> [--default <value>]', ErrorClassification.Validation);
   }
 
   const paths = planningPaths(projectDir, workstream);
@@ -90,6 +100,7 @@ export const configGet: QueryHandler = async (args, projectDir, workstream) => {
   try {
     raw = await readFile(paths.config, 'utf-8');
   } catch {
+    if (defaultValue !== undefined) return { data: defaultValue };
     throw new GSDError(`No config.json found at ${paths.config}`, ErrorClassification.Validation);
   }
 
@@ -106,11 +117,13 @@ export const configGet: QueryHandler = async (args, projectDir, workstream) => {
     if (current === undefined || current === null || typeof current !== 'object') {
       // UNIX convention (cf. `git config --get`): missing key exits 1, not 10.
       // See issue #2544 — callers use `if ! gsd-sdk query config-get k; then` patterns.
+      if (defaultValue !== undefined) return { data: defaultValue };
       throw new GSDError(`Key not found: ${keyPath}`, ErrorClassification.Execution);
     }
     current = (current as Record<string, unknown>)[key];
   }
   if (current === undefined) {
+    if (defaultValue !== undefined) return { data: defaultValue };
     throw new GSDError(`Key not found: ${keyPath}`, ErrorClassification.Execution);
   }
 

--- a/tests/bug-2803-config-get-default-flag.test.cjs
+++ b/tests/bug-2803-config-get-default-flag.test.cjs
@@ -1,0 +1,132 @@
+/**
+ * Regression test for bug #2803
+ *
+ * `gsd-sdk query config-get <key> --default <value>` silently ignored the
+ * --default flag. When the key was missing, the SDK threw "Error: Key not found"
+ * and exited 1, identical to calling it without --default.
+ *
+ * The CJS path (gsd-tools.cjs config-get <key> --default <value>) honored
+ * --default correctly since #1893. The SDK handler was never ported.
+ *
+ * Fix: configGet in sdk/src/query/config-query.ts now strips --default <value>
+ * from args before key lookup and returns { data: defaultValue } instead of
+ * throwing when the key is absent (config missing, key missing, or nested
+ * object missing).
+ */
+
+'use strict';
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+const { createTempProject, cleanup } = require('./helpers.cjs');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const SDK_CLI = path.join(REPO_ROOT, 'sdk', 'dist', 'cli.js');
+
+/**
+ * Invoke `gsd-sdk query config-get <...args>` against a project dir.
+ * Returns { exitCode, stdout, stderr }.
+ */
+function runConfigGet(args, projectDir) {
+  const argv = ['query', 'config-get', ...args, '--project-dir', projectDir];
+  let stdout = '';
+  let stderr = '';
+  let exitCode = 0;
+  try {
+    stdout = execFileSync(process.execPath, [SDK_CLI, ...argv], {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, GSD_SESSION_KEY: '' },
+    });
+  } catch (err) {
+    exitCode = err.status ?? 1;
+    stdout = err.stdout?.toString() ?? '';
+    stderr = err.stderr?.toString() ?? '';
+  }
+  let json = null;
+  try { json = JSON.parse(stdout.trim()); } catch { /* ok */ }
+  return { exitCode, stdout: stdout.trim(), stderr: stderr.trim(), json };
+}
+
+describe('bug-2803: config-get --default flag honored in SDK', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject('gsd-test-2803-');
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('--default returns fallback value when key absent, exit 0', () => {
+    // Write a config without the key
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ mode: 'balanced' })
+    );
+
+    const result = runConfigGet(
+      ['workflow.test_command', '--default', 'FALLBACK'],
+      tmpDir
+    );
+
+    assert.strictEqual(result.exitCode, 0, 'should exit 0 when --default provided');
+    assert.ok(result.json !== null, 'should emit JSON');
+    assert.strictEqual(result.json, 'FALLBACK', 'data should be the default value');
+  });
+
+  test('--default not consumed as key path', () => {
+    // The key path should still be the first positional, not --default
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ mode: 'quality' })
+    );
+
+    const result = runConfigGet(['mode', '--default', 'balanced'], tmpDir);
+
+    assert.strictEqual(result.exitCode, 0, 'should exit 0 for found key');
+    assert.strictEqual(result.json, 'quality', 'should return actual value when key exists');
+  });
+
+  test('--default with empty string value works', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({})
+    );
+
+    const result = runConfigGet(['missing.key', '--default', ''], tmpDir);
+
+    assert.strictEqual(result.exitCode, 0, 'should exit 0 with empty default');
+    assert.strictEqual(result.json, '', 'data should be empty string');
+  });
+
+  test('without --default: missing key still exits 1', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ mode: 'balanced' })
+    );
+
+    const result = runConfigGet(['workflow.missing_key'], tmpDir);
+
+    assert.strictEqual(result.exitCode, 1, 'should exit 1 when key absent and no --default');
+  });
+
+  test('--default with nested missing path', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ workflow: {} })
+    );
+
+    const result = runConfigGet(
+      ['workflow.test_command', '--default', 'npm test'],
+      tmpDir
+    );
+
+    assert.strictEqual(result.exitCode, 0, 'should exit 0 with default for nested missing key');
+    assert.strictEqual(result.json, 'npm test', 'data should be the default value');
+  });
+});


### PR DESCRIPTION
## What

`gsd-sdk query config.get <key> --default <value>` threw "Config key not found" instead of returning the default value when the key was absent from `config.json`.

## Why

The `configGet` handler in `sdk/src/query/config-query.ts` had no logic to detect or consume the `--default` flag. When a key was missing, it always exited with an error regardless of whether a fallback was supplied.

## How

- Added `--default` flag parsing in the `configGet` handler: when `--default <value>` is present in `args`, the value is captured and returned when the requested key is absent
- Missing key without `--default` still exits with an error (backward compatible)
- Regression test: `tests/bug-2803-config-get-default-flag.test.cjs`

Closes #2803

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Codex hooks migration to properly handle hyphenated and quoted keys
  * Prevented generation of empty hook handler structures
  * Corrected classification of nested configuration tables

* **New Features**
  * Added `--default` option to config query command for fallback values when keys are missing

* **Documentation**
  * Updated release notes documenting v1.39.0-rc.5 migration improvements and new functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->