### PR TITLE
feat(plan-phase): --mvp vertical-slice planning — PRD Phase 1 (#2826)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased](https://github.com/gsd-build/get-shit-done/compare/v1.38.5...HEAD)
 
 ### Added
+- **`--mvp` flag on `/gsd plan-phase`** — opt-in vertical-slice planning. Plans are
+  organized as feature slices (UI→API→DB) instead of horizontal layers, so each task
+  moves a real user-visible capability forward. Persistable per-phase via `**Mode:** mvp`
+  in ROADMAP.md. New-project Phase 1 + `--mvp` triggers Walking Skeleton output
+  (`SKELETON.md`) capturing architectural decisions for subsequent phases. Single
+  planner agent, mode-switched (no new agent surface). PRD Phases 2–4 (`mvp-phase`
+  command, TDD wiring, discovery/UX) deferred to follow-up plans. (#2826)
 - `--minimal` install flag (alias `--core-only`) writes only the main-loop core skills
   (`new-project`, `discuss-phase`, `plan-phase`, `execute-phase`, `help`, `update`) and
   zero `gsd-*` subagents. Cuts cold-start system-prompt overhead from ~12k tokens to

--- a/agents/gsd-planner.md
+++ b/agents/gsd-planner.md
@@ -302,6 +302,29 @@ This prevents the "scavenger hunt" anti-pattern where executors explore the code
 
 Exceptions where `tdd="true"` is not needed: `type="checkpoint:*"` tasks, configuration-only files, documentation, migration scripts, glue code wiring existing tested components, styling-only changes.
 
+## MVP Mode Detection
+
+**When `MVP_MODE` is enabled (passed by the plan-phase orchestrator):** Decompose tasks as **vertical feature slices**, not horizontal layers. Required reading: `@~/.claude/get-shit-done/references/planner-mvp-mode.md` (loaded conditionally by the orchestrator).
+
+**Core rule:** After each task completes, a real user can do something they could not do after the previous task. If a task only "lays foundation," it is horizontal disguised as vertical — restructure.
+
+**Plan structure under MVP_MODE:**
+
+1. Frame the phase goal as a user story at the top of `PLAN.md`:
+   ```
+   ## Phase Goal
+   **As a** [user], **I want to** [capability], **so that** [outcome].
+   ```
+2. First task: failing end-to-end test for the happy path.
+3. Second task: thinnest UI → API → DB slice that makes the test pass (stubs allowed for non-critical branches).
+4. Third+ tasks: replace stubs with real implementations, add validation, error states, polish.
+
+**Mode is all-or-nothing per phase** (PRD decision Q1). Do not produce a plan that mixes vertical-slice tasks with horizontal layer tasks within the same phase.
+
+**Walking Skeleton mode** (`WALKING_SKELETON=true`, set by orchestrator for Phase 1 + new project under `--mvp`): The first deliverable is a Walking Skeleton — the thinnest possible end-to-end stack. In addition to `PLAN.md`, produce `SKELETON.md` using the template at `@~/.claude/get-shit-done/references/skeleton-template.md`. `SKELETON.md` records architectural decisions (framework, DB, auth, deployment, directory layout) that subsequent phases will build on without renegotiating.
+
+**Compatibility with TDD detection:** When both `MVP_MODE=true` and `workflow.tdd_mode=true`, every behavior-adding task uses `tdd="true"` and a `<behavior>` block, AND the task ordering follows the vertical-slice structure above. The first task is always a failing end-to-end test.
+
 ## User Setup Detection
 
 For tasks involving external services, identify human-required configuration:

--- a/docs/INVENTORY-MANIFEST.json
+++ b/docs/INVENTORY-MANIFEST.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-04-27",
+  "generated": "2026-04-29",
   "families": {
     "agents": [
       "gsd-advisor-researcher",
@@ -237,6 +237,7 @@
       "planner-antipatterns.md",
       "planner-chunked.md",
       "planner-gap-closure.md",
+      "planner-mvp-mode.md",
       "planner-reviews.md",
       "planner-revision.md",
       "planner-source-audit.md",
@@ -245,6 +246,7 @@
       "questioning.md",
       "revision-loop.md",
       "scout-codebase.md",
+      "skeleton-template.md",
       "sketch-interactivity.md",
       "sketch-theme-system.md",
       "sketch-tooling.md",

--- a/docs/INVENTORY.md
+++ b/docs/INVENTORY.md
@@ -271,7 +271,7 @@ Full roster at `get-shit-done/workflows/*.md`. Workflows are thin orchestrators 
 
 ---
 
-## References (51 shipped)
+## References (53 shipped)
 
 Full roster at `get-shit-done/references/*.md`. References are shared knowledge documents that workflows and agents `@-reference`. The groupings below match [`docs/ARCHITECTURE.md`](ARCHITECTURE.md#references-get-shit-donereferencesmd) — core, workflow, thinking-model clusters, and the modular planner decomposition.
 
@@ -356,8 +356,10 @@ The `gsd-planner` agent is decomposed into a core agent plus reference modules t
 | `planner-reviews.md` | Cross-AI review integration (reads REVIEWS.md from `/gsd-review`). |
 | `planner-revision.md` | Plan revision patterns for iterative refinement. |
 | `planner-source-audit.md` | Planner source-audit and authority-limit rules. |
+| `planner-mvp-mode.md` | Vertical-slice planning rules for MVP mode. |
+| `skeleton-template.md` | SKELETON.md template emitted for new-project Walking Skeleton (Phase 1 + `--mvp`). |
 
-> **Subdirectory:** `get-shit-done/references/few-shot-examples/` contains additional few-shot examples (`plan-checker.md`, `verifier.md`) that are referenced from specific agents. These are not counted in the 51 top-level references.
+> **Subdirectory:** `get-shit-done/references/few-shot-examples/` contains additional few-shot examples (`plan-checker.md`, `verifier.md`) that are referenced from specific agents. These are not counted in the 53 top-level references.
 
 ---
 

--- a/get-shit-done/bin/lib/roadmap.cjs
+++ b/get-shit-done/bin/lib/roadmap.cjs
@@ -85,6 +85,11 @@ function searchPhaseInContent(content, escapedPhase, phaseNum) {
   const goalMatch = section.match(/\*\*Goal(?::\*\*|\*\*:)\s*([^\n]+)/i);
   const goal = goalMatch ? goalMatch[1].trim() : null;
 
+  // Mode: vertical-MVP slice mode flag. Lowercased + trimmed for canonical
+  // comparison; unrecognized values are preserved verbatim for forward-compat.
+  const modeMatch = section.match(/\*\*Mode(?::\*\*|\*\*:)\s*([^\n]+)/i);
+  const mode = modeMatch ? modeMatch[1].trim().toLowerCase() : null;
+
   // Extract success criteria as structured array
   const criteriaMatch = section.match(/\*\*Success Criteria\*\*[^\n]*:\s*\n((?:\s*\d+\.\s*[^\n]+\n?)+)/i);
   const success_criteria = criteriaMatch
@@ -96,6 +101,7 @@ function searchPhaseInContent(content, escapedPhase, phaseNum) {
     phase_number: phaseNum,
     phase_name: phaseName,
     goal,
+    mode,
     success_criteria,
     section,
   };
@@ -181,6 +187,9 @@ function cmdRoadmapAnalyze(cwd, raw) {
     const goalMatch = section.match(/\*\*Goal(?::\*\*|\*\*:)\s*([^\n]+)/i);
     const goal = goalMatch ? goalMatch[1].trim() : null;
 
+    const modeMatch = section.match(/\*\*Mode(?::\*\*|\*\*:)\s*([^\n]+)/i);
+    const mode = modeMatch ? modeMatch[1].trim().toLowerCase() : null;
+
     const dependsMatch = section.match(/\*\*Depends on(?::\*\*|\*\*:)\s*([^\n]+)/i);
     const depends_on = dependsMatch ? dependsMatch[1].trim() : null;
 
@@ -227,6 +236,7 @@ function cmdRoadmapAnalyze(cwd, raw) {
       number: phaseNum,
       name: phaseName,
       goal,
+      mode,
       depends_on,
       plan_count: planCount,
       summary_count: summaryCount,

--- a/get-shit-done/references/planner-mvp-mode.md
+++ b/get-shit-done/references/planner-mvp-mode.md
@@ -1,0 +1,53 @@
+# Planner — MVP Mode (Vertical Slice Strategy)
+
+> Loaded by `gsd-planner` only when `MVP_MODE=true`. Standard horizontal-layer planning rules continue to apply for all other phases.
+
+## Core Rule
+
+**Decompose by feature slice, not by technical layer.** Every task must move the user-facing capability forward. After each task, a real user can click through more of the feature than they could before.
+
+**Forbidden** in MVP mode:
+- "Create the database schema" as a standalone task
+- "Build the API layer" as a standalone task
+- "Wire up the UI" as a final integration task
+
+**Required** in MVP mode:
+- The first non-test task produces a working end-to-end path. Stubs are allowed for non-critical branches; the happy path must be real.
+- Each subsequent task either adds a new slice OR refines an existing slice (validation, error states, edge cases).
+- The phase goal is framed as a user story: "**As a** [user], **I want to** [do X], **so that** [Y]."
+
+## Task Order Pattern
+
+For a feature `F`:
+
+1. **Failing end-to-end test** for the happy path of `F`.
+2. **Thinnest viable slice** — UI form → API endpoint → DB read/write — that makes the test pass. Hard-coded values, missing validation, no error states are fine here.
+3. **Real data layer** — replace any stubs from Task 2 with real queries.
+4. **Validation + error states** — invalid input, network failure, empty states.
+5. **Production polish** — loading indicators, edge cases, accessibility checks.
+
+Tasks 3-5 are not always all needed; gate by the phase's acceptance criteria.
+
+## Walking Skeleton Mode (`WALKING_SKELETON=true`)
+
+When the orchestrator sets `WALKING_SKELETON=true` (Phase 1 of a new project under `--mvp`), the plan changes shape:
+
+- The "feature" is the application itself. Pick the smallest meaningful capability that proves the full stack works (e.g., "user can sign up and see their name on a dashboard").
+- The plan **must include**:
+  - Project scaffold (framework init, routing, build, lint)
+  - One real DB read/write
+  - One real UI interaction wired to the API
+  - Deployment to a dev environment (or a documented local-run command that exercises the full stack)
+- The plan **must produce** `SKELETON.md` in the phase directory alongside `PLAN.md`. Use the template at `@~/.claude/get-shit-done/references/skeleton-template.md`. `SKELETON.md` records the architectural decisions that subsequent phases will build on (chosen framework, DB, deployment target, auth approach, directory layout).
+
+`SKELETON.md` is the architectural backbone for every later vertical slice; treat it as a contract, not a scratchpad.
+
+## Anti-Patterns to Reject
+
+- **Layer cake disguised as slices.** Three "vertical" tasks where Task 1 is "all the schemas", Task 2 is "all the endpoints", Task 3 is "all the UI" — that is horizontal planning with new labels. Reject.
+- **Skeleton bloat.** Walking Skeleton is the *thinnest* working stack, not "Phase 1 of a normal app." If Skeleton has more than ~5 tasks, you are not skeletonizing.
+- **Premature SPIDR splitting.** SPIDR splitting is the `mvp-phase` command's job (Phase 2 of the PRD), not the planner's. If the phase scope feels too large, surface it via the verification loop, do not split silently.
+
+## Acceptance Test for Your Plan
+
+Before emitting the plan, ask: **after Task N completes, can a real user *do* something they could not do after Task N-1?** If the answer is "no, but the foundation is laid", you have a horizontal task disguised as a slice. Restructure.

--- a/get-shit-done/references/skeleton-template.md
+++ b/get-shit-done/references/skeleton-template.md
@@ -1,0 +1,48 @@
+# SKELETON.md Template
+
+> Emitted by `gsd-planner` when `WALKING_SKELETON=true` (Phase 1 + `--mvp` + new project). Records the architectural decisions the rest of the project will build on.
+
+```markdown
+# Walking Skeleton — [Project Name]
+
+**Phase:** 1
+**Generated:** {ISO date}
+
+## Capability Proven End-to-End
+
+> One sentence: the smallest user-visible capability that exercises the full stack.
+
+Example: "A signed-in user can view their email on a dashboard page served by the deployed app."
+
+## Architectural Decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Framework | (e.g., Next.js 15 App Router) | Why this fits the project |
+| Data layer | (e.g., Postgres + Drizzle) | Why |
+| Auth | (e.g., session cookies + bcrypt) | Why |
+| Deployment target | (e.g., Vercel preview) | Why |
+| Directory layout | (e.g., feature-folders under src/features/*) | Why |
+
+## Stack Touched in Phase 1
+
+- [ ] Project scaffold (framework, build, lint, test runner)
+- [ ] Routing — at least one real route
+- [ ] Database — at least one real read AND one real write
+- [ ] UI — at least one interactive element wired to the API
+- [ ] Deployment — running on dev environment OR documented local full-stack run command
+
+## Out of Scope (Deferred to Later Slices)
+
+> Anything that is *not* in the skeleton. Be explicit — this list prevents future phases from re-litigating Phase 1's minimalism.
+
+- (e.g., password reset, email verification, multi-tenancy)
+
+## Subsequent Slice Plan
+
+Each later phase adds one vertical slice on top of this skeleton without altering its architectural decisions:
+
+- Phase 2: [next user capability]
+- Phase 3: [next user capability]
+- ...
+```

--- a/get-shit-done/workflows/plan-phase.md
+++ b/get-shit-done/workflows/plan-phase.md
@@ -38,6 +38,7 @@ AGENT_SKILLS_PLANNER=$(gsd-sdk query agent-skills gsd-planner)
 AGENT_SKILLS_CHECKER=$(gsd-sdk query agent-skills gsd-plan-checker)
 CONTEXT_WINDOW=$(gsd-sdk query config-get context_window 2>/dev/null || echo "200000")
 TDD_MODE=$(gsd-sdk query config-get workflow.tdd_mode 2>/dev/null || echo "false")
+MVP_MODE_CFG=$(gsd-sdk query config-get workflow.mvp_mode 2>/dev/null || echo "false")
 ```
 
 When `TDD_MODE` is `true`, the planner agent is instructed to apply `type: tdd` to eligible tasks using heuristics from `references/tdd.md`. The planner's `<required_reading>` is extended to include `@~/.claude/get-shit-done/references/tdd.md` so gate enforcement rules are available during planning.
@@ -54,9 +55,36 @@ Parse JSON for: `researcher_model`, `planner_model`, `checker_model`, `research_
 
 ## 2. Parse and Normalize Arguments
 
-Extract from $ARGUMENTS: phase number (integer or decimal like `2.1`), flags (`--research`, `--skip-research`, `--gaps`, `--skip-verify`, `--skip-ui`, `--prd <filepath>`, `--reviews`, `--text`, `--bounce`, `--skip-bounce`, `--chunked`).
+Extract from $ARGUMENTS: phase number (integer or decimal like `2.1`), flags (`--research`, `--skip-research`, `--gaps`, `--skip-verify`, `--skip-ui`, `--prd <filepath>`, `--reviews`, `--text`, `--bounce`, `--skip-bounce`, `--chunked`, `--mvp`).
 
 Set `TEXT_MODE=true` if `--text` is present in $ARGUMENTS OR `text_mode` from init JSON is `true`. When `TEXT_MODE` is active, replace every `AskUserQuestion` call with a plain-text numbered list and ask the user to type their choice number. This is required for Claude Code remote sessions (`/rc` mode) where TUI menus don't work through the Claude App.
+
+**MVP_MODE resolution.** Resolve `MVP_MODE` once and reuse for the rest of the workflow. Order (first hit wins):
+
+1. **CLI flag.** If `$ARGUMENTS` contains `--mvp`, set `MVP_MODE=true`.
+2. **Roadmap phase mode.** Otherwise, query the phase's mode field:
+   ```bash
+   PHASE_MODE=$(gsd-sdk query roadmap.get-phase "${PHASE}" --pick mode)
+   if [ "$PHASE_MODE" = "mvp" ]; then MVP_MODE=true; fi
+   ```
+3. **Config default.** Otherwise, `MVP_MODE="$MVP_MODE_CFG"` (resolved in Step 1).
+4. **Fallback.** `MVP_MODE=false`.
+
+The mode is **all-or-nothing per phase** (per PRD decision Q1). Do not allow `--mvp` to apply selectively to a subset of tasks within a phase.
+
+**Walking Skeleton gate.** When `MVP_MODE=true` AND `phase_number == "01"` AND there are zero prior phase summaries (new project), the planner runs in **Walking Skeleton mode** (per PRD decision Q2 — new projects only). Detect with:
+
+```bash
+WALKING_SKELETON=false
+if [ "$MVP_MODE" = "true" ] && [ "$padded_phase" = "01" ]; then
+  PRIOR_SUMMARIES=$(gsd-sdk query phases.list --pick summaries_total 2>/dev/null || echo "0")
+  if [ "$PRIOR_SUMMARIES" = "0" ]; then WALKING_SKELETON=true; fi
+fi
+```
+
+When `WALKING_SKELETON=true`:
+- Planner is instructed to produce `SKELETON.md` in the phase directory alongside `PLAN.md`. The template lives at `@~/.claude/get-shit-done/references/skeleton-template.md`.
+- The plan must scaffold project + routing + one real DB read/write + one real UI interaction + dev deployment — the thinnest possible end-to-end working slice.
 
 Extract `--prd <filepath>` from $ARGUMENTS. If present, set PRD_FILE to the filepath.
 
@@ -755,6 +783,15 @@ ${TDD_MODE === 'true' ? `
 - UI, config, glue code, CRUD → standard plan (type: execute)
 Each TDD plan gets one feature with RED/GREEN/REFACTOR gate sequence.
 </tdd_mode_active>
+` : ''}
+
+**MVP_MODE:** ${MVP_MODE} (when true, follow vertical-slice rules from `@~/.claude/get-shit-done/references/planner-mvp-mode.md`; when false, ignore MVP guidance entirely.)
+**WALKING_SKELETON:** ${WALKING_SKELETON} (when true, the first deliverable must be a Walking Skeleton — produce SKELETON.md alongside PLAN.md.)
+
+${MVP_MODE === 'true' ? `
+<mvp_mode_active>
+**MVP Mode is ENABLED.** Follow vertical-slice planning rules from @~/.claude/get-shit-done/references/planner-mvp-mode.md. Each plan must deliver a complete vertical slice — thin end-to-end functionality rather than horizontal layers.
+</mvp_mode_active>
 ` : ''}
 </planning_context>
 

--- a/tests/plan-phase-mvp-flag.test.cjs
+++ b/tests/plan-phase-mvp-flag.test.cjs
@@ -3,10 +3,12 @@
  * Contract test: verifies the workflow markdown documents the agreed
  * resolution order (CLI flag → roadmap mode → config → default false).
  */
-const { test, describe } = require('node:test');
+const { test, describe, beforeEach, afterEach } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
+
+const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
 
 const WORKFLOW = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'plan-phase.md');
 
@@ -44,5 +46,30 @@ describe('plan-phase workflow — --mvp flag', () => {
       /MVP_MODE[^\n]*planner|planner[^\n]*MVP_MODE/i,
       'workflow must wire MVP_MODE into the planner subagent prompt'
     );
+  });
+});
+
+describe('plan-phase --mvp — resolution chain integration', () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = createTempProject(); });
+  afterEach(() => { cleanup(tmpDir); });
+
+  test('roadmap.get-phase reports mode=mvp when set in roadmap', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      `# Roadmap\n\n## v1.0.0\n\n### Phase 1: Auth\n**Goal:** Users can log in\n**Mode:** mvp\n`
+    );
+    const result = runGsdTools('roadmap get-phase 1 --pick mode', tmpDir);
+    assert.ok(result.success);
+    assert.strictEqual(result.output.trim(), 'mvp');
+  });
+
+  test('config-get workflow.mvp_mode default is empty/unset', () => {
+    const result = runGsdTools('config-get workflow.mvp_mode', tmpDir);
+    // Either success with empty output OR a non-zero exit; both are fine.
+    // Real assertion: the key isn't accidentally set to "true" in tmp project.
+    if (result.success) {
+      assert.notStrictEqual(result.output.trim(), 'true');
+    }
   });
 });

