### PR TITLE
chore(ci): disable CodeRabbit docstring coverage check

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,26 @@
+# CodeRabbit configuration — gsd-build/get-shit-done
+#
+# Schema: https://docs.coderabbit.ai/reference/yaml-template/
+#
+# Project context: GSD ships a CLI tool + an agent runtime, not a documented
+# public library. We carry rich JSDoc on internal helpers that warrant it
+# (see bin/install.js, get-shit-done/bin/lib/*.cjs) but we do not enforce a
+# blanket docstring coverage bar — see issue #2932 for rationale.
+
+reviews:
+  pre_merge_checks:
+    # Disable docstring coverage check.
+    #
+    # The check produces false-positive warnings on PRs whose new code is
+    # entirely test files: it counts test(...) / beforeEach / afterEach
+    # arrow-function callbacks as functions and then reports 0% coverage
+    # because nothing has JSDoc. There is no per-check path filter in CR's
+    # documented schema that would let us exclude tests/** while keeping
+    # the check active elsewhere, and the top-level path_filters approach
+    # would silence ALL CR review on tests (security scans, out-of-scope
+    # checks, line-level findings) which we want to keep.
+    #
+    # All other CR pre-merge checks (out-of-scope, security, title) remain
+    # at their defaults.
+    docstrings:
+      mode: off


### PR DESCRIPTION
## Linked Issue

Closes #2932

The linked issue carries the `approved-enhancement` label.

---

## Enhancement summary

Adds `.coderabbit.yaml` at repo root with a single setting: `reviews.pre_merge_checks.docstrings.mode: off`. Disables CR's docstring coverage pre-merge check, which has been firing as a false-positive warning on test-only PRs (#2919 → 0%, #2921 → 50%) because CR counts `test(...)` / `beforeEach` / `afterEach` arrow-function callbacks as functions.

## What changed

| File | Lines | Purpose |
|---|---|---|
| `.coderabbit.yaml` (NEW) | +26 | CR config; disables docstring check; in-file comment explains rationale |

## Spec compliance — acceptance criteria from #2932

- [x] `.coderabbit.yaml` exists at repo root with `reviews.pre_merge_checks.docstrings.mode: off`
- [x] No other CR pre-merge checks are disabled
- [x] No top-level `path_filters` introduced
- [ ] Verified on next PR that the docstring coverage line no longer appears (post-merge verification)

## Why disabling vs lowering the threshold or adding path filters

Per #2932 analysis: CR's documented schema for `reviews.pre_merge_checks.docstrings` only accepts `mode` and `threshold` — no per-check path filter. The top-level `path_filters` would silence ALL CR review on `tests/**` (security scans, out-of-scope checks, the substantive findings) which we want to keep. Lowering the threshold is a partial fix that still warns on most test-only PRs. Disabling the check entirely is the only narrowly-scoped option that addresses the root cause.

## Reversibility

Trivial — delete the file or change `mode: off` → `mode: warning` to restore the default behavior.

## Checklist

- [x] Issue linked above with `Closes #2932`
- [x] Linked issue has the `approved-enhancement` label
- [x] All acceptance criteria from the issue are met (post-merge verification of the runtime behavior is the only outstanding item)
- [x] No commits to `main`; PR base is `main`
- [x] No other config or behavior changes

## Breaking changes

None — config-only change affecting CR review surface, not runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review configuration to customize pre-merge verification checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->