### PR TITLE
Fix: migrate context7 MCP references to v2 tool names

### DIFF
--- a/agents/gsd-advisor-researcher.md
+++ b/agents/gsd-advisor-researcher.md
@@ -22,7 +22,7 @@ When you need library or framework documentation, check in this order:
 
 1. If Context7 MCP tools (`mcp__context7__*`) are available in your environment, use them:
    - Resolve library ID: `mcp__context7__resolve-library-id` with `libraryName`
-   - Fetch docs: `mcp__context7__get-library-docs` with `context7CompatibleLibraryId` and `topic`
+   - Fetch docs: `mcp__context7__query-docs` with `libraryId` and `topic`
 
 2. If Context7 MCP is not available (upstream bug anthropics/claude-code#13898 strips MCP
    tools from agents with a `tools:` frontmatter restriction), use the CLI fallback via Bash:

--- a/agents/gsd-ai-researcher.md
+++ b/agents/gsd-ai-researcher.md
@@ -21,7 +21,7 @@ When you need library or framework documentation, check in this order:
 
 1. If Context7 MCP tools (`mcp__context7__*`) are available in your environment, use them:
    - Resolve library ID: `mcp__context7__resolve-library-id` with `libraryName`
-   - Fetch docs: `mcp__context7__get-library-docs` with `context7CompatibleLibraryId` and `topic`
+   - Fetch docs: `mcp__context7__query-docs` with `libraryId` and `topic`
 
 2. If Context7 MCP is not available (upstream bug anthropics/claude-code#13898 strips MCP
    tools from agents with a `tools:` frontmatter restriction), use the CLI fallback via Bash:

--- a/agents/gsd-domain-researcher.md
+++ b/agents/gsd-domain-researcher.md
@@ -21,7 +21,7 @@ When you need library or framework documentation, check in this order:
 
 1. If Context7 MCP tools (`mcp__context7__*`) are available in your environment, use them:
    - Resolve library ID: `mcp__context7__resolve-library-id` with `libraryName`
-   - Fetch docs: `mcp__context7__get-library-docs` with `context7CompatibleLibraryId` and `topic`
+   - Fetch docs: `mcp__context7__query-docs` with `libraryId` and `topic`
 
 2. If Context7 MCP is not available (upstream bug anthropics/claude-code#13898 strips MCP
    tools from agents with a `tools:` frontmatter restriction), use the CLI fallback via Bash:

--- a/agents/gsd-executor.md
+++ b/agents/gsd-executor.md
@@ -26,7 +26,7 @@ When you need library or framework documentation, check in this order:
 
 1. If Context7 MCP tools (`mcp__context7__*`) are available in your environment, use them:
    - Resolve library ID: `mcp__context7__resolve-library-id` with `libraryName`
-   - Fetch docs: `mcp__context7__get-library-docs` with `context7CompatibleLibraryId` and `topic`
+   - Fetch docs: `mcp__context7__query-docs` with `libraryId` and `topic`
 
 2. If Context7 MCP is not available (upstream bug anthropics/claude-code#13898 strips MCP
    tools from agents with a `tools:` frontmatter restriction), use the CLI fallback via Bash:

--- a/agents/gsd-phase-researcher.md
+++ b/agents/gsd-phase-researcher.md
@@ -38,7 +38,7 @@ When you need library or framework documentation, check in this order:
 
 1. If Context7 MCP tools (`mcp__context7__*`) are available in your environment, use them:
    - Resolve library ID: `mcp__context7__resolve-library-id` with `libraryName`
-   - Fetch docs: `mcp__context7__get-library-docs` with `context7CompatibleLibraryId` and `topic`
+   - Fetch docs: `mcp__context7__query-docs` with `libraryId` and `topic`
 
 2. If Context7 MCP is not available (upstream bug anthropics/claude-code#13898 strips MCP
    tools from agents with a `tools:` frontmatter restriction), use the CLI fallback via Bash:

--- a/agents/gsd-project-researcher.md
+++ b/agents/gsd-project-researcher.md
@@ -37,7 +37,7 @@ When you need library or framework documentation, check in this order:
 
 1. If Context7 MCP tools (`mcp__context7__*`) are available in your environment, use them:
    - Resolve library ID: `mcp__context7__resolve-library-id` with `libraryName`
-   - Fetch docs: `mcp__context7__get-library-docs` with `context7CompatibleLibraryId` and `topic`
+   - Fetch docs: `mcp__context7__query-docs` with `libraryId` and `topic`
 
 2. If Context7 MCP is not available (upstream bug anthropics/claude-code#13898 strips MCP
    tools from agents with a `tools:` frontmatter restriction), use the CLI fallback via Bash:

--- a/agents/gsd-ui-researcher.md
+++ b/agents/gsd-ui-researcher.md
@@ -32,7 +32,7 @@ When you need library or framework documentation, check in this order:
 
 1. If Context7 MCP tools (`mcp__context7__*`) are available in your environment, use them:
    - Resolve library ID: `mcp__context7__resolve-library-id` with `libraryName`
-   - Fetch docs: `mcp__context7__get-library-docs` with `context7CompatibleLibraryId` and `topic`
+   - Fetch docs: `mcp__context7__query-docs` with `libraryId` and `topic`
 
 2. If Context7 MCP is not available (upstream bug anthropics/claude-code#13898 strips MCP
    tools from agents with a `tools:` frontmatter restriction), use the CLI fallback via Bash:

--- a/get-shit-done/workflows/discovery-phase.md
+++ b/get-shit-done/workflows/discovery-phase.md
@@ -58,8 +58,8 @@ For: Single known library, confirming syntax/version still correct.
 2. Fetch relevant docs:
 
    ```
-   mcp__context7__get-library-docs with:
-   - context7CompatibleLibraryID: [from step 1]
+   mcp__context7__query-docs with:
+   - libraryId: [from step 1]
    - topic: [specific concern]
    ```
 
@@ -94,7 +94,7 @@ For: Choosing between options, new external integration.
    ```
    For each library/framework:
    - mcp__context7__resolve-library-id
-   - mcp__context7__get-library-docs (mode: "code" for API, "info" for concepts)
+   - mcp__context7__query-docs (mode: "code" for API, "info" for concepts)
    ```
 
 3. **Official docs** for anything Context7 lacks.


### PR DESCRIPTION
## Summary

Updates GSD agents and workflows to use Context7 MCP v2 tool names. Fixes silent failures when agents call deprecated v1 names against current Upstash MCP servers.

## Changes

- `mcp__context7__get-library-docs` → `mcp__context7__query-docs`
- `context7CompatibleLibraryId` / `context7CompatibleLibraryID` → `libraryId`

## Affected files

- 7 agent definitions in `agents/`
- 1 workflow in `get-shit-done/workflows/discovery-phase.md`

## Why now

Upstash released context7-mcp v2.0 (April 2026) with these renames. Current GSD agents call the v1 names which now return MCP error -32602 (Invalid arguments). Verified locally — after this patch, agents successfully call context7 end-to-end against context7-mcp@2.2.3.

## Test plan

- [x] All v2 tool calls verified against context7-mcp@2.2.3 with real Upstash lookups (FastAPI, React, NATS, Apache Fineract).
- [x] No remaining v1 references after this diff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation retrieval system across multiple research and workflow components to use an improved tool interface. This ensures consistent and streamlined access to library documentation throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->