### PR TITLE
feat(#2995): post-install path audit for workflow-invoked scripts

### DIFF
--- a/.changeset/lively-goats-run.md
+++ b/.changeset/lively-goats-run.md
@@ -1,0 +1,5 @@
+---
+type: Added
+pr: 2995
+---
+Post-install path smoke test for workflow-invoked scripts — audits every node ${GSD_HOME}/...cjs invocation in workflows resolves at the runtime-installed path. See #2995.

--- a/.changeset/plucky-otters-roam.md
+++ b/.changeset/plucky-otters-roam.md
@@ -1,0 +1,5 @@
+---
+type: Added
+pr: 2995
+---
+Post-install path smoke test for workflow-invoked scripts — audits every node ${GSD_HOME}/...cjs invocation in workflows resolves at the runtime-installed path. See #2995.

--- a/scripts/audit-workflow-script-paths.cjs
+++ b/scripts/audit-workflow-script-paths.cjs
@@ -1,0 +1,69 @@
+'use strict';
+
+/**
+ * Post-install path audit for workflow-invoked scripts (#2995).
+ *
+ * Walks workflowsDir, extracts every `${GSD_HOME[...]}/<path>.<cjs|js|sh>`
+ * token, and asserts:
+ *   1. the file exists in the repo at that <path> (catches typos)
+ *   2. <path>'s first segment is in installedPrefixes (catches the
+ *      #2994 class: source-vs-deployed-path mismatches)
+ *
+ * Pure function over (workflowsDir, repoRoot, installedPrefixes); no
+ * filesystem mutation. Tests assert on the typed AUDIT_FINDING enum.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const AUDIT_FINDING = Object.freeze({
+  MISSING_FROM_REPO: 'missing_from_repo',
+  NOT_INSTALLED: 'not_installed',
+});
+
+// Match `${GSD_HOME}` or `${GSD_HOME:-...}` followed by a /-rooted path
+// ending in .cjs/.js/.sh. The path is captured verbatim (relative to
+// the install root).
+const REF_RE = /\$\{GSD_HOME(?::-[^}]*)?\}\/([A-Za-z0-9_./-]+\.(?:cjs|js|sh))/g;
+
+function listWorkflowFiles(dir) {
+  if (!fs.existsSync(dir)) return [];
+  return fs
+    .readdirSync(dir, { withFileTypes: true })
+    .filter((e) => e.isFile() && e.name.endsWith('.md'))
+    .map((e) => path.join(dir, e.name));
+}
+
+function extractReferences(content) {
+  const out = [];
+  let m;
+  // RegExp objects with /g state must be reset per call.
+  const re = new RegExp(REF_RE.source, 'g');
+  while ((m = re.exec(content)) !== null) {
+    out.push(m[1]);
+  }
+  return out;
+}
+
+function auditWorkflowScriptPaths({ workflowsDir, repoRoot, installedPrefixes }) {
+  const findings = [];
+  const installedSet = new Set(installedPrefixes);
+  for (const file of listWorkflowFiles(workflowsDir)) {
+    const content = fs.readFileSync(file, 'utf8');
+    const workflow = path.basename(file);
+    for (const ref of extractReferences(content)) {
+      const firstSegment = ref.split('/')[0];
+      if (!installedSet.has(firstSegment)) {
+        findings.push({ workflow, path: ref, kind: AUDIT_FINDING.NOT_INSTALLED });
+        continue;
+      }
+      const sourceFile = path.join(repoRoot, ref);
+      if (!fs.existsSync(sourceFile)) {
+        findings.push({ workflow, path: ref, kind: AUDIT_FINDING.MISSING_FROM_REPO });
+      }
+    }
+  }
+  return { ok: findings.length === 0, findings };
+}
+
+module.exports = { auditWorkflowScriptPaths, AUDIT_FINDING, extractReferences };

--- a/scripts/audit-workflow-script-paths.cjs
+++ b/scripts/audit-workflow-script-paths.cjs
@@ -53,9 +53,13 @@ function auditWorkflowScriptPaths({ workflowsDir, repoRoot, installedPrefixes })
     const workflow = path.basename(file);
     for (const ref of extractReferences(content)) {
       const firstSegment = ref.split('/')[0];
+      // #2996 CR: emit BOTH findings simultaneously when a reference is
+      // both outside an installed prefix AND missing from the repo. The
+      // earlier `continue` short-circuited MISSING_FROM_REPO, so a
+      // developer who moved a missing reference to an installed prefix
+      // would only discover the second issue on a subsequent CI run.
       if (!installedSet.has(firstSegment)) {
         findings.push({ workflow, path: ref, kind: AUDIT_FINDING.NOT_INSTALLED });
-        continue;
       }
       const sourceFile = path.join(repoRoot, ref);
       if (!fs.existsSync(sourceFile)) {

--- a/tests/bug-2995-post-install-script-paths.test.cjs
+++ b/tests/bug-2995-post-install-script-paths.test.cjs
@@ -17,11 +17,14 @@ const { auditWorkflowScriptPaths, AUDIT_FINDING } = require(
 // structured report. Tests assert on the typed report — no regex on
 // console output.
 
+// #2996 CR: per-fixture repos are rooted under a single tmpRoot so the
+// after()-hook actually cleans them up. The previous shape created tmpRoot
+// in before() but never used it, leaking each fixture's mkdtempSync dir.
 let tmpRoot;
 function fixtureRepo({ workflows, files }) {
   // workflows: { 'foo.md': '...content with ${GSD_HOME}/...' }
   // files:     [ 'get-shit-done/bin/x.cjs', ... ]  — files to create in repo
-  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-2995-'));
+  const repoRoot = fs.mkdtempSync(path.join(tmpRoot, 'repo-'));
   const workflowsDir = path.join(repoRoot, 'get-shit-done', 'workflows');
   fs.mkdirSync(workflowsDir, { recursive: true });
   for (const [name, body] of Object.entries(workflows || {})) {
@@ -35,7 +38,7 @@ function fixtureRepo({ workflows, files }) {
   return { repoRoot, workflowsDir };
 }
 
-before(() => { tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-2995-root-')); });
+before(() => { tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-2995-')); });
 after(() => { fs.rmSync(tmpRoot, { recursive: true, force: true }); });
 
 describe('Bug #2995: post-install script-paths audit (#2995)', () => {
@@ -200,6 +203,31 @@ describe('Bug #2995: real workflow audit', () => {
         `(if intentionally tracked) add an entry to KNOWN_GAPS with the issue reference.`,
       );
     }
+  });
+
+  // #2996 CR: a reference that is both outside an installed prefix AND
+  // missing from the repo must emit BOTH findings in one run. Previously
+  // the code short-circuited on NOT_INSTALLED, hiding MISSING_FROM_REPO
+  // until the developer fixed the prefix and re-ran CI.
+  test('a reference that is both not-installed AND missing-from-repo emits both findings (no short-circuit)', () => {
+    const { repoRoot, workflowsDir } = fixtureRepo({
+      workflows: {
+        'foo.md': '```bash\nnode "${GSD_HOME}/scripts/missing.cjs"\n```\n',
+      },
+      // Note: scripts/missing.cjs intentionally NOT created in the repo.
+    });
+    const r = auditWorkflowScriptPaths({
+      workflowsDir,
+      repoRoot,
+      installedPrefixes: ['get-shit-done', 'agents', 'hooks', 'commands'],
+    });
+    assert.equal(r.ok, false);
+    const kinds = r.findings.filter((f) => f.path === 'scripts/missing.cjs').map((f) => f.kind).sort();
+    assert.deepEqual(
+      kinds,
+      [AUDIT_FINDING.MISSING_FROM_REPO, AUDIT_FINDING.NOT_INSTALLED].sort(),
+      'expected both NOT_INSTALLED and MISSING_FROM_REPO findings for the same ref',
+    );
   });
 
   test('KNOWN_GAPS entries still match real findings — fixed gaps must be removed from the allow-list', () => {

--- a/tests/bug-2995-post-install-script-paths.test.cjs
+++ b/tests/bug-2995-post-install-script-paths.test.cjs
@@ -1,0 +1,219 @@
+'use strict';
+process.env.GSD_TEST_MODE = '1';
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..');
+const { auditWorkflowScriptPaths, AUDIT_FINDING } = require(
+  path.join(ROOT, 'scripts', 'audit-workflow-script-paths.cjs'),
+);
+
+// auditWorkflowScriptPaths is a pure function: it walks workflowsDir,
+// extracts every ${GSD_HOME}/<path> script reference, and returns a
+// structured report. Tests assert on the typed report — no regex on
+// console output.
+
+let tmpRoot;
+function fixtureRepo({ workflows, files }) {
+  // workflows: { 'foo.md': '...content with ${GSD_HOME}/...' }
+  // files:     [ 'get-shit-done/bin/x.cjs', ... ]  — files to create in repo
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-2995-'));
+  const workflowsDir = path.join(repoRoot, 'get-shit-done', 'workflows');
+  fs.mkdirSync(workflowsDir, { recursive: true });
+  for (const [name, body] of Object.entries(workflows || {})) {
+    fs.writeFileSync(path.join(workflowsDir, name), body);
+  }
+  for (const rel of files || []) {
+    const full = path.join(repoRoot, rel);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, '');
+  }
+  return { repoRoot, workflowsDir };
+}
+
+before(() => { tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-2995-root-')); });
+after(() => { fs.rmSync(tmpRoot, { recursive: true, force: true }); });
+
+describe('Bug #2995: post-install script-paths audit (#2995)', () => {
+  test('AUDIT_FINDING enum exposes the documented codes', () => {
+    assert.deepEqual(
+      Object.keys(AUDIT_FINDING).sort(),
+      ['MISSING_FROM_REPO', 'NOT_INSTALLED'].sort(),
+    );
+  });
+
+  test('returns { ok: true, findings: [] } when workflow refs an existing, installed-path script', () => {
+    const { repoRoot, workflowsDir } = fixtureRepo({
+      workflows: {
+        'good.md': 'node "${GSD_HOME}/get-shit-done/bin/foo.cjs" --json\n',
+      },
+      files: ['get-shit-done/bin/foo.cjs'],
+    });
+    const r = auditWorkflowScriptPaths({
+      workflowsDir,
+      repoRoot,
+      installedPrefixes: ['get-shit-done', 'commands', 'agents', 'hooks'],
+    });
+    assert.deepEqual(r, { ok: true, findings: [] });
+  });
+});
+
+describe('Bug #2995: detection paths', () => {
+  const { auditWorkflowScriptPaths, AUDIT_FINDING } = require(require('node:path').join(__dirname, '..', 'scripts', 'audit-workflow-script-paths.cjs'));
+
+  test('reports MISSING_FROM_REPO when the referenced file does not exist in the repo', () => {
+    const { repoRoot, workflowsDir } = fixtureRepo({
+      workflows: {
+        'foo.md': 'node "${GSD_HOME}/get-shit-done/bin/typo.cjs" --json\n',
+      },
+      files: [],
+    });
+    const r = auditWorkflowScriptPaths({
+      workflowsDir,
+      repoRoot,
+      installedPrefixes: ['get-shit-done'],
+    });
+    assert.equal(r.ok, false);
+    assert.equal(r.findings.length, 1);
+    assert.deepEqual(r.findings[0], {
+      workflow: 'foo.md',
+      path: 'get-shit-done/bin/typo.cjs',
+      kind: AUDIT_FINDING.MISSING_FROM_REPO,
+    });
+  });
+
+  test('reports NOT_INSTALLED when first path segment is outside installedPrefixes (the #2994 case)', () => {
+    const { repoRoot, workflowsDir } = fixtureRepo({
+      workflows: {
+        'foo.md': 'node "${GSD_HOME}/scripts/verify-reapply-patches.cjs"\n',
+      },
+      files: ['scripts/verify-reapply-patches.cjs'],  // file exists, but `scripts/` not in installed prefixes
+    });
+    const r = auditWorkflowScriptPaths({
+      workflowsDir,
+      repoRoot,
+      installedPrefixes: ['get-shit-done', 'commands', 'agents', 'hooks'],
+    });
+    assert.equal(r.ok, false);
+    assert.equal(r.findings.length, 1);
+    assert.deepEqual(r.findings[0], {
+      workflow: 'foo.md',
+      path: 'scripts/verify-reapply-patches.cjs',
+      kind: AUDIT_FINDING.NOT_INSTALLED,
+    });
+  });
+
+  test('handles ${GSD_HOME:-$HOME/.claude}/... default-fallback syntax', () => {
+    const { repoRoot, workflowsDir } = fixtureRepo({
+      workflows: {
+        'a.md': 'node "${GSD_HOME:-$HOME/.claude}/get-shit-done/bin/x.cjs"\n',
+      },
+      files: ['get-shit-done/bin/x.cjs'],
+    });
+    const r = auditWorkflowScriptPaths({
+      workflowsDir,
+      repoRoot,
+      installedPrefixes: ['get-shit-done'],
+    });
+    assert.deepEqual(r, { ok: true, findings: [] });
+  });
+
+  test('reports both findings when one workflow has multiple problems', () => {
+    const { repoRoot, workflowsDir } = fixtureRepo({
+      workflows: {
+        'multi.md': [
+          'node "${GSD_HOME}/scripts/a.cjs"',
+          'node "${GSD_HOME}/get-shit-done/bin/b.cjs"',
+          'node "${GSD_HOME}/get-shit-done/bin/missing.cjs"',
+        ].join('\n') + '\n',
+      },
+      files: ['scripts/a.cjs', 'get-shit-done/bin/b.cjs'],
+    });
+    const r = auditWorkflowScriptPaths({
+      workflowsDir,
+      repoRoot,
+      installedPrefixes: ['get-shit-done'],
+    });
+    assert.equal(r.ok, false);
+    assert.equal(r.findings.length, 2);
+    const kinds = r.findings.map((f) => f.kind).sort();
+    assert.deepEqual(kinds, [AUDIT_FINDING.MISSING_FROM_REPO, AUDIT_FINDING.NOT_INSTALLED]);
+  });
+
+  test('extracts no findings from a workflow without GSD_HOME script refs', () => {
+    const { repoRoot, workflowsDir } = fixtureRepo({
+      workflows: {
+        'plain.md': '# A workflow\n\nSome prose, no script refs.\n',
+      },
+    });
+    const r = auditWorkflowScriptPaths({
+      workflowsDir,
+      repoRoot,
+      installedPrefixes: ['get-shit-done'],
+    });
+    assert.deepEqual(r, { ok: true, findings: [] });
+  });
+});
+
+describe('Bug #2995: real workflow audit', () => {
+  const { auditWorkflowScriptPaths, AUDIT_FINDING } = require(require('node:path').join(__dirname, '..', 'scripts', 'audit-workflow-script-paths.cjs'));
+
+  // The set of top-level directories the installer (bin/install.js) actually
+  // copies into ${configDir}/. Touching this set requires updating both
+  // bin/install.js AND this constant — the parity is intentional.
+  const INSTALLED_PREFIXES = [
+    'get-shit-done',  // workflows, references, bin/lib, templates
+    'commands',       // commands/gsd/*.md (Claude Code local + Gemini global)
+    'skills',         // skills/gsd-*/SKILL.md (Claude Code 2.1.88+ global, Codex, etc.)
+    'agents',         // agents/gsd-*.md
+    'hooks',          // hooks/gsd-*.{sh,js}
+  ];
+
+  // Known existing gaps tracked in their own issues. Removing an entry should
+  // land in the same PR that fixes the underlying issue; CI surfaces any NEW
+  // gap as a hard failure.
+  const KNOWN_GAPS = new Set([
+    'reapply-patches.md|scripts/verify-reapply-patches.cjs|not_installed',  // tracked in #2994
+  ]);
+
+  test('no NEW workflow refs fail to resolve at the deployed path (KNOWN_GAPS allow-listed)', () => {
+    const r = auditWorkflowScriptPaths({
+      workflowsDir: require('node:path').join(ROOT, 'get-shit-done', 'workflows'),
+      repoRoot: ROOT,
+      installedPrefixes: INSTALLED_PREFIXES,
+    });
+    const newGaps = r.findings.filter(
+      (f) => !KNOWN_GAPS.has(`${f.workflow}|${f.path}|${f.kind}`),
+    );
+    if (newGaps.length > 0) {
+      const summary = newGaps.map(
+        (f) => `  ${f.workflow}: ${f.path} (${f.kind})`,
+      ).join('\n');
+      assert.fail(
+        `New workflow ref does not resolve at the deployed path:\n${summary}\n\n` +
+        `Either move the script under one of [${INSTALLED_PREFIXES.join(', ')}], ` +
+        `update bin/install.js to copy the new top-level directory, or ` +
+        `(if intentionally tracked) add an entry to KNOWN_GAPS with the issue reference.`,
+      );
+    }
+  });
+
+  test('KNOWN_GAPS entries still match real findings — fixed gaps must be removed from the allow-list', () => {
+    const r = auditWorkflowScriptPaths({
+      workflowsDir: require('node:path').join(ROOT, 'get-shit-done', 'workflows'),
+      repoRoot: ROOT,
+      installedPrefixes: INSTALLED_PREFIXES,
+    });
+    const realKeys = new Set(r.findings.map((f) => `${f.workflow}|${f.path}|${f.kind}`));
+    const stale = [...KNOWN_GAPS].filter((k) => !realKeys.has(k));
+    assert.deepEqual(
+      stale,
+      [],
+      `KNOWN_GAPS contains entries not present in audit findings — remove these: ${stale.join(', ')}`,
+    );
+  });
+});


