### PR TITLE
fix(#2948): wire spike --wrap-up flag dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   posting a comment that points to the contribution guide. (#2872)
 
 ### Fixed — 1.40.0-rc.1
+- **`spike --wrap-up` now dispatches correctly** — `/gsd-spike --wrap-up` was silently no-oping because the flag dispatch wiring was omitted when the micro-skill entry point was absorbed in #2790. (#2948)
 - **`config-get context_window` returns `200000` when key absent** — querying an unset `context_window` previously exited 1 with "Key not found", surfacing a confusing error in planning logs even though the workflow fallback worked correctly. `cmdConfigGet` now consults a `SCHEMA_DEFAULTS` map and returns the documented default (`200000`, exit 0) for absent schema-defaulted keys; unknown absent keys still error as before. (#2943)
 - **`gap-analysis` now parses non-`REQ-` requirement IDs and ignores traceability table headers** — `parseRequirements()` no longer hard-codes the `REQ-` prefix and now accepts uppercase prefixed IDs such as `TST-01`, `BACK-07`, and `INSP-04`; markdown table header rows (for example `| REQ-ID | ... |`) are excluded so header tokens are not reported as phantom uncovered requirements. Added regression coverage for mixed-prefix REQUIREMENTS files with traceability tables. (#2897)
 - **Gemini slash commands namespaced as `/gsd:<cmd>` instead of `/gsd-<cmd>`** —

--- a/commands/gsd/spike.md
+++ b/commands/gsd/spike.md
@@ -30,6 +30,7 @@ Does not require `/gsd-new-project` — auto-creates `.planning/spikes/` if need
 
 <execution_context>
 @~/.claude/get-shit-done/workflows/spike.md
+@~/.claude/get-shit-done/workflows/spike-wrap-up.md
 @~/.claude/get-shit-done/references/ui-brand.md
 </execution_context>
 
@@ -47,6 +48,9 @@ Idea: $ARGUMENTS
 </context>
 
 <process>
-Execute the spike workflow from @~/.claude/get-shit-done/workflows/spike.md end-to-end.
+Parse the first token of $ARGUMENTS:
+- If it is `--wrap-up`: strip the flag, execute the spike-wrap-up workflow from @~/.claude/get-shit-done/workflows/spike-wrap-up.md.
+- Otherwise: pass all of $ARGUMENTS as the idea to the spike workflow from @~/.claude/get-shit-done/workflows/spike.md end-to-end.
+
 Preserve all workflow gates (prior spike check, decomposition, research, risk ordering, observability assessment, verification, MANIFEST updates, commit patterns).
 </process>

--- a/get-shit-done/workflows/spike.md
+++ b/get-shit-done/workflows/spike.md
@@ -1,7 +1,7 @@
 <purpose>
 Spike an idea through experiential exploration — build focused experiments to feel the pieces
 of a future app, validate feasibility, and produce verified knowledge for the real build.
-Saves artifacts to `.planning/spikes/`. Companion to `/gsd-spike-wrap-up`.
+Saves artifacts to `.planning/spikes/`. Companion to `/gsd-spike --wrap-up`.
 
 Supports two modes:
 - **Idea mode** (default) — user describes an idea to spike
@@ -421,7 +421,7 @@ gsd-sdk query commit "docs(spikes): update conventions" --files .planning/spikes
 
 **Package findings** — wrap spike knowledge into an implementation blueprint
 
-`/gsd-spike-wrap-up`
+`/gsd-spike --wrap-up`
 
 ───────────────────────────────────────────────────────────────
 

--- a/tests/bug-2948-spike-wrap-up-dispatch.test.cjs
+++ b/tests/bug-2948-spike-wrap-up-dispatch.test.cjs
@@ -1,0 +1,89 @@
+/**
+ * Regression test for bug #2948
+ *
+ * `/gsd-spike --wrap-up` was silently no-oping because:
+ * 1. `commands/gsd/spike.md` listed `--wrap-up` as a flag but had no dispatch block.
+ * 2. `workflows/spike.md` still referenced the deleted `/gsd-spike-wrap-up` entry-point
+ *    instead of the correct `/gsd-spike --wrap-up` form.
+ *
+ * Fix:
+ * - `commands/gsd/spike.md` now has a `Parse the first token of $ARGUMENTS` dispatch block
+ *   that routes `--wrap-up` to spike-wrap-up.md, and `spike-wrap-up.md` is listed in
+ *   the execution_context so the runtime can find it.
+ * - `workflows/spike.md` companion references updated from `/gsd-spike-wrap-up` to
+ *   `/gsd-spike --wrap-up`.
+ */
+
+'use strict';
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const SPIKE_CMD_PATH = path.join(__dirname, '..', 'commands', 'gsd', 'spike.md');
+const SPIKE_WORKFLOW_PATH = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'spike.md');
+
+describe('bug-2948: /gsd-spike --wrap-up dispatch wiring', () => {
+  describe('commands/gsd/spike.md', () => {
+    let content;
+
+    test('spike.md command file exists', () => {
+      assert.ok(fs.existsSync(SPIKE_CMD_PATH), 'commands/gsd/spike.md should exist');
+      content = fs.readFileSync(SPIKE_CMD_PATH, 'utf-8');
+    });
+
+    test('contains --wrap-up dispatch logic', () => {
+      const text = fs.readFileSync(SPIKE_CMD_PATH, 'utf-8');
+      assert.ok(
+        text.includes('--wrap-up'),
+        'commands/gsd/spike.md must contain --wrap-up dispatch logic'
+      );
+    });
+
+    test('references spike-wrap-up workflow in execution_context', () => {
+      const text = fs.readFileSync(SPIKE_CMD_PATH, 'utf-8');
+      // Extract the execution_context block
+      const execContextMatch = text.match(/<execution_context>([\s\S]*?)<\/execution_context>/);
+      assert.ok(execContextMatch, 'spike.md must have an <execution_context> block');
+      const execContext = execContextMatch[1];
+      assert.ok(
+        execContext.includes('spike-wrap-up'),
+        'execution_context must reference spike-wrap-up.md so the runtime can find it when --wrap-up is set'
+      );
+    });
+
+    test('has a parse/dispatch block for first token of $ARGUMENTS', () => {
+      const text = fs.readFileSync(SPIKE_CMD_PATH, 'utf-8');
+      assert.ok(
+        text.includes('Parse the first token of $ARGUMENTS'),
+        'commands/gsd/spike.md must have a "Parse the first token of $ARGUMENTS" dispatch block'
+      );
+    });
+  });
+
+  describe('get-shit-done/workflows/spike.md', () => {
+    let content;
+
+    test('spike workflow file exists', () => {
+      assert.ok(fs.existsSync(SPIKE_WORKFLOW_PATH), 'get-shit-done/workflows/spike.md should exist');
+      content = fs.readFileSync(SPIKE_WORKFLOW_PATH, 'utf-8');
+    });
+
+    test('does NOT reference the old deleted /gsd-spike-wrap-up entry-point', () => {
+      const text = fs.readFileSync(SPIKE_WORKFLOW_PATH, 'utf-8');
+      assert.ok(
+        !text.includes('/gsd-spike-wrap-up'),
+        'workflows/spike.md must not reference the deleted /gsd-spike-wrap-up command; use /gsd-spike --wrap-up instead'
+      );
+    });
+
+    test('references /gsd-spike --wrap-up as the canonical wrap-up invocation', () => {
+      const text = fs.readFileSync(SPIKE_WORKFLOW_PATH, 'utf-8');
+      assert.ok(
+        text.includes('/gsd-spike --wrap-up'),
+        'workflows/spike.md must reference /gsd-spike --wrap-up as the wrap-up command'
+      );
+    });
+  });
+});

--- a/tests/bug-2948-spike-wrap-up-dispatch.test.cjs
+++ b/tests/bug-2948-spike-wrap-up-dispatch.test.cjs
@@ -7,12 +7,16 @@
  *    instead of the correct `/gsd-spike --wrap-up` form.
  *
  * Fix:
- * - `commands/gsd/spike.md` now has a `Parse the first token of $ARGUMENTS` dispatch block
- *   that routes `--wrap-up` to spike-wrap-up.md, and `spike-wrap-up.md` is listed in
- *   the execution_context so the runtime can find it.
+ * - `commands/gsd/spike.md` now has a dispatch block that routes `--wrap-up` to
+ *   spike-wrap-up.md, and spike-wrap-up.md is listed in execution_context so the
+ *   runtime can find it.
  * - `workflows/spike.md` companion references updated from `/gsd-spike-wrap-up` to
  *   `/gsd-spike --wrap-up`.
  */
+
+// allow-test-rule: source-text-is-the-product
+// commands/gsd/*.md files ARE what the runtime loads — testing their
+// frontmatter and section content tests the deployed system-prompt contract.
 
 'use strict';
 
@@ -24,65 +28,116 @@ const path = require('node:path');
 const SPIKE_CMD_PATH = path.join(__dirname, '..', 'commands', 'gsd', 'spike.md');
 const SPIKE_WORKFLOW_PATH = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'spike.md');
 
+/**
+ * Parse YAML frontmatter + body from a markdown file.
+ * Returns a shallow { key: value } map of frontmatter fields plus `_body`.
+ * Mirrors the parseFrontmatter utility used in enh-2792-namespace-skills.test.cjs.
+ */
+function parseFrontmatter(content) {
+  const lines = content.split(/\r?\n/);
+  let openIdx = -1;
+  let closeIdx = -1;
+  for (let i = 0; i < lines.length; i += 1) {
+    if (lines[i].trim() === '---') {
+      if (openIdx === -1) openIdx = i;
+      else { closeIdx = i; break; }
+    }
+  }
+  assert.ok(openIdx !== -1 && closeIdx !== -1, 'frontmatter block must be delimited by --- on its own lines');
+  const fm = {};
+  for (const line of lines.slice(openIdx + 1, closeIdx)) {
+    const m = line.match(/^([A-Za-z][A-Za-z0-9_-]*):\s*(.*)$/);
+    if (!m) continue;
+    const [, key, raw] = m;
+    fm[key] = raw.trim().replace(/^["']|["']$/g, '');
+  }
+  fm._body = lines.slice(closeIdx + 1).join('\n');
+  return fm;
+}
+
+/**
+ * Extract the text content of a named XML-like section from a markdown body.
+ * Returns null if the section is absent.
+ */
+function extractSection(body, tag) {
+  const open = `<${tag}>`;
+  const close = `</${tag}>`;
+  const start = body.indexOf(open);
+  const end = body.indexOf(close);
+  if (start === -1 || end === -1) return null;
+  return body.slice(start + open.length, end);
+}
+
+/**
+ * Parse the @-prefixed workflow references out of an execution_context section.
+ * Returns an array of resolved reference strings (@ stripped).
+ */
+function parseExecutionContextRefs(section) {
+  return section
+    .split(/\r?\n/)
+    .map(l => l.trim())
+    .filter(l => l.startsWith('@'))
+    .map(l => l.slice(1).trim());
+}
+
 describe('bug-2948: /gsd-spike --wrap-up dispatch wiring', () => {
-  describe('commands/gsd/spike.md', () => {
-    let content;
-
-    test('spike.md command file exists', () => {
+  describe('commands/gsd/spike.md — frontmatter and section contract', () => {
+    test('spike.md command file exists and has valid frontmatter', () => {
       assert.ok(fs.existsSync(SPIKE_CMD_PATH), 'commands/gsd/spike.md should exist');
-      content = fs.readFileSync(SPIKE_CMD_PATH, 'utf-8');
+      const fm = parseFrontmatter(fs.readFileSync(SPIKE_CMD_PATH, 'utf-8'));
+      assert.ok(fm.name, 'frontmatter must have a name field');
     });
 
-    test('contains --wrap-up dispatch logic', () => {
-      const text = fs.readFileSync(SPIKE_CMD_PATH, 'utf-8');
+    test('argument-hint frontmatter field advertises --wrap-up flag', () => {
+      const fm = parseFrontmatter(fs.readFileSync(SPIKE_CMD_PATH, 'utf-8'));
       assert.ok(
-        text.includes('--wrap-up'),
-        'commands/gsd/spike.md must contain --wrap-up dispatch logic'
+        fm['argument-hint'] && fm['argument-hint'].includes('--wrap-up'),
+        `argument-hint must advertise --wrap-up; got: "${fm['argument-hint']}"`
       );
     });
 
-    test('references spike-wrap-up workflow in execution_context', () => {
-      const text = fs.readFileSync(SPIKE_CMD_PATH, 'utf-8');
-      // Extract the execution_context block
-      const execContextMatch = text.match(/<execution_context>([\s\S]*?)<\/execution_context>/);
-      assert.ok(execContextMatch, 'spike.md must have an <execution_context> block');
-      const execContext = execContextMatch[1];
+    test('execution_context section includes spike-wrap-up workflow reference', () => {
+      const fm = parseFrontmatter(fs.readFileSync(SPIKE_CMD_PATH, 'utf-8'));
+      const execSection = extractSection(fm._body, 'execution_context');
+      assert.ok(execSection !== null, 'spike.md must have an <execution_context> section');
+      const refs = parseExecutionContextRefs(execSection);
       assert.ok(
-        execContext.includes('spike-wrap-up'),
-        'execution_context must reference spike-wrap-up.md so the runtime can find it when --wrap-up is set'
+        refs.some(r => r.includes('spike-wrap-up')),
+        `execution_context must declare a spike-wrap-up reference so the runtime can load the workflow; ` +
+        `declared refs: ${JSON.stringify(refs)}`
       );
     });
 
-    test('has a parse/dispatch block for first token of $ARGUMENTS', () => {
-      const text = fs.readFileSync(SPIKE_CMD_PATH, 'utf-8');
+    test('context or process section routes --wrap-up to the spike-wrap-up workflow', () => {
+      const fm = parseFrontmatter(fs.readFileSync(SPIKE_CMD_PATH, 'utf-8'));
+      const contextSection = extractSection(fm._body, 'context') || '';
+      const processSection = extractSection(fm._body, 'process') || '';
+      const dispatchText = contextSection + processSection;
       assert.ok(
-        text.includes('Parse the first token of $ARGUMENTS'),
-        'commands/gsd/spike.md must have a "Parse the first token of $ARGUMENTS" dispatch block'
+        dispatchText.includes('--wrap-up') && dispatchText.includes('spike-wrap-up'),
+        'The <context> or <process> section must contain routing that maps --wrap-up to the spike-wrap-up workflow'
       );
     });
   });
 
-  describe('get-shit-done/workflows/spike.md', () => {
-    let content;
-
+  describe('get-shit-done/workflows/spike.md — companion references', () => {
     test('spike workflow file exists', () => {
       assert.ok(fs.existsSync(SPIKE_WORKFLOW_PATH), 'get-shit-done/workflows/spike.md should exist');
-      content = fs.readFileSync(SPIKE_WORKFLOW_PATH, 'utf-8');
     });
 
-    test('does NOT reference the old deleted /gsd-spike-wrap-up entry-point', () => {
-      const text = fs.readFileSync(SPIKE_WORKFLOW_PATH, 'utf-8');
+    test('does NOT reference the deleted /gsd-spike-wrap-up entry-point', () => {
+      const fm = parseFrontmatter(fs.readFileSync(SPIKE_WORKFLOW_PATH, 'utf-8'));
       assert.ok(
-        !text.includes('/gsd-spike-wrap-up'),
+        !fm._body.includes('/gsd-spike-wrap-up'),
         'workflows/spike.md must not reference the deleted /gsd-spike-wrap-up command; use /gsd-spike --wrap-up instead'
       );
     });
 
     test('references /gsd-spike --wrap-up as the canonical wrap-up invocation', () => {
-      const text = fs.readFileSync(SPIKE_WORKFLOW_PATH, 'utf-8');
+      const fm = parseFrontmatter(fs.readFileSync(SPIKE_WORKFLOW_PATH, 'utf-8'));
       assert.ok(
-        text.includes('/gsd-spike --wrap-up'),
-        'workflows/spike.md must reference /gsd-spike --wrap-up as the wrap-up command'
+        fm._body.includes('/gsd-spike --wrap-up'),
+        'workflows/spike.md must reference /gsd-spike --wrap-up as the canonical wrap-up command'
       );
     });
   });

--- a/tests/bug-2948-spike-wrap-up-dispatch.test.cjs
+++ b/tests/bug-2948-spike-wrap-up-dispatch.test.cjs
@@ -108,14 +108,26 @@ describe('bug-2948: /gsd-spike --wrap-up dispatch wiring', () => {
       );
     });
 
-    test('context or process section routes --wrap-up to the spike-wrap-up workflow', () => {
+    test('process section dispatches first-token --wrap-up to spike-wrap-up workflow', () => {
       const fm = parseFrontmatter(fs.readFileSync(SPIKE_CMD_PATH, 'utf-8'));
-      const contextSection = extractSection(fm._body, 'context') || '';
-      const processSection = extractSection(fm._body, 'process') || '';
-      const dispatchText = contextSection + processSection;
+      const processSection = extractSection(fm._body, 'process');
+      assert.ok(processSection, 'spike.md must have a <process> section');
+
+      const rules = processSection
+        .split(/\r?\n/)
+        .map(line => line.trim())
+        .filter(Boolean);
+
+      const wrapUpRule = rules.find(line => line.startsWith('- If it is `--wrap-up`:'));
+      const fallbackRule = rules.find(line => line.startsWith('- Otherwise:'));
+
       assert.ok(
-        dispatchText.includes('--wrap-up') && dispatchText.includes('spike-wrap-up'),
-        'The <context> or <process> section must contain routing that maps --wrap-up to the spike-wrap-up workflow'
+        wrapUpRule && wrapUpRule.includes('strip the flag') && wrapUpRule.includes('spike-wrap-up'),
+        'process must define a --wrap-up branch that strips the flag and routes to spike-wrap-up'
+      );
+      assert.ok(
+        fallbackRule && fallbackRule.includes('spike workflow'),
+        'process must define an Otherwise fallback to the normal spike workflow'
       );
     });
   });

--- a/tests/bug-2948-spike-wrap-up-dispatch.test.cjs
+++ b/tests/bug-2948-spike-wrap-up-dispatch.test.cjs
@@ -35,17 +35,23 @@ const SPIKE_WORKFLOW_PATH = path.join(__dirname, '..', 'get-shit-done', 'workflo
  */
 function parseFrontmatter(content) {
   const lines = content.split(/\r?\n/);
-  let openIdx = -1;
+
+  // Frontmatter must start at the very first line; a mid-file '---' is a
+  // horizontal rule, not a frontmatter delimiter.
+  if (lines[0]?.trim() !== '---') {
+    return { _body: content };
+  }
+
   let closeIdx = -1;
-  for (let i = 0; i < lines.length; i += 1) {
+  for (let i = 1; i < lines.length; i += 1) {
     if (lines[i].trim() === '---') {
-      if (openIdx === -1) openIdx = i;
-      else { closeIdx = i; break; }
+      closeIdx = i;
+      break;
     }
   }
-  assert.ok(openIdx !== -1 && closeIdx !== -1, 'frontmatter block must be delimited by --- on its own lines');
+  assert.ok(closeIdx !== -1, 'frontmatter block must be delimited by --- on its own lines');
   const fm = {};
-  for (const line of lines.slice(openIdx + 1, closeIdx)) {
+  for (const line of lines.slice(1, closeIdx)) {
     const m = line.match(/^([A-Za-z][A-Za-z0-9_-]*):\s*(.*)$/);
     if (!m) continue;
     const [, key, raw] = m;


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #2948

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

`/gsd-spike --wrap-up` silently no-oped: the flag was documented in `commands/gsd/spike.md` but no dispatch block existed, so the flag was passed straight through to the spike workflow (which ignores it) and the spike-wrap-up workflow was never invoked.

## What this fix does

Adds a `Parse the first token of $ARGUMENTS` dispatch block to `commands/gsd/spike.md` that routes `--wrap-up` to the spike-wrap-up workflow, adds `spike-wrap-up.md` to the `<execution_context>` so the runtime can load it, and updates both companion references in `workflows/spike.md` from the deleted `/gsd-spike-wrap-up` form to `/gsd-spike --wrap-up`.

## Root cause

When the `spike-wrap-up` micro-skill entry-point was absorbed into the main `spike` command in #2790, the dispatch wiring (flag detection + workflow routing) was never added to `commands/gsd/spike.md`.

## Testing

### How I verified the fix

Structural test `tests/bug-2948-spike-wrap-up-dispatch.test.cjs` asserts:
- `commands/gsd/spike.md` contains `--wrap-up` dispatch logic
- `commands/gsd/spike.md` references `spike-wrap-up` in the `<execution_context>` block
- `commands/gsd/spike.md` has the `Parse the first token of $ARGUMENTS` dispatch block
- `workflows/spike.md` does NOT contain `/gsd-spike-wrap-up` (old deleted form)
- `workflows/spike.md` contains `/gsd-spike --wrap-up` (new canonical form)

All 6334 tests pass (`npm test`).

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] CHANGELOG.md updated if this is a user-facing fix
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The /gsd-spike --wrap-up command now dispatches correctly instead of silently doing nothing.

* **Documentation**
  * Workflow docs updated to consistently reference the corrected --wrap-up invocation.

* **Tests**
  * Added a regression test to validate the --wrap-up invocation routes to the wrap-up workflow.

* **Changelog**
  * Added a "Fixed — 1.40.0-rc.1" entry noting the wrap-up dispatch fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->