--- a/tests/plan-phase-mvp-flag.test.cjs
+++ b/tests/plan-phase-mvp-flag.test.cjs
@@ -1,0 +1,48 @@
+/**
+ * plan-phase workflow — --mvp flag parsing and MVP_MODE resolution
+ * Contract test: verifies the workflow markdown documents the agreed
+ * resolution order (CLI flag → roadmap mode → config → default false).
+ */
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const WORKFLOW = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'plan-phase.md');
+
+describe('plan-phase workflow — --mvp flag', () => {
+  const content = fs.readFileSync(WORKFLOW, 'utf-8');
+
+  test('argument list documents --mvp flag', () => {
+    const argsLine = content.match(/Extract from \$ARGUMENTS:[^\n]*/);
+    assert.ok(argsLine, 'Step 2 arg-extraction line not found');
+    assert.match(argsLine[0], /--mvp/, 'argument list must mention --mvp');
+  });
+
+  test('workflow defines MVP_MODE resolution block', () => {
+    assert.match(content, /MVP_MODE/, 'workflow must declare MVP_MODE');
+    assert.match(content, /workflow\.mvp_mode/, 'must read workflow.mvp_mode config');
+    assert.match(
+      content,
+      /roadmap[^\n]*mode|phase[^\n]*\.mode/i,
+      'must consult phase mode from roadmap'
+    );
+  });
+
+  test('Walking Skeleton gate references new-project + Phase 1', () => {
+    assert.match(content, /SKELETON\.md/, 'workflow must mention SKELETON.md');
+    assert.match(
+      content,
+      /Walking Skeleton|walking_skeleton/i,
+      'workflow must label the gate as Walking Skeleton'
+    );
+  });
+
+  test('planner spawn passes MVP_MODE to gsd-planner', () => {
+    assert.match(
+      content,
+      /MVP_MODE[^\n]*planner|planner[^\n]*MVP_MODE/i,
+      'workflow must wire MVP_MODE into the planner subagent prompt'
+    );
+  });
+});

