### PR TITLE
fix: gap-analysis parses mixed requirement prefixes and skips table headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   posting a comment that points to the contribution guide. (#2872)
 
 ### Fixed — 1.40.0-rc.1
+- **`gap-analysis` now parses non-`REQ-` requirement IDs and ignores traceability table headers** — `parseRequirements()` no longer hard-codes the `REQ-` prefix and now accepts uppercase prefixed IDs such as `TST-01`, `BACK-07`, and `INSP-04`; markdown table header rows (for example `| REQ-ID | ... |`) are excluded so header tokens are not reported as phantom uncovered requirements. Added regression coverage for mixed-prefix REQUIREMENTS files with traceability tables. (#2897)
 - **Gemini slash commands namespaced as `/gsd:<cmd>` instead of `/gsd-<cmd>`** —
   Gemini CLI namespaces commands under `gsd:`, so `/gsd-plan-phase` was unexecutable.
   Body-text references in commands, agents, banners, and patch-reapply hints are now

--- a/get-shit-done/bin/lib/gap-checker.cjs
+++ b/get-shit-done/bin/lib/gap-checker.cjs
@@ -31,7 +31,10 @@ function parseRequirements(reqMd) {
   const out = [];
   const seen = new Set();
 
-  const checkboxRe = /^\s*-\s*\[[x ]\]\s*\*\*(REQ-[A-Za-z0-9_-]+)\*\*\s*(.*)$/gm;
+  // Prefix-agnostic ID format: REQ-01, TST-01, BACK-07, INSP-04, etc.
+  const ID_PATTERN = '[A-Z][A-Z0-9]*-[A-Za-z0-9_-]+';
+
+  const checkboxRe = new RegExp(`^\\s*-\\s*\\[[x ]\\]\\s*\\*\\*(${ID_PATTERN})\\*\\*\\s*(.*)$`, 'gm');
   let cm = checkboxRe.exec(reqMd);
   while (cm !== null) {
     const id = cm[1];
@@ -42,15 +45,28 @@ function parseRequirements(reqMd) {
     cm = checkboxRe.exec(reqMd);
   }
 
-  const tableRe = /\|\s*(REQ-[A-Za-z0-9_-]+)\s*\|/g;
-  let tm = tableRe.exec(reqMd);
-  while (tm !== null) {
-    const id = tm[1];
-    if (!seen.has(id)) {
-      seen.add(id);
-      out.push({ id, text: '' });
+  const tableIdRe = new RegExp(`\\|\\s*(${ID_PATTERN})\\s*\\|`, 'g');
+  const separatorRowRe = /^\s*\|[\s:|-]+\|\s*$/;
+  const lines = reqMd.split(/\r?\n/);
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (!line.includes('|')) continue;
+
+    // Skip markdown table separator rows and header rows immediately preceding them.
+    if (separatorRowRe.test(line)) continue;
+    if (i + 1 < lines.length && separatorRowRe.test(lines[i + 1])) continue;
+
+    let tm = tableIdRe.exec(line);
+    while (tm !== null) {
+      const id = tm[1];
+      if (!seen.has(id)) {
+        seen.add(id);
+        out.push({ id, text: '' });
+      }
+      tm = tableIdRe.exec(line);
     }
-    tm = tableRe.exec(reqMd);
+    tableIdRe.lastIndex = 0;
   }
 
   return out;

--- a/get-shit-done/bin/lib/gap-checker.cjs
+++ b/get-shit-done/bin/lib/gap-checker.cjs
@@ -45,7 +45,7 @@ function parseRequirements(reqMd) {
     cm = checkboxRe.exec(reqMd);
   }
 
-  const tableIdRe = new RegExp(`\\|\\s*(${ID_PATTERN})\\s*\\|`, 'g');
+  const tableFirstCellRe = new RegExp(`^\\s*\\|\\s*(${ID_PATTERN})\\s*\\|`);
   const separatorRowRe = /^\s*\|[\s:|-]+\|\s*$/;
   const lines = reqMd.split(/\r?\n/);
 
@@ -57,16 +57,13 @@ function parseRequirements(reqMd) {
     if (separatorRowRe.test(line)) continue;
     if (i + 1 < lines.length && separatorRowRe.test(lines[i + 1])) continue;
 
-    let tm = tableIdRe.exec(line);
-    while (tm !== null) {
-      const id = tm[1];
-      if (!seen.has(id)) {
-        seen.add(id);
-        out.push({ id, text: '' });
-      }
-      tm = tableIdRe.exec(line);
+    const tm = tableFirstCellRe.exec(line);
+    if (!tm) continue;
+    const id = tm[1];
+    if (!seen.has(id)) {
+      seen.add(id);
+      out.push({ id, text: '' });
     }
-    tableIdRe.lastIndex = 0;
   }
 
   return out;

--- a/tests/post-planning-gaps-2493.test.cjs
+++ b/tests/post-planning-gaps-2493.test.cjs
@@ -267,6 +267,32 @@ describe('gap-analysis CLI (#2493)', () => {
     assert.ok(reqRows.every(x => x.status === 'Covered'));
   });
 
+  test('does not parse requirement-like IDs from non-first table columns', () => {
+    const requirementsMd = [
+      '# Requirements',
+      '',
+      '| REQ-ID | Phase | Plan(s) |',
+      '|--------|-------|---------|',
+      '| TST-01 | Phase 01 | PLAN-01 |',
+      '| BACK-07 | Phase 01 | PLAN-02 |',
+    ].join('\n');
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'REQUIREMENTS.md'), `${requirementsMd}\n`);
+
+    writePlan('01', '# Plan\n\nCovers TST-01 and BACK-07 only.\n');
+
+    const r = runGsdTools(['gap-analysis', '--phase-dir', phaseDir], tmpDir);
+    assert.ok(r.success, r.error);
+    const out = JSON.parse(r.output);
+
+    const ids = out.rows
+      .filter(x => x.source === 'REQUIREMENTS.md')
+      .map(x => x.item);
+
+    assert.deepStrictEqual(ids, ['BACK-07', 'TST-01']);
+    assert.ok(!ids.includes('PLAN-01'));
+    assert.ok(!ids.includes('PLAN-02'));
+  });
+
   test('REQUIREMENTS.md missing → CONTEXT-only run still works', () => {
     writeContext([{ id: 'D-01', text: 'foo' }]);
     writePlan('01', '# Plan mentioning D-01\n');

--- a/tests/post-planning-gaps-2493.test.cjs
+++ b/tests/post-planning-gaps-2493.test.cjs
@@ -240,6 +240,33 @@ describe('gap-analysis CLI (#2493)', () => {
     assert.deepStrictEqual(reqRows, ['REQ-01', 'REQ-02', 'REQ-10']);
   });
 
+  test('parses non-REQ prefixes and ignores traceability header tokens', () => {
+    const requirementsMd = [
+      '# Requirements',
+      '',
+      '| REQ-ID | Phase | Plan(s) |',
+      '|--------|-------|---------|',
+      '| TST-01 | Phase 01 | TBD |',
+      '| BACK-07 | Phase 01 | TBD |',
+      '',
+      '- [ ] **INSP-04** Inspector requirement.',
+    ].join('\n');
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'REQUIREMENTS.md'), `${requirementsMd}\n`);
+
+    writePlan('01', '# Plan\n\nCovers TST-01, BACK-07, and INSP-04.\n');
+
+    const r = runGsdTools(['gap-analysis', '--phase-dir', phaseDir], tmpDir);
+    assert.ok(r.success, r.error);
+    const out = JSON.parse(r.output);
+
+    const reqRows = out.rows.filter(x => x.source === 'REQUIREMENTS.md');
+    const ids = reqRows.map(x => x.item);
+
+    assert.deepStrictEqual(ids, ['BACK-07', 'INSP-04', 'TST-01']);
+    assert.ok(!ids.includes('REQ-ID'), 'traceability header token must not be parsed as a requirement ID');
+    assert.ok(reqRows.every(x => x.status === 'Covered'));
+  });
+
   test('REQUIREMENTS.md missing → CONTEXT-only run still works', () => {
     writeContext([{ id: 'D-01', text: 'foo' }]);
     writePlan('01', '# Plan mentioning D-01\n');


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #2897

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

`gap-analysis` only parsed IDs prefixed with `REQ-` and also parsed markdown traceability header tokens like `REQ-ID` as if they were real requirement IDs.

## What this fix does

- Makes requirement ID parsing prefix-agnostic for uppercase prefixes (`[A-Z][A-Z0-9]*-...`) so IDs like `TST-01`, `BACK-07`, and `INSP-04` are included.
- Skips markdown table separator rows and their header rows, preventing `REQ-ID` (or similar header labels) from being treated as requirements.
- Adds a regression test covering mixed-prefix IDs + traceability table headers.

## Root cause

`parseRequirements()` in `gap-checker.cjs` hard-coded `REQ-` in checkbox and table regexes, and the table regex scanned whole file text without excluding header rows.

## Testing

### How I verified the fix

- Red → Green regression loop:
  - Added test `parses non-REQ prefixes and ignores traceability header tokens` in `tests/post-planning-gaps-2493.test.cjs`.
  - Verified it failed before the fix (only `REQ-ID` detected).
  - Applied fix and re-ran.
- Commands run:
  - `node --test tests/post-planning-gaps-2493.test.cjs`
  - `npm test`

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] CHANGELOG.md updated if this is a user-facing fix
- [x] No unnecessary dependencies added

## Breaking changes

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Gap-analysis now recognizes requirement IDs with custom prefixes (e.g., TST-01, BACK-07, INSP-04) instead of only REQ-.
  * Parsing excludes markdown table header rows to avoid false-positive requirement matches.
  * Improved handling of mixed-prefix REQUIREMENTS files with traceability tables so only valid first-column IDs are extracted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->