### PR TITLE
fix(#2950): update stale deleted-command references in workflow files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   now auto-closes PRs opened without a closing keyword that links a tracking issue,
   posting a comment that points to the contribution guide. (#2872)
 
+### Fixed
+
+- **Stale deleted command references updated across workflow files** — `help.md`, `do.md`, `settings.md`, `discuss-phase.md`, `new-project.md`, `plan-phase.md`, `spike.md`, and `sketch.md` referenced command names removed in #2790; updated to new consolidated equivalents. (#2950)
+
 ### Fixed — 1.40.0-rc.1
 - **`config-get context_window` returns `200000` when key absent** — querying an unset `context_window` previously exited 1 with "Key not found", surfacing a confusing error in planning logs even though the workflow fallback worked correctly. `cmdConfigGet` now consults a `SCHEMA_DEFAULTS` map and returns the documented default (`200000`, exit 0) for absent schema-defaulted keys; unknown absent keys still error as before. (#2943)
 - **`gap-analysis` now parses non-`REQ-` requirement IDs and ignores traceability table headers** — `parseRequirements()` no longer hard-codes the `REQ-` prefix and now accepts uppercase prefixed IDs such as `TST-01`, `BACK-07`, and `INSP-04`; markdown table header rows (for example `| REQ-ID | ... |`) are excluded so header tokens are not reported as phantom uncovered requirements. Added regression coverage for mixed-prefix REQUIREMENTS files with traceability tables. (#2897)

--- a/get-shit-done/workflows/discuss-phase.md
+++ b/get-shit-done/workflows/discuss-phase.md
@@ -252,7 +252,7 @@ RAW_SKETCHES=$(ls .planning/sketches/MANIFEST.md 2>/dev/null)
 
 If findings skills exist, read SKILL.md and reference files; extract validated patterns, landmines, constraints, design decisions. Add them to `<prior_decisions>`.
 
-If raw spikes/sketches exist but no findings skill, note: `⚠ Unpackaged spikes/sketches detected — run /gsd-spike-wrap-up or /gsd-sketch-wrap-up to make findings available.`
+If raw spikes/sketches exist but no findings skill, note: `⚠ Unpackaged spikes/sketches detected — run /gsd-spike --wrap-up or /gsd-sketch --wrap-up to make findings available.`
 
 Build internal `<prior_decisions>` with sections for Project-Level (from PROJECT.md / REQUIREMENTS.md), From Prior Phases (per-phase decisions), and From Spike/Sketch Findings (validated patterns, landmines, design decisions).
 

--- a/get-shit-done/workflows/do.md
+++ b/get-shit-done/workflows/do.md
@@ -44,18 +44,18 @@ Evaluate `$ARGUMENTS` against these routing rules. Apply the **first matching** 
 | A bug, error, crash, failure, or something broken | `/gsd-debug` | Needs systematic investigation |
 | Spiking, "test if", "will this work", "experiment", "prove this out", validate feasibility | `/gsd-spike` | Throwaway experiment to validate feasibility |
 | Sketching, "mockup", "what would this look like", "prototype the UI", "design this", explore visual direction | `/gsd-sketch` | Throwaway HTML mockups to explore design |
-| Wrapping up spikes, "package the spikes", "consolidate spike findings" | `/gsd-spike-wrap-up` | Package spike findings into reusable skill |
-| Wrapping up sketches, "package the designs", "consolidate sketch findings" | `/gsd-sketch-wrap-up` | Package sketch findings into reusable skill |
+| Wrapping up spikes, "package the spikes", "consolidate spike findings" | `/gsd-spike --wrap-up` | Package spike findings into reusable skill |
+| Wrapping up sketches, "package the designs", "consolidate sketch findings" | `/gsd-sketch --wrap-up` | Package sketch findings into reusable skill |
 | Exploring, researching, comparing, or "how does X work" | `/gsd-research-phase` | Domain research before planning |
 | Discussing vision, "how should X look", brainstorming | `/gsd-discuss-phase` | Needs context gathering |
-| A complex task: refactoring, migration, multi-file architecture, system redesign | `/gsd-add-phase` | Needs a full phase with plan/build cycle |
+| A complex task: refactoring, migration, multi-file architecture, system redesign | `/gsd-phase` | Needs a full phase with plan/build cycle |
 | Planning a specific phase or "plan phase N" | `/gsd-plan-phase` | Direct planning request |
 | Executing a phase or "build phase N", "run phase N" | `/gsd-execute-phase` | Direct execution request |
 | Running all remaining phases automatically | `/gsd-autonomous` | Full autonomous execution |
 | A review or quality concern about existing work | `/gsd-verify-work` | Needs verification |
 | Checking progress, status, "where am I" | `/gsd-progress` | Status check |
 | Resuming work, "pick up where I left off" | `/gsd-resume-work` | Session restoration |
-| A note, idea, or "remember to..." | `/gsd-add-todo` | Capture for later |
+| A note, idea, or "remember to..." | `/gsd-capture` | Capture for later |
 | Adding tests, "write tests", "test coverage" | `/gsd-add-tests` | Test generation |
 | Completing a milestone, shipping, releasing | `/gsd-complete-milestone` | Milestone lifecycle |
 | A specific, actionable, small task (add feature, fix typo, update config) | `/gsd-quick` | Self-contained, single executor |
@@ -66,7 +66,7 @@ Evaluate `$ARGUMENTS` against these routing rules. Apply the **first matching** 
 
 ```
 "Refactor the authentication system" could be:
-1. /gsd-add-phase — Full planning cycle (recommended for multi-file refactors)
+1. /gsd-phase — Full planning cycle (recommended for multi-file refactors)
 2. /gsd-quick — Quick execution (if scope is small and clear)
 
 Which approach fits better?

--- a/get-shit-done/workflows/help.md
+++ b/get-shit-done/workflows/help.md
@@ -172,26 +172,26 @@ Usage: `/gsd-fast "add .env to gitignore"`
 
 ### Roadmap Management
 
-**`/gsd-add-phase <description>`**
+**`/gsd-phase <description>`**
 Add new phase to end of current milestone.
 
 - Appends to ROADMAP.md
 - Uses next sequential number
 - Updates phase directory structure
 
-Usage: `/gsd-add-phase "Add admin dashboard"`
+Usage: `/gsd-phase "Add admin dashboard"`
 
-**`/gsd-insert-phase <after> <description>`**
+**`/gsd-phase --insert <after> <description>`**
 Insert urgent work as decimal phase between existing phases.
 
 - Creates intermediate phase (e.g., 7.1 between 7 and 8)
 - Useful for discovered work that must happen mid-milestone
 - Maintains phase ordering
 
-Usage: `/gsd-insert-phase 7 "Fix critical auth bug"`
+Usage: `/gsd-phase --insert 7 "Fix critical auth bug"`
 Result: Creates Phase 7.1
 
-**`/gsd-remove-phase <number>`**
+**`/gsd-phase --remove <number>`**
 Remove a future phase and renumber subsequent phases.
 
 - Deletes phase directory and all references
@@ -199,7 +199,7 @@ Remove a future phase and renumber subsequent phases.
 - Only works on future (unstarted) phases
 - Git commit preserves historical record
 
-Usage: `/gsd-remove-phase 17`
+Usage: `/gsd-phase --remove 17`
 Result: Phase 17 deleted, phases 18-20 become 17-19
 
 ### Milestone Management
@@ -305,7 +305,7 @@ Rapidly sketch UI/design ideas using throwaway HTML mockups with multi-variant e
 Usage: `/gsd-sketch "dashboard layout for the admin panel"`
 Usage: `/gsd-sketch --quick "form card grouping"`
 
-**`/gsd-spike-wrap-up`**
+**`/gsd-spike --wrap-up`**
 Package spike findings into a persistent project skill.
 
 - Curates each spike one-at-a-time (include/exclude/partial/UAT)
@@ -314,9 +314,9 @@ Package spike findings into a persistent project skill.
 - Writes summary to `.planning/spikes/WRAP-UP-SUMMARY.md`
 - Adds auto-load routing line to project CLAUDE.md
 
-Usage: `/gsd-spike-wrap-up`
+Usage: `/gsd-spike --wrap-up`
 
-**`/gsd-sketch-wrap-up`**
+**`/gsd-sketch --wrap-up`**
 Package sketch design findings into a persistent project skill.
 
 - Curates each sketch one-at-a-time (include/exclude/partial/revisit)
@@ -325,7 +325,7 @@ Package sketch design findings into a persistent project skill.
 - Writes summary to `.planning/sketches/WRAP-UP-SUMMARY.md`
 - Adds auto-load routing line to project CLAUDE.md
 
-Usage: `/gsd-sketch-wrap-up`
+Usage: `/gsd-sketch --wrap-up`
 
 ### Quick Notes
 
@@ -344,7 +344,7 @@ Usage: `/gsd-note --global cross-project idea`
 
 ### Todo Management
 
-**`/gsd-add-todo [description]`**
+**`/gsd-capture [description]`**
 Capture idea or task as todo from current conversation.
 
 - Extracts context from conversation (or uses provided description)
@@ -353,8 +353,8 @@ Capture idea or task as todo from current conversation.
 - Checks for duplicates before creating
 - Updates STATE.md todo count
 
-Usage: `/gsd-add-todo` (infers from conversation)
-Usage: `/gsd-add-todo Add auth token refresh`
+Usage: `/gsd-capture` (infers from conversation)
+Usage: `/gsd-capture Add auth token refresh`
 
 **`/gsd-check-todos [area]`**
 List pending todos and select one to work on.
@@ -473,7 +473,7 @@ Configure workflow toggles and model profile interactively.
 
 Usage: `/gsd-settings`
 
-**`/gsd-set-profile <profile>`**
+**`/gsd-config --profile <profile>`**
 Quick switch model profile for GSD agents.
 
 - `quality` — Opus everywhere except verification
@@ -481,7 +481,7 @@ Quick switch model profile for GSD agents.
 - `budget` — Sonnet for writing, Haiku for research/verification
 - `inherit` — Use current session model for all agents (OpenCode `/model`)
 
-Usage: `/gsd-set-profile budget`
+Usage: `/gsd-config --profile budget`
 
 ### Utility Commands
 
@@ -627,7 +627,7 @@ Example config:
 **Adding urgent mid-milestone work:**
 
 ```
-/gsd-insert-phase 5 "Critical security fix"
+/gsd-phase --insert 5 "Critical security fix"
 /gsd-plan-phase 5.1
 /gsd-execute-phase 5.1
 ```
@@ -643,8 +643,8 @@ Example config:
 **Capturing ideas during work:**
 
 ```
-/gsd-add-todo                    # Capture from conversation context
-/gsd-add-todo Fix modal z-index  # Capture with explicit description
+/gsd-capture                    # Capture from conversation context
+/gsd-capture Fix modal z-index  # Capture with explicit description
 /gsd-check-todos                 # Review and work on todos
 /gsd-check-todos api             # Filter by area
 ```

--- a/get-shit-done/workflows/new-project.md
+++ b/get-shit-done/workflows/new-project.md
@@ -269,8 +269,8 @@ If any of these exist, surface them before questioning:
 ⚡ Prior exploration detected:
 {if SPIKE_SKILL}  ✓ Spike findings skill: {path} — validated patterns from experiments
 {if SKETCH_SKILL}  ✓ Sketch findings skill: {path} — validated design decisions
-{if HAS_SPIKES && !SPIKE_SKILL}  ◆ Raw spikes in .planning/spikes/ — consider `/gsd-spike-wrap-up` to package findings
-{if HAS_SKETCHES && !SKETCH_SKILL}  ◆ Raw sketches in .planning/sketches/ — consider `/gsd-sketch-wrap-up` to package findings
+{if HAS_SPIKES && !SPIKE_SKILL}  ◆ Raw spikes in .planning/spikes/ — consider `/gsd-spike --wrap-up` to package findings
+{if HAS_SKETCHES && !SKETCH_SKILL}  ◆ Raw sketches in .planning/sketches/ — consider `/gsd-sketch --wrap-up` to package findings
 
 These findings will be incorporated into project context and available to planning agents.
 ```

--- a/get-shit-done/workflows/plan-phase.md
+++ b/get-shit-done/workflows/plan-phase.md
@@ -996,7 +996,7 @@ rest become a follow-up phase
 
 Use AskUserQuestion with these 3 options.
 
-**If "Split":** Use `/gsd-insert-phase` to create the sub-phases, then replan each.
+**If "Split":** Use `/gsd-phase --insert` to create the sub-phases, then replan each.
 **If "Proceed":** Return to planner with instruction to attempt all items at full fidelity, accepting more plans/tasks.
 **If "Prioritize":** Use AskUserQuestion (multiSelect) to let user pick which items are "now" vs "later". Create CONTEXT.md for each sub-phase with the selected items.
 
@@ -1025,7 +1025,7 @@ Options:
 Use AskUserQuestion for each gap (or batch if multiple gaps).
 
 **If "Add plan":** Return to planner (step 8) with instruction to add plans covering the missing items, preserving existing plans.
-**If "Split":** Use `/gsd-insert-phase` for overflow items, then replan.
+**If "Split":** Use `/gsd-phase --insert` for overflow items, then replan.
 **If "Defer":** Record in CONTEXT.md `## Deferred Ideas` with developer's confirmation. Proceed to step 10.
 
 ## 10. Spawn gsd-plan-checker Agent

--- a/get-shit-done/workflows/settings.md
+++ b/get-shit-done/workflows/settings.md
@@ -45,7 +45,7 @@ Parse current values (default to `true` if not present):
 - `workflow.ui_safety_gate` — prompt to run /gsd-ui-phase before planning frontend phases (default: true if absent)
 - `workflow.ai_integration_phase` — framework selection + eval strategy for AI phases (default: true if absent)
 - `workflow.tdd_mode` — enforce RED/GREEN/REFACTOR gate sequence during execute-phase (default: false if absent)
-- `workflow.code_review` — enable /gsd-code-review and /gsd-code-review-fix commands (default: true if absent)
+- `workflow.code_review` — enable /gsd-code-review and /gsd-code-review --fix commands (default: true if absent)
 - `workflow.code_review_depth` — default depth for /gsd-code-review: `quick`, `standard`, or `deep` (default: `"standard"` if absent; only relevant when `code_review` is on)
 - `workflow.ui_review` — run visual quality audit (/gsd-ui-review) in autonomous mode (default: true if absent)
 - `commit_docs` — whether `.planning/` files are committed to git (default: true if absent)
@@ -150,7 +150,7 @@ AskUserQuestion([
     ]
   },
   {
-    question: "Enable Code Review? (/gsd-code-review and /gsd-code-review-fix commands)",
+    question: "Enable Code Review? (/gsd-code-review and /gsd-code-review --fix commands)",
     header: "Code Review",
     multiSelect: false,
     options: [
@@ -457,12 +457,12 @@ Display:
 These settings apply to future /gsd-plan-phase and /gsd-execute-phase runs.
 
 Quick commands:
-- /gsd-settings-integrations — configure API keys (Brave/Firecrawl/Exa), review.models CLI routing, and agent_skills injection
-- /gsd-set-profile <profile> — switch model profile
+- /gsd-config --integrations — configure API keys (Brave/Firecrawl/Exa), review.models CLI routing, and agent_skills injection
+- /gsd-config --profile <profile> — switch model profile
 - /gsd-plan-phase --research — force research
 - /gsd-plan-phase --skip-research — skip research
 - /gsd-plan-phase --skip-verify — skip plan check
-- /gsd-settings-advanced — power-user tuning (plan bounce, timeouts, branch templates, cross-AI, context window)
+- /gsd-config --advanced — power-user tuning (plan bounce, timeouts, branch templates, cross-AI, context window)
 ```
 </step>
 

--- a/get-shit-done/workflows/sketch.md
+++ b/get-shit-done/workflows/sketch.md
@@ -1,7 +1,7 @@
 <purpose>
 Explore design directions through throwaway HTML mockups before committing to implementation.
 Each sketch produces 2-3 variants for comparison. Saves artifacts to `.planning/sketches/`.
-Companion to `/gsd-sketch-wrap-up`.
+Companion to `/gsd-sketch --wrap-up`.
 
 Supports two modes:
 - **Idea mode** (default) — user describes a design idea to sketch
@@ -331,7 +331,7 @@ After all sketches complete:
 
 **Package findings** — wrap design decisions into a reusable skill
 
-`/gsd-sketch-wrap-up`
+`/gsd-sketch --wrap-up`
 
 ───────────────────────────────────────────────────────────────
 

--- a/get-shit-done/workflows/spike.md
+++ b/get-shit-done/workflows/spike.md
@@ -1,7 +1,7 @@
 <purpose>
 Spike an idea through experiential exploration — build focused experiments to feel the pieces
 of a future app, validate feasibility, and produce verified knowledge for the real build.
-Saves artifacts to `.planning/spikes/`. Companion to `/gsd-spike-wrap-up`.
+Saves artifacts to `.planning/spikes/`. Companion to `/gsd-spike --wrap-up`.
 
 Supports two modes:
 - **Idea mode** (default) — user describes an idea to spike
@@ -421,7 +421,7 @@ gsd-sdk query commit "docs(spikes): update conventions" --files .planning/spikes
 
 **Package findings** — wrap spike knowledge into an implementation blueprint
 
-`/gsd-spike-wrap-up`
+`/gsd-spike --wrap-up`
 
 ───────────────────────────────────────────────────────────────
 

--- a/tests/bug-2950-stale-command-refs.test.cjs
+++ b/tests/bug-2950-stale-command-refs.test.cjs
@@ -1,0 +1,140 @@
+/**
+ * Bug #2950: Stale deleted command references in workflow files
+ *
+ * Multiple workflow files referenced command names removed in #2790
+ * (gsd-add-phase, gsd-insert-phase, gsd-remove-phase, gsd-add-todo,
+ * gsd-set-profile, gsd-settings-integrations, gsd-settings-advanced,
+ * gsd-spike-wrap-up, gsd-sketch-wrap-up, gsd-code-review-fix).
+ *
+ * Fix: Update every occurrence to the new consolidated forms:
+ *   /gsd-phase (no flag | --insert | --remove)
+ *   /gsd-capture
+ *   /gsd-config (--profile | --integrations | --advanced)
+ *   /gsd-spike --wrap-up
+ *   /gsd-sketch --wrap-up
+ *   /gsd-code-review --fix
+ */
+
+'use strict';
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const WORKFLOWS_DIR = path.join(__dirname, '..', 'get-shit-done', 'workflows');
+
+function read(filename) {
+  return fs.readFileSync(path.join(WORKFLOWS_DIR, filename), 'utf-8');
+}
+
+// Deleted command names that must not appear anywhere in the fixed files.
+const DELETED_COMMANDS = [
+  '/gsd-add-phase',
+  '/gsd-insert-phase',
+  '/gsd-remove-phase',
+  '/gsd-add-todo',
+  '/gsd-set-profile',
+  '/gsd-settings-integrations',
+  '/gsd-settings-advanced',
+  '/gsd-spike-wrap-up',
+  '/gsd-sketch-wrap-up',
+  '/gsd-code-review-fix',
+];
+
+// Per-file assertions: [file, deletedCmd, newForm]
+const FILE_ASSERTIONS = [
+  // help.md
+  ['help.md', '/gsd-add-phase', '/gsd-phase "Add admin dashboard"'],
+  ['help.md', '/gsd-insert-phase', '/gsd-phase --insert 7 "Fix critical auth bug"'],
+  ['help.md', '/gsd-remove-phase', '/gsd-phase --remove 17'],
+  ['help.md', '/gsd-spike-wrap-up', '/gsd-spike --wrap-up'],
+  ['help.md', '/gsd-sketch-wrap-up', '/gsd-sketch --wrap-up'],
+  ['help.md', '/gsd-add-todo', '/gsd-capture'],
+  ['help.md', '/gsd-set-profile', '/gsd-config --profile budget'],
+
+  // do.md
+  ['do.md', '/gsd-spike-wrap-up', '/gsd-spike --wrap-up'],
+  ['do.md', '/gsd-sketch-wrap-up', '/gsd-sketch --wrap-up'],
+  ['do.md', '/gsd-add-phase', '/gsd-phase'],
+  ['do.md', '/gsd-add-todo', '/gsd-capture'],
+
+  // settings.md
+  ['settings.md', '/gsd-code-review-fix', '/gsd-code-review --fix'],
+  ['settings.md', '/gsd-settings-integrations', '/gsd-config --integrations'],
+  ['settings.md', '/gsd-set-profile', '/gsd-config --profile'],
+  ['settings.md', '/gsd-settings-advanced', '/gsd-config --advanced'],
+
+  // discuss-phase.md
+  ['discuss-phase.md', '/gsd-spike-wrap-up', '/gsd-spike --wrap-up'],
+  ['discuss-phase.md', '/gsd-sketch-wrap-up', '/gsd-sketch --wrap-up'],
+
+  // new-project.md
+  ['new-project.md', '/gsd-spike-wrap-up', '/gsd-spike --wrap-up'],
+  ['new-project.md', '/gsd-sketch-wrap-up', '/gsd-sketch --wrap-up'],
+
+  // plan-phase.md
+  ['plan-phase.md', '/gsd-insert-phase', '/gsd-phase --insert'],
+
+  // spike.md
+  ['spike.md', '/gsd-spike-wrap-up', '/gsd-spike --wrap-up'],
+
+  // sketch.md
+  ['sketch.md', '/gsd-sketch-wrap-up', '/gsd-sketch --wrap-up'],
+];
+
+describe('bug #2950: stale deleted-command references removed from workflow files', () => {
+  // Build a map of file → content to avoid re-reading
+  const files = [...new Set(FILE_ASSERTIONS.map(([f]) => f))];
+  const contentMap = {};
+  for (const f of files) {
+    contentMap[f] = read(f);
+  }
+
+  // For each (file, deletedCmd) pair, assert the old name is absent
+  for (const [file, deletedCmd] of FILE_ASSERTIONS) {
+    test(`${file}: does not contain deleted command "${deletedCmd}"`, () => {
+      const content = contentMap[file];
+      assert.ok(
+        !content.includes(deletedCmd),
+        `${file} still contains deleted command "${deletedCmd}" — update to new form`
+      );
+    });
+  }
+
+  // For each (file, deletedCmd, newForm) triple, assert the new form is present
+  for (const [file, , newForm] of FILE_ASSERTIONS) {
+    test(`${file}: contains new form "${newForm}"`, () => {
+      const content = contentMap[file];
+      assert.ok(
+        content.includes(newForm),
+        `${file} is missing expected new form "${newForm}"`
+      );
+    });
+  }
+
+  // Blanket check: no affected workflow file contains any of the deleted command names
+  // (catches any we might have missed in per-file assertions above)
+  const affectedFiles = [
+    'help.md',
+    'do.md',
+    'settings.md',
+    'discuss-phase.md',
+    'new-project.md',
+    'plan-phase.md',
+    'spike.md',
+    'sketch.md',
+  ];
+
+  for (const file of affectedFiles) {
+    const content = read(file);
+    for (const deleted of DELETED_COMMANDS) {
+      test(`${file}: blanket check — "${deleted}" not present`, () => {
+        assert.ok(
+          !content.includes(deleted),
+          `${file} contains deleted command "${deleted}"`
+        );
+      });
+    }
+  }
+});

--- a/tests/gsd-settings-advanced.test.cjs
+++ b/tests/gsd-settings-advanced.test.cjs
@@ -201,11 +201,15 @@ describe('gsd-settings-advanced — VALID_CONFIG_KEYS coverage', () => {
 // ─── /gsd-settings mentions /gsd-settings-advanced ────────────────────────────
 
 describe('/gsd-settings advertises /gsd-settings-advanced', () => {
-  test('settings workflow confirmation mentions gsd-settings-advanced', () => {
+  test('settings workflow mentions canonical /gsd-config --advanced', () => {
     const text = fs.readFileSync(SETTINGS_WORKFLOW_PATH, 'utf-8');
     assert.ok(
-      text.includes('gsd-settings-advanced') || text.includes('gsd:settings-advanced') || text.includes('gsd-config --advanced'),
-      'get-shit-done/workflows/settings.md must mention /gsd-settings-advanced, /gsd:settings-advanced, or /gsd-config --advanced'
+      text.includes('gsd-config --advanced'),
+      'get-shit-done/workflows/settings.md must mention /gsd-config --advanced'
+    );
+    assert.ok(
+      !text.includes('gsd-settings-advanced') && !text.includes('gsd:settings-advanced'),
+      'get-shit-done/workflows/settings.md must not mention legacy /gsd-settings-advanced variants'
     );
   });
 });

--- a/tests/gsd-settings-advanced.test.cjs
+++ b/tests/gsd-settings-advanced.test.cjs
@@ -204,8 +204,8 @@ describe('/gsd-settings advertises /gsd-settings-advanced', () => {
   test('settings workflow confirmation mentions gsd-settings-advanced', () => {
     const text = fs.readFileSync(SETTINGS_WORKFLOW_PATH, 'utf-8');
     assert.ok(
-      text.includes('gsd-settings-advanced') || text.includes('gsd:settings-advanced'),
-      'get-shit-done/workflows/settings.md must mention /gsd-settings-advanced or /gsd:settings-advanced'
+      text.includes('gsd-settings-advanced') || text.includes('gsd:settings-advanced') || text.includes('gsd-config --advanced'),
+      'get-shit-done/workflows/settings.md must mention /gsd-settings-advanced, /gsd:settings-advanced, or /gsd-config --advanced'
     );
   });
 });

--- a/tests/settings-integrations.test.cjs
+++ b/tests/settings-integrations.test.cjs
@@ -268,8 +268,8 @@ describe('#2529 /gsd-settings mentions new command', () => {
   test('settings workflow mentions /gsd-settings-integrations in its confirmation output', () => {
     const src = fs.readFileSync(SETTINGS_WORKFLOW_PATH, 'utf-8');
     assert.ok(
-      src.includes('/gsd-settings-integrations'),
-      'settings.md must mention /gsd-settings-integrations as a follow-up'
+      src.includes('/gsd-settings-integrations') || src.includes('gsd-config --integrations'),
+      'settings.md must mention /gsd-settings-integrations or /gsd-config --integrations as a follow-up'
     );
   });
 });

--- a/tests/settings-integrations.test.cjs
+++ b/tests/settings-integrations.test.cjs
@@ -265,11 +265,15 @@ describe('#2529 config merge safety', () => {
 // ─── /gsd-settings mentions /gsd-settings-integrations ──────────────────────
 
 describe('#2529 /gsd-settings mentions new command', () => {
-  test('settings workflow mentions /gsd-settings-integrations in its confirmation output', () => {
+  test('settings workflow mentions canonical /gsd-config --integrations', () => {
     const src = fs.readFileSync(SETTINGS_WORKFLOW_PATH, 'utf-8');
     assert.ok(
-      src.includes('/gsd-settings-integrations') || src.includes('gsd-config --integrations'),
-      'settings.md must mention /gsd-settings-integrations or /gsd-config --integrations as a follow-up'
+      src.includes('gsd-config --integrations'),
+      'settings.md must mention /gsd-config --integrations'
+    );
+    assert.ok(
+      !src.includes('/gsd-settings-integrations'),
+      'settings.md must not mention the legacy /gsd-settings-integrations variant'
     );
   });
 });


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

Fixes #2950

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

Eight workflow files (`help.md`, `do.md`, `settings.md`, `discuss-phase.md`, `new-project.md`, `plan-phase.md`, `spike.md`, `sketch.md`) referenced command names deleted in #2790. Users following those references received "command not found" errors.

## What this fix does

Replaces every deleted command name with its canonical new form:
- `/gsd-add-phase` → `/gsd-phase`
- `/gsd-insert-phase` → `/gsd-phase --insert`
- `/gsd-remove-phase` → `/gsd-phase --remove`
- `/gsd-add-todo` → `/gsd-capture`
- `/gsd-set-profile` → `/gsd-config --profile`
- `/gsd-settings-integrations` → `/gsd-config --integrations`
- `/gsd-settings-advanced` → `/gsd-config --advanced`
- `/gsd-spike-wrap-up` → `/gsd-spike --wrap-up`
- `/gsd-sketch-wrap-up` → `/gsd-sketch --wrap-up`
- `/gsd-code-review-fix` → `/gsd-code-review --fix`

## Root cause

The #2790 skill consolidation deleted 31 micro-skill commands and absorbed their functionality into consolidated commands with flags, but the workflow documentation files were not updated in that PR.

## Testing

### How I verified the fix

Ran the new regression test (`tests/bug-2950-stale-command-refs.test.cjs`) which asserts both absence of old names and presence of new forms for every affected file. All 124 tests pass.

### Regression test added?

- [x] Yes — added `tests/bug-2950-stale-command-refs.test.cjs` with 124 assertions (absence of deleted names + presence of new forms, blanket per-file sweep for all 10 deleted commands across all 8 affected files).

### Platforms tested

- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] CHANGELOG.md updated if this is a user-facing fix
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated workflow guides and usage examples to use consolidated flag-based command forms (e.g., wrap-up and phase/setting operations) across help, planning, settings, project setup, spike, and sketch docs.

* **Bug Fixes**
  * Removed stale references to removed command names to avoid confusion.

* **Tests**
  * Added automated checks to detect stale or missing command references in workflow documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->