--- a/tests/planner-mvp-mode.test.cjs
+++ b/tests/planner-mvp-mode.test.cjs
@@ -1,0 +1,49 @@
+/**
+ * gsd-planner agent — MVP-mode branch contract
+ * Verifies the agent definition contains the MVP-mode planning section,
+ * conditional reference loading, and Walking Skeleton handling.
+ */
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const AGENT = path.join(__dirname, '..', 'agents', 'gsd-planner.md');
+const REF_MVP = path.join(__dirname, '..', 'get-shit-done', 'references', 'planner-mvp-mode.md');
+const REF_SKEL = path.join(__dirname, '..', 'get-shit-done', 'references', 'skeleton-template.md');
+
+describe('gsd-planner — MVP-mode branch', () => {
+  const content = fs.readFileSync(AGENT, 'utf-8');
+
+  test('agent defines an MVP Mode Detection section', () => {
+    assert.match(content, /MVP\s*Mode|MVP_MODE/i, 'must reference MVP mode');
+    assert.match(content, /vertical[\s-]?slice/i, 'must use vertical-slice terminology');
+  });
+
+  test('agent describes Walking Skeleton handling', () => {
+    assert.match(content, /Walking\s*Skeleton/i, 'must mention Walking Skeleton');
+    assert.match(content, /SKELETON\.md/, 'must mention SKELETON.md output');
+  });
+
+  test('agent references planner-mvp-mode.md conditionally', () => {
+    assert.match(
+      content,
+      /references\/planner-mvp-mode\.md/,
+      'must reference the MVP-mode rules file'
+    );
+  });
+
+  test('referenced files exist on disk', () => {
+    assert.ok(fs.existsSync(REF_MVP), `${REF_MVP} must exist`);
+    assert.ok(fs.existsSync(REF_SKEL), `${REF_SKEL} must exist`);
+  });
+
+  test('agent does not introduce horizontal/MVP mixing language', () => {
+    // Q1: all-or-nothing per phase. Reject phrasing that would imply mixing.
+    assert.doesNotMatch(
+      content,
+      /mix[a-z\s]*horizontal[a-z\s]*MVP|MVP[a-z\s]*and[a-z\s]*horizontal[a-z\s]*tasks/i,
+      'agent must enforce all-or-nothing per phase'
+    );
+  });
+});

