### PR TITLE
fix(sdk): agent-skills CLI emits raw <agent_skills> block, not JSON-stringified

### DIFF
--- a/sdk/src/cli.ts
+++ b/sdk/src/cli.ts
@@ -443,7 +443,15 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<void
           output = extractField(output, pickField);
         }
 
-        console.log(JSON.stringify(output, null, 2));
+        // Handlers that opt into `format: 'text'` emit raw stdout so callers
+        // can interpolate the value verbatim (e.g. via `$(gsd-sdk query …)`).
+        // `--field` extraction always falls back to JSON because the picked
+        // value may be a non-string. (#2914)
+        if (result.format === 'text' && !pickField) {
+          process.stdout.write(String(output));
+        } else {
+          console.log(JSON.stringify(output, null, 2));
+        }
       }
     } catch (err) {
       if (err instanceof GSDError) {

--- a/sdk/src/query/skills-cli.integration.test.ts
+++ b/sdk/src/query/skills-cli.integration.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Regression: issue #2914 — `gsd-sdk query agent-skills <type>` must emit the
+ * raw `<agent_skills>` XML block on stdout, not a JSON-stringified string.
+ *
+ * Workflows interpolate the CLI output directly into Task() spawn prompts via
+ * `$(gsd-sdk query agent-skills <type>)`. JSON.stringify wraps the block in
+ * double quotes and escapes newlines (`\n`), corrupting the prompt.
+ *
+ * This test spawns the CLI binary so it covers the cli.ts wrapper layer where
+ * the regression actually lives — a unit test on `agentSkills` alone won't
+ * catch it.
+ */
+
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const SDK_ROOT = resolve(__dirname, '..', '..');
+const CLI_PATH = join(SDK_ROOT, 'dist', 'cli.js');
+
+describe('issue #2914 — CLI agent-skills output is raw XML, not JSON-stringified', () => {
+  let tmpDir: string;
+
+  beforeAll(() => {
+    if (!existsSync(CLI_PATH)) {
+      execFileSync('npm', ['run', 'build'], { cwd: SDK_ROOT, stdio: 'inherit' });
+    }
+  }, 120_000);
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'gsd-2914-'));
+    // Deterministic fixture: one configured skill with a real SKILL.md.
+    const skillDir = join(tmpDir, 'skills', 'dynamic', 'gsd-planner');
+    await mkdir(skillDir, { recursive: true });
+    await writeFile(
+      join(skillDir, 'SKILL.md'),
+      '---\nname: gsd-planner\ndescription: planner skill\n---\n\n# gsd-planner\n',
+    );
+    await mkdir(join(tmpDir, '.planning'), { recursive: true });
+    await writeFile(
+      join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ agent_skills: { 'gsd-planner': ['skills/dynamic/gsd-planner'] } }, null, 2),
+    );
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('writes the raw <agent_skills> block (no JSON quoting / no escaped \\n) on stdout', () => {
+    const stdout = execFileSync('node', [CLI_PATH, 'query', 'agent-skills', 'gsd-planner'], {
+      cwd: tmpDir,
+      encoding: 'utf8',
+    });
+
+    const expected =
+      '<agent_skills>\n' +
+      'Read these user-configured skills:\n' +
+      '- @skills/dynamic/gsd-planner/SKILL.md\n' +
+      '</agent_skills>';
+
+    // Strict byte-match — no leading `"`, no escaped `\n`, no JSON.stringify pretty-print.
+    expect(stdout).toBe(expected);
+    expect(stdout.startsWith('<agent_skills>')).toBe(true);
+    expect(stdout.includes('\\n')).toBe(false);
+  });
+});

--- a/sdk/src/query/skills.ts
+++ b/sdk/src/query/skills.ts
@@ -125,5 +125,8 @@ export const agentSkills: QueryHandler = async (args, projectDir) => {
   const lines = validEntries.map((e) => `- @${e.ref}`).join('\n');
   return {
     data: `<agent_skills>\nRead these user-configured skills:\n${lines}\n</agent_skills>`,
+    // Emit as raw text so workflows can interpolate the block via
+    // `$(gsd-sdk query agent-skills <type>)` without JSON quoting / escaped \n. (#2914)
+    format: 'text',
   };
 };

--- a/sdk/src/query/utils.ts
+++ b/sdk/src/query/utils.ts
@@ -24,6 +24,15 @@ import { GSDError, ErrorClassification } from '../errors.js';
 /** Structured result returned by all query handlers. */
 export interface QueryResult<T = unknown> {
   data: T;
+  /**
+   * Output mode for the CLI wrapper.
+   * - `'json'` (default): CLI emits `JSON.stringify(data, null, 2)` followed by a newline.
+   * - `'text'`: CLI writes `String(data)` raw to stdout — no JSON quoting, no escaping,
+   *   no trailing newline. Use for handlers whose output is interpolated verbatim
+   *   into shell-substituted contexts (e.g. `$(gsd-sdk query agent-skills <type>)`
+   *   embedded into a Task() spawn prompt). See #2914.
+   */
+  format?: 'json' | 'text';
 }
 
 /** Signature for a query handler function. */


### PR DESCRIPTION
## Linked Issue

Fixes #2914

## What was broken

`@gsd-build/sdk@0.1.0`'s `agentSkills` handler reads `config.agent_skills[agentType]` correctly and returns the `<agent_skills>...</agent_skills>` XML block. But the CLI wrapper at `sdk/src/cli.ts:446` `JSON.stringify`s every handler return value unconditionally. Workflows that interpolate `$(gsd-sdk query agent-skills <agent>)` therefore embed a JSON-quoted string with escaped `\n` literals into spawn prompts — the project-local skills are never delivered to subagents.

Reporter [confirmed in the issue thread](https://github.com/gsd-build/get-shit-done/issues/2914#issuecomment-4355700406): handler-side fix landed in main as part of #2402; the CLI-wrapper layer is the still-broken half.

## What this fix does

Three-part fix matching the reporter's narrow proposal:

1. `sdk/src/query/utils.ts` — add `format?: 'json' | 'text'` to `QueryResult`.
2. `sdk/src/query/skills.ts` — `agentSkills` returns `format: 'text'` so the CLI knows to emit raw stdout.
3. `sdk/src/cli.ts` — when `result.format === 'text'` (and not `--field`-picking, since the picked value may be non-string), `process.stdout.write(String(output))` instead of `console.log(JSON.stringify(output, null, 2))`. JSON path preserved for every other handler.

## Testing

- Added `sdk/src/query/skills-cli.integration.test.ts` — spawns the built CLI binary via `execFileSync` and asserts raw stdout byte-shape (no leading `"`, parses as the expected XML block). The existing handler-level `skills.test.ts` cannot catch this regression because the bug lives in the CLI wrapper layer.
- Local vitest run: 9/9 pass on the affected files.

### Regression test added?

- [x] Yes — `sdk/src/query/skills-cli.integration.test.ts`

### Platforms tested

- [x] macOS

### Runtimes tested

- [x] Claude Code

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug
- [x] Regression test added at the CLI wrapper layer where the bug lives
- [x] Vitest passes for affected files

## Breaking changes

None — `format` is optional; all existing handlers default to JSON behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `gsd-sdk query` command now intelligently formats output: raw text when handlers specify text format and no field extraction is used; JSON otherwise.
  * `agent-skills` query now outputs unmodified XML directly to stdout.

* **Tests**
  * Added regression test for `agent-skills` command to validate raw XML output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->