### PR DESCRIPTION
## Enhancement PR

---

## Linked Issue

Closes #2995
Refs #2994

---

## What this enhancement improves

Catches the gap class surfaced by #2994: a workflow references a script via `${GSD_HOME}/<path>` that ships in the npm tarball but is not copied to the user's config dir at install time. Unit tests don't catch it because they resolve scripts via `path.join(__dirname, '..', 'scripts', …)` — the **source layout**, not the **deployed layout**.

This PR adds a structural test that walks every workflow file, extracts every `${GSD_HOME}/<path>` reference, and asserts the path's first segment is in `INSTALLED_PREFIXES` (the set of dirs `bin/install.js` actually copies). Catches the gap at PR time.

## How it was implemented

TDD per #2995, structured-IR assertions throughout:

| Module | Purpose | Tests |
|---|---|---|
| `scripts/audit-workflow-script-paths.cjs` | Pure `auditWorkflowScriptPaths({ workflowsDir, repoRoot, installedPrefixes })` returns `{ ok, findings }` via frozen `AUDIT_FINDING` enum (`MISSING_FROM_REPO` / `NOT_INSTALLED`). Tolerates `${GSD_HOME:-...}` default-fallback syntax. | 7 (synthetic) |
| `tests/bug-2995-post-install-script-paths.test.cjs` | Real workflow audit + KNOWN_GAPS allow-list. New gaps fail CI; KNOWN_GAPS entries that no longer match real findings also fail (forces the allow-list to shrink). | 2 (real) |

