### PR TITLE
fix(config-get): return schema default for context_window when absent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   posting a comment that points to the contribution guide. (#2872)
 
 ### Fixed — 1.40.0-rc.1
+- **`config-get context_window` returns `200000` when key absent** — querying an unset `context_window` previously exited 1 with "Key not found", surfacing a confusing error in planning logs even though the workflow fallback worked correctly. `cmdConfigGet` now consults a `SCHEMA_DEFAULTS` map and returns the documented default (`200000`, exit 0) for absent schema-defaulted keys; unknown absent keys still error as before. (#2943)
 - **`gap-analysis` now parses non-`REQ-` requirement IDs and ignores traceability table headers** — `parseRequirements()` no longer hard-codes the `REQ-` prefix and now accepts uppercase prefixed IDs such as `TST-01`, `BACK-07`, and `INSP-04`; markdown table header rows (for example `| REQ-ID | ... |`) are excluded so header tokens are not reported as phantom uncovered requirements. Added regression coverage for mixed-prefix REQUIREMENTS files with traceability tables. (#2897)
 - **Gemini slash commands namespaced as `/gsd:<cmd>` instead of `/gsd-<cmd>`** —
   Gemini CLI namespaces commands under `gsd:`, so `/gsd-plan-phase` was unexecutable.

--- a/get-shit-done/bin/lib/config.cjs
+++ b/get-shit-done/bin/lib/config.cjs
@@ -377,6 +377,15 @@ function cmdConfigSet(cwd, keyPath, value, raw) {
   output(setConfigValueResult, raw, `${keyPath}=${parsedValue}`);
 }
 
+/**
+ * Schema-level defaults for well-known config keys.
+ * When a key is absent from config.json and no --default flag was supplied,
+ * cmdConfigGet checks here before emitting "Key not found".
+ */
+const SCHEMA_DEFAULTS = {
+  'context_window': 200000,
+};
+
 function cmdConfigGet(cwd, keyPath, raw, defaultValue) {
   const configPath = path.join(planningDir(cwd), 'config.json');
   const hasDefault = defaultValue !== undefined;
@@ -406,6 +415,11 @@ function cmdConfigGet(cwd, keyPath, raw, defaultValue) {
   for (const key of keys) {
     if (current === undefined || current === null || typeof current !== 'object') {
       if (hasDefault) { output(defaultValue, raw, String(defaultValue)); return; }
+      if (Object.prototype.hasOwnProperty.call(SCHEMA_DEFAULTS, keyPath)) {
+        const def = SCHEMA_DEFAULTS[keyPath];
+        output(def, raw, String(def));
+        return;
+      }
       error(`Key not found: ${keyPath}`);
     }
     current = current[key];
@@ -413,6 +427,11 @@ function cmdConfigGet(cwd, keyPath, raw, defaultValue) {
 
   if (current === undefined) {
     if (hasDefault) { output(defaultValue, raw, String(defaultValue)); return; }
+    if (Object.prototype.hasOwnProperty.call(SCHEMA_DEFAULTS, keyPath)) {
+      const def = SCHEMA_DEFAULTS[keyPath];
+      output(def, raw, String(def));
+      return;
+    }
     error(`Key not found: ${keyPath}`);
   }
 

--- a/tests/bug-2943-config-get-context-window-default.test.cjs
+++ b/tests/bug-2943-config-get-context-window-default.test.cjs
@@ -1,0 +1,128 @@
+/**
+ * Regression test for bug #2943
+ *
+ * `gsd-tools.cjs config-get context_window` (and the SDK equivalent) threw
+ * "Key not found: context_window" when the key was absent from config.json,
+ * even though context_window has a documented schema default of 200000.
+ *
+ * Fix: `cmdConfigGet` in bin/lib/config.cjs now consults a SCHEMA_DEFAULTS map
+ * before emitting "Key not found", so schema-defaulted keys always return the
+ * default value (exit 0) when not explicitly set in the project config.
+ */
+
+'use strict';
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { execFileSync } = require('node:child_process');
+
+const GSD_TOOLS = path.join(__dirname, '..', 'get-shit-done', 'bin', 'gsd-tools.cjs');
+
+describe('bug-2943: config-get returns schema default for context_window', () => {
+  let tmpDir;
+  let planningDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-test-2943-'));
+    planningDir = path.join(tmpDir, '.planning');
+    fs.mkdirSync(planningDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  /**
+   * Run config-get with optional extra args. Returns { exitCode, stdout, stderr }.
+   * Uses --raw so we get the plain scalar value, not JSON-wrapped.
+   */
+  function runConfigGet(keyPath, extraArgs = []) {
+    const args = [GSD_TOOLS, 'config-get', keyPath, '--raw', '--cwd', tmpDir, ...extraArgs];
+    let stdout = '';
+    let stderr = '';
+    let exitCode = 0;
+    try {
+      stdout = execFileSync(process.execPath, args, {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 5000,
+      });
+    } catch (err) {
+      exitCode = err.status ?? 1;
+      stdout = err.stdout?.toString() ?? '';
+      stderr = err.stderr?.toString() ?? '';
+    }
+    return { exitCode, stdout: stdout.trim(), stderr: stderr.trim() };
+  }
+
+  test('returns "200000" (exit 0) when context_window absent from config.json', () => {
+    // Fixture A: config with unrelated keys, no context_window
+    fs.writeFileSync(
+      path.join(planningDir, 'config.json'),
+      JSON.stringify({ workflow: { auto_advance: false } })
+    );
+
+    const result = runConfigGet('context_window');
+
+    assert.strictEqual(result.exitCode, 0, 'should exit 0 (schema default applied)');
+    assert.strictEqual(result.stdout, '200000', 'should return schema default of 200000');
+  });
+
+  test('returns configured value when context_window is explicitly set', () => {
+    // Fixture B: config has context_window: 1000000
+    fs.writeFileSync(
+      path.join(planningDir, 'config.json'),
+      JSON.stringify({ context_window: 1000000 })
+    );
+
+    const result = runConfigGet('context_window');
+
+    assert.strictEqual(result.exitCode, 0, 'should exit 0 for found key');
+    assert.strictEqual(result.stdout, '1000000', 'should return configured value not schema default');
+  });
+
+  test('--default flag overrides schema default', () => {
+    // config has context_window but we pass --default with a different value —
+    // when key IS present, real value wins over any default
+    fs.writeFileSync(
+      path.join(planningDir, 'config.json'),
+      JSON.stringify({ workflow: { auto_advance: false } })
+    );
+
+    const result = runConfigGet('context_window', ['--default', '200000']);
+
+    assert.strictEqual(result.exitCode, 0, 'should exit 0 when --default provided');
+    assert.strictEqual(result.stdout, '200000', 'should return the --default value');
+  });
+
+  test('errors with "Key not found" (exit 1) for an unknown absent key — no regression', () => {
+    // An unrecognised key with no schema default still errors as before
+    fs.writeFileSync(
+      path.join(planningDir, 'config.json'),
+      JSON.stringify({ workflow: { auto_advance: false } })
+    );
+
+    const result = runConfigGet('totally_unknown_key_xyz');
+
+    assert.strictEqual(result.exitCode, 1, 'should exit 1 for unknown absent key');
+    assert.ok(
+      result.stderr.includes('Key not found') || result.stdout.includes('Key not found'),
+      `expected "Key not found" in output, got stderr="${result.stderr}" stdout="${result.stdout}"`
+    );
+  });
+
+  test('--default flag still works for arbitrary absent keys', () => {
+    fs.writeFileSync(
+      path.join(planningDir, 'config.json'),
+      JSON.stringify({})
+    );
+
+    const result = runConfigGet('some.missing.key', ['--default', '200000']);
+
+    assert.strictEqual(result.exitCode, 0, 'should exit 0 when --default supplied');
+    assert.strictEqual(result.stdout, '200000', 'should return the explicit --default value');
+  });
+});

--- a/tests/bug-2943-config-get-context-window-default.test.cjs
+++ b/tests/bug-2943-config-get-context-window-default.test.cjs
@@ -92,10 +92,10 @@ describe('bug-2943: config-get returns schema default for context_window', () =>
       JSON.stringify({ workflow: { auto_advance: false } })
     );
 
-    const result = runConfigGet('context_window', ['--default', '200000']);
+    const result = runConfigGet('context_window', ['--default', '123456']);
 
     assert.strictEqual(result.exitCode, 0, 'should exit 0 when --default provided');
-    assert.strictEqual(result.stdout, '200000', 'should return the --default value');
+    assert.strictEqual(result.stdout, '123456', 'should return the --default value, not schema default');
   });
 
   test('errors with "Key not found" (exit 1) for an unknown absent key — no regression', () => {

--- a/tests/subagent-timeout.test.cjs
+++ b/tests/subagent-timeout.test.cjs
@@ -199,16 +199,17 @@ describe('config-get context_window (#1472)', () => {
     assert.strictEqual(output, 1000000);
   });
 
-  test('config-get context_window errors when key is absent', () => {
+  test('config-get context_window returns schema default (200000) when key is absent', () => {
+    // Bug #2943: context_window has a schema-level default of 200000.
+    // config-get must return it (exit 0) rather than "Key not found" (exit 1).
     const configPath = path.join(tmpDir, '.planning', 'config.json');
     fs.writeFileSync(configPath, JSON.stringify({}, null, 2));
 
     const result = runGsdTools('config-get context_window', tmpDir);
-    assert.strictEqual(result.success, false);
-    assert.ok(
-      result.error.includes('Key not found'),
-      `Expected "Key not found" in error: ${result.error}`
-    );
+    assert.ok(result.success, `Expected success but got: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output, 200000, 'schema default for context_window should be 200000');
   });
 });
 


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #2943

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

`gsd-tools.cjs config-get context_window` (and `gsd-sdk query config-get context_window`) threw "Key not found: context_window" with exit code 1 whenever the key was absent from `config.json`, even though `context_window` has a documented schema default of 200000.

## What this fix does

`cmdConfigGet` in `bin/lib/config.cjs` now consults a `SCHEMA_DEFAULTS` map before emitting "Key not found". When `context_window` is absent from config, it returns `200000` (exit 0) without requiring a `--default` flag. Unknown keys with no schema default still error as before.

## Root cause

`cmdConfigGet` had no knowledge of schema-level defaults. The default of 200000 was applied in `sdk/src/query/init.ts` and `sdk/src/query/config-gates.ts` via `config.context_window ?? 200000`, but the CLI command itself had no fallback path — it went straight to `error('Key not found')` for any absent key.

## Testing

### How I verified the fix

Added `tests/bug-2943-config-get-context-window-default.test.cjs` with 5 tests covering:
1. Returns `200000` (exit 0) when `context_window` absent — schema default applied
2. Returns configured value when `context_window` is explicitly set
3. `--default` flag still works and overrides schema default
4. Unknown absent keys still error with "Key not found" (no regression)
5. `--default` flag still works for arbitrary absent keys

Also updated the stale assertion in `tests/subagent-timeout.test.cjs` that was asserting the old broken behavior.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] CHANGELOG.md updated if this is a user-facing fix
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `config-get` now returns documented schema default values for certain well-known keys (e.g., context_window) when those keys are missing, and exits successfully instead of reporting "Key not found".
* **Tests**
  * Added and updated tests validating default-return behavior, explicit config values, and `--default` handling.
* **Documentation**
  * Changelog updated noting the fix for config-get defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->