### PR TITLE
docs(#2856): add docs/RELEASE-v1.39.0-rc.6.md

### DIFF
--- a/docs/RELEASE-v1.39.0-rc.6.md
+++ b/docs/RELEASE-v1.39.0-rc.6.md
@@ -1,0 +1,144 @@
+# v1.39.0-rc.6 Release Notes
+
+Pre-release candidate. Published to npm under the `next` tag.
+
+```bash
+npx get-shit-done-cc@next
+```
+
+---
+
+## What's in this release
+
+**rc.6 is a republish of rc.5.** No new fixes were rolled in — `release/1.39.0`
+was bumped from `1.39.0-rc.5` to `1.39.0-rc.6` without first being merged with
+`main`, so the branch contents at the time of tag are byte-for-byte equivalent
+to rc.5 plus the version-bump commit.
+
+```
+$ git log v1.39.0-rc.5..v1.39.0-rc.6 --pretty='%h %s'
+388118d8 chore: bump to 1.39.0-rc.6
+```
+
+If you are already on `1.39.0-rc.5`, there is nothing new to install in rc.6.
+The expected next step is an rc.7 cut that first merges `main` into
+`release/1.39.0` so the eight fixes that landed after rc.5 reach the registry.
+
+### Known issue: split publish
+
+The release workflow run for rc.6 published the main package successfully but
+the SDK publish step failed:
+
+```
+npm error code E404
+npm error 404 Not Found - PUT https://registry.npmjs.org/@gsd-build%2fsdk
+npm error 404  The requested resource '@gsd-build/sdk@1.39.0-rc.6' could not be
+              found or you do not have permission to access it.
+```
+
+| Package | Version on npm `next` | Notes |
+|---------|----------------------|-------|
+| `get-shit-done-cc` | `1.39.0-rc.6` | Published |
+| `@gsd-build/sdk` | `0.1.0` only | rc.5 and rc.6 never published — registry permission / scope-creation error |
+
+If your install path uses `@gsd-build/sdk@next`, it will fall back to `0.1.0`.
+Tracked in the rc.7 follow-up below.
+
+---
+
+## What was in rc.5
+
+### Fixed
+
+**Codex hooks migrator correctness hardening** (#2809)
+
+Five edge-cases in the `[[hooks.<Event>]]` → `[[hooks.<Event>.hooks]]` two-level
+nested schema migration path, discovered across five rounds of code review:
+
+| Finding | Fix |
+|---------|-----|
+| `parseHooksBody` used a bare regex (`/^([\w.]+)\s*=/`) that silently dropped hyphenated keys such as `status-message` and any quoted TOML key | Replaced with `parseTomlKey()`, the existing full TOML key parser |
+| `buildNestedBlock` unconditionally emitted `[[hooks.TYPE.hooks]]` even when no handler fields were present, producing an entry with `type = "command"` but no `command` | Added guard: matcher-only / handler-field-free sections emit only the event-entry block |
+| `legacyMapSections` filter used `section.path.startsWith('hooks.')` without checking the segment count, so three-segment tables like `[hooks.SessionStart.hooks]` were misclassified as event entries and re-emitted as bogus nested events | Now uses `section.segments.length === 2` (same fix previously applied to `staleNamespacedAotSections`) |
+| No regression test for quoted event names containing dots — `[[hooks."before.tool"]]` has a 2-segment path but 3 dot-parts, and a `split('.')` check would misclassify it | Regression test added; quoted-dot names are correctly treated as a single two-segment namespace |
+| Handler command path assertion in install tests used a regex (`/gsd-check-update\.js/`) rather than the exact absolute path | Strengthened to `assert.strictEqual` with `path.join(codexHome, 'hooks', 'gsd-check-update.js')` |
+
+---
+
+## What was in rc.4
+
+### Added
+
+**`--minimal` install flag** (alias `--core-only`) (#2762)
+
+Writes only the six core skills needed to run the main workflow loop:
+`new-project`, `discuss-phase`, `plan-phase`, `execute-phase`, `help`, `update`.
+No `gsd-*` subagents are installed.
+
+| Mode | Cold-start system-prompt overhead |
+|------|-----------------------------------|
+| full (default) | ~12k tokens |
+| minimal | ~700 tokens |
+
+Useful for local LLMs with 32K–128K context windows. Sonnet 4.6 / Opus 4.7 users
+don't need it — the full surface is the right default for cloud models.
+
+The install manifest records `mode: "minimal" | "full"`. Run `gsd update` without
+`--minimal` at any time to expand to the full skill set.
+
+### Fixed (rc.4)
+
+**Codex install no longer corrupts `~/.codex/config.toml`** (#2760)
+
+The installer now:
+
+- Strips legacy `[agents]` (single-bracket) and `[[agents]]` (sequence) blocks
+  unconditionally — both are invalid in the current Codex TOML schema, regardless of
+  whether a GSD marker is present.
+- Emits the GSD-managed hook in the shape the user's config already uses:
+  `[[hooks.<Event>]]` namespaced AoT if any existing hook uses that form, otherwise
+  top-level `[[hooks]]`.
+- Migrates any legacy `[hooks.<Event>]` (map format) to `[[hooks.<Event>]]` (array
+  format) during write.
+- Writes atomically via a temp file + `renameSync` — no partial writes.
+- Validates the post-write bytes with a strict TOML parser that rejects duplicate
+  keys, repeated table headers, trailing bytes after values, and unsupported value
+  types.
+- On any pre-write or write-time failure, restores the pre-install snapshot and aborts
+  with a clear error instead of warn-and-continue.
+
+---
+
+## Installing the pre-release
+
+```bash
+# npm
+npm install -g get-shit-done-cc@next
+
+# npx (one-shot)
+npx get-shit-done-cc@next
+```
+
+To pin to this exact RC:
+
+```bash
+npm install -g get-shit-done-cc@1.39.0-rc.6
+```
+
+> **Note:** `@gsd-build/sdk@1.39.0-rc.6` is **not** on the registry — see the
+> "Known issue: split publish" section above. Pin with `@1.39.0-rc.5` if your
+> install needs the SDK package directly (also missing — see issue), otherwise
+> the `0.1.0` fallback applies.
+
+---
+
+## What's next
+
+- **rc.7** — cut from `release/1.39.0` after merging `main` into the release branch,
+  so the eight fixes that landed after rc.5 (#2828, #2829, #2831, #2832, #2835,
+  #2836, #2838, #2839) actually reach the registry. Track in the rc.6 audit issue.
+- **`@gsd-build/sdk` registry fix** — investigate the 404 on `PUT /@gsd-build%2fsdk`.
+  Likely a one-time `npm publish --access public` is needed to create the scoped
+  package on the registry before the workflow can publish into it.
+- Run `finalize` on the release workflow to promote `1.39.0` to `latest` once an RC
+  with the full main-branch contents is stable.

--- a/docs/RELEASE-v1.39.0-rc.6.md
+++ b/docs/RELEASE-v1.39.0-rc.6.md
@@ -15,7 +15,7 @@ was bumped from `1.39.0-rc.5` to `1.39.0-rc.6` without first being merged with
 `main`, so the branch contents at the time of tag are byte-for-byte equivalent
 to rc.5 plus the version-bump commit.
 
-```
+```bash
 $ git log v1.39.0-rc.5..v1.39.0-rc.6 --pretty='%h %s'
 388118d8 chore: bump to 1.39.0-rc.6
 ```
@@ -23,26 +23,6 @@ $ git log v1.39.0-rc.5..v1.39.0-rc.6 --pretty='%h %s'
 If you are already on `1.39.0-rc.5`, there is nothing new to install in rc.6.
 The expected next step is an rc.7 cut that first merges `main` into
 `release/1.39.0` so the eight fixes that landed after rc.5 reach the registry.
-
-### Known issue: split publish
-
-The release workflow run for rc.6 published the main package successfully but
-the SDK publish step failed:
-
-```
-npm error code E404
-npm error 404 Not Found - PUT https://registry.npmjs.org/@gsd-build%2fsdk
-npm error 404  The requested resource '@gsd-build/sdk@1.39.0-rc.6' could not be
-              found or you do not have permission to access it.
-```
-
-| Package | Version on npm `next` | Notes |
-|---------|----------------------|-------|
-| `get-shit-done-cc` | `1.39.0-rc.6` | Published |
-| `@gsd-build/sdk` | `0.1.0` only | rc.5 and rc.6 never published — registry permission / scope-creation error |
-
-If your install path uses `@gsd-build/sdk@next`, it will fall back to `0.1.0`.
-Tracked in the rc.7 follow-up below.
 
 ---
 
@@ -125,20 +105,12 @@ To pin to this exact RC:
 npm install -g get-shit-done-cc@1.39.0-rc.6
 ```
 
-> **Note:** `@gsd-build/sdk@1.39.0-rc.6` is **not** on the registry — see the
-> "Known issue: split publish" section above. Pin with `@1.39.0-rc.5` if your
-> install needs the SDK package directly (also missing — see issue), otherwise
-> the `0.1.0` fallback applies.
-
 ---
 
 ## What's next
 
 - **rc.7** — cut from `release/1.39.0` after merging `main` into the release branch,
   so the eight fixes that landed after rc.5 (#2828, #2829, #2831, #2832, #2835,
-  #2836, #2838, #2839) actually reach the registry. Track in the rc.6 audit issue.
-- **`@gsd-build/sdk` registry fix** — investigate the 404 on `PUT /@gsd-build%2fsdk`.
-  Likely a one-time `npm publish --access public` is needed to create the scoped
-  package on the registry before the workflow can publish into it.
+  #2836, #2838, #2839) actually reach the registry.
 - Run `finalize` on the release workflow to promote `1.39.0` to `latest` once an RC
   with the full main-branch contents is stable.


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #2856

## What was broken

`docs/RELEASE-v1.39.0-rc.6.md` was missing — every prior RC in the 1.39.0 train (`rc.4`, `rc.5`) has per-RC release notes in `docs/`, but rc.6 was tagged this morning without one.

## What this fix does

Adds `docs/RELEASE-v1.39.0-rc.6.md` following the same shape as `RELEASE-v1.39.0-rc.5.md`:
- `# v1.39.0-rc.6 Release Notes` header
- "Pre-release candidate. Published to npm under the `next` tag." tagline
- Install snippet
- "What's in this release" — honestly states rc.6 = rc.5 content + version bump only (release/1.39.0 wasn't merged with main before the bump, so the eight fixes that landed after rc.5 didn't make it in)
- "Known issue: split publish" section documenting the `@gsd-build/sdk@1.39.0-rc.6` 404 publish failure (the main package landed but the SDK didn't)
- Full recap of "What was in rc.5" and "What was in rc.4" carried forward from the prior file
- "Installing the pre-release" + "What's next" sections

## Root cause

Process gap: when the release workflow's \`rc\` action runs, it bumps the version on \`release/1.39.0\` and tags, but does NOT first merge \`main\`. So if maintainers don't manually sync the release branch beforehand, rc.X+1 ships with rc.X content. Worth a follow-up to add a pre-bump merge step or a check that fails if release/N is N commits behind main.

## Testing

### How I verified the fix

- Verified rc.6 ↔ rc.5 delta via \`git log v1.39.0-rc.5..v1.39.0-rc.6 --pretty='%h %s'\` → only the version-bump commit.
- Verified npm registry state: \`npm view @gsd-build/sdk versions\` returns \`["0.1.0"]\` only — confirming the split-publish issue is real.
- Cross-referenced workflow run [25108511480](https://github.com/gsd-build/get-shit-done/actions/runs/25108511480) failed-job log for the exact 404 error wording.

### Regression test added?

- [ ] No — docs-only change. A follow-up to gate the release workflow on \`release/N\` being in sync with \`main\` would be a separate issue.

### Platforms tested

- [x] N/A (docs-only change)

### Runtimes tested

- [x] N/A (docs-only change)

## Checklist

- [x] Issue linked above with \`Fixes #2856\`
- [x] Linked issue created with priority + area labels
- [x] Fix is scoped — single new file under docs/
- [x] All existing tests pass (no test changes)

## Breaking changes

None. Documentation-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added release notes for v1.39.0-rc.6, noting it is a republish of rc.5 with only a version bump.
  * Documented that rc.5 users need no reinstall, provided npm/npx install and pinning instructions, and outlined next steps for rc.7 and final promotion to latest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->