### PR TITLE
enh(statusline): add statusline.context_position opt-in flag (#2937)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased](https://github.com/gsd-build/get-shit-done/compare/v1.38.5...HEAD)
 
 ### Added — 1.40.0-rc.1
+- **`statusline.context_position` opt-in flag** — controls whether the
+  context-window meter renders at the `"end"` of the statusline (default,
+  byte-identical to prior behavior) or at the `"front"` immediately after the
+  model name. Front placement keeps the meter visible when the line is
+  truncated by a narrow terminal. Default preserves existing layout — no
+  behavioral change for users who don't opt in. (#2937)
 - **Six namespace meta-skills with keyword-tag descriptions** — replace the flat 86-skill
   listing with two-stage hierarchical routing. Model sees 6 namespace routers
   (`gsd:workflow`, `gsd:project`, `gsd:review`, `gsd:context`, `gsd:manage`,

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -256,6 +256,7 @@ If `.planning/` is in `.gitignore`, `commit_docs` is automatically `false` regar
 | `hooks.context_warnings` | boolean | `true` | Show context window usage warnings via context monitor hook |
 | `hooks.workflow_guard` | boolean | `false` | Warn when file edits happen outside GSD workflow context (advises using `/gsd-quick` or `/gsd-fast`) |
 | `statusline.show_last_command` | boolean | `false` | Append `last: /<cmd>` suffix to the statusline showing the most recently invoked slash command. Opt-in; reads the active session transcript to extract the latest `<command-name>` tag (closes #2538) |
+| `statusline.context_position` | enum | `"end"` | Where the context-window meter renders. `"end"` (default) keeps the meter after the directory name — byte-identical to prior behavior. `"front"` renders the meter immediately after the model name so it stays visible when narrow terminals truncate the line (closes #2937) |
 
 The prompt injection guard hook (`gsd-prompt-guard.js`) is always active and cannot be disabled — it's a security feature, not a workflow toggle.
 

--- a/get-shit-done/bin/lib/config-schema.cjs
+++ b/get-shit-done/bin/lib/config-schema.cjs
@@ -51,6 +51,7 @@ const VALID_CONFIG_KEYS = new Set([
   'hooks.workflow_guard',
   'workflow.context_coverage_gate',
   'statusline.show_last_command',
+  'statusline.context_position',
   'workflow.ui_review',
   'workflow.max_discuss_passes',
   'features.thinking_partner',

--- a/hooks/gsd-statusline.js
+++ b/hooks/gsd-statusline.js
@@ -427,6 +427,19 @@ function runStatusline() {
       // Never break the statusline on config/transcript errors
     }
 
+    // Context-meter position (opt-in via statusline.context_position, #2937).
+    // Default 'end' preserves byte-identical output. 'front' puts the meter
+    // immediately after the model name so it stays visible when the line is
+    // truncated by a narrow terminal.
+    let contextPosition = 'end';
+    try {
+      const cfg = readGsdConfig(dir);
+      const v = getConfigValue(cfg, 'statusline.context_position');
+      if (v === 'front' || v === 'end') contextPosition = v;
+    } catch (e) {
+      // Never break the statusline on config errors
+    }
+
     // Output
     const dirname = path.basename(dir);
     const middle = task
@@ -435,28 +448,58 @@ function runStatusline() {
         ? `\x1b[2m${gsdStateStr}\x1b[0m`
         : null;
 
-    if (middle) {
-      process.stdout.write(`${gsdUpdate}\x1b[2m${model}\x1b[0m │ ${middle} │ \x1b[2m${dirname}\x1b[0m${ctx}${lastCmdSuffix}`);
-    } else {
-      process.stdout.write(`${gsdUpdate}\x1b[2m${model}\x1b[0m │ \x1b[2m${dirname}\x1b[0m${ctx}${lastCmdSuffix}`);
-    }
+    process.stdout.write(composeStatusline({
+      gsdUpdate, model, ctx, middle, dirname, lastCmdSuffix, position: contextPosition,
+    }));
   } catch (e) {
     // Silent fail - don't break statusline on parse errors
   }
 });
 }
 
+/**
+ * Compose the final statusline string from its segments. Single source of
+ * truth for layout — used by both runStatusline (real output) and
+ * renderStatusline (test output) so layout regressions surface in tests.
+ *
+ * @param {object} parts
+ * @param {string} parts.gsdUpdate     - leading update-available indicator (already formatted, possibly empty)
+ * @param {string} parts.model         - model display name (raw, no ANSI)
+ * @param {string} parts.ctx           - context meter segment (already formatted with ANSI + leading space, possibly empty)
+ * @param {string|null} parts.middle   - middle segment (task or gsdState, already ANSI-wrapped) or null
+ * @param {string} parts.dirname       - directory basename (raw, no ANSI)
+ * @param {string} parts.lastCmdSuffix - last-slash-command suffix (already formatted, possibly empty)
+ * @param {'front'|'end'} parts.position - where to render the context meter (default 'end' for back-compat)
+ * @returns {string}
+ */
+function composeStatusline({ gsdUpdate = '', model, ctx = '', middle = null, dirname, lastCmdSuffix = '', position = 'end' } = {}) {
+  const modelSeg = `\x1b[2m${model}\x1b[0m`;
+  const dirSeg = `\x1b[2m${dirname}\x1b[0m`;
+  if (position === 'front') {
+    if (middle) return `${gsdUpdate}${modelSeg}${ctx} │ ${middle} │ ${dirSeg}${lastCmdSuffix}`;
+    return `${gsdUpdate}${modelSeg}${ctx} │ ${dirSeg}${lastCmdSuffix}`;
+  }
+  // 'end' — preserved byte-for-byte from previous behavior
+  if (middle) return `${gsdUpdate}${modelSeg} │ ${middle} │ ${dirSeg}${ctx}${lastCmdSuffix}`;
+  return `${gsdUpdate}${modelSeg} │ ${dirSeg}${ctx}${lastCmdSuffix}`;
+}
+
 // Export helpers for unit tests. Harmless when run as a script.
 module.exports = {
   readGsdState, parseStateMd, formatGsdState,
   readGsdConfig, getConfigValue, readLastSlashCommand,
+  composeStatusline,
 };
 
 /**
  * Render the statusline from an already-parsed hook input object. Exported for
  * testing without feeding stdin. Returns the rendered string.
+ *
+ * Optional `ctx` parameter (default '') lets tests assert the placement of the
+ * context meter for issue #2937. Production rendering goes through
+ * runStatusline which builds ctx from the live context_window data.
  */
-function renderStatusline(data) {
+function renderStatusline(data, ctx = '') {
   const model = data.model?.display_name || 'Claude';
   const dir = data.workspace?.current_dir || process.cwd();
   const dirname = path.basename(dir);
@@ -472,12 +515,16 @@ function renderStatusline(data) {
     }
   } catch (e) { /* swallow */ }
 
+  let position = 'end';
+  try {
+    const cfg = readGsdConfig(dir);
+    const v = getConfigValue(cfg, 'statusline.context_position');
+    if (v === 'front' || v === 'end') position = v;
+  } catch (e) { /* swallow */ }
+
   const gsdStateStr = formatGsdState(readGsdState(dir) || {});
   const middle = gsdStateStr ? `\x1b[2m${gsdStateStr}\x1b[0m` : null;
-  if (middle) {
-    return `\x1b[2m${model}\x1b[0m │ ${middle} │ \x1b[2m${dirname}\x1b[0m${lastCmdSuffix}`;
-  }
-  return `\x1b[2m${model}\x1b[0m │ \x1b[2m${dirname}\x1b[0m${lastCmdSuffix}`;
+  return composeStatusline({ model, ctx, middle, dirname, lastCmdSuffix, position });
 }
 
 module.exports.renderStatusline = renderStatusline;

--- a/sdk/src/query/config-schema.ts
+++ b/sdk/src/query/config-schema.ts
@@ -53,6 +53,7 @@ export const VALID_CONFIG_KEYS: ReadonlySet<string> = new Set([
   'hooks.workflow_guard',
   'workflow.context_coverage_gate',
   'statusline.show_last_command',
+  'statusline.context_position',
   'workflow.ui_review',
   'workflow.max_discuss_passes',
   'features.thinking_partner',

--- a/tests/enh-2937-statusline-context-position.test.cjs
+++ b/tests/enh-2937-statusline-context-position.test.cjs
@@ -1,0 +1,156 @@
+'use strict';
+
+/**
+ * Enhancement #2937 — statusline `context_position` flag.
+ *
+ * Asserts that:
+ *   - default (flag absent) layout puts the context meter at the END of the
+ *     line, after the directory name (byte-identical to prior behavior)
+ *   - statusline.context_position="end" produces the same default layout
+ *   - statusline.context_position="front" puts the context meter immediately
+ *     after the model name, before the GSD-state segment
+ *   - composeStatusline handles the no-middle case for both positions
+ *   - the config key is registered in the schema so /gsd-settings can surface it
+ *   - invalid values (e.g. "middle") fall back to default 'end' behavior
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const statusline = require('../hooks/gsd-statusline.js');
+const { VALID_CONFIG_KEYS } = require('../get-shit-done/bin/lib/config-schema.cjs');
+
+const CTX = ' \x1b[32m███░░░░░░░ 30%\x1b[0m';
+
+function makeProject({ position }) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'enh-2937-'));
+  fs.mkdirSync(path.join(dir, '.planning'), { recursive: true });
+  if (position !== undefined) {
+    fs.writeFileSync(
+      path.join(dir, '.planning', 'config.json'),
+      JSON.stringify({ statusline: { context_position: position } }),
+    );
+  }
+  return { dir, cleanup: () => fs.rmSync(dir, { recursive: true, force: true }) };
+}
+
+function buildInput(dir) {
+  return {
+    model: { display_name: 'Claude' },
+    workspace: { current_dir: dir },
+    session_id: 'test-session',
+  };
+}
+
+test('config schema registers statusline.context_position', () => {
+  assert.ok(
+    VALID_CONFIG_KEYS.has('statusline.context_position'),
+    'statusline.context_position must be in VALID_CONFIG_KEYS',
+  );
+});
+
+test('composeStatusline default position is "end" (back-compat)', () => {
+  const out = statusline.composeStatusline({
+    model: 'Claude',
+    ctx: CTX,
+    middle: '\x1b[2mph 1/3\x1b[0m',
+    dirname: 'project',
+  });
+  // ctx must appear after dirname
+  const ctxIdx = out.indexOf(CTX);
+  const dirIdx = out.indexOf('project');
+  assert.ok(ctxIdx > dirIdx, `ctx must come after dirname in 'end' mode; got: ${out}`);
+});
+
+test('composeStatusline position=front puts ctx immediately after model', () => {
+  const out = statusline.composeStatusline({
+    model: 'Claude',
+    ctx: CTX,
+    middle: '\x1b[2mph 1/3\x1b[0m',
+    dirname: 'project',
+    position: 'front',
+  });
+  const modelIdx = out.indexOf('Claude');
+  const ctxIdx = out.indexOf(CTX);
+  const middleIdx = out.indexOf('ph 1/3');
+  assert.ok(modelIdx < ctxIdx, `model must come before ctx; got: ${out}`);
+  assert.ok(ctxIdx < middleIdx, `ctx must come before middle in 'front' mode; got: ${out}`);
+});
+
+test('composeStatusline position=end with no middle keeps ctx at end', () => {
+  const out = statusline.composeStatusline({
+    model: 'Claude',
+    ctx: CTX,
+    middle: null,
+    dirname: 'project',
+    position: 'end',
+  });
+  assert.ok(out.endsWith(CTX), `ctx must be at end when middle absent; got: ${out}`);
+});
+
+test('composeStatusline position=front with no middle puts ctx after model', () => {
+  const out = statusline.composeStatusline({
+    model: 'Claude',
+    ctx: CTX,
+    middle: null,
+    dirname: 'project',
+    position: 'front',
+  });
+  const modelIdx = out.indexOf('Claude');
+  const ctxIdx = out.indexOf(CTX);
+  const dirIdx = out.indexOf('project');
+  assert.ok(modelIdx < ctxIdx && ctxIdx < dirIdx, `expected model -> ctx -> dirname; got: ${out}`);
+});
+
+test('renderStatusline default (flag absent) keeps ctx at end', () => {
+  const { dir, cleanup } = makeProject({});
+  try {
+    const out = statusline.renderStatusline(buildInput(dir), CTX);
+    const ctxIdx = out.indexOf(CTX);
+    const dirIdx = out.indexOf(path.basename(dir));
+    assert.ok(ctxIdx > dirIdx, `default must be 'end' mode; got: ${out}`);
+  } finally {
+    cleanup();
+  }
+});
+
+test('renderStatusline with context_position="front" moves ctx before dirname', () => {
+  const { dir, cleanup } = makeProject({ position: 'front' });
+  try {
+    const out = statusline.renderStatusline(buildInput(dir), CTX);
+    const ctxIdx = out.indexOf(CTX);
+    const dirIdx = out.indexOf(path.basename(dir));
+    assert.ok(ctxIdx < dirIdx, `'front' mode must place ctx before dirname; got: ${out}`);
+  } finally {
+    cleanup();
+  }
+});
+
+test('renderStatusline with context_position="end" matches default', () => {
+  const a = makeProject({});
+  const b = makeProject({ position: 'end' });
+  try {
+    const outDefault = statusline.renderStatusline(buildInput(a.dir), CTX);
+    const outExplicit = statusline.renderStatusline(buildInput(b.dir), CTX);
+    // Strip the dirname (different temp paths) for comparison
+    const stripDir = (s, dir) => s.replace(path.basename(dir), 'DIR');
+    assert.strictEqual(stripDir(outDefault, a.dir), stripDir(outExplicit, b.dir));
+  } finally {
+    a.cleanup(); b.cleanup();
+  }
+});
+
+test('renderStatusline rejects invalid values and falls back to "end"', () => {
+  const { dir, cleanup } = makeProject({ position: 'middle' });
+  try {
+    const out = statusline.renderStatusline(buildInput(dir), CTX);
+    const ctxIdx = out.indexOf(CTX);
+    const dirIdx = out.indexOf(path.basename(dir));
+    assert.ok(ctxIdx > dirIdx, `invalid value must fall back to 'end'; got: ${out}`);
+  } finally {
+    cleanup();
+  }
+});


### PR DESCRIPTION
## Linked Issue

Closes #2937

> ⚠️ **Heads-up to maintainers**: this PR is opened **before** #2937 receives `approved-enhancement`. I'm aware of the auto-close policy and have no objection if it gets closed pending approval — the branch (`behagoras:enh/2937-statusline-context-position`) will remain ready to push when the enhancement is approved. Opening now to give you the implementation alongside the proposal so you can evaluate scope concretely.

## What this enhancement improves

The placement of the context-window meter in `hooks/gsd-statusline.js`. Today the meter sits at the end of the line, after the directory name, where it's the first segment to be clipped when the terminal is narrow. The line gets noticeably wider when `formatGsdState` produces the `[██████████] 100% · milestone complete` Scene 3 from #2833, and the meter — the most-useful, most-changing segment — disappears.

## Before / After

**Before** (default behavior, unchanged):
```
{gsdUpdate?}{model} │ {middle} │ {dirname}{ctx}{lastCmdSuffix?}
```
Real example pulled from a 1M-context session at the moment this enhancement was drafted (~95 chars; gets clipped to `… ghe…` in narrow terminals):
```
Opus 4.7 (1M context) │ v1.0 [██████████] 100% · milestone complete │ gheller-pos ███░░░░░░░ 30%
```

**After** (with `statusline.context_position: "front"` opt-in):
```
{gsdUpdate?}{model}{ctx} │ {middle} │ {dirname}{lastCmdSuffix?}
```
```
Opus 4.7 (1M context) ███░░░░░░░ 30% │ v1.0 [██████████] 100% · milestone complete │ gheller-pos
```

**After** (default — flag absent, or `"end"`): byte-identical to "Before".

## How it was implemented

- Extracted layout into a single `composeStatusline({ gsdUpdate, model, ctx, middle, dirname, lastCmdSuffix, position })` helper inside `hooks/gsd-statusline.js`. Both `runStatusline` (production) and `renderStatusline` (test export) delegate to it. This is the smallest change that makes layout testable without duplicating the template string.
- Read `statusline.context_position` via the existing `readGsdConfig` + `getConfigValue` helpers (the same pattern `statusline.show_last_command` uses, courtesy of #2538).
- Validate input against `'front' | 'end'`; any other value falls back to `'end'`. Errors are swallowed so the statusline never breaks on a malformed `config.json`.
- Registered the key in `get-shit-done/bin/lib/config-schema.cjs` and mirrored it in `sdk/src/query/config-schema.ts` (keeps `#2653` parity test green).
- Added `tests/enh-2937-statusline-context-position.test.cjs` — 9 assertions covering schema registration, both layouts via `composeStatusline`, both layouts via `renderStatusline`, the no-middle case in both modes, default-equals-explicit-end equivalence, and invalid-value fallback.
- Documented the flag in `docs/CONFIGURATION.md` directly below the `show_last_command` row, and added a CHANGELOG entry under `1.40.0-rc.1`.

Files changed:

```
CHANGELOG.md                                              |  +6
docs/CONFIGURATION.md                                     |  +1
get-shit-done/bin/lib/config-schema.cjs                   |  +1
hooks/gsd-statusline.js                                   | +57 -10
sdk/src/query/config-schema.ts                            |  +1
tests/enh-2937-statusline-context-position.test.cjs       | +146 (new)
```

## Testing

### How I verified the enhancement works

1. Unit test (run via `npm test`): the new `tests/enh-2937-statusline-context-position.test.cjs` exercises both `composeStatusline` and `renderStatusline` for each layout, plus the schema registration and the invalid-value fallback.
2. Full repo test suite — **6150/6150 pass** locally (`npm test`).
3. End-to-end smoke test through the real hook entrypoint, three runs covering the three meaningful states:

```bash
$ echo '{"model":{"display_name":"Opus 4.7"},"workspace":{"current_dir":"/tmp/p"},"session_id":"t","context_window":{"total_tokens":1000000,"remaining_percentage":75}}' | node hooks/gsd-statusline.js
# default (no .planning/config.json):
Opus 4.7 │ p ███░░░░░░░ 30%

# with statusline.context_position=front:
Opus 4.7 ███░░░░░░░ 30% │ p

# with statusline.context_position=end (explicit):
Opus 4.7 │ p ███░░░░░░░ 30%   ← byte-identical to default
```

### Platforms tested

- [x] macOS (Darwin 25.2.0)
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

The change is shell-agnostic — it edits a Node.js hook that takes JSON on stdin and writes ANSI to stdout. No path handling, no shell interaction. CI will exercise the others.

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

The hook lives at `hooks/gsd-statusline.js` and is consumed via Claude Code's `statusLine.command` config. Other runtimes that adopt the same hook get the change for free.

---

## Scope confirmation

This PR matches the scope sketched in #2937 exactly:

- ✅ One opt-in config flag in the existing `statusline.*` namespace
- ✅ Default value preserves byte-for-byte the prior layout
- ✅ Mirrors the precedent set by `statusline.show_last_command` (#2538)
- ✅ Edits the four files named in the issue's "Scope of changes" section, plus the SDK mirror (required by the existing `#2653` parity test) and CHANGELOG (per the enhancement-PR convention)
- ✅ No new commands, no new workflows, no new concepts

No scope creep. Total diff: **+222 / -10** lines (most of which is the new test file).
