### PR TITLE
fix(#2832): gsd-sdk auto detects Codex runtime correctly

### DIFF
--- a/sdk/src/cli.ts
+++ b/sdk/src/cli.ts
@@ -17,6 +17,8 @@ import { CLITransport } from './cli-transport.js';
 import { WSTransport } from './ws-transport.js';
 import { InitRunner } from './init-runner.js';
 import { validateWorkstreamName } from './workstream-utils.js';
+import { loadConfig } from './config.js';
+import { assertRuntimeSupportsAutoMode } from './runtime-gate.js';
 
 // ─── Parsed CLI args ─────────────────────────────────────────────────────────
 
@@ -556,6 +558,18 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<void
 
   // ─── Auto command ─────────────────────────────────────────────────────────
   if (args.command === 'auto') {
+    // #2832: refuse to silently route non-Claude runtime projects through the
+    // Claude Agent SDK. Load project config (best effort — falls back to
+    // defaults when missing) and gate before constructing GSD/InitRunner.
+    try {
+      const cfg = await loadConfig(args.projectDir, args.ws);
+      assertRuntimeSupportsAutoMode(cfg);
+    } catch (err) {
+      console.error(`Fatal error: ${(err as Error).message}`);
+      process.exitCode = 1;
+      return;
+    }
+
     const gsd = new GSD({
       projectDir: args.projectDir,
       model: args.model,

--- a/sdk/src/runtime-gate.test.ts
+++ b/sdk/src/runtime-gate.test.ts
@@ -65,4 +65,20 @@ describe('assertRuntimeSupportsAutoMode', () => {
     // so they fall through to 'claude' rather than hard-blocking.
     expect(() => assertRuntimeSupportsAutoMode({ runtime: 'totally-bogus' })).not.toThrow();
   });
+
+  it('attributes source to config when GSD_RUNTIME is set to an unsupported value', () => {
+    // Unsupported env values fall through to config in detectRuntime; the
+    // gate's error message must report config (not the discarded env value)
+    // as the source so users debug the right thing.
+    process.env.GSD_RUNTIME = 'unsupported-env';
+    let caught: Error | undefined;
+    try {
+      assertRuntimeSupportsAutoMode({ runtime: 'codex' });
+    } catch (err) {
+      caught = err as Error;
+    }
+    expect(caught).toBeDefined();
+    expect(caught!.message).toMatch(/config\.runtime="codex"/);
+    expect(caught!.message).not.toMatch(/GSD_RUNTIME=unsupported-env/);
+  });
 });

--- a/sdk/src/runtime-gate.test.ts
+++ b/sdk/src/runtime-gate.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Unit tests for runtime-gate.ts
+ *
+ * Regression tests for #2832: gsd-sdk auto silently routed Codex (and other
+ * non-Claude) runtime projects through the Claude Agent SDK, picked
+ * Claude-Sonnet defaults from the profile map, and reported instant failures.
+ * The gate fails fast with an actionable error so users either set the right
+ * runtime or fall back to the in-session GSD slash commands.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { assertRuntimeSupportsAutoMode } from './runtime-gate.js';
+
+describe('assertRuntimeSupportsAutoMode', () => {
+  let prevEnv: string | undefined;
+  beforeEach(() => {
+    prevEnv = process.env.GSD_RUNTIME;
+    delete process.env.GSD_RUNTIME;
+  });
+  afterEach(() => {
+    if (prevEnv === undefined) delete process.env.GSD_RUNTIME;
+    else process.env.GSD_RUNTIME = prevEnv;
+  });
+
+  it('passes for runtime: claude (config)', () => {
+    expect(() => assertRuntimeSupportsAutoMode({ runtime: 'claude' })).not.toThrow();
+  });
+
+  it('passes when no runtime configured (defaults to claude)', () => {
+    expect(() => assertRuntimeSupportsAutoMode(undefined)).not.toThrow();
+    expect(() => assertRuntimeSupportsAutoMode({})).not.toThrow();
+  });
+
+  it('throws for runtime: codex via config', () => {
+    expect(() => assertRuntimeSupportsAutoMode({ runtime: 'codex' })).toThrow(/codex/);
+  });
+
+  it('throws for GSD_RUNTIME=codex even when config says claude', () => {
+    process.env.GSD_RUNTIME = 'codex';
+    expect(() => assertRuntimeSupportsAutoMode({ runtime: 'claude' })).toThrow(/codex/);
+  });
+
+  it('error message references issue #2832 and slash-command workaround', () => {
+    let caught: Error | undefined;
+    try {
+      assertRuntimeSupportsAutoMode({ runtime: 'codex' });
+    } catch (err) {
+      caught = err as Error;
+    }
+    expect(caught).toBeDefined();
+    expect(caught!.message).toMatch(/#2832/);
+    expect(caught!.message).toMatch(/gsd-discuss-phase|gsd-plan-phase|gsd-execute-phase/);
+  });
+
+  it('throws for gemini runtime', () => {
+    expect(() => assertRuntimeSupportsAutoMode({ runtime: 'gemini' })).toThrow();
+  });
+
+  it('throws for opencode runtime', () => {
+    expect(() => assertRuntimeSupportsAutoMode({ runtime: 'opencode' })).toThrow();
+  });
+
+  it('passes for unknown runtime values (fall through to claude default)', () => {
+    // Mirrors detectRuntime: unknown values are NOT in SUPPORTED_RUNTIMES,
+    // so they fall through to 'claude' rather than hard-blocking.
+    expect(() => assertRuntimeSupportsAutoMode({ runtime: 'totally-bogus' })).not.toThrow();
+  });
+});

--- a/sdk/src/runtime-gate.ts
+++ b/sdk/src/runtime-gate.ts
@@ -1,0 +1,45 @@
+/**
+ * Runtime gate — guards entry points that only support the Claude runtime.
+ *
+ * The autonomous SDK orchestrator (`gsd-sdk auto`) currently drives plan
+ * execution through `@anthropic-ai/claude-agent-sdk`. It has no Codex /
+ * Gemini / OpenCode dispatcher today, so silently routing a non-Claude
+ * project's autonomous run through the Claude path is incorrect: it picks
+ * Claude models, hits Claude APIs, and confuses users debugging "why is my
+ * Codex run choosing claude-sonnet-4-6?" (issue #2832).
+ *
+ * Fail fast with an actionable error instead. The fix surfaces the limitation
+ * up front and points users at the supported in-session GSD slash commands
+ * for non-Claude runtimes.
+ */
+import { detectRuntime, type Runtime } from './query/helpers.js';
+
+/**
+ * Throw a clear error when the active runtime is not Claude.
+ *
+ * Precedence mirrors `detectRuntime`: `GSD_RUNTIME` env var > `config.runtime`
+ * > `'claude'`. Unknown / missing runtime values default to Claude (the
+ * historical behavior) so existing Claude users are unaffected.
+ *
+ * @param config Project config (with optional `runtime` field).
+ * @throws Error with a runtime-specific actionable message when non-Claude.
+ */
+export function assertRuntimeSupportsAutoMode(config?: Record<string, unknown> | { runtime?: unknown }): void {
+  const cfg = (config ?? {}) as Record<string, unknown>;
+  const runtime: Runtime = detectRuntime({ runtime: cfg.runtime });
+  if (runtime === 'claude') return;
+
+  const env = process.env.GSD_RUNTIME;
+  const source = env ? `GSD_RUNTIME=${env}` : `config.runtime="${String(cfg.runtime ?? '')}"`;
+
+  throw new Error(
+    `gsd-sdk auto currently supports the Claude runtime only ` +
+    `(detected runtime=${runtime} via ${source}). ` +
+    `Autonomous terminal runs through the Claude Agent SDK; non-Claude ` +
+    `runtimes (Codex, Gemini, OpenCode, etc.) must drive GSD via the ` +
+    `in-session slash commands (e.g. /gsd-discuss-phase, /gsd-plan-phase, ` +
+    `/gsd-execute-phase) until issue #2832 lands a multi-runtime executor. ` +
+    `To run on Claude anyway, unset GSD_RUNTIME and set runtime: "claude" ` +
+    `in .planning/config.json.`,
+  );
+}

--- a/sdk/src/runtime-gate.ts
+++ b/sdk/src/runtime-gate.ts
@@ -12,7 +12,7 @@
  * up front and points users at the supported in-session GSD slash commands
  * for non-Claude runtimes.
  */
-import { detectRuntime, type Runtime } from './query/helpers.js';
+import { detectRuntime, SUPPORTED_RUNTIMES, type Runtime } from './query/helpers.js';
 
 /**
  * Throw a clear error when the active runtime is not Claude.
@@ -29,8 +29,15 @@ export function assertRuntimeSupportsAutoMode(config?: Record<string, unknown> |
   const runtime: Runtime = detectRuntime({ runtime: cfg.runtime });
   if (runtime === 'claude') return;
 
+  // Source attribution must reflect what `detectRuntime()` actually used:
+  // a `GSD_RUNTIME` value that isn't in SUPPORTED_RUNTIMES falls through to
+  // the config tier, so reporting it as the source would be misleading.
   const env = process.env.GSD_RUNTIME;
-  const source = env ? `GSD_RUNTIME=${env}` : `config.runtime="${String(cfg.runtime ?? '')}"`;
+  const envIsSupported =
+    typeof env === 'string' && (SUPPORTED_RUNTIMES as readonly string[]).includes(env);
+  const source = envIsSupported
+    ? `GSD_RUNTIME=${env}`
+    : `config.runtime="${String(cfg.runtime ?? '')}"`;
 
   throw new Error(
     `gsd-sdk auto currently supports the Claude runtime only ` +

--- a/sdk/src/session-runner.test.ts
+++ b/sdk/src/session-runner.test.ts
@@ -133,6 +133,23 @@ describe('runPhaseStepSession', () => {
       expect(opts.model).toBe('claude-sonnet-4-6');
     });
 
+    it('respects GSD_RUNTIME env precedence over config (no Claude id when env=codex)', async () => {
+      const prev = process.env.GSD_RUNTIME;
+      process.env.GSD_RUNTIME = 'codex';
+      try {
+        await runPhaseStepSession(
+          'prompt',
+          PhaseStepType.Execute,
+          makeConfig({ model_profile: 'balanced' } as Partial<GSDConfig>),
+        );
+        const opts = mockQueryCalls[0].options as { model?: string };
+        expect(opts.model).toBeUndefined();
+      } finally {
+        if (prev === undefined) delete process.env.GSD_RUNTIME;
+        else process.env.GSD_RUNTIME = prev;
+      }
+    });
+
     it('explicit options.model wins for any runtime', async () => {
       await runPhaseStepSession(
         'prompt',

--- a/sdk/src/session-runner.test.ts
+++ b/sdk/src/session-runner.test.ts
@@ -95,4 +95,53 @@ describe('runPhaseStepSession', () => {
     expect(result.success).toBe(true);
     expect(result.sessionId).toBe('test-session');
   });
+
+  // ─── #2832: runtime-aware model resolution ─────────────────────────────────
+  // Issue: with `runtime: codex` and `model_profile: balanced`, resolveModel
+  // mapped balanced -> 'claude-sonnet-4-6' and forced the Codex run through
+  // a Claude model. For non-Claude runtimes the SDK must NOT inject a Claude
+  // model id; it should leave model unset (or honor explicit overrides) and
+  // let the runtime use its configured default.
+  describe('resolveModel runtime awareness (#2832)', () => {
+    it('does NOT pass a Claude profile model id when runtime is codex', async () => {
+      await runPhaseStepSession(
+        'prompt',
+        PhaseStepType.Execute,
+        makeConfig({ runtime: 'codex', model_profile: 'balanced' } as Partial<GSDConfig>),
+      );
+      const opts = mockQueryCalls[0].options as { model?: string };
+      expect(opts.model).toBeUndefined();
+    });
+
+    it('does NOT pass a Claude profile model id when resolve_model_ids is "omit"', async () => {
+      await runPhaseStepSession(
+        'prompt',
+        PhaseStepType.Execute,
+        makeConfig({ resolve_model_ids: 'omit', model_profile: 'balanced' } as Partial<GSDConfig>),
+      );
+      const opts = mockQueryCalls[0].options as { model?: string };
+      expect(opts.model).toBeUndefined();
+    });
+
+    it('still maps profile -> Claude id when runtime is claude (no regression)', async () => {
+      await runPhaseStepSession(
+        'prompt',
+        PhaseStepType.Execute,
+        makeConfig({ runtime: 'claude', model_profile: 'balanced' } as Partial<GSDConfig>),
+      );
+      const opts = mockQueryCalls[0].options as { model?: string };
+      expect(opts.model).toBe('claude-sonnet-4-6');
+    });
+
+    it('explicit options.model wins for any runtime', async () => {
+      await runPhaseStepSession(
+        'prompt',
+        PhaseStepType.Execute,
+        makeConfig({ runtime: 'codex' } as Partial<GSDConfig>),
+        { model: 'gpt-5.3-codex' },
+      );
+      const opts = mockQueryCalls[0].options as { model?: string };
+      expect(opts.model).toBe('gpt-5.3-codex');
+    });
+  });
 });

--- a/sdk/src/session-runner.ts
+++ b/sdk/src/session-runner.ts
@@ -20,11 +20,31 @@ import { getToolsForPhase } from './tool-scoping.js';
  * Resolve model identifier from options or config profile.
  *
  * Priority: explicit model option > config model_profile > default.
+ *
+ * Runtime-aware (#2832): the profile -> Claude-id map only applies when the
+ * project is targeting the Claude runtime. For Codex, Gemini, OpenCode, etc.,
+ * forcing a Claude model id (e.g. 'claude-sonnet-4-6') silently routes the
+ * autonomous run through the Claude path, which is wrong for those runtimes.
+ * In those cases — and whenever `resolve_model_ids: "omit"` is set — leave
+ * `model` unset so the runtime falls back to its configured default.
  */
 function resolveModel(options?: SessionOptions, config?: GSDConfig): string | undefined {
   if (options?.model) return options.model;
 
-  // Map model_profile names to model IDs
+  // Honor the explicit "don't resolve model ids" config knob (#2652, #2832).
+  // Mirrors `query/config-query.ts` resolve_model_ids === 'omit' branch.
+  if ((config as Record<string, unknown> | undefined)?.resolve_model_ids === 'omit') {
+    return undefined;
+  }
+
+  // Profile -> Claude id map. Applies only on the Claude runtime.
+  const runtime = (config as Record<string, unknown> | undefined)?.runtime;
+  const isClaudeRuntime = runtime === undefined || runtime === null || runtime === 'claude';
+  if (!isClaudeRuntime) {
+    // Non-Claude runtimes: never inject a Claude id from the profile map.
+    return undefined;
+  }
+
   if (config?.model_profile) {
     const profileMap: Record<string, string> = {
       balanced: 'claude-sonnet-4-6',

--- a/sdk/src/session-runner.ts
+++ b/sdk/src/session-runner.ts
@@ -13,6 +13,7 @@ import type { GSDConfig } from './config.js';
 import { buildExecutorPrompt, parseAgentTools, DEFAULT_ALLOWED_TOOLS } from './prompt-builder.js';
 import type { GSDEventStream, EventStreamContext } from './event-stream.js';
 import { getToolsForPhase } from './tool-scoping.js';
+import { detectRuntime } from './query/helpers.js';
 
 // ─── Model resolution ────────────────────────────────────────────────────────
 
@@ -38,9 +39,12 @@ function resolveModel(options?: SessionOptions, config?: GSDConfig): string | un
   }
 
   // Profile -> Claude id map. Applies only on the Claude runtime.
-  const runtime = (config as Record<string, unknown> | undefined)?.runtime;
-  const isClaudeRuntime = runtime === undefined || runtime === null || runtime === 'claude';
-  if (!isClaudeRuntime) {
+  // Use `detectRuntime` so `GSD_RUNTIME` env precedence is honored — a Codex
+  // run with a Claude-shaped config must NOT be silently routed to Claude.
+  const runtime = detectRuntime({
+    runtime: (config as Record<string, unknown> | undefined)?.runtime,
+  });
+  if (runtime !== 'claude') {
     // Non-Claude runtimes: never inject a Claude id from the profile map.
     return undefined;
   }


### PR DESCRIPTION
## Summary

Closes #2832.

`gsd-sdk auto` was silently routing non-Claude runtime projects (Codex, Gemini, OpenCode, etc.) through `@anthropic-ai/claude-agent-sdk`, picking a Claude model from the profile map (e.g. `balanced -> claude-sonnet-4-6`), and reporting instant `[FAILED] $0.00 0.1s` flakes that masked the real problem. The reporter on rc.5 confirmed the run still chose `claude-sonnet-4-6` for a Codex-configured project.

## Root cause

1. `session-runner.ts:resolveModel()` mapped `model_profile` to Claude model ids unconditionally, ignoring `config.runtime` and `config.resolve_model_ids === 'omit'`.
2. The `auto` command in `cli.ts` constructed `GSD` / `InitRunner` without consulting the configured runtime, so non-Claude projects entered the Claude-only execution path.

## Fix

- New `sdk/src/runtime-gate.ts` exports `assertRuntimeSupportsAutoMode(config)`. It uses the existing `detectRuntime()` (env > config > 'claude' precedence) and throws a clear, actionable error for non-Claude runtimes pointing users at the in-session GSD slash commands until a multi-runtime executor lands.
- `cli.ts` `auto` branch loads the project config and calls the gate before constructing the runner.
- `session-runner.ts:resolveModel()` is now runtime-aware: profile -> Claude id only when runtime is Claude; honors `resolve_model_ids: "omit"`; `options.model` still always wins.

## Test plan

- [x] New `sdk/src/runtime-gate.test.ts` (8 cases) covers claude / unset / unknown pass, codex / gemini / opencode throw, `GSD_RUNTIME` overrides `config.runtime`, error message contains `#2832` and slash-command guidance.
- [x] New `resolveModel runtime awareness (#2832)` block in `sdk/src/session-runner.test.ts` (4 cases) asserts no Claude id is injected for `runtime: codex` or `resolve_model_ids: omit`, claude path is unchanged, and explicit `options.model` wins on any runtime.
- [x] `npx tsc --noEmit` clean.
- [x] Targeted vitest run: 58 passed, 0 failed (`runtime-gate`, `session-runner`, `cli`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto mode now validates runtime compatibility and only allows autonomous execution on Claude; guidance provided for other runtimes.

* **Bug Fixes**
  * Model resolution is runtime-aware and respects resolve settings, avoiding unintended Claude model mapping in non-Claude environments.

* **Tests**
  * Added unit tests covering runtime gating, environment-variable precedence, and runtime-aware model resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->