--- a/tests/roadmap-mode-field.test.cjs
+++ b/tests/roadmap-mode-field.test.cjs
@@ -1,0 +1,77 @@
+/**
+ * Roadmap parser — `**Mode:**` field extraction
+ * Covers PRD: vertical-mvp-slice Phase 1 (Q1: all-or-nothing per phase).
+ */
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
+
+const ROADMAP_WITH_MODE = `# Roadmap
+
+## v1.0.0
+
+### Phase 1: User Auth MVP
+**Goal:** A user can register and log in
+**Mode:** mvp
+**Success Criteria**:
+1. Registration works
+2. Login works
+
+### Phase 2: Bulk Import
+**Goal:** Admin can upload CSV
+**Success Criteria**:
+1. CSV parses
+`;
+
+describe('roadmap parser — mode field', () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = createTempProject(); });
+  afterEach(() => { cleanup(tmpDir); });
+
+  test('roadmap.get-phase returns mode="mvp" when **Mode:** mvp present', () => {
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), ROADMAP_WITH_MODE);
+    const result = runGsdTools('roadmap get-phase 1', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+    const out = JSON.parse(result.output);
+    assert.strictEqual(out.found, true);
+    assert.strictEqual(out.mode, 'mvp');
+  });
+
+  test('roadmap.get-phase returns mode=null when **Mode:** absent', () => {
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), ROADMAP_WITH_MODE);
+    const result = runGsdTools('roadmap get-phase 2', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+    const out = JSON.parse(result.output);
+    assert.strictEqual(out.found, true);
+    assert.strictEqual(out.mode, null);
+  });
+
+  test('roadmap.analyze surfaces mode per phase', () => {
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), ROADMAP_WITH_MODE);
+    const result = runGsdTools('roadmap analyze', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+    const out = JSON.parse(result.output);
+    const p1 = out.phases.find(p => p.number === '1');
+    const p2 = out.phases.find(p => p.number === '2');
+    assert.strictEqual(p1.mode, 'mvp');
+    assert.strictEqual(p2.mode, null);
+  });
+
+  test('mode field is case-insensitive and trimmed', () => {
+    const variant = ROADMAP_WITH_MODE.replace('**Mode:** mvp', '**mode**:  MVP  ');
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), variant);
+    const result = runGsdTools('roadmap get-phase 1', tmpDir);
+    const out = JSON.parse(result.output);
+    assert.strictEqual(out.mode, 'mvp');
+  });
+
+  test('unrecognized mode value is preserved verbatim (forward-compat)', () => {
+    const variant = ROADMAP_WITH_MODE.replace('**Mode:** mvp', '**Mode:** experimental');
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), variant);
+    const result = runGsdTools('roadmap get-phase 1', tmpDir);
+    const out = JSON.parse(result.output);
+    assert.strictEqual(out.mode, 'experimental');
+  });
+});


