### PR TITLE
fix(#2801): add ingest-docs handler to gsd-tools init dispatch

### DIFF
--- a/docs/RELEASE-v1.39.0-rc.5.md
+++ b/docs/RELEASE-v1.39.0-rc.5.md
@@ -2,7 +2,7 @@
 
 Pre-release candidate. Published to npm under the `next` tag.
 
-```
+```bash
 npx get-shit-done-cc@next
 ```
 

--- a/get-shit-done/bin/gsd-tools.cjs
+++ b/get-shit-done/bin/gsd-tools.cjs
@@ -884,6 +884,9 @@ async function runCommand(command, args, cwd, raw, defaultValue) {
         case 'quick':
           init.cmdInitQuick(cwd, args.slice(2).join(' '), raw);
           break;
+        case 'ingest-docs':
+          init.cmdInitIngestDocs(cwd, raw);
+          break;
         case 'resume':
           init.cmdInitResume(cwd, raw);
           break;
@@ -918,7 +921,7 @@ async function runCommand(command, args, cwd, raw, defaultValue) {
           init.cmdInitRemoveWorkspace(cwd, args[2], raw);
           break;
         default:
-          error(`Unknown init workflow: ${workflow}\nAvailable: execute-phase, plan-phase, new-project, new-milestone, quick, resume, verify-work, phase-op, todos, milestone-op, map-codebase, progress, manager, new-workspace, list-workspaces, remove-workspace`);
+          error(`Unknown init workflow: ${workflow}\nAvailable: execute-phase, plan-phase, new-project, new-milestone, quick, ingest-docs, resume, verify-work, phase-op, todos, milestone-op, map-codebase, progress, manager, new-workspace, list-workspaces, remove-workspace`);
       }
       break;
     }

--- a/get-shit-done/bin/lib/init.cjs
+++ b/get-shit-done/bin/lib/init.cjs
@@ -562,6 +562,25 @@ function cmdInitQuick(cwd, description, raw) {
   output(withProjectRoot(cwd, result), raw);
 }
 
+/**
+ * Init handler for ingest-docs workflow (#2801).
+ *
+ * Returns the minimal set of fields that ingest-docs.md needs to detect
+ * whether a project/planning dir exists and choose new vs merge mode.
+ * Mirrors the initIngestDocs SDK handler in sdk/src/query/init.ts.
+ */
+function cmdInitIngestDocs(cwd, raw) {
+  const config = loadConfig(cwd);
+  const result = {
+    project_exists: pathExistsInternal(cwd, '.planning/PROJECT.md'),
+    planning_exists: fs.existsSync(planningRoot(cwd)),
+    has_git: fs.existsSync(path.join(cwd, '.git')),
+    project_path: '.planning/PROJECT.md',
+    commit_docs: config.commit_docs,
+  };
+  output(withProjectRoot(cwd, result), raw);
+}
+
 function cmdInitResume(cwd, raw) {
   const config = loadConfig(cwd);
 
@@ -1928,6 +1947,7 @@ module.exports = {
   cmdInitNewProject,
   cmdInitNewMilestone,
   cmdInitQuick,
+  cmdInitIngestDocs,
   cmdInitResume,
   cmdInitVerifyWork,
   cmdInitPhaseOp,

--- a/get-shit-done/workflows/ingest-docs.md
+++ b/get-shit-done/workflows/ingest-docs.md
@@ -52,7 +52,7 @@ If `PATH_NOT_FOUND` or `MANIFEST_NOT_FOUND`: display error and exit.
 Run the init query:
 
 ```bash
-INIT=$(gsd-sdk query init.ingest-docs)
+INIT=$(gsd-tools init ingest-docs)
 ```
 
 Parse `project_exists`, `planning_exists`, `has_git`, `project_path` from INIT.
@@ -289,7 +289,7 @@ Preview the merge diff to the user and gate via approve-revise-abort before writ
 Commit the ingest results:
 
 ```bash
-gsd-sdk query commit "docs: ingest {N} docs from {SCAN_PATH} (#2387)" --files \
+gsd-tools commit "docs: ingest {N} docs from {SCAN_PATH} (#2387)" --files \
   .planning/PROJECT.md \
   .planning/REQUIREMENTS.md \
   .planning/ROADMAP.md \

--- a/tests/bug-2801-ingest-docs-handler.test.cjs
+++ b/tests/bug-2801-ingest-docs-handler.test.cjs
@@ -89,6 +89,7 @@ describe('bug-2801: gsd-tools init ingest-docs handler exists', () => {
     assert.strictEqual(exitCode, 0);
     const json = JSON.parse(stdout.trim());
     assert.ok(Object.prototype.hasOwnProperty.call(json, 'project_path'), 'project_path present');
+    assert.ok(Object.prototype.hasOwnProperty.call(json, 'commit_docs'), 'commit_docs present');
   });
 
   test('planning_exists is true when .planning/ directory exists', () => {
@@ -102,23 +103,26 @@ describe('bug-2801: gsd-tools init ingest-docs handler exists', () => {
 describe('bug-2801: ingest-docs.md workflow calls gsd-tools not gsd-sdk', () => {
   test('no bash code block in ingest-docs.md calls gsd-sdk', () => {
     const content = fs.readFileSync(WORKFLOW_FILE, 'utf-8');
-    const codeBlocks = [];
+    // Extract bash fenced code blocks structurally.
+    const bashBlocks = [];
     const codeBlockRe = /```bash\n([\s\S]*?)```/g;
     let m;
     while ((m = codeBlockRe.exec(content)) !== null) {
-      codeBlocks.push(m[1]);
+      bashBlocks.push(m[1]);
     }
-    assert.ok(codeBlocks.length > 0, 'expected bash code blocks in workflow');
+    assert.ok(bashBlocks.length > 0, 'expected bash code blocks in workflow');
 
-    const sdkCalls = codeBlocks
+    // Check every line in every bash block — not just lines that start with the token,
+    // since gsd-sdk can appear in subshell expansions like $(gsd-sdk query ...).
+    const sdkCalls = bashBlocks
       .join('\n')
       .split('\n')
-      .filter(line => line.trim().startsWith('gsd-sdk'));
+      .filter((line) => /\bgsd-sdk\b/.test(line));
 
     assert.deepStrictEqual(
       sdkCalls,
       [],
-      `workflow still calls gsd-sdk (should use gsd-tools): ${sdkCalls.join(', ')}`
+      `workflow bash blocks still reference gsd-sdk (should use gsd-tools): ${sdkCalls.join(', ')}`
     );
   });
 

--- a/tests/bug-2801-ingest-docs-handler.test.cjs
+++ b/tests/bug-2801-ingest-docs-handler.test.cjs
@@ -1,0 +1,136 @@
+/**
+ * Regression test for bug #2801
+ *
+ * `/gsd-ingest-docs` was broken because:
+ * 1. `workflows/ingest-docs.md` called `gsd-sdk query init.ingest-docs` but the
+ *    installed binary is `gsd-tools` (not `gsd-sdk`).
+ * 2. `gsd-tools init` had no `ingest-docs` case in its dispatch switch.
+ *
+ * The fix:
+ * - Added `case 'ingest-docs'` to the `init` switch in `gsd-tools.cjs`.
+ * - Exported `cmdInitIngestDocs` from `init.cjs`.
+ * - Updated `workflows/ingest-docs.md` to call `gsd-tools init ingest-docs`.
+ *
+ * This test prevents regression of the dispatch omission.
+ */
+
+'use strict';
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const childProc = require('node:child_process');
+const { createTempProject, cleanup, TOOLS_PATH } = require('./helpers.cjs');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const WORKFLOW_FILE = path.join(REPO_ROOT, 'get-shit-done', 'workflows', 'ingest-docs.md');
+
+function spawnGsdTools(args, projectDir) {
+  let stdout = '';
+  let exitCode = 0;
+  try {
+    stdout = childProc.execFileSync(
+      process.execPath,
+      [TOOLS_PATH, ...args, '--cwd', projectDir],
+      {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        env: { ...process.env, GSD_SESSION_KEY: '' },
+      }
+    );
+  } catch (err) {
+    exitCode = err.status ?? 1;
+    stdout = (err.stdout?.toString() ?? '') + (err.stderr?.toString() ?? '');
+  }
+  return { exitCode, stdout };
+}
+
+describe('bug-2801: gsd-tools init ingest-docs handler exists', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject('gsd-test-2801-');
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('init ingest-docs exits 0 (not "Unknown init workflow")', () => {
+    const { exitCode, stdout } = spawnGsdTools(['init', 'ingest-docs', '--raw'], tmpDir);
+    assert.strictEqual(exitCode, 0, `expected exit 0, got: ${stdout}`);
+  });
+
+  test('init ingest-docs returns JSON with project_exists field', () => {
+    const { exitCode, stdout } = spawnGsdTools(['init', 'ingest-docs', '--raw'], tmpDir);
+    assert.strictEqual(exitCode, 0);
+    let json;
+    try { json = JSON.parse(stdout.trim()); } catch { assert.fail(`non-JSON output: ${stdout}`); }
+    assert.ok(Object.prototype.hasOwnProperty.call(json, 'project_exists'), 'project_exists present');
+  });
+
+  test('init ingest-docs returns JSON with planning_exists field', () => {
+    const { exitCode, stdout } = spawnGsdTools(['init', 'ingest-docs', '--raw'], tmpDir);
+    assert.strictEqual(exitCode, 0);
+    const json = JSON.parse(stdout.trim());
+    assert.ok(Object.prototype.hasOwnProperty.call(json, 'planning_exists'), 'planning_exists present');
+  });
+
+  test('init ingest-docs returns JSON with has_git field', () => {
+    const { exitCode, stdout } = spawnGsdTools(['init', 'ingest-docs', '--raw'], tmpDir);
+    assert.strictEqual(exitCode, 0);
+    const json = JSON.parse(stdout.trim());
+    assert.ok(Object.prototype.hasOwnProperty.call(json, 'has_git'), 'has_git present');
+  });
+
+  test('init ingest-docs returns JSON with project_path field', () => {
+    const { exitCode, stdout } = spawnGsdTools(['init', 'ingest-docs', '--raw'], tmpDir);
+    assert.strictEqual(exitCode, 0);
+    const json = JSON.parse(stdout.trim());
+    assert.ok(Object.prototype.hasOwnProperty.call(json, 'project_path'), 'project_path present');
+  });
+
+  test('planning_exists is true when .planning/ directory exists', () => {
+    const { exitCode, stdout } = spawnGsdTools(['init', 'ingest-docs', '--raw'], tmpDir);
+    assert.strictEqual(exitCode, 0);
+    const json = JSON.parse(stdout.trim());
+    assert.strictEqual(json.planning_exists, true, 'planning_exists should be true (.planning/ created by createTempProject)');
+  });
+});
+
+describe('bug-2801: ingest-docs.md workflow calls gsd-tools not gsd-sdk', () => {
+  test('no bash code block in ingest-docs.md calls gsd-sdk', () => {
+    const content = fs.readFileSync(WORKFLOW_FILE, 'utf-8');
+    const codeBlocks = [];
+    const codeBlockRe = /```bash\n([\s\S]*?)```/g;
+    let m;
+    while ((m = codeBlockRe.exec(content)) !== null) {
+      codeBlocks.push(m[1]);
+    }
+    assert.ok(codeBlocks.length > 0, 'expected bash code blocks in workflow');
+
+    const sdkCalls = codeBlocks
+      .join('\n')
+      .split('\n')
+      .filter(line => line.trim().startsWith('gsd-sdk'));
+
+    assert.deepStrictEqual(
+      sdkCalls,
+      [],
+      `workflow still calls gsd-sdk (should use gsd-tools): ${sdkCalls.join(', ')}`
+    );
+  });
+
+  test('ingest-docs.md init step uses gsd-tools init ingest-docs', () => {
+    const content = fs.readFileSync(WORKFLOW_FILE, 'utf-8');
+    const lines = content.split('\n');
+    const initLine = lines.find(l => /gsd-tools\s+init\s+ingest-docs/.test(l));
+    assert.ok(initLine, 'workflow must contain "gsd-tools init ingest-docs"');
+  });
+
+  test('cmdInitIngestDocs is exported from init.cjs', () => {
+    const init = require(path.join(REPO_ROOT, 'get-shit-done', 'bin', 'lib', 'init.cjs'));
+    assert.strictEqual(typeof init.cmdInitIngestDocs, 'function', 'cmdInitIngestDocs must be exported');
+  });
+});


### PR DESCRIPTION
## What

`/gsd-ingest-docs` was completely broken: the workflow called `gsd-sdk query init.ingest-docs` but the installed binary is `gsd-tools`, which had no `ingest-docs` case in its `init` dispatch switch.

## Why

Two compounding problems:
1. The `workflows/ingest-docs.md` still referenced the old `gsd-sdk` binary name after the rename to `gsd-tools`
2. The `init` switch in `gsd-tools.cjs` was missing the `ingest-docs` case, so even correcting the binary name would have produced "Unknown init workflow: ingest-docs"

## How

- Added `cmdInitIngestDocs` function to `get-shit-done/bin/lib/init.cjs` returning `project_exists`, `planning_exists`, `has_git`, `project_path`, `commit_docs` (matching the shape the workflow parses)
- Exported `cmdInitIngestDocs` from `module.exports` in `init.cjs`
- Added `case 'ingest-docs'` to the `init` switch in `gsd-tools.cjs`
- Updated `workflows/ingest-docs.md` line 55: `gsd-sdk query init.ingest-docs` → `gsd-tools init ingest-docs`
- Updated `workflows/ingest-docs.md` line 292: `gsd-sdk query commit` → `gsd-tools commit`
- Regression test: `tests/bug-2801-ingest-docs-handler.test.cjs`

Closes #2801

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced new `ingest-docs` workflow for automated documentation ingestion and processing.

* **Bug Fixes**
  * Enhanced Codex hooks migrator with improved TOML key parsing, nested block generation, and legacy section classification for better reliability.

* **Tests**
  * Added comprehensive regression test suite for documentation ingestion workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->