### PR TITLE
feat(workflows): atomic Write+commit ordering for SUMMARY.md (#2806)

### DIFF
--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -551,13 +551,7 @@ increases monotonically across waves. `{status}` is `complete` (success),
        only (STATE.md and ROADMAP.md are excluded automatically). Do NOT skip or defer
        this commit — the orchestrator force-removes the worktree after you return, and
        any uncommitted SUMMARY.md will be permanently lost (#2070).
-
-       REQUIRED ORDER: SUMMARY.md MUST be committed BEFORE any concluding narrative output.
-       Do NOT emit "Now writing the SUMMARY.md" or similar narration between the Write and
-       the commit. Treat Write+commit as one atomic block: Write tool call → commit tool
-       call → only then any concluding text. Response truncation between Write and commit
-       is a known failure mode and the rescue net (#2070) should not be relied on as
-       primary defense.
+       REQUIRED ORDER: Write SUMMARY.md → commit → only then any narration. No text between Write and commit (truncation risk; #2070 rescue is not primary defense).
        </parallel_execution>
 
        <execution_context>
@@ -612,13 +606,7 @@ increases monotonically across waves. `{status}` is `complete` (success),
        <sequential_execution>
        You are running as a SEQUENTIAL executor agent on the main working tree.
        Use normal git commits (with hooks). Do NOT use --no-verify.
-
-       REQUIRED ORDER: SUMMARY.md MUST be committed BEFORE any concluding narrative output.
-       Do NOT emit "Now writing the SUMMARY.md" or similar narration between the Write and
-       the commit. Treat Write+commit as one atomic block: Write tool call → commit tool
-       call → only then any concluding text. Response truncation between Write and commit
-       is a known failure mode and the rescue net (#2070) should not be relied on as
-       primary defense.
+       REQUIRED ORDER: Write SUMMARY.md → commit → only then any narration. No text between Write and commit (truncation risk; #2070 rescue is not primary defense).
        </sequential_execution>
    ```
 

--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -551,6 +551,13 @@ increases monotonically across waves. `{status}` is `complete` (success),
        only (STATE.md and ROADMAP.md are excluded automatically). Do NOT skip or defer
        this commit — the orchestrator force-removes the worktree after you return, and
        any uncommitted SUMMARY.md will be permanently lost (#2070).
+
+       REQUIRED ORDER: SUMMARY.md MUST be committed BEFORE any concluding narrative output.
+       Do NOT emit "Now writing the SUMMARY.md" or similar narration between the Write and
+       the commit. Treat Write+commit as one atomic block: Write tool call → commit tool
+       call → only then any concluding text. Response truncation between Write and commit
+       is a known failure mode and the rescue net (#2070) should not be relied on as
+       primary defense.
        </parallel_execution>
 
        <execution_context>
@@ -605,6 +612,13 @@ increases monotonically across waves. `{status}` is `complete` (success),
        <sequential_execution>
        You are running as a SEQUENTIAL executor agent on the main working tree.
        Use normal git commits (with hooks). Do NOT use --no-verify.
+
+       REQUIRED ORDER: SUMMARY.md MUST be committed BEFORE any concluding narrative output.
+       Do NOT emit "Now writing the SUMMARY.md" or similar narration between the Write and
+       the commit. Treat Write+commit as one atomic block: Write tool call → commit tool
+       call → only then any concluding text. Response truncation between Write and commit
+       is a known failure mode and the rescue net (#2070) should not be relied on as
+       primary defense.
        </sequential_execution>
    ```
 

--- a/get-shit-done/workflows/execute-plan.md
+++ b/get-shit-done/workflows/execute-plan.md
@@ -116,7 +116,12 @@ Pattern B only (verify-only checkpoints). Skip for A/C.
 2. Per segment:
    - Subagent route: spawn gsd-executor for assigned tasks only. Prompt: task range, plan path, read full plan for context, execute assigned tasks, track deviations, NO SUMMARY/commit. Track via agent protocol.
    - Main route: execute tasks using standard flow (step name="execute")
-3. After ALL segments: aggregate files/deviations/decisions → create SUMMARY.md → commit → self-check:
+3. **Critical ordering — write and commit SUMMARY.md as one atomic block.** Do NOT
+   emit narrative output between the Write tool call and the commit tool call.
+   Truncation at this boundary is a known failure mode (see #2070 rescue logic in
+   execute-phase.md step 5.5).
+
+   After ALL segments: aggregate files/deviations/decisions → create SUMMARY.md → commit → self-check:
    - Verify key-files.created exist on disk with `[ -f ]`
    - Check `git log --oneline --all --grep="{phase}-{plan}"` returns ≥1 commit
    - Re-run ALL `<acceptance_criteria>` from every task — if any fail, fix before finalizing SUMMARY
@@ -331,6 +336,11 @@ If user_setup exists: create `{phase}-USER-SETUP.md` using template `~/.claude/g
 </step>
 
 <step name="create_summary">
+**Critical ordering — write and commit SUMMARY.md as one atomic block.** Do NOT
+emit narrative output between the Write tool call and the commit tool call.
+Truncation at this boundary is a known failure mode (see #2070 rescue logic in
+execute-phase.md step 5.5).
+
 Create `{phase}-{plan}-SUMMARY.md` at `.planning/phases/XX-name/`. Use `~/.claude/get-shit-done/templates/summary.md`.
 
 **Frontmatter:** phase, plan, subsystem, tags | requires/provides/affects | tech-stack.added/patterns | key-files.created/modified | key-decisions | requirements-completed (**MUST** copy `requirements` array from PLAN.md frontmatter verbatim) | duration ($DURATION), completed ($PLAN_END_TIME date).
@@ -432,6 +442,11 @@ Extract requirement IDs from the plan's frontmatter (e.g., `requirements: [AUTH-
 </step>
 
 <step name="git_commit_metadata">
+**Critical ordering — write and commit SUMMARY.md as one atomic block.** Do NOT
+emit narrative output between the Write tool call and the commit tool call.
+Truncation at this boundary is a known failure mode (see #2070 rescue logic in
+execute-phase.md step 5.5).
+
 Task code already committed per-task. Commit plan metadata:
 
 ```bash

--- a/get-shit-done/workflows/execute-plan.md
+++ b/get-shit-done/workflows/execute-plan.md
@@ -121,12 +121,13 @@ Pattern B only (verify-only checkpoints). Skip for A/C.
    Truncation at this boundary is a known failure mode (see #2070 rescue logic in
    execute-phase.md step 5.5).
 
-   After ALL segments: aggregate files/deviations/decisions → create SUMMARY.md → commit → self-check:
+   After ALL segments: aggregate files/deviations/decisions → create SUMMARY.md → self-check:
    - Verify key-files.created exist on disk with `[ -f ]`
    - Check `git log --oneline --all --grep="{phase}-{plan}"` returns ≥1 commit
    - Re-run ALL `<acceptance_criteria>` from every task — if any fail, fix before finalizing SUMMARY
    - Re-run the plan-level `<verification>` commands — log results in SUMMARY
    - Append `## Self-Check: PASSED` or `## Self-Check: FAILED` to SUMMARY
+   Then commit (no narrative between Write and commit).
 
    **Known Claude Code bug (classifyHandoffIfNeeded):** If any segment agent reports "failed" with `classifyHandoffIfNeeded is not defined`, this is a Claude Code runtime bug — not a real failure. Run spot-checks; if they pass, treat as successful.
 


### PR DESCRIPTION
## Enhancement PR

---

## Linked Issue

Closes #2806

---

## What this enhancement improves

The executor agent's reliability when writing and committing `SUMMARY.md` at the end of a plan. Today the agent's response stream frequently truncates between `Write SUMMARY.md` and the subsequent `git commit`, forcing the orchestrator-side rescue net (#2070) to do load-bearing work it was designed only as a safety fallback for.

## Before / After

**Before:** In a real 7-plan / 4-wave phase execution on `get-shit-done-cc@1.38.5` (Opus 4.7, 1M context), 4 of the first 5 executors truncated at `"Now writing the SUMMARY.md."` between the Write and the commit. Each truncation triggered the orchestrator's `docs(recovery): rescue uncommitted SUMMARY.md` commit path. The 2 plans that did not truncate received an explicit prompt-time override.

**After:** The executor spawn prompt and `execute-plan.md` step body explicitly forbid emitting narrative output between the `Write` tool call and the `commit` tool call. They must be treated as one atomic block, with concluding text only after the commit. The #2070 rescue net stays in place as defense-in-depth, but is no longer the primary success path.

## How it was implemented

Template-text additions only — no behavior change to surrounding logic:

- `get-shit-done/workflows/execute-phase.md` — appended a `REQUIRED ORDER` directive inside both the `<parallel_execution>` (worktree) and `<sequential_execution>` blocks of the executor spawn prompt.
- `get-shit-done/workflows/execute-plan.md` — added the `Critical ordering — write and commit SUMMARY.md as one atomic block.` prefix to the `segment_execution` aggregate step (line 119), the `create_summary` step (line 333), and the `git_commit_metadata` step (line 434).

## Testing

### How I verified the enhancement works

Source-text additions only at the prompt-template layer — no Node code paths to exercise. Verification is end-to-end at runtime: the test plan below covers parallel and sequential modes against a multi-plan phase to confirm executors commit `SUMMARY.md` before emitting concluding text and that the rescue-net commits stop appearing.

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

---

## Checklist

- [x] Issue linked above with `Closes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `approved-enhancement` label — **PR will be closed if missing**
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass (`npm test`)
- [ ] New or updated tests cover the enhanced behavior — N/A, prompt-template-only addition; runtime test plan below
- [ ] CHANGELOG.md updated
- [ ] Documentation updated if behavior or output changed
- [x] No unnecessary dependencies added

## Test plan

- [ ] Run `/gsd-execute-phase` against a multi-plan phase with `workflow.use_worktrees: true` and `parallelization: true`; confirm executor agents commit SUMMARY.md before emitting concluding text and that the orchestrator-side `docs(recovery): rescue uncommitted SUMMARY.md` commits do not appear.
- [ ] Verify sequential-mode (`workflow.use_worktrees: false`) executor still commits SUMMARY.md atomically.

## Breaking changes

None. Template-text additions to existing prompt blocks; no surrounding logic changes; the #2070 rescue net stays in place unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability by enforcing atomic write→commit ordering for summary persistence and prohibiting any output between the write and commit to prevent truncation.

* **Documentation**
  * Clarified execution guidance and step wording, including repositioning a self-check to occur before the final commit in segmented flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->