### PR DESCRIPTION
## Feature PR

## Linked Issue

Closes #2885

Refs #2826 (umbrella PRD, Phases 1–4). Phase 2 ships via #2874 (issue #2875). Phase 3a via #2878 (#2877). Phase 3b via #2880 (#2879). Phase 4 via #2883 (#2882).

---

## Feature summary

Implements **Phase 1 of 4** of the Vertical MVP Slice feature: the planner-side foundation. Adds an opt-in `--mvp` flag to `/gsd plan-phase` that switches `gsd-planner` from horizontal (layer-by-layer) to vertical (slice-by-slice) planning. Adds a `**Mode:** mvp` field to ROADMAP.md phase sections so MVP mode persists per-phase without requiring the flag on every invocation. New-project Phase 1 + `--mvp` triggers Walking Skeleton output (`SKELETON.md`) recording the architectural decisions that subsequent phases build on.

This PR is the planner-side foundation only. The `/gsd mvp-phase` convenience command, `verify-phase` MVP UAT framing, `--mvp --tdd` execute-phase enforcement, and `new-project` mode prompt are explicitly **deferred** to follow-up PRs (PRD Phases 2–4) — see the *Spec compliance* and *Scope confirmation* sections below for the exact split.

## What changed

### New files

| File | Purpose |
|------|---------|
| `get-shit-done/references/planner-mvp-mode.md` | Vertical-slice planning rules loaded by `gsd-planner` when `MVP_MODE=true`. |
| `get-shit-done/references/skeleton-template.md` | `SKELETON.md` template emitted under `WALKING_SKELETON=true`. |
| `tests/roadmap-mode-field.test.cjs` | Parser tests for the new `**Mode:**` field (5 cases). |
| `tests/plan-phase-mvp-flag.test.cjs` | Workflow contract tests + CLI integration tests for `--mvp` (6 cases). |
| `tests/planner-mvp-mode.test.cjs` | Agent contract tests for the new MVP Mode Detection section (5 cases). |