**Total:** 9 tests, 0 raw-text-matching violations.

### KNOWN_GAPS allow-list

The audit immediately catches #2994's gap (`reapply-patches.md` → `scripts/verify-reapply-patches.cjs`). One allow-list entry contains exactly that gap. The companion test asserts every allow-list entry matches a real finding, so #2994's fix MUST remove the entry — the allow-list is forced to shrink as bugs fix.

## Why now

The pattern of "deterministic script called from a workflow via `${GSD_HOME}`" is becoming common (#2972, #2992, presumably more). Without this structural test, every new instance is a chance to repeat #2994. With it, the lint catches the gap before merge.

## Testing

### How I verified the enhancement works

1. `node --test tests/bug-2995-post-install-script-paths.test.cjs` — 9 tests pass.
2. The real-workflow audit returns exactly one finding (`reapply-patches.md` / `scripts/verify-reapply-patches.cjs` / `not_installed`); the allow-list contains exactly that entry; CI passes.
3. Negative test: removing the allow-list entry makes the test fail with the expected diagnostic.
4. `npm run lint:tests` — 0 violations.

### Regression test added?

- [x] Yes — the test IS the regression coverage. It runs against the live workflow tree on every PR. New `${GSD_HOME}` references must point at installed paths or fail CI.

### Platforms tested

- [x] N/A (pure Node + fs + path stdlib)

### Runtimes tested

- [x] N/A (build/test tooling)

---

## Scope confirmation

- [x] Implementation matches scope approved in #2995.

---

## Checklist

- [x] Issue linked above with `Closes #2995`
- [x] Linked issue has the `approved-enhancement` label
- [x] All existing tests pass (`npm test`)
- [x] New tests cover the audit (9 tests)
- [ ] CHANGELOG.md update — pre-cutover for #2978's changeset workflow; reconcile when #2978 lands
- [x] No unnecessary dependencies added (pure stdlib)

## Breaking changes

None for users. For contributors: a new CI check fails any PR that adds a `${GSD_HOME}/<path>` reference where `<path>` doesn't exist in the source repo or its first segment isn't in `INSTALLED_PREFIXES`. The fix is to put the script under `get-shit-done/bin/` (which is installed) or update `bin/install.js` to copy the new top-level dir.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workflow script path auditing to detect missing or uninstalled script references.

* **Tests**
  * Added comprehensive test suite validating the auditing across multiple scenarios, including integration checks against real workflows with an allow-list for known gaps.

* **Documentation**
  * Added a changeset entry describing the new post-install path smoke test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->