### PR TITLE
fix(release-sdk): allow empty/redundant commits during hotfix cherry-pick

### DIFF
--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -167,7 +167,7 @@ jobs:
                 SUBJECT=$(git log -1 --format='%s' "$SHA")
                 if echo "$SUBJECT" | grep -qE '^(fix|chore)(\([^)]+\))?!?: '; then
                   echo "→ cherry-picking $SHA  $SUBJECT"
-                  if ! git cherry-pick -x "$SHA"; then
+                  if ! git cherry-pick -x --allow-empty --keep-redundant-commits "$SHA"; then
                     git cherry-pick --abort || true
                     # On real runs: push the partial-pick state so the operator
                     # can fetch + resolve $SHA + push + re-run with auto_cherry_pick=false.


### PR DESCRIPTION
## Summary

Discovered while running a hotfix 1.39.1 dry-run against `release-sdk.yml`: the auto-cherry-pick step aborted on commit `b328f326` ("fix(code-review): wire --fix dispatch and update stale command references (#2947)") with "previous cherry-pick is now empty".

Root cause: `b328f326` is an empty no-op commit on `main` — its tree hash is identical to its parent's. `git cherry-pick -x` exits non-zero on empty commits, and the workflow's loop (`if ! git cherry-pick -x "$SHA"; then ... exit 1; fi`) treats any non-zero as a hard conflict, bricking the whole hotfix run.

This is a recurring class of failure (squash-merges whose contents were already merged via an earlier PR, revert/re-apply pairs, etc.) — exactly the kind of upstream noise the automation should absorb, not abort on.

Fix: pass `--allow-empty --keep-redundant-commits` to `git cherry-pick`. Empty picks are preserved on the hotfix branch with `-x` provenance, matching `main` 1:1. Picks whose diff resolves to empty after applying to the new base also pass through cleanly.

## Test plan

- [ ] Re-run hotfix 1.39.1 dry-run on this branch — auto-cherry-pick should clear `b328f326` and proceed through the remaining fix commits.
- [ ] Confirm `--allow-empty` does not mask real merge conflicts (those still leave the worktree dirty and exit non-zero).

https://claude.ai/code/session_01LApueb9PVs2uSBhsLprVzG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LApueb9PVs2uSBhsLprVzG)_