### Modified files

| File | What changed |
|------|-------------|
| `get-shit-done/bin/lib/roadmap.cjs` | `searchPhaseInContent` and `cmdRoadmapAnalyze` now extract a `mode` field from `**Mode:** <value>` lines. Lowercased + trimmed; unrecognized values preserved verbatim for forward-compat. |
| `get-shit-done/workflows/plan-phase.md` | Step 1 reads `workflow.mvp_mode` config. Step 2 parses `--mvp` and resolves `MVP_MODE` (CLI flag → roadmap mode → config → false). New Walking Skeleton gate fires for new-project Phase 1. Planner spawn block (`<planning_context>` shared by all 3 default-flow spawns) wires `MVP_MODE` and `WALKING_SKELETON` into the planner prompt and conditionally injects `references/planner-mvp-mode.md`. |
| `agents/gsd-planner.md` | New `## MVP Mode Detection` section between `## TDD Detection` and `## User Setup Detection`. Mode-switched (single agent — per PRD decision Q4). |
| `docs/INVENTORY.md`, `docs/INVENTORY-MANIFEST.json` | Register the two new reference files (count 51 → 53). Required to keep the inventory parity test green. |
| `CHANGELOG.md` | User-facing entry under `[Unreleased]`. |

## Implementation notes

**Decisions locked during planning (PRD open questions):**

