### PR TITLE
fix(#3006): retarget PR-template CHANGELOG checkboxes at changeset workflow

### DIFF
--- a/.changeset/merry-lynx-wander.md
+++ b/.changeset/merry-lynx-wander.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3007
+---
+**PR templates now point at the changeset workflow** — the `Fix`, `Enhancement`, and `Feature` PR templates previously asked contributors to tick `CHANGELOG.md updated`, which contradicted the post-#2978 rule that `CHANGELOG.md` must not be edited directly. Each checkbox now references `npm run changeset` (and the `no-changelog` opt-out where applicable).

--- a/.github/PULL_REQUEST_TEMPLATE/enhancement.md
+++ b/.github/PULL_REQUEST_TEMPLATE/enhancement.md
@@ -73,7 +73,7 @@ Closes #
 - [ ] Changes are scoped to the approved enhancement — nothing extra included
 - [ ] All existing tests pass (`npm test`)
 - [ ] New or updated tests cover the enhanced behavior
-- [ ] CHANGELOG.md updated
+- [ ] `.changeset/` fragment added (`npm run changeset -- --type Changed --pr <NNN> --body "..."`) — or `no-changelog` label applied if not user-facing
 - [ ] Documentation updated if behavior or output changed
 - [ ] No unnecessary dependencies added
 

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -94,7 +94,7 @@ Closes #
 - [ ] Implementation scope matches the approved spec exactly
 - [ ] All existing tests pass (`npm test`)
 - [ ] New tests cover the happy path, error cases, and edge cases
-- [ ] CHANGELOG.md updated with a user-facing description of the feature
+- [ ] `.changeset/` fragment added with a user-facing description of the feature (`npm run changeset -- --type Added --pr <NNN> --body "..."`)
 - [ ] Documentation updated — commands, workflows, references, README if applicable
 - [ ] No unnecessary external dependencies added
 - [ ] Works on Windows (backslash paths handled)

--- a/.github/PULL_REQUEST_TEMPLATE/fix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/fix.md
@@ -63,7 +63,7 @@ Fixes #
 - [ ] Fix is scoped to the reported bug — no unrelated changes included
 - [ ] Regression test added (or explained why not)
 - [ ] All existing tests pass (`npm test`)
-- [ ] CHANGELOG.md updated if this is a user-facing fix
+- [ ] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
 - [ ] No unnecessary dependencies added
 
 ## Breaking changes


### PR DESCRIPTION
## What

Replaces the stale \`- [ ] CHANGELOG.md updated\` checkbox in all three PR templates (\`fix.md\`, \`enhancement.md\`, \`feature.md\`) with one that references \`npm run changeset\` and the \`no-changelog\` opt-out label where applicable.

## Why

\`CONTRIBUTING.md\` (since #2978) tells contributors **do not edit \`CHANGELOG.md\` directly** — every user-facing change drops a \`.changeset/\` fragment, and CI enforces it via \`scripts/changeset/lint.cjs\`. The PR-template checkboxes still pointed at the old flow, so contributors using \`gh pr create\` were funneled back into the conflict-prone direct-edit path the changeset system was built to eliminate.

## Issue

Closes #3006

## Linked issue label

\`confirmed-bug\` ✅ (set on #3006 at creation)

## Test plan

- [x] Each of the three PR templates shows the new checkbox copy with the correct \`--type\` argument (\`Fixed\` / \`Changed\` / \`Added\`)
- [x] Grep across \`CONTRIBUTING.md\`, \`.github/\`, \`docs/\` shows no remaining "edit CHANGELOG.md" instructions
- [x] \`.changeset/merry-lynx-wander.md\` fragment added — \`Changeset Required\` CI will pass

## Scope

Three lines in three template files plus the changeset fragment. No code changes, no behavior changes. Pure documentation correction.

## Breaking changes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)