### PR TITLE
fix(#2872): auto-close PRs that omit the issue-link keyword

### DIFF
--- a/.github/workflows/require-issue-link.yml
+++ b/.github/workflows/require-issue-link.yml
@@ -24,19 +24,20 @@ jobs:
             echo "found=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Comment and fail if no issue link
+      - name: Comment, close, and fail if no issue link
         if: steps.check.outputs.found == 'false'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           # Uses GitHub API SDK — no shell string interpolation of untrusted input
           script: |
             const repoUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}`;
+            const prNumber = context.payload.pull_request.number;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
+              issue_number: prNumber,
               body: [
-                '## Missing issue link',
+                '## Missing issue link — PR auto-closed',
                 '',
                 'This PR does not reference an issue. **All PRs must link to an open issue** using a closing keyword in the PR body:',
                 '',
@@ -46,7 +47,13 @@ jobs:
                 '',
                 `If no issue exists for this change, [open one first](${repoUrl}/issues/new/choose), then update this PR body with the reference.`,
                 '',
-                'This PR will remain blocked until a valid `Closes #NNN`, `Fixes #NNN`, or `Resolves #NNN` line is present in the description.',
+                'To resume work after fixing the body: edit the PR description to add a valid `Closes #NNN`, `Fixes #NNN`, or `Resolves #NNN` line, then click **Reopen pull request**. The workflow will re-evaluate on reopen.',
               ].join('\n')
             });
-            core.setFailed('PR body must contain a closing issue reference (e.g. "Closes #123")');
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+              state: 'closed',
+            });
+            core.setFailed('PR body must contain a closing issue reference (e.g. "Closes #123") — PR closed.');


### PR DESCRIPTION
## Bug fix PR

## Linked Issue

Closes #2872

---

## Root cause

\`.github/workflows/require-issue-link.yml\` ran on \`opened/edited/reopened/synchronize\` and, when the PR body lacked \`(closes|fixes|resolves)\\s+#\\d+\`, called \`github.rest.issues.createComment\` + \`core.setFailed()\`. \`core.setFailed()\` fails the workflow run, which fails the required status check — but it does not transition the pull request to \`closed\`. PR templates (\`fix.md\`, \`enhancement.md\`, \`feature.md\`) advertise auto-close behavior; nothing in the workflow delivered it.

PR #2863 (Apr 29) reproduced the gap: opened without a closing keyword, the workflow commented + failed the check, and the PR sat open until a maintainer manually closed it at 2026-04-29T21:10:27Z.

## Fix

One file, one step renamed (\`Comment and fail\` → \`Comment, close, and fail\`), and three behavioural changes inside the inline \`github-script\`:

1. Added \`await github.rest.pulls.update({ ..., pull_number: prNumber, state: 'closed' })\` after the comment is posted.
2. Updated the comment heading to \`## Missing issue link — PR auto-closed\` and the trailing instruction to tell the author how to recover (\"edit body, then click Reopen pull request\").
3. Updated the \`core.setFailed()\` message to mirror the new behaviour (\`...PR closed.\`).

The workflow's existing security posture is preserved: \`PR_BODY\` continues to be bound via \`env:\` and the \`github-script\` step uses \`github.rest.*\` SDK calls — no shell interpolation of untrusted input is added.

The \`pull_request\` trigger already grants the \`pull-requests: write\` permission needed for \`pulls.update\`.

## Reopen path

The trigger list already includes \`reopened\`, so when an author edits the PR body to add \`Closes #N\` and clicks **Reopen pull request**, the workflow re-runs and exits cleanly. No extra plumbing required.

## Testing

### How I verified the fix works

- YAML parses cleanly (\`python3 -c \"import yaml; yaml.safe_load(open(...))\"\`).
- Logic walkthrough on \`pulls.update\` API: confirmed the SDK call uses \`pull_number\` (not \`issue_number\`) and \`state: 'closed'\` (the canonical close transition).
- Live verification will happen on the next PR opened without a closing keyword — there is no realistic way to test a \`pull_request\` workflow's behaviour locally without re-creating the GitHub event payload, so this PR is verified by code review + the existing suite (which doesn't cover GitHub Actions but is unaffected by this change).

### Acceptance criteria coverage (from #2872)

- [x] A PR opened with a body containing no \`(closes|fixes|resolves)\\s+#\\d+\` is auto-closed by \`require-issue-link.yml\` — \`pulls.update({state: 'closed'})\` added.
- [x] The closing comment cites the policy and tells the author how to reopen — heading + recovery instruction updated.
- [x] The existing positive path (PRs that *do* link an issue) is unaffected — the new logic lives entirely under \`if: steps.check.outputs.found == 'false'\`. The found=true path returns immediately without entering this step.

### Platforms tested

- [x] N/A (GitHub Actions workflow runs on \`ubuntu-latest\`)

### Runtimes tested

- [x] N/A (CI infrastructure)

---

## Checklist

- [x] Issue linked above with \`Closes #NNN\`
- [x] Linked issue documents the bug — #2872
- [x] Changes are scoped to the bug fix
- [x] CHANGELOG.md updated — no, this is internal CI hygiene, not user-facing behaviour. Existing CI workflow changes in the repo (e.g. #2828's canary workflow) were called out in CHANGELOG; happy to add an Unreleased/Fixed entry if reviewers prefer.
- [x] No unnecessary dependencies added

## Breaking changes

For any author who has been opening PRs without an issue link expecting only a red check (and a chance to add the link before merge), the new behaviour closes the PR immediately. Recovery is one click (edit body + Reopen). The PR templates already promised this behaviour, so this aligns implementation with documentation rather than introducing a surprise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pull request validation workflow now automatically closes submissions missing issue links and provides guidance for resubmission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->