### PR TITLE
fix(#2835): align CR-INTEGRATION tests with hyphen-form skill names

### DIFF
--- a/tests/code-review.test.cjs
+++ b/tests/code-review.test.cjs
@@ -29,6 +29,141 @@ const AGENTS_DIR = path.join(__dirname, '..', 'agents');
 const COMMANDS_DIR = path.join(__dirname, '..', 'commands', 'gsd');
 const WORKFLOWS_DIR = path.join(__dirname, '..', 'get-shit-done', 'workflows');
 
+/**
+ * Parse top-level (non-nested, non-escaped) Skill() invocations from a workflow .md file.
+ *
+ * Returns an array of structured objects: [{ skill, args }]
+ *  - `skill` is the value of the `skill="..."` keyword argument
+ *  - `args` is the value of the `args="..."` keyword argument (or null if absent)
+ *
+ * Skips occurrences inside escaped string contexts like
+ *   prompt="... Skill(skill=\"x\", args=\"y\") ..."
+ * by walking the file character-by-character and tracking whether we are inside
+ * a double-quoted string. Escaped quotes (\") are treated as literal content.
+ *
+ * This avoids regex/.includes() text-matching: callers receive a structured list
+ * and assert against fields and tokenized args.
+ */
+function parseWorkflowSkillInvocations(content) {
+  const invocations = [];
+  let i = 0;
+  let inString = false;
+
+  while (i < content.length) {
+    const ch = content[i];
+
+    if (inString) {
+      if (ch === '\\' && i + 1 < content.length) {
+        // Skip escape sequence (e.g. \" or \\)
+        i += 2;
+        continue;
+      }
+      if (ch === '"') {
+        inString = false;
+      }
+      i += 1;
+      continue;
+    }
+
+    if (ch === '"') {
+      inString = true;
+      i += 1;
+      continue;
+    }
+
+    // Look for top-level "Skill(" at this position
+    if (content.startsWith('Skill(', i)) {
+      const callStart = i + 'Skill('.length;
+      // Find the matching close paren, respecting strings/escapes inside the call
+      let j = callStart;
+      let depth = 1;
+      let innerInString = false;
+      while (j < content.length && depth > 0) {
+        const c = content[j];
+        if (innerInString) {
+          if (c === '\\' && j + 1 < content.length) {
+            j += 2;
+            continue;
+          }
+          if (c === '"') innerInString = false;
+          j += 1;
+          continue;
+        }
+        if (c === '"') {
+          innerInString = true;
+        } else if (c === '(') {
+          depth += 1;
+        } else if (c === ')') {
+          depth -= 1;
+          if (depth === 0) break;
+        }
+        j += 1;
+      }
+      const callBody = content.slice(callStart, j);
+      const parsed = parseSkillCallBody(callBody);
+      if (parsed) invocations.push(parsed);
+      i = j + 1;
+      continue;
+    }
+
+    i += 1;
+  }
+
+  return invocations;
+}
+
+/**
+ * Parse the body of a Skill(...) call into { skill, args }.
+ * Body looks like: skill="name", args="value" (args optional).
+ * Returns null if no skill keyword is found.
+ */
+function parseSkillCallBody(body) {
+  const kwargs = {};
+  const isIdentChar = (c) => /[A-Za-z0-9_]/.test(c);
+  const isWs = (c) => /\s/.test(c);
+  let i = 0;
+  while (i < body.length) {
+    // Skip whitespace and commas
+    while (i < body.length && (isWs(body[i]) || body[i] === ',')) i += 1;
+    if (i >= body.length) break;
+
+    // Read identifier key
+    const keyStart = i;
+    while (i < body.length && isIdentChar(body[i])) i += 1;
+    const key = body.slice(keyStart, i);
+    if (!key) break;
+
+    // Expect '='
+    while (i < body.length && isWs(body[i])) i += 1;
+    if (body[i] !== '=') break;
+    i += 1;
+    while (i < body.length && isWs(body[i])) i += 1;
+
+    // Expect quoted value
+    if (body[i] !== '"') break;
+    i += 1;
+    let value = '';
+    while (i < body.length) {
+      const c = body[i];
+      if (c === '\\' && i + 1 < body.length) {
+        value += body[i + 1];
+        i += 2;
+        continue;
+      }
+      if (c === '"') {
+        i += 1;
+        break;
+      }
+      value += c;
+      i += 1;
+    }
+    kwargs[key] = value;
+  }
+
+  if (!('skill' in kwargs)) return null;
+  return { skill: kwargs.skill, args: 'args' in kwargs ? kwargs.args : null };
+}
+
 // Plugin directory resolution (cross-platform safe)
 const PLUGIN_WORKFLOWS_DIR = process.env.GSD_PLUGIN_ROOT || path.join(os.homedir(), '.claude', 'get-shit-done', 'workflows');
 const PLUGIN_AVAILABLE = fs.existsSync(PLUGIN_WORKFLOWS_DIR);
@@ -367,10 +502,12 @@ describe('CR-INTEGRATION: workflow integration points', () => {
   test('autonomous.md contains gsd-code-review skill invocation', () => {
     const content = fs.readFileSync(path.join(WORKFLOWS_DIR, 'autonomous.md'), 'utf-8');
 
-    // Parse Skill(skill="<name>", ...) invocations and assert canonical hyphen form is referenced.
-    // Canonical command form is hyphen (gsd-code-review); colon form (gsd:code-review) is the
-    // legacy frontmatter-name form removed in PR #2819.
-    const skillNames = Array.from(content.matchAll(/Skill\(\s*skill\s*=\s*"([^"]+)"/g)).map(m => m[1]);
+    // Parse Skill(...) invocations into structured objects and assert canonical
+    // hyphen form is referenced. Canonical command form is hyphen
+    // (gsd-code-review); colon form (gsd:code-review) is the legacy
+    // frontmatter-name form removed in PR #2819.
+    const invocations = parseWorkflowSkillInvocations(content);
+    const skillNames = invocations.map(inv => inv.skill);
     assert.ok(skillNames.includes('gsd-code-review'),
       `autonomous.md must invoke Skill(skill="gsd-code-review", ...); found skills: ${JSON.stringify(skillNames)}`);
     assert.ok(!skillNames.includes('gsd:code-review'),
@@ -380,7 +517,8 @@ describe('CR-INTEGRATION: workflow integration points', () => {
   test('autonomous.md contains gsd-code-review-fix skill invocation', () => {
     const content = fs.readFileSync(path.join(WORKFLOWS_DIR, 'autonomous.md'), 'utf-8');
 
-    const skillNames = Array.from(content.matchAll(/Skill\(\s*skill\s*=\s*"([^"]+)"/g)).map(m => m[1]);
+    const invocations = parseWorkflowSkillInvocations(content);
+    const skillNames = invocations.map(inv => inv.skill);
     assert.ok(skillNames.includes('gsd-code-review-fix'),
       `autonomous.md must invoke Skill(skill="gsd-code-review-fix", ...); found skills: ${JSON.stringify(skillNames)}`);
     assert.ok(!skillNames.includes('gsd:code-review-fix'),
@@ -390,10 +528,14 @@ describe('CR-INTEGRATION: workflow integration points', () => {
   test('autonomous.md contains --auto flag for code-review-fix', () => {
     const content = fs.readFileSync(path.join(WORKFLOWS_DIR, 'autonomous.md'), 'utf-8');
 
-    // Find the gsd-code-review-fix Skill invocation and assert its args include --auto.
-    const fixMatch = content.match(/Skill\(\s*skill\s*=\s*"gsd-code-review-fix"\s*,\s*args\s*=\s*"([^"]*)"/);
-    assert.ok(fixMatch, 'autonomous.md missing Skill(skill="gsd-code-review-fix", ...) invocation');
-    assert.ok(fixMatch[1].includes('--auto'),
-      `autonomous.md gsd-code-review-fix args missing --auto flag; got args="${fixMatch[1]}"`);
+    // Find the gsd-code-review-fix Skill invocation, then tokenize its args
+    // (whitespace-split) and assert --auto is one of the tokens. This avoids
+    // substring matches that could conflate --auto with --auto-foo.
+    const invocations = parseWorkflowSkillInvocations(content);
+    const fixInvocation = invocations.find(inv => inv.skill === 'gsd-code-review-fix');
+    assert.ok(fixInvocation, 'autonomous.md missing Skill(skill="gsd-code-review-fix", ...) invocation');
+    const argTokens = new Set((fixInvocation.args ?? '').split(/\s+/).filter(Boolean));
+    assert.ok(argTokens.has('--auto'),
+      `autonomous.md gsd-code-review-fix args missing --auto flag; got args="${fixInvocation.args}"`);
   });
 });

--- a/tests/code-review.test.cjs
+++ b/tests/code-review.test.cjs
@@ -360,24 +360,40 @@ describe('CR-INTEGRATION: workflow integration points', () => {
       'quick.md missing config-get workflow.code_review call');
   });
 
-  test('autonomous.md contains gsd:code-review skill invocation', { skip: !PLUGIN_AVAILABLE ? 'Plugin dir not installed' : false }, () => {
-    const content = fs.readFileSync(path.join(PLUGIN_WORKFLOWS_DIR, 'autonomous.md'), 'utf-8');
+  // autonomous.md tests read from the repo's canonical workflow source (WORKFLOWS_DIR),
+  // not the user-installed plugin dir. The plugin dir can lag behind the repo until the
+  // user re-installs, so asserting against it produces false negatives. The repo file
+  // is the source of truth and is always present in CI checkouts.
+  test('autonomous.md contains gsd-code-review skill invocation', () => {
+    const content = fs.readFileSync(path.join(WORKFLOWS_DIR, 'autonomous.md'), 'utf-8');
 
-    assert.ok(content.includes('gsd:code-review'),
-      'autonomous.md missing gsd:code-review skill invocation');
+    // Parse Skill(skill="<name>", ...) invocations and assert canonical hyphen form is referenced.
+    // Canonical command form is hyphen (gsd-code-review); colon form (gsd:code-review) is the
+    // legacy frontmatter-name form removed in PR #2819.
+    const skillNames = Array.from(content.matchAll(/Skill\(\s*skill\s*=\s*"([^"]+)"/g)).map(m => m[1]);
+    assert.ok(skillNames.includes('gsd-code-review'),
+      `autonomous.md must invoke Skill(skill="gsd-code-review", ...); found skills: ${JSON.stringify(skillNames)}`);
+    assert.ok(!skillNames.includes('gsd:code-review'),
+      'autonomous.md must not use legacy colon form gsd:code-review (canonical is hyphen form)');
   });
 
-  test('autonomous.md contains gsd:code-review-fix skill invocation', { skip: !PLUGIN_AVAILABLE ? 'Plugin dir not installed' : false }, () => {
-    const content = fs.readFileSync(path.join(PLUGIN_WORKFLOWS_DIR, 'autonomous.md'), 'utf-8');
+  test('autonomous.md contains gsd-code-review-fix skill invocation', () => {
+    const content = fs.readFileSync(path.join(WORKFLOWS_DIR, 'autonomous.md'), 'utf-8');
 
-    assert.ok(content.includes('gsd:code-review-fix'),
-      'autonomous.md missing gsd:code-review-fix skill invocation');
+    const skillNames = Array.from(content.matchAll(/Skill\(\s*skill\s*=\s*"([^"]+)"/g)).map(m => m[1]);
+    assert.ok(skillNames.includes('gsd-code-review-fix'),
+      `autonomous.md must invoke Skill(skill="gsd-code-review-fix", ...); found skills: ${JSON.stringify(skillNames)}`);
+    assert.ok(!skillNames.includes('gsd:code-review-fix'),
+      'autonomous.md must not use legacy colon form gsd:code-review-fix (canonical is hyphen form)');
   });
 
-  test('autonomous.md contains --auto flag for code-review-fix', { skip: !PLUGIN_AVAILABLE ? 'Plugin dir not installed' : false }, () => {
-    const content = fs.readFileSync(path.join(PLUGIN_WORKFLOWS_DIR, 'autonomous.md'), 'utf-8');
+  test('autonomous.md contains --auto flag for code-review-fix', () => {
+    const content = fs.readFileSync(path.join(WORKFLOWS_DIR, 'autonomous.md'), 'utf-8');
 
-    assert.ok(content.includes('--auto'),
-      'autonomous.md missing --auto flag for code-review-fix iteration');
+    // Find the gsd-code-review-fix Skill invocation and assert its args include --auto.
+    const fixMatch = content.match(/Skill\(\s*skill\s*=\s*"gsd-code-review-fix"\s*,\s*args\s*=\s*"([^"]*)"/);
+    assert.ok(fixMatch, 'autonomous.md missing Skill(skill="gsd-code-review-fix", ...) invocation');
+    assert.ok(fixMatch[1].includes('--auto'),
+      `autonomous.md gsd-code-review-fix args missing --auto flag; got args="${fixMatch[1]}"`);
   });
 });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2835

## What was broken

CR-INTEGRATION tests in \`tests/code-review.test.cjs\` asserted that \`autonomous.md\` contained \`gsd:code-review\` (legacy colon form). PR #2819 migrated all skill invocations to the canonical hyphen form (\`gsd-code-review\`), so the tests would fail against the current repo state.

## What this fix does

- Read \`autonomous.md\` from the canonical repo \`WORKFLOWS_DIR\` rather than the user-installed plugin dir (which can lag behind the repo until the user re-installs).
- Replace substring matching with structural parsing of \`Skill(skill=\"...\")\` invocations.
- Assert the canonical hyphen form is present AND explicitly reject the legacy colon form (so a future regression to the old name fails immediately).

## Root cause

The original tests were written when the colon form was canonical. PR #2819 inverted that, but the tests weren't updated. They also pointed at the plugin install dir, which is the wrong source of truth — the repo file is.

## Testing

### How I verified the fix

- \`node --test tests/code-review.test.cjs\` → 39/39 pass.
- Verified the new tests fail if \`autonomous.md\` is reverted to colon form.

### Regression test added?

- [x] Yes — three updated tests in \`tests/code-review.test.cjs\` now structurally assert hyphen form and reject colon form.

### Platforms tested

- [x] N/A (test-only change)

### Runtimes tested

- [x] N/A (test-only change)

## Checklist

- [x] Issue linked above with \`Fixes #2835\`
- [x] Linked issue has \`confirmed\` label
- [x] Fix is scoped — test-only change
- [x] Regression test added (in fact, tests _are_ the change)
- [x] All existing tests pass

## Breaking changes

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved workflow integration tests to parse and validate skill invocations rather than relying on text matches.
  * Enforced canonical hyphenated skill names and removed acceptance of legacy colon forms.
  * Made automation flag checks precise by verifying standalone tokens instead of broad substring matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->