| # | Question | Decision |
|---|---|---|
| Q1 | Hybrid phases (mix MVP + horizontal in one phase)? | All-or-nothing per phase |
| Q2 | Walking Skeleton scope | New projects only (Phase 1 + `--mvp` + zero prior summaries) |
| Q4 | Planner agent split? | Single agent, mode-switched |

Q3 (SPIDR depth — full interactive flow) and Q5 (graphify viz — distinct treatment for MVP phases) are recorded for follow-up PRs since they belong to PRD Phases 2 and 4 respectively.

**Architecture choices:**
- The roadmap is markdown, not YAML, so the new field lives on a `**Mode:** <value>` line parsed by regex parallel to the existing `**Goal:**` / `**Success Criteria**:` extraction. The PRD's example `mode: mvp` YAML notation was conceptual; this PR uses the actual roadmap shape.
- Heavy planner guidance (slice ordering, anti-patterns, Walking Skeleton rules) lives in `references/planner-mvp-mode.md`, not in the agent — to respect the existing `agent-size-budget` test and mirror the established `references/tdd.md` injection pattern.
- The Walking Skeleton gate uses `padded_phase = "01"` (matching the variable already in scope from Step 2's init JSON parse), not `phase_number`.

**Scope notes:**
- One commit on this branch (`d732c4fd chore(inventory): register new planner references`) was not in the original PRD scope. Two new reference files broke the inventory parity test; updating `INVENTORY.md` + `INVENTORY-MANIFEST.json` was the smallest fix to keep the suite green.
- The branch was rebased onto `origin/main` to drop a duplicate commit (a `--mvp` frontmatter announcement was already merged via PR #2830's squash).

## Spec compliance

The linked issue lists 9 acceptance criteria spanning all 4 PRD phases. **This PR delivers Phase 1 only.** Criteria below are explicitly checked only when the implementation in this PR satisfies them.

- [x] `plan-phase <N> --mvp` produces a PLAN.md organized by feature slice — workflow wires `MVP_MODE` into planner; planner agent + reference contain the slice-based decomposition rules
- [x] On a new project, `plan-phase 1 --mvp` enters Walking Skeleton mode and produces `SKELETON.md` — gate in workflow Step 2 + agent emits `SKELETON.md` per `references/skeleton-template.md`
- [x] A phase entry in ROADMAP.md with `mode: mvp` causes `plan-phase` to behave identically to `plan-phase --mvp` — resolution order in workflow Step 2 (CLI flag → roadmap mode → config → false)
- [x] All existing non-MVP tests pass without modification — `npm test` 5842/5842 pass
- [ ] `/gsd mvp-phase <N>` prompts for a user story and acceptance criteria before invoking `plan-phase --mvp --tdd` — **deferred to PRD Phase 2**
- [ ] `verify-phase` on a phase with `mode: mvp` generates a UAT script that begins with user-flow steps — **deferred to PRD Phase 3**
- [ ] `--mvp --tdd` combined: each behavior-adding task has an explicit "write failing test" step before implementation — **partial: agent mentions TDD compatibility, but execute-phase enforcement is deferred to PRD Phase 3**
- [ ] `new-project` presents a horizontal vs. vertical mode choice — **deferred to PRD Phase 4**
- [ ] New tests cover all 5 areas listed in the issue — **3 of 5 covered in this PR (slice plan structure, Walking Skeleton, mode auto-detection); the `/gsd mvp-phase` and `verify-phase` UAT framing tests are deferred with their respective implementations**

Follow-up PRs will be opened for PRD Phases 2–4. This PR is intentionally a working subset that ships independently.

## Testing

### Test coverage

- `tests/roadmap-mode-field.test.cjs` — parser presence/absence, case-insensitive, trim, forward-compat unrecognized values (5 cases)
- `tests/plan-phase-mvp-flag.test.cjs` — workflow contract: `--mvp` in args list, MVP_MODE block, Walking Skeleton gate, planner spawn wiring; CLI integration: `roadmap get-phase --pick mode`, `config-get workflow.mvp_mode` default unset (6 cases)
- `tests/planner-mvp-mode.test.cjs` — agent contract: MVP Mode Detection section exists, Walking Skeleton handling, references resolve, anti-mixing language enforces Q1 decision (5 cases)

Total new tests: 16. Full suite: 5842 pass / 0 fail (was 5826 pre-PR).

### Platforms tested

- [x] macOS (Darwin 25.4.0)
- [ ] Windows (including backslash path handling)
- [ ] Linux

The change is markdown content + a roadmap parser regex — no path handling, no OS-specific behavior. Test suite is platform-agnostic Node.js.

### Runtimes tested

- [x] Claude Code (Opus 4.7)
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Codex
- [ ] Copilot
- [ ] Other: ___

The feature itself is runtime-agnostic (lives in `.md` workflow/agent files and `.cjs` lib). Workflow already includes `vscode_askquestions` Copilot fallback per existing convention.

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue **for PRD Phase 1**. PRD Phases 2–4 are explicitly deferred to follow-up PRs (see Spec compliance section).
- [x] No additional features, commands, or behaviors were added beyond what was approved — the only out-of-PRD-scope commit is `d732c4fd` (inventory parity fix), which is a mechanical consequence of registering the two new reference files.
- [x] Scope partition between this PR and follow-ups is documented inline above so a reviewer can verify the cutline matches the PRD's "Implementation Plan (High Level)" section.

---

## Checklist

- [x] Issue linked above with `Closes #2826`
- [x] Linked issue has the `approved-feature` label
- [x] Acceptance criteria listed above with explicit per-item delivery status (Phase 1 items ✅; Phase 2–4 items deferred)
- [x] Implementation scope partitioned cleanly between this PR and follow-up PRD phases
- [x] All existing tests pass (`npm test` 5842/5842)
- [x] New tests cover the happy path, error cases (case-insensitive, absent field), and edge cases (forward-compat unrecognized values)
- [x] CHANGELOG.md updated
- [x] Documentation updated — INVENTORY.md, INVENTORY-MANIFEST.json, command frontmatter (already on main from #2830 squash), and the two new reference files
- [x] No unnecessary external dependencies added
- [x] Works on Windows (the change has no path-handling component; markdown + regex only)

## Breaking changes

None. The new `**Mode:**` field on ROADMAP.md phases is optional (absent → `mode: null` → fallback chain → `MVP_MODE=false`, identical to current behavior). The `--mvp` flag is additive. The `gsd-planner` agent's MVP Mode Detection section is a no-op when `MVP_MODE=false` (the orchestrator only injects MVP context and the conditional reference reading when MVP_MODE is true). Existing non-MVP projects are unaffected.

## Screenshots / recordings

N/A — no UI changes.

