### PR TITLE
fix(#2992): deterministic latest-version check — package name is a constant, not LLM choice

### DIFF
--- a/.changeset/calm-tigers-frolic.md
+++ b/.changeset/calm-tigers-frolic.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3008
+---
+**`tests/install-minimal.test.cjs:307` no longer races on shared `os.tmpdir()` under parallel CI** — the previous shape compared `listTmpStageDirs()` snapshots before and after the throw. Under `scripts/run-tests.cjs --test-concurrency=4`, `tests/install-minimal-all-runtimes.test.cjs` runs in a parallel process and creates/removes `gsd-minimal-skills-*` dirs in the shared OS tmpdir between snapshots, so `deepStrictEqual` failed deterministically when the parallel process happened to have a live stage dir during the snapshot window. Fix: stub `fs.mkdtempSync` to record THIS call's stage dir, then assert that exact path no longer exists after the throw — no global filesystem snapshot, no race. (#3008)

--- a/.changeset/merry-lynx-sing.md
+++ b/.changeset/merry-lynx-sing.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 2992
+---
+/gsd-update queries wrong npm package names — moved package name into a deterministic check-latest-version.cjs script and updated the workflow to use ${GSD_DIR} from get_installed_version. See #2992.

--- a/.changeset/witty-newts-greet.md
+++ b/.changeset/witty-newts-greet.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 2992
+---
+/gsd-update queries wrong npm package names — moved package name into a deterministic check-latest-version.cjs script and updated the workflow to use ${GSD_DIR} from get_installed_version. See #2992.

--- a/get-shit-done/bin/check-latest-version.cjs
+++ b/get-shit-done/bin/check-latest-version.cjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Deterministic latest-version check for /gsd-update (#2992).
+ *
+ * The /gsd-update workflow's check_latest_version step was previously
+ * prescribed in LLM-driven prose ("run `npm view get-shit-done-cc
+ * version`"). The executing model could shortcut the prescription and
+ * invent npm queries against wrong-shaped names (`@get-shit-done/cli`,
+ * `get-shit-done-cli`, `gsd`), all of which 404 or — worse — return an
+ * unrelated typosquat package.
+ *
+ * This script makes the package name a CONSTANT in code, not a free
+ * choice at execution time. The workflow calls it via `npm run
+ * check-latest-version -- --json` and parses the structured response.
+ *
+ * Tests assert on the typed CHECK_REASON enum and the structured result
+ * record, never on console prose. See CONTRIBUTING.md "Prohibited: Raw
+ * Text Matching on Test Outputs".
+ */
+
+const cp = require('node:child_process');
+
+// Hardcoded. Do not parameterise — the whole point of this script is that
+// the package name is not a runtime choice for the caller.
+const PACKAGE_NAME = 'get-shit-done-cc';
+
+const CHECK_REASON = Object.freeze({
+  OK: 'ok',
+  FAIL_NPM_FAILED: 'fail_npm_failed',
+  FAIL_INVALID_OUTPUT: 'fail_invalid_output',
+});
+
+const SEMVER_RE = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/;
+
+/**
+ * Pure-ish: takes an injected spawn function so tests don't actually run npm.
+ * In production, defaults to cp.spawnSync('npm', ...).
+ */
+function checkLatestVersion(opts = {}) {
+  const defaultSpawn = () => cp.spawnSync('npm', ['view', PACKAGE_NAME, 'version'], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    shell: process.platform === 'win32', // npm is npm.cmd on Windows
+  });
+  const spawn = opts.spawn || defaultSpawn;
+
+  const r = spawn();
+  if (!r || r.status !== 0) {
+    return {
+      ok: false,
+      reason: CHECK_REASON.FAIL_NPM_FAILED,
+      detail: r && r.stderr ? r.stderr.trim() : 'npm exited non-zero',
+    };
+  }
+  const version = (r.stdout || '').trim();
+  if (!SEMVER_RE.test(version)) {
+    return {
+      ok: false,
+      reason: CHECK_REASON.FAIL_INVALID_OUTPUT,
+      detail: version || '(empty)',
+    };
+  }
+  return { ok: true, version, reason: CHECK_REASON.OK };
+}
+
+function main() {
+  const json = process.argv.includes('--json');
+  const r = checkLatestVersion();
+  if (json) {
+    process.stdout.write(JSON.stringify(r) + '\n');
+  } else if (r.ok) {
+    process.stdout.write(r.version + '\n');
+  } else {
+    process.stderr.write(`check-latest-version: ${r.reason}: ${r.detail}\n`);
+  }
+  process.exit(r.ok ? 0 : 1);
+}
+
+if (require.main === module) main();
+
+module.exports = { checkLatestVersion, CHECK_REASON, PACKAGE_NAME };

--- a/get-shit-done/bin/check-latest-version.cjs
+++ b/get-shit-done/bin/check-latest-version.cjs
@@ -53,10 +53,21 @@ function checkLatestVersion(opts = {}) {
 
   const r = spawn();
   if (!r || r.status !== 0) {
+    // Distinguish timeout (status null, signal set, stderr empty) from a
+    // genuine npm failure. Without this, both surfaced as "npm exited
+    // non-zero" and the operator couldn't tell which (#2993 CR).
+    let detail;
+    if (r && r.signal) {
+      detail = `npm timed out (signal: ${r.signal})`;
+    } else if (r && r.stderr) {
+      detail = r.stderr.trim();
+    } else {
+      detail = 'npm exited non-zero';
+    }
     return {
       ok: false,
       reason: CHECK_REASON.FAIL_NPM_FAILED,
-      detail: r && r.stderr ? r.stderr.trim() : 'npm exited non-zero',
+      detail,
     };
   }
   const version = (r.stdout || '').trim();

--- a/get-shit-done/bin/check-latest-version.cjs
+++ b/get-shit-done/bin/check-latest-version.cjs
@@ -43,6 +43,11 @@ function checkLatestVersion(opts = {}) {
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],
     shell: process.platform === 'win32', // npm is npm.cmd on Windows
+    // Bound the registry call so a hung network/registry doesn't block the
+    // entire /gsd-update workflow indefinitely (#2993 CR). 15s is generous
+    // for `npm view <pkg> version`; on timeout, spawnSync returns with
+    // signal !== null and the existing failure path emits FAIL_NPM_FAILED.
+    timeout: 15_000,
   });
   const spawn = opts.spawn || defaultSpawn;
 

--- a/get-shit-done/workflows/update.md
+++ b/get-shit-done/workflows/update.md
@@ -272,7 +272,7 @@ Proceed to install step (treat as version 0.0.0 for comparison).
 Check npm for latest version via the deterministic script. **Do NOT run `npm view` or `npm search` directly** — the package name must come from the script, not from a free choice at execution time. (#2992: LLM-driven prescriptions of npm package names produced wrong-package queries; moving the package name into a script constant closes that gap.)
 
 ```bash
-LATEST_RESULT="$(node "${GSD_HOME:-$HOME/.claude}/get-shit-done/bin/check-latest-version.cjs" --json 2>/dev/null)"
+LATEST_RESULT="$(node "${GSD_HOME:-$HOME/.claude/}/get-shit-done/bin/check-latest-version.cjs" --json 2>/dev/null)"
 LATEST_STATUS=$?
 ```
 

--- a/get-shit-done/workflows/update.md
+++ b/get-shit-done/workflows/update.md
@@ -222,34 +222,41 @@ if [ "$IS_LOCAL" = true ]; then
   INSTALLED_VERSION="$(cat "$LOCAL_VERSION_FILE")"
   INSTALL_SCOPE="LOCAL"
   TARGET_RUNTIME="$LOCAL_RUNTIME"
+  RESOLVED_GSD_DIR="$LOCAL_DIR"
 elif [ -n "$GLOBAL_VERSION_FILE" ] && [ -f "$GLOBAL_VERSION_FILE" ] && [ -f "$GLOBAL_MARKER_FILE" ] && grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+' "$GLOBAL_VERSION_FILE"; then
   INSTALLED_VERSION="$(cat "$GLOBAL_VERSION_FILE")"
   INSTALL_SCOPE="GLOBAL"
   TARGET_RUNTIME="$GLOBAL_RUNTIME"
+  RESOLVED_GSD_DIR="$GLOBAL_DIR"
 elif [ -n "$LOCAL_RUNTIME" ] && [ -f "$LOCAL_MARKER_FILE" ]; then
   # Runtime detected but VERSION missing/corrupt: treat as unknown version, keep runtime target
   INSTALLED_VERSION="0.0.0"
   INSTALL_SCOPE="LOCAL"
   TARGET_RUNTIME="$LOCAL_RUNTIME"
+  RESOLVED_GSD_DIR="$LOCAL_DIR"
 elif [ -n "$GLOBAL_RUNTIME" ] && [ -f "$GLOBAL_MARKER_FILE" ]; then
   INSTALLED_VERSION="0.0.0"
   INSTALL_SCOPE="GLOBAL"
   TARGET_RUNTIME="$GLOBAL_RUNTIME"
+  RESOLVED_GSD_DIR="$GLOBAL_DIR"
 else
   INSTALLED_VERSION="0.0.0"
   INSTALL_SCOPE="UNKNOWN"
   TARGET_RUNTIME="claude"
+  RESOLVED_GSD_DIR=""
 fi
 
 echo "$INSTALLED_VERSION"
 echo "$INSTALL_SCOPE"
 echo "$TARGET_RUNTIME"
+echo "$RESOLVED_GSD_DIR"
 ```
 
 Parse output:
 - Line 1 = installed version (`0.0.0` means unknown version)
 - Line 2 = install scope (`LOCAL`, `GLOBAL`, or `UNKNOWN`)
 - Line 3 = target runtime (`claude`, `opencode`, `gemini`, `kilo`, or `codex`)
+- Line 4 = resolved GSD config dir (e.g. `/Users/me/.claude`, `/Users/me/.gemini`); empty if scope is `UNKNOWN`. Capture this as `GSD_DIR` and pass it to subsequent steps so they don't have to re-derive the runtime path.
 - If scope is `UNKNOWN`, proceed to install step using `--claude --global` fallback.
 
 If multiple runtime installs are detected and the invoking runtime cannot be determined from execution_context, ask the user which runtime to update before running install.
@@ -271,9 +278,17 @@ Proceed to install step (treat as version 0.0.0 for comparison).
 <step name="check_latest_version">
 Check npm for latest version via the deterministic script. **Do NOT run `npm view` or `npm search` directly** — the package name must come from the script, not from a free choice at execution time. (#2992: LLM-driven prescriptions of npm package names produced wrong-package queries; moving the package name into a script constant closes that gap.)
 
+The `GSD_DIR` value emitted by `get_installed_version` (line 4) resolves to the runtime-specific config dir (`~/.claude/`, `~/.gemini/`, `~/.codex/`, etc.), so the script invocation works for every runtime — not just Claude. If `GSD_DIR` is empty (scope `UNKNOWN`), skip this step and go directly to install.
+
 ```bash
-LATEST_RESULT="$(node "${GSD_HOME:-$HOME/.claude/}/get-shit-done/bin/check-latest-version.cjs" --json 2>/dev/null)"
-LATEST_STATUS=$?
+if [ -z "$GSD_DIR" ]; then
+  # No install detected — fall through to install step; the version-check is skipped.
+  LATEST_OK=false
+  LATEST_REASON="no_install_detected"
+else
+  LATEST_RESULT="$(node "$GSD_DIR/get-shit-done/bin/check-latest-version.cjs" --json 2>/dev/null)"
+  LATEST_STATUS=$?
+fi
 ```
 
 `LATEST_RESULT` is a JSON document with the documented shape `{ ok: bool, version: string, reason: string, detail?: string }`. Parse via `jq`:

--- a/get-shit-done/workflows/update.md
+++ b/get-shit-done/workflows/update.md
@@ -113,6 +113,12 @@ if [ -n "$PREFERRED_CONFIG_DIR" ] && { [ -f "$PREFERRED_CONFIG_DIR/get-shit-done
   echo "$INSTALLED_VERSION"
   echo "$INSTALL_SCOPE"
   echo "${PREFERRED_RUNTIME:-claude}"
+  # 4-line output contract (#2993 CR): early-return path must also emit
+  # GSD_DIR or downstream check_latest_version misreads the install as
+  # UNKNOWN. PREFERRED_CONFIG_DIR is the resolved config dir we just
+  # validated above (line 95-96); it is the right GSD_DIR value for
+  # this fast path.
+  echo "$PREFERRED_CONFIG_DIR"
   exit 0
 fi
 
@@ -301,7 +307,7 @@ fi
 
 **If `LATEST_OK` is not `true`** (or `LATEST_STATUS` is non-zero):
 
-```
+```text
 Couldn't check for updates (reason: {LATEST_REASON}, exit: {LATEST_STATUS}).
 
 To update manually: `npx get-shit-done-cc --global`

--- a/get-shit-done/workflows/update.md
+++ b/get-shit-done/workflows/update.md
@@ -299,9 +299,19 @@ if [ -z "$GSD_DIR" ]; then
 else
   LATEST_RESULT="$(node "$GSD_DIR/get-shit-done/bin/check-latest-version.cjs" --json 2>/dev/null)"
   LATEST_STATUS=$?
-  LATEST_OK="$(printf '%s' "$LATEST_RESULT" | jq -r '.ok // false')"
-  LATEST_VERSION="$(printf '%s' "$LATEST_RESULT" | jq -r '.version // empty')"
-  LATEST_REASON="$(printf '%s' "$LATEST_RESULT" | jq -r '.reason // empty')"
+  # #2993 CR: when node is missing or the script doesn't exist, LATEST_RESULT
+  # is empty and piping it to `jq` produces a parse error on stderr while
+  # leaving LATEST_OK / LATEST_REASON as empty strings. Fail the check with a
+  # meaningful reason instead of a blank diagnostic.
+  if [ -n "$LATEST_RESULT" ]; then
+    LATEST_OK="$(printf '%s' "$LATEST_RESULT" | jq -r '.ok // false')"
+    LATEST_VERSION="$(printf '%s' "$LATEST_RESULT" | jq -r '.version // empty')"
+    LATEST_REASON="$(printf '%s' "$LATEST_RESULT" | jq -r '.reason // empty')"
+  else
+    LATEST_OK=false
+    LATEST_VERSION=""
+    LATEST_REASON="script_not_found_or_node_unavailable"
+  fi
 fi
 ```
 

--- a/get-shit-done/workflows/update.md
+++ b/get-shit-done/workflows/update.md
@@ -280,23 +280,23 @@ Check npm for latest version via the deterministic script. **Do NOT run `npm vie
 
 The `GSD_DIR` value emitted by `get_installed_version` (line 4) resolves to the runtime-specific config dir (`~/.claude/`, `~/.gemini/`, `~/.codex/`, etc.), so the script invocation works for every runtime — not just Claude. If `GSD_DIR` is empty (scope `UNKNOWN`), skip this step and go directly to install.
 
+`LATEST_RESULT` is a JSON document with the documented shape `{ ok: bool, version: string, reason: string, detail?: string }`. Parse via `jq` ONLY when the script actually ran. When `GSD_DIR` is empty (scope `UNKNOWN`), skip the check entirely and seed the parsed fields with their no-op values so downstream logic does not mistake an unset `LATEST_RESULT` for a failed network check (#2993 CR feedback):
+
 ```bash
 if [ -z "$GSD_DIR" ]; then
-  # No install detected — fall through to install step; the version-check is skipped.
+  # No install detected — fall through to install step; version-check is skipped.
+  LATEST_RESULT=""
+  LATEST_STATUS=0
   LATEST_OK=false
+  LATEST_VERSION=""
   LATEST_REASON="no_install_detected"
 else
   LATEST_RESULT="$(node "$GSD_DIR/get-shit-done/bin/check-latest-version.cjs" --json 2>/dev/null)"
   LATEST_STATUS=$?
+  LATEST_OK="$(printf '%s' "$LATEST_RESULT" | jq -r '.ok // false')"
+  LATEST_VERSION="$(printf '%s' "$LATEST_RESULT" | jq -r '.version // empty')"
+  LATEST_REASON="$(printf '%s' "$LATEST_RESULT" | jq -r '.reason // empty')"
 fi
-```
-
-`LATEST_RESULT` is a JSON document with the documented shape `{ ok: bool, version: string, reason: string, detail?: string }`. Parse via `jq`:
-
-```bash
-LATEST_OK="$(printf '%s' "$LATEST_RESULT" | jq -r '.ok // false')"
-LATEST_VERSION="$(printf '%s' "$LATEST_RESULT" | jq -r '.version // empty')"
-LATEST_REASON="$(printf '%s' "$LATEST_RESULT" | jq -r '.reason // empty')"
 ```
 
 **If `LATEST_OK` is not `true`** (or `LATEST_STATUS` is non-zero):

--- a/get-shit-done/workflows/update.md
+++ b/get-shit-done/workflows/update.md
@@ -269,15 +269,25 @@ Proceed to install step (treat as version 0.0.0 for comparison).
 </step>
 
 <step name="check_latest_version">
-Check npm for latest version:
+Check npm for latest version via the deterministic script. **Do NOT run `npm view` or `npm search` directly** — the package name must come from the script, not from a free choice at execution time. (#2992: LLM-driven prescriptions of npm package names produced wrong-package queries; moving the package name into a script constant closes that gap.)
 
 ```bash
-npm view get-shit-done-cc version 2>/dev/null
+LATEST_RESULT="$(node "${GSD_HOME:-$HOME/.claude}/get-shit-done/bin/check-latest-version.cjs" --json 2>/dev/null)"
+LATEST_STATUS=$?
 ```
 
-**If npm check fails:**
+`LATEST_RESULT` is a JSON document with the documented shape `{ ok: bool, version: string, reason: string, detail?: string }`. Parse via `jq`:
+
+```bash
+LATEST_OK="$(printf '%s' "$LATEST_RESULT" | jq -r '.ok // false')"
+LATEST_VERSION="$(printf '%s' "$LATEST_RESULT" | jq -r '.version // empty')"
+LATEST_REASON="$(printf '%s' "$LATEST_RESULT" | jq -r '.reason // empty')"
 ```
-Couldn't check for updates (offline or npm unavailable).
+
+**If `LATEST_OK` is not `true`** (or `LATEST_STATUS` is non-zero):
+
+```
+Couldn't check for updates (reason: {LATEST_REASON}, exit: {LATEST_STATUS}).
 
 To update manually: `npx get-shit-done-cc --global`
 ```

--- a/tests/bug-2992-check-latest-version.test.cjs
+++ b/tests/bug-2992-check-latest-version.test.cjs
@@ -44,6 +44,29 @@ describe('Bug #2992: error paths', () => {
     });
     assert.equal(r.ok, false);
     assert.equal(r.reason, CHECK_REASON.FAIL_NPM_FAILED);
+    assert.equal(r.detail, 'npm ERR! 404',
+      'detail should be the trimmed stderr when npm reports a real error');
+  });
+
+  // #2993 CR: distinguish timeout from genuine npm failure in `detail`.
+  // spawnSync sets status=null and signal='SIGTERM' on timeout; stderr is
+  // typically empty. Without the signal-first branch, both shape as
+  // 'npm exited non-zero' and the operator cannot tell timeout from failure.
+  test('FAIL_NPM_FAILED detail names the signal when spawn times out', () => {
+    const r = checkLatestVersion({
+      spawn: () => ({ status: null, signal: 'SIGTERM', stdout: '', stderr: '' }),
+    });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, CHECK_REASON.FAIL_NPM_FAILED);
+    assert.equal(r.detail, 'npm timed out (signal: SIGTERM)',
+      'detail should explicitly name the signal when status is null and signal is set');
+  });
+
+  test('FAIL_NPM_FAILED detail falls back to generic when neither stderr nor signal is present', () => {
+    const r = checkLatestVersion({
+      spawn: () => ({ status: 1, stdout: '', stderr: '' }),
+    });
+    assert.equal(r.detail, 'npm exited non-zero');
   });
 
   test('FAIL_INVALID_OUTPUT when npm prints something that is not a semver', () => {

--- a/tests/bug-2992-check-latest-version.test.cjs
+++ b/tests/bug-2992-check-latest-version.test.cjs
@@ -1,0 +1,73 @@
+'use strict';
+process.env.GSD_TEST_MODE = '1';
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const cp = require('node:child_process');
+
+const ROOT = path.join(__dirname, '..');
+const { checkLatestVersion, CHECK_REASON, PACKAGE_NAME } = require(
+  path.join(ROOT, 'get-shit-done', 'bin', 'check-latest-version.cjs'),
+);
+
+// checkLatestVersion is a pure-ish function: it spawns one fixed npm
+// command, validates the output, and returns { ok, version | reason }.
+// The package name is HARDCODED — not a free choice for the caller.
+// Tests use a pluggable spawn so no real npm process is invoked.
+
+describe('Bug #2992: deterministic latest-version check', () => {
+  test('PACKAGE_NAME is the constant get-shit-done-cc (no callers can override)', () => {
+    assert.equal(PACKAGE_NAME, 'get-shit-done-cc');
+  });
+
+  test('CHECK_REASON enum exposes the documented codes', () => {
+    assert.deepEqual(
+      Object.keys(CHECK_REASON).sort(),
+      ['FAIL_INVALID_OUTPUT', 'FAIL_NPM_FAILED', 'OK'].sort(),
+    );
+  });
+
+  test('returns { ok: true, version } when npm prints a valid semver', () => {
+    const fakeSpawn = () => ({ status: 0, stdout: '1.39.1\n', stderr: '' });
+    const r = checkLatestVersion({ spawn: fakeSpawn });
+    assert.deepEqual(r, { ok: true, version: '1.39.1', reason: CHECK_REASON.OK });
+  });
+});
+
+describe('Bug #2992: error paths', () => {
+  const { checkLatestVersion, CHECK_REASON } = require(require('node:path').join(__dirname, '..', 'get-shit-done', 'bin', 'check-latest-version.cjs'));
+
+  test('FAIL_NPM_FAILED when npm exits non-zero (e.g. offline, 404)', () => {
+    const r = checkLatestVersion({
+      spawn: () => ({ status: 1, stdout: '', stderr: 'npm ERR! 404\n' }),
+    });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, CHECK_REASON.FAIL_NPM_FAILED);
+  });
+
+  test('FAIL_INVALID_OUTPUT when npm prints something that is not a semver', () => {
+    // E.g. if a future npm version changes the output format, or if the
+    // network returns an HTML error page captured as stdout.
+    const r = checkLatestVersion({
+      spawn: () => ({ status: 0, stdout: '<html>not a version</html>\n', stderr: '' }),
+    });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, CHECK_REASON.FAIL_INVALID_OUTPUT);
+  });
+
+  test('FAIL_INVALID_OUTPUT when stdout is empty', () => {
+    const r = checkLatestVersion({
+      spawn: () => ({ status: 0, stdout: '', stderr: '' }),
+    });
+    assert.equal(r.ok, false);
+    assert.equal(r.reason, CHECK_REASON.FAIL_INVALID_OUTPUT);
+  });
+
+  test('accepts pre-release semver (e.g. 1.40.0-rc.1)', () => {
+    const r = checkLatestVersion({
+      spawn: () => ({ status: 0, stdout: '1.40.0-rc.1\n', stderr: '' }),
+    });
+    assert.deepEqual(r, { ok: true, version: '1.40.0-rc.1', reason: CHECK_REASON.OK });
+  });
+});

--- a/tests/install-minimal.test.cjs
+++ b/tests/install-minimal.test.cjs
@@ -301,33 +301,51 @@ describe('install-profiles: cleanupStagedSkills', () => {
   });
 
   test('mid-copy failure removes the partial staged dir and re-throws', () => {
+    // The previous shape of this test compared listTmpStageDirs() snapshots
+    // before and after the throw. That assertion was unsound under
+    // `--test-concurrency=4` (scripts/run-tests.cjs:24): a parallel test
+    // process (notably install-minimal-all-runtimes.test.cjs, which also
+    // calls stageSkillsForMode) creates and removes `gsd-minimal-skills-*`
+    // dirs in the shared os.tmpdir() between our two snapshots, so
+    // deepStrictEqual failed deterministically when the parallel process
+    // happened to have a live stage dir during our snapshot window.
+    //
+    // Fix: observe THIS test's own stage dir directly. Stub fs.mkdtempSync
+    // to record the path stageSkillsForMode creates; on throw, assert that
+    // exact path no longer exists. No global tmpdir scan, no race with
+    // parallel processes.
     cleanupStagedSkills();
     const src = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-stage-fail-'));
     fs.writeFileSync(path.join(src, 'plan-phase.md'), '# plan\n');
-    try {
-      // Force a failure mid-loop by making fs.copyFileSync throw on the
-      // second allowlisted file. Capture the staged dir from the first
-      // successful call (we can't see it directly, so we count tmp dirs).
-      const before = listTmpStageDirs();
-      const realCopy = fs.copyFileSync;
-      let copyCount = 0;
-      fs.copyFileSync = (s, d) => {
-        copyCount++;
-        if (copyCount === 2) throw new Error('synthetic disk full');
-        return realCopy(s, d);
-      };
-      // Need at least 2 allowlisted files in src for the second copy to fire.
-      fs.writeFileSync(path.join(src, 'execute-phase.md'), '# x\n');
-      try {
-        assert.throws(() => stageSkillsForMode(src, 'minimal'), /synthetic disk full/);
-      } finally {
-        fs.copyFileSync = realCopy;
+    fs.writeFileSync(path.join(src, 'execute-phase.md'), '# x\n');
+    const realCopy = fs.copyFileSync;
+    const realMkdtemp = fs.mkdtempSync;
+    let stagedDir = null;
+    fs.mkdtempSync = (prefix, ...rest) => {
+      const out = realMkdtemp(prefix, ...rest);
+      // Only track the stage dir created by stageSkillsForMode (its
+      // `gsd-minimal-skills-` prefix). Don't capture our own
+      // `gsd-stage-fail-` parent dir created above.
+      if (typeof prefix === 'string' && prefix.endsWith('gsd-minimal-skills-')) {
+        stagedDir = out;
       }
-      const after = listTmpStageDirs();
-      // Partial dir must have been cleaned up by stageSkillsForMode itself
-      // before re-throwing — so the count is unchanged.
-      assert.deepStrictEqual(after, before, 'partial staged dir should be removed on throw');
+      return out;
+    };
+    let copyCount = 0;
+    fs.copyFileSync = (s, d) => {
+      copyCount++;
+      if (copyCount === 2) throw new Error('synthetic disk full');
+      return realCopy(s, d);
+    };
+    try {
+      assert.throws(() => stageSkillsForMode(src, 'minimal'), /synthetic disk full/);
+      assert.notStrictEqual(stagedDir, null,
+        'stageSkillsForMode should have invoked mkdtempSync before the copy throw');
+      assert.equal(fs.existsSync(stagedDir), false,
+        `partial staged dir should be removed on throw, but ${stagedDir} still exists`);
     } finally {
+      fs.copyFileSync = realCopy;
+      fs.mkdtempSync = realMkdtemp;
       fs.rmSync(src, { recursive: true, force: true });
       cleanupStagedSkills();
     }


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #2992

---

## What was broken

Running `/gsd-update` caused Claude (the executing model) to query npm for **wrong package names** before finding the correct one. From the user's reported session:

```
npm view @get-shit-done/cli version       → 404
npm search "get-shit-done"                → returns an unrelated 2016 timer package
npm view get-shit-done-cli version        → 404
npm view gsd version                      → 404
npm view get-shit-done-cc version         → 1.39.1   ← finally correct
```

The user had to interrupt with *"that is not right it is get-shit-done-cc"* before the right command ran.

## What this fix does

Moves the latest-version check from LLM-driven prose into a **deterministic Node script** where the package name is a module constant. The executing model can no longer invent the package name at runtime because it's not a free choice — the script wraps `cp.spawnSync('npm', ['view', PACKAGE_NAME, 'version'])` and `PACKAGE_NAME = 'get-shit-done-cc'` is hardcoded.

Same architectural pattern as #2972 (`scripts/verify-reapply-patches.cjs` for the Step 5 gate fidelity bug). Durable-by-construction.

## Root cause

`get-shit-done/workflows/update.md` line 275 correctly prescribed `npm view get-shit-done-cc version`. But that's prose; the LLM executing the workflow can shortcut the prescription. Same anti-pattern that bit #2969 (the Hunk Verification Gate where `verified: yes` was filled in without checking).

## Testing

### How I verified the fix

1. `node --test tests/bug-2992-check-latest-version.test.cjs` — 7 tests pass via injected mock-spawn.
2. `npm run lint:tests` — 0 violations across 354 test files.
3. End-to-end smoke: `node get-shit-done/bin/check-latest-version.cjs --json` against live npm returned `{"ok":true,"version":"1.39.1","reason":"ok"}` — the structured contract the workflow consumes.

### Regression test added?

- [x] Yes — `tests/bug-2992-check-latest-version.test.cjs` covers:
  - `PACKAGE_NAME === 'get-shit-done-cc'` (locks the constant — anyone trying to soften this fails the test)
  - `CHECK_REASON` enum shape via `Object.keys().sort()` deepEqual
  - Happy path, npm-non-zero, invalid-output, empty-output, pre-release semver

All assertions on typed structured fields, never on script prose. Per CONTRIBUTING.md "Prohibited: Raw Text Matching on Test Outputs".

### Platforms tested

- [x] macOS
- [ ] Windows — covered by `{ shell: process.platform === 'win32' }` since `npm` is `npm.cmd` on Windows (same fix shape as #2962). Live verification needs a Windows runner.

### Runtimes tested

- [x] Claude Code (the runtime where the bug was reported)

---

## Checklist

- [x] Issue linked above with `Fixes #2992`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes
- [x] Regression test added (7 tests)
- [x] All existing tests pass (`npm test` — 0 fail)
- [ ] CHANGELOG.md updated — pre-cutover for #2978's changeset workflow; will reconcile when #2978 lands
- [x] No unnecessary dependencies added (pure stdlib)

## Breaking changes

None. The workflow's user-facing output is identical; only the under-the-hood mechanism changes from LLM-driven `npm view` to deterministic `node check-latest-version.cjs --json`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a deterministic CLI to check the latest npm package version and optionally emit a structured JSON result.

* **Chores**
  * Update workflow to invoke the CLI, parse JSON, and skip checks when runtime config location is unknown.

* **Tests**
  * New deterministic tests covering success, invalid output, and external-command failures.
  * Fix flaky install-minimal test to avoid tmpdir race conditions.

* **Documentation**
  * Added changeset entries describing the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->