### PR TITLE
fix(#2893): surface non-canonical plan filenames instead of silently returning zero plans

### DIFF
--- a/get-shit-done/bin/lib/phase.cjs
+++ b/get-shit-done/bin/lib/phase.cjs
@@ -8,6 +8,47 @@ const { escapeRegex, loadConfig, normalizePhaseName, comparePhaseNum, findPhaseI
 const { extractFrontmatter } = require('./frontmatter.cjs');
 const { writeStateMd, readModifyWriteStateMd, stateExtractField, stateReplaceField, stateReplaceFieldWithFallback, updatePerformanceMetricsSection } = require('./state.cjs');
 
+// #2893 — strict canonical filter: `{padded_phase}-{NN}-PLAN.md` or `PLAN.md`.
+// Documented in agents/gsd-planner.md (write_phase_prompt step). The wider
+// "looks like a plan but isn't canonical" probe below is used to surface a
+// loud warning instead of silently returning zero plans.
+const isCanonicalPlanFile = (f) => f.endsWith('-PLAN.md') || f === 'PLAN.md';
+
+// Any .md file with PLAN anywhere in the basename — the diagnostic net for
+// catching agent deviations like `01-PLAN-01-foundation.md` (#2893).
+// Excludes derivative files (`-PLAN-OUTLINE.md`, `*.pre-bounce.md`, etc.) that
+// the planner legitimately produces alongside canonical plans.
+const PLAN_OUTLINE_RE = /-PLAN-OUTLINE\.md$/i;
+const PLAN_PRE_BOUNCE_RE = /-PLAN.*\.pre-bounce\.md$/i;
+const looksLikePlanFile = (f) =>
+  /\.md$/i.test(f)
+  && /PLAN/i.test(f)
+  && !PLAN_OUTLINE_RE.test(f)
+  && !PLAN_PRE_BOUNCE_RE.test(f);
+
+/**
+ * Detect plan-shaped files that the canonical filter would reject. Returns
+ * a warning string when offenders exist, else null. Centralised so every
+ * read site (phase-plan-index, phases list --type plans, find-phase) emits
+ * the same message.
+ *
+ * @param {string[]} dirFiles — readdirSync output for one phase directory
+ * @param {string[]} matchedFiles — what the canonical filter accepted
+ * @returns {string|null}
+ */
+function describeNonCanonicalPlans(dirFiles, matchedFiles) {
+  const matched = new Set(matchedFiles);
+  const offenders = dirFiles.filter((f) => looksLikePlanFile(f) && !matched.has(f));
+  if (offenders.length === 0) return null;
+  return (
+    `Found ${offenders.length} plan-shaped file(s) in this phase that don't match the canonical ` +
+    `naming convention "{padded_phase}-{NN}-PLAN.md" (or bare "PLAN.md") and were skipped: ` +
+    offenders.map((f) => `"${f}"`).join(', ') +
+    `. Rename to the canonical form (e.g. "01-01-PLAN.md") so the executor can detect them. ` +
+    `See agents/gsd-planner.md write_phase_prompt step for the full contract.`
+  );
+}
+
 function cmdPhasesList(cwd, options, raw) {
   const phasesDir = path.join(planningDir(cwd), 'phases');
   const { type, phase, includeArchived } = options;
@@ -52,13 +93,18 @@ function cmdPhasesList(cwd, options, raw) {
     // If listing files of a specific type
     if (type) {
       const files = [];
+      const warnings = [];
       for (const dir of dirs) {
         const dirPath = path.join(phasesDir, dir);
         const dirFiles = fs.readdirSync(dirPath);
 
         let filtered;
         if (type === 'plans') {
-          filtered = dirFiles.filter(f => f.endsWith('-PLAN.md') || f === 'PLAN.md');
+          filtered = dirFiles.filter(isCanonicalPlanFile);
+          // #2893 — surface plan-shaped files the canonical filter rejected
+          // so callers (executor init, etc.) don't silently see zero plans.
+          const w = describeNonCanonicalPlans(dirFiles, filtered);
+          if (w) warnings.push(`${dir}: ${w}`);
         } else if (type === 'summaries') {
           filtered = dirFiles.filter(f => f.endsWith('-SUMMARY.md') || f === 'SUMMARY.md');
         } else {
@@ -73,6 +119,7 @@ function cmdPhasesList(cwd, options, raw) {
         count: files.length,
         phase_dir: phase ? dirs[0].replace(/^\d+(?:\.\d+)*-?/, '') : null,
       };
+      if (warnings.length) result.warning = warnings.join(' | ');
       output(result, raw, files.join('\n'));
       return;
     }
@@ -176,8 +223,10 @@ function cmdFindPhase(cwd, phase, raw) {
 
     const phaseDir = path.join(phasesDir, match);
     const phaseFiles = fs.readdirSync(phaseDir);
-    const plans = phaseFiles.filter(f => f.endsWith('-PLAN.md') || f === 'PLAN.md').sort();
+    const plans = phaseFiles.filter(isCanonicalPlanFile).sort();
     const summaries = phaseFiles.filter(f => f.endsWith('-SUMMARY.md') || f === 'SUMMARY.md').sort();
+    // #2893 — same diagnostic as phase-plan-index for consistency.
+    const planNamingWarning = describeNonCanonicalPlans(phaseFiles, plans);
 
     const result = {
       found: true,
@@ -187,6 +236,7 @@ function cmdFindPhase(cwd, phase, raw) {
       plans,
       summaries,
     };
+    if (planNamingWarning) result.warning = planNamingWarning;
 
     output(result, raw, result.directory);
   } catch {
@@ -229,8 +279,11 @@ function cmdPhasePlanIndex(cwd, phase, raw) {
 
   // Get all files in phase directory
   const phaseFiles = fs.readdirSync(phaseDir);
-  const planFiles = phaseFiles.filter(f => f.endsWith('-PLAN.md') || f === 'PLAN.md').sort();
+  const planFiles = phaseFiles.filter(isCanonicalPlanFile).sort();
   const summaryFiles = phaseFiles.filter(f => f.endsWith('-SUMMARY.md') || f === 'SUMMARY.md');
+  // #2893 — surface plan-shaped files the canonical filter rejected so a
+  // misnamed plan never silently produces plan_count: 0 at executor init.
+  const planNamingWarning = describeNonCanonicalPlans(phaseFiles, planFiles);
 
   // Build set of plan IDs with summaries
   const completedPlanIds = new Set(
@@ -305,6 +358,7 @@ function cmdPhasePlanIndex(cwd, phase, raw) {
     incomplete,
     has_checkpoints: hasCheckpoints,
   };
+  if (planNamingWarning) result.warning = planNamingWarning;
 
   output(result, raw);
 }

--- a/tests/phase.test.cjs
+++ b/tests/phase.test.cjs
@@ -222,6 +222,54 @@ describe('phase-plan-index command', () => {
     assert.deepStrictEqual(output.waves, {}, 'waves should be empty');
     assert.deepStrictEqual(output.incomplete, [], 'incomplete should be empty');
     assert.strictEqual(output.has_checkpoints, false, 'no checkpoints');
+    assert.ok(output.warning === undefined, 'truly empty dir must not emit a warning');
+  });
+
+  // #2893 — when the planner produces filenames that don't match the canonical
+  // `{padded_phase}-{NN}-PLAN.md` contract, the executor used to silently see
+  // plan_count: 0 with no signal. Now the response must include a `warning`
+  // field naming every offender, so the user gets an actionable error instead
+  // of "execute-phase blocked, no clue why".
+  test('non-canonical plan filenames surface a warning naming each offender (#2893)', () => {
+    const phaseDir = path.join(tmpDir, '.planning', 'phases', '03-api');
+    fs.mkdirSync(phaseDir, { recursive: true });
+
+    // The reporter's exact symptom: planner wrote `{phase-id}-PLAN-{N}-{slug}.md`.
+    fs.writeFileSync(path.join(phaseDir, '01-PLAN-01-foundation.md'), '---\n---\n');
+    fs.writeFileSync(path.join(phaseDir, '01-PLAN-02-api.md'), '---\n---\n');
+
+    const result = runGsdTools('phase-plan-index 03', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.plans.length, 0, 'non-canonical files are not silently accepted');
+    assert.ok(typeof output.warning === 'string', 'warning field must be present');
+    assert.ok(output.warning.includes('01-PLAN-01-foundation.md'), 'warning names the first offender');
+    assert.ok(output.warning.includes('01-PLAN-02-api.md'), 'warning names the second offender');
+    assert.ok(
+      output.warning.includes('{padded_phase}-{NN}-PLAN.md'),
+      'warning cites the canonical pattern so user knows what to rename to',
+    );
+  });
+
+  test('canonical plans suppress the warning even alongside derivative files (#2893)', () => {
+    const phaseDir = path.join(tmpDir, '.planning', 'phases', '03-api');
+    fs.mkdirSync(phaseDir, { recursive: true });
+
+    // Canonical plan + the legitimate derivative artifacts the planner emits.
+    fs.writeFileSync(path.join(phaseDir, '03-01-PLAN.md'), '---\nwave: 1\n---\n');
+    fs.writeFileSync(path.join(phaseDir, '03-PLAN-OUTLINE.md'), '# outline\n');
+    fs.writeFileSync(path.join(phaseDir, '03-01-PLAN.pre-bounce.md'), '---\n---\n');
+
+    const result = runGsdTools('phase-plan-index 03', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.plans.length, 1, 'canonical plan detected');
+    assert.ok(
+      output.warning === undefined,
+      `outline and pre-bounce files must not trigger the warning, got: ${output.warning}`,
+    );
   });
 
   test('extracts single plan with frontmatter', () => {

--- a/tests/phase.test.cjs
+++ b/tests/phase.test.cjs
@@ -272,6 +272,91 @@ describe('phase-plan-index command', () => {
     );
   });
 
+  // #2893 parity — find-phase reads the same phase directory and applies the
+  // same canonical filter, so it must emit the same warning shape. Without
+  // these tests the two code paths could silently diverge.
+  test('find-phase: non-canonical plan filenames surface the same warning (#2893 parity)', () => {
+    const phaseDir = path.join(tmpDir, '.planning', 'phases', '03-api');
+    fs.mkdirSync(phaseDir, { recursive: true });
+    fs.writeFileSync(path.join(phaseDir, '01-PLAN-01-foundation.md'), '---\n---\n');
+    fs.writeFileSync(path.join(phaseDir, '01-PLAN-02-api.md'), '---\n---\n');
+
+    const result = runGsdTools('find-phase 03', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.found, true, 'phase directory found');
+    assert.deepStrictEqual(output.plans, [], 'non-canonical files are not silently accepted');
+    assert.ok(typeof output.warning === 'string', 'warning field must be present');
+    assert.ok(output.warning.includes('01-PLAN-01-foundation.md'), 'warning names the first offender');
+    assert.ok(output.warning.includes('01-PLAN-02-api.md'), 'warning names the second offender');
+    assert.ok(
+      output.warning.includes('{padded_phase}-{NN}-PLAN.md'),
+      'warning cites the canonical pattern',
+    );
+  });
+
+  test('find-phase: canonical plans + derivatives suppress the warning (#2893 parity)', () => {
+    const phaseDir = path.join(tmpDir, '.planning', 'phases', '03-api');
+    fs.mkdirSync(phaseDir, { recursive: true });
+    fs.writeFileSync(path.join(phaseDir, '03-01-PLAN.md'), '---\nwave: 1\n---\n');
+    fs.writeFileSync(path.join(phaseDir, '03-PLAN-OUTLINE.md'), '# outline\n');
+    fs.writeFileSync(path.join(phaseDir, '03-01-PLAN.pre-bounce.md'), '---\n---\n');
+
+    const result = runGsdTools('find-phase 03', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.deepStrictEqual(output.plans, ['03-01-PLAN.md'], 'canonical plan detected');
+    assert.ok(
+      output.warning === undefined,
+      `outline and pre-bounce files must not trigger the warning, got: ${output.warning}`,
+    );
+  });
+
+  // #2893 parity — `phases list --type plans` aggregates across phase dirs
+  // and prefixes each warning with `${dir}: ` so the user can locate the
+  // offending phase. Test mirrors the find-phase pair but accounts for that
+  // prefix in the assertion.
+  test('phases list --type plans: non-canonical filenames surface a per-dir warning (#2893 parity)', () => {
+    const phaseDir = path.join(tmpDir, '.planning', 'phases', '03-api');
+    fs.mkdirSync(phaseDir, { recursive: true });
+    fs.writeFileSync(path.join(phaseDir, '01-PLAN-01-foundation.md'), '---\n---\n');
+    fs.writeFileSync(path.join(phaseDir, '01-PLAN-02-api.md'), '---\n---\n');
+
+    const result = runGsdTools('phases list --type plans --phase 03', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.deepStrictEqual(output.files, [], 'non-canonical files are not silently accepted');
+    assert.ok(typeof output.warning === 'string', 'warning field must be present');
+    assert.ok(output.warning.includes('03-api:'), 'warning is prefixed with the offending phase dir');
+    assert.ok(output.warning.includes('01-PLAN-01-foundation.md'), 'warning names the first offender');
+    assert.ok(output.warning.includes('01-PLAN-02-api.md'), 'warning names the second offender');
+    assert.ok(
+      output.warning.includes('{padded_phase}-{NN}-PLAN.md'),
+      'warning cites the canonical pattern',
+    );
+  });
+
+  test('phases list --type plans: canonical plans suppress the warning (#2893 parity)', () => {
+    const phaseDir = path.join(tmpDir, '.planning', 'phases', '03-api');
+    fs.mkdirSync(phaseDir, { recursive: true });
+    fs.writeFileSync(path.join(phaseDir, '03-01-PLAN.md'), '---\nwave: 1\n---\n');
+    fs.writeFileSync(path.join(phaseDir, '03-PLAN-OUTLINE.md'), '# outline\n');
+    fs.writeFileSync(path.join(phaseDir, '03-01-PLAN.pre-bounce.md'), '---\n---\n');
+
+    const result = runGsdTools('phases list --type plans --phase 03', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.deepStrictEqual(output.files, ['03-01-PLAN.md'], 'canonical plan detected');
+    assert.ok(
+      output.warning === undefined,
+      `outline and pre-bounce files must not trigger the warning, got: ${output.warning}`,
+    );
+  });
+
   test('extracts single plan with frontmatter', () => {
     const phaseDir = path.join(tmpDir, '.planning', 'phases', '03-api');
     fs.mkdirSync(phaseDir, { recursive: true });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Closes #2893

## Diagnosis

Reporter saw \`plan_count: 0\` from \`/gsd:execute-phase\` even though five plan files existed on disk. Their planner had written files like \`01-PLAN-01-foundation.md\`, while \`phase-plan-index\`'s strict filter (\`f.endsWith('-PLAN.md') || f === 'PLAN.md'\`) rejected them silently — collapsing two distinct states into the same \`plans: []\` return:

- directory truly has no plans (legit empty)
- directory has plans but the filter rejected them (user/agent error)

The canonical contract is documented in three places:
- \`agents/gsd-planner.md\` \`write_phase_prompt\` step (lines 1063-1080) — explicit \"NEVER use \`PLAN-NN.md\` / \`01-PLAN-01.md\` / \`plan-NN.md\`\"
- \`commands/gsd/plan-phase.md\`
- \`references/universal-anti-patterns.md\` rule 26

It mandates \`{padded_phase}-{NN}-PLAN.md\`. The strict filter is correct per that contract. **The bug is that the executor never tells the user when the contract was violated** — they just see \`plan_count: 0\` with no signal. LLM-driven planners can deviate, especially older versions. Silent-empty is a class-of-bug.

## What this fix does

Adds \`describeNonCanonicalPlans()\` — a diagnostic helper that scans the phase directory for files matching \`*PLAN*.md\` (the diagnostic net) that the canonical filter rejected, **excluding legit derivatives** like \`*-PLAN-OUTLINE.md\` and \`*-PLAN.pre-bounce.md\` so healthy installs don't get false warnings.

When offenders exist, the response gets a \`warning\` field naming each one and citing the canonical pattern. Wired into all three filter sites:
- \`phase-plan-index\` (the executor's main entry point — the symptom site)
- \`phases list --type plans\`
- \`find-phase\`

**The strict filter itself is unchanged.** Existing canonical plans behave identically. This is purely diagnostic — converts silent-empty into loud-with-actionable-error. **Why not loosen the filter to accept \`*PLAN*.md\`?** Because the canonical contract is enforced in three other places. Loosening here would silently accept whatever the model produces and erode the contract. Loud rejection at one end is better than silent acceptance at both.

## Reporter version

Reporter listed \`1.22.4\` in the issue, but per maintainer guidance treat as \`1.38.4\` for fix scoping. The bug is present on current main (1.39.0-rc.4) and earlier — the filter line has been unchanged across these versions.

## Testing

### How I verified the fix works

Three new tests in \`tests/phase.test.cjs\` under the existing \`phase-plan-index command\` describe block:

1. **\`non-canonical plan filenames surface a warning naming each offender (#2893)\`** — drives the reporter's exact filename pattern (\`01-PLAN-01-foundation.md\`, \`01-PLAN-02-api.md\`), asserts \`plans: []\` is preserved (no silent acceptance), asserts \`warning\` field is a string that names every offender and cites \`{padded_phase}-{NN}-PLAN.md\`.
2. **\`canonical plans suppress the warning even alongside derivative files (#2893)\`** — canonical \`03-01-PLAN.md\` plus \`03-PLAN-OUTLINE.md\` plus \`03-01-PLAN.pre-bounce.md\` (the planner's legit derivatives). Asserts no false-positive warning.
3. **\`empty phase directory returns empty plans array\`** (existing test, extended) — asserts \`warning === undefined\` for truly empty directories.

\`node --test tests/phase.test.cjs\`: 94/94 pass (was 92, +2 new).

\`npm test\`: 5820/5828 pass. The 8 failures are pre-existing failures from \`tests/code-review.test.cjs\` and \`tests/bug-2838-summary-rescue-gitignored-planning.test.cjs\` — they reference user-installed plugin paths under \`~/.claude/get-shit-done/workflows/\` and reproduce on plain \`main\` with my changes stashed. Unrelated to this fix.

### Regression test added?

- [x] Yes — three new tests cover the bug, the false-positive case, and the no-op case.

### Platforms tested

- [x] macOS

### Runtimes tested

- [x] N/A — \`gsd-tools.cjs\` runs the same way under every runtime

## Checklist

- [x] Issue linked above with \`Closes #NNN\`
- [x] Linked issue has the \`bug\` label (added during triage)
- [x] Fix is scoped to the reported bug
- [x] Regression tests added
- [x] All existing \`phase.test.cjs\` tests pass
- [x] No unnecessary dependencies added

## Breaking changes

None. The \`warning\` field is additive on the response object. Existing consumers that key off \`plans\` / \`waves\` / \`incomplete\` / \`has_checkpoints\` see no behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Plan discovery tightened to accept only canonical plan filenames (nonconforming files are ignored).
  * Commands now emit validation warnings that list non-canonical plan files and instruct renaming to the canonical plan filename pattern.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->