### PR TITLE
fix(test): unbreak gemini-namespacing after #2790 skill consolidation

### DIFF
--- a/tests/gemini-namespacing.test.cjs
+++ b/tests/gemini-namespacing.test.cjs
@@ -93,8 +93,12 @@ describe('Gemini Slash Command Namespacing (Regex)', () => {
   });
 
   test('converts commands ending with punctuation', () => {
-    const input = 'Run /gsd-help. Or /gsd-scan!';
-    const expected = 'Run /gsd:help. Or /gsd:scan!';
+    // Use two stable, foundational commands so this test doesn't drift when
+    // the roster gets consolidated (cf. #2790, which removed `scan`). `help`
+    // and `health` are both bedrock; if either ever gets removed, swap to
+    // any other entry currently in commands/gsd/.
+    const input = 'Run /gsd-help. Or /gsd-health!';
+    const expected = 'Run /gsd:help. Or /gsd:health!';
     assert.strictEqual(convertSlashCommandsToGeminiMentions(input), expected);
   });
 


### PR DESCRIPTION
## Summary

CI on `main` is failing on `tests/gemini-namespacing.test.cjs` after [#2824](https://github.com/gsd-build/get-shit-done/pull/2824) (consolidate 86 → 59 skills) merged. The punctuation test hardcoded `/gsd-scan` as a known command, but `commands/gsd/scan.md` was removed by the consolidation — the roster correctly returns \"unknown, leave unchanged\", so the assertion fails:

\`\`\`
actual:   'Run /gsd:help. Or /gsd-scan!'
expected: 'Run /gsd:help. Or /gsd:scan!'
\`\`\`

The conversion behavior is right; the test fixture is stale.

## Fix

Swap `scan` → `health` in the one affected assertion. Both `help` and `health` are bedrock commands likely to survive future consolidations. The test still exercises the original intent (period vs exclamation punctuation on adjacent slash commands). Added a comment so the next consolidation reviewer knows the swap pattern.

## Verification

- `node --test tests/gemini-namespacing.test.cjs` — 13/13 pass
- `npm test` — 5936/5936 pass locally

## Test plan

- [x] CI passes on this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated regression test to verify command conversion and namespacing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->