### PR TITLE
chore(#2868): switch canary publish from main to dev branch

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -1,3 +1,12 @@
+# Release stream policy:
+#   dev   → @canary  (this workflow — preview builds for the long-lived integration branch)
+#   main  → @next    (RC train, see release.yml)
+#   main  → @latest  (stable cuts, see release.yml)
+#
+# Streams do not mix. The publish/tag steps below gate on `refs/heads/dev` so a
+# workflow_dispatch run on any other branch (including main) completes the
+# build/test/dry-run validation but does not publish or tag.
+
 name: Canary
 
 on:
@@ -80,7 +89,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Tag and push
-        if: ${{ github.ref == 'refs/heads/main' && !inputs.dry_run }}
+        if: ${{ github.ref == 'refs/heads/dev' && !inputs.dry_run }}
         env:
           CANARY_VERSION: ${{ steps.canary.outputs.canary_version }}
         run: |
@@ -88,19 +97,19 @@ jobs:
           git push origin "v${CANARY_VERSION}"
 
       - name: Publish to npm (canary)
-        if: ${{ github.ref == 'refs/heads/main' && !inputs.dry_run }}
+        if: ${{ github.ref == 'refs/heads/dev' && !inputs.dry_run }}
         run: npm publish --provenance --access public --tag canary
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish SDK to npm (canary)
-        if: ${{ github.ref == 'refs/heads/main' && !inputs.dry_run }}
+        if: ${{ github.ref == 'refs/heads/dev' && !inputs.dry_run }}
         run: cd sdk && npm publish --provenance --access public --tag canary
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Verify publish
-        if: ${{ github.ref == 'refs/heads/main' && !inputs.dry_run }}
+        if: ${{ github.ref == 'refs/heads/dev' && !inputs.dry_run }}
         env:
           CANARY_VERSION: ${{ steps.canary.outputs.canary_version }}
         run: |

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -141,10 +141,14 @@ jobs:
         env:
           CANARY_VERSION: ${{ steps.canary.outputs.canary_version }}
           DRY_RUN: ${{ inputs.dry_run }}
+          PUBLISH_ELIGIBLE: ${{ github.ref == 'refs/heads/dev' && !inputs.dry_run }}
+          BRANCH_REF: ${{ github.ref }}
         run: |
           echo "## Canary v${CANARY_VERSION}" >> "$GITHUB_STEP_SUMMARY"
           if [ "$DRY_RUN" = "true" ]; then
             echo "**DRY RUN** — npm publish, tagging, and push skipped" >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$PUBLISH_ELIGIBLE" != "true" ]; then
+            echo "**VALIDATION ONLY** — publish/tag skipped for \`${BRANCH_REF}\`; canary publish is gated to \`refs/heads/dev\`." >> "$GITHUB_STEP_SUMMARY"
           else
             echo "- Published to npm as \`canary\`" >> "$GITHUB_STEP_SUMMARY"
             echo "- SDK also published: \`@gsd-build/sdk@${CANARY_VERSION}\` on \`canary\`" >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   optional `dry_run` boolean and the same publish-verification gate as `release.yml`. (#2828)
 
 ### Changed
+- **Canary release workflow now publishes from `dev` branch only** — `.github/workflows/canary.yml`
+  swaps its four publish-step guards from `refs/heads/main` to `refs/heads/dev`. Aligns the
+  workflow with the new branch→dist-tag policy (`dev` → `@canary`, `main` → `@next`/`@latest`).
+  Added a header comment documenting the policy. `workflow_dispatch` runs on `main` (or any
+  other branch) now complete build/test/dry-run validation but skip publish + tag, instead
+  of the previous behaviour where `main` published and `dev` silently no-op'd. (#2868)
 - **Skill descriptions trimmed to ≤ 100 chars across all `commands/gsd/*.md`** — three
   anti-patterns eliminated: flag documentation already present in `argument-hint:` (e.g.
   `discuss-phase` was 380 chars, now 76), `Triggers:` keyword-stuffing lists, and


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #2868

The linked issue carries the \`approved-enhancement\` label.

---

## What this enhancement improves

\`.github/workflows/canary.yml\` — branch ownership of the \`@canary\` npm dist-tag.

## Before / After

**Before:** The four publish-step guards in \`canary.yml\` (Tag and push, Publish to npm, Publish SDK to npm, Verify publish) gated on \`github.ref == 'refs/heads/main'\`. This was correct when \`main\` was the only long-lived branch, but with the new \`dev\` integration branch landing #2867 the assumption inverted: \`dev\` is the canary stream, \`main\` runs RCs (\`@next\`) and stable cuts (\`@latest\`). A \`workflow_dispatch\` of \`canary.yml\` on \`dev\` would run build/test/dry-run successfully and then **silently skip** publish + tag.

**After:** The four guards now read \`github.ref == 'refs/heads/dev'\`. \`dev\` publishes \`@canary\`. \`main\` runs (or any other branch) complete validation but skip publish + tag — explicit no-op rather than silent skip-of-the-only-stream-it-was-supposed-to-publish.

A header comment was added to \`canary.yml\` documenting the policy:

\`\`\`
# Release stream policy:
#   dev   → @canary  (this workflow — preview builds for the long-lived integration branch)
#   main  → @next    (RC train, see release.yml)
#   main  → @latest  (stable cuts, see release.yml)
\`\`\`

## How it was implemented

Two-file change:
1. \`.github/workflows/canary.yml\` — header comment + swap \`refs/heads/main\` → \`refs/heads/dev\` on all four guarded steps.
2. \`CHANGELOG.md\` — Unreleased / Changed entry.

The existing canary version counter (\`while git tag -l \"v\${BASE}-canary.\${N}\" ...\`) needs no change: it scans all existing canary tags regardless of which branch produced them, so the dev stream picks up sequentially from where main left off.

## Testing

### How I verified the enhancement works

- YAML parses cleanly (\`python3 -c \"import yaml; yaml.safe_load(open('.github/workflows/canary.yml'))\"\`).
- \`grep -n \"refs/heads/\"\` confirms zero remaining \`refs/heads/main\` references and four \`refs/heads/dev\` guards on the previously \`main\`-gated steps.
- Full validation requires a real \`workflow_dispatch\` of \`canary.yml\` on \`dev\` after merge — the only path that exercises the \`refs/heads/dev\` true-branch is a real run on that branch.

### Acceptance criteria coverage (from #2868)

- [x] \`workflow_dispatch\` of \`canary.yml\` on \`dev\` runs to completion including the publish steps (no silent skip) — gated steps now evaluate true on \`dev\`.
- [x] Two canary streams (\`main\` and \`dev\`) do not collide — there is only one canary stream now (\`dev\`), \`main\` does not publish to \`@canary\` at all.
- [x] CI policy is documented in the workflow file — header comment block at the top of \`canary.yml\`.

### Platforms tested

- [x] N/A (workflow file — runs on \`ubuntu-latest\` runner only)

### Runtimes tested

- [x] N/A (release infrastructure)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

The implementation diverges from the issue's *suggested* change (\`main || dev\` extension) per repo-owner clarification: \`dev\` *is* canary, \`main\` is for RCs/releases and does not publish to canary. The acceptance criteria are unchanged and all met.

---

## Checklist

- [x] Issue linked above with \`Closes #NNN\`
- [x] Linked issue has the \`approved-enhancement\` label
- [x] Changes are scoped to the approved enhancement
- [ ] All existing tests pass — workflow file change; full \`npm test\` not required but suite is green on main as of 1.39.0-rc.7
- [x] New or updated tests cover the enhanced behavior — N/A, validated via real \`workflow_dispatch\` post-merge
- [x] CHANGELOG.md updated
- [x] Documentation updated — header comment in workflow file
- [x] No unnecessary dependencies added

## Breaking changes

\`workflow_dispatch\` of \`canary.yml\` on \`main\` no longer publishes a canary. If anyone has tooling or muscle memory that runs the canary workflow against \`main\`, they need to switch to running it against \`dev\`. Practically this is internal-only: the workflow has only been used by repo maintainers, and the new \`dev\` branch is the explicit replacement venue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Canary release workflow now publishes from the dev branch instead of main. Publishes/tags run only on dev; other branches (including manual runs on main) perform build/test/validation but skip publishing and tagging.
* **Documentation**
  * Changelog updated to reflect the new canary publishing policy and branch→release behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->