### PR TITLE
fix(#3008): kill cross-process race in install-minimal:307 mid-copy test

### DIFF
--- a/.changeset/calm-tigers-frolic.md
+++ b/.changeset/calm-tigers-frolic.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3008
+---
+**`tests/install-minimal.test.cjs:307` no longer races on shared `os.tmpdir()` under parallel CI** — the previous shape compared `listTmpStageDirs()` snapshots before and after the throw. Under `scripts/run-tests.cjs --test-concurrency=4`, `tests/install-minimal-all-runtimes.test.cjs` runs in a parallel process and creates/removes `gsd-minimal-skills-*` dirs in the shared OS tmpdir between snapshots, so `deepStrictEqual` failed deterministically when the parallel process happened to have a live stage dir during the snapshot window. Fix: stub `fs.mkdtempSync` to record THIS call's stage dir, then assert that exact path no longer exists after the throw — no global filesystem snapshot, no race. (#3008)

--- a/tests/install-minimal.test.cjs
+++ b/tests/install-minimal.test.cjs
@@ -305,33 +305,51 @@ describe('install-profiles: cleanupStagedSkills', () => {
   });
 
   test('mid-copy failure removes the partial staged dir and re-throws', () => {
+    // The previous shape of this test compared listTmpStageDirs() snapshots
+    // before and after the throw. That assertion was unsound under
+    // `--test-concurrency=4` (scripts/run-tests.cjs:24): a parallel test
+    // process (notably install-minimal-all-runtimes.test.cjs, which also
+    // calls stageSkillsForMode) creates and removes `gsd-minimal-skills-*`
+    // dirs in the shared os.tmpdir() between our two snapshots, so
+    // deepStrictEqual failed deterministically when the parallel process
+    // happened to have a live stage dir during our snapshot window.
+    //
+    // Fix: observe THIS test's own stage dir directly. Stub fs.mkdtempSync
+    // to record the path stageSkillsForMode creates; on throw, assert that
+    // exact path no longer exists. No global tmpdir scan, no race with
+    // parallel processes.
     cleanupStagedSkills();
     const src = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-stage-fail-'));
     fs.writeFileSync(path.join(src, 'plan-phase.md'), '# plan\n');
-    try {
-      // Force a failure mid-loop by making fs.copyFileSync throw on the
-      // second allowlisted file. Capture the staged dir from the first
-      // successful call (we can't see it directly, so we count tmp dirs).
-      const before = listTmpStageDirs();
-      const realCopy = fs.copyFileSync;
-      let copyCount = 0;
-      fs.copyFileSync = (s, d) => {
-        copyCount++;
-        if (copyCount === 2) throw new Error('synthetic disk full');
-        return realCopy(s, d);
-      };
-      // Need at least 2 allowlisted files in src for the second copy to fire.
-      fs.writeFileSync(path.join(src, 'execute-phase.md'), '# x\n');
-      try {
-        assert.throws(() => stageSkillsForMode(src, 'minimal'), /synthetic disk full/);
-      } finally {
-        fs.copyFileSync = realCopy;
+    fs.writeFileSync(path.join(src, 'execute-phase.md'), '# x\n');
+    const realCopy = fs.copyFileSync;
+    const realMkdtemp = fs.mkdtempSync;
+    let stagedDir = null;
+    fs.mkdtempSync = (prefix, ...rest) => {
+      const out = realMkdtemp(prefix, ...rest);
+      // Only track the stage dir created by stageSkillsForMode (its
+      // `gsd-minimal-skills-` prefix). Don't capture our own
+      // `gsd-stage-fail-` parent dir created above.
+      if (typeof prefix === 'string' && prefix.endsWith('gsd-minimal-skills-')) {
+        stagedDir = out;
       }
-      const after = listTmpStageDirs();
-      // Partial dir must have been cleaned up by stageSkillsForMode itself
-      // before re-throwing — so the count is unchanged.
-      assert.deepStrictEqual(after, before, 'partial staged dir should be removed on throw');
+      return out;
+    };
+    let copyCount = 0;
+    fs.copyFileSync = (s, d) => {
+      copyCount++;
+      if (copyCount === 2) throw new Error('synthetic disk full');
+      return realCopy(s, d);
+    };
+    try {
+      assert.throws(() => stageSkillsForMode(src, 'minimal'), /synthetic disk full/);
+      assert.notStrictEqual(stagedDir, null,
+        'stageSkillsForMode should have invoked mkdtempSync before the copy throw');
+      assert.equal(fs.existsSync(stagedDir), false,
+        `partial staged dir should be removed on throw, but ${stagedDir} still exists`);
     } finally {
+      fs.copyFileSync = realCopy;
+      fs.mkdtempSync = realMkdtemp;
       fs.rmSync(src, { recursive: true, force: true });
       cleanupStagedSkills();
     }


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #3008

> Linked issue has the \`confirmed-bug\` label.

---

## What was broken

\`tests/install-minimal.test.cjs:307 - mid-copy failure removes the partial staged dir and re-throws\` failed deterministically on PRs #2993, #2999, #3005 across ubuntu-22, ubuntu-24, macos-24.

CI failure data (PR #2993, run 25238555786):
\`\`\`
expected (before): ['gsd-minimal-skills-km1O1O']
actual   (after):  []
\`\`\`

The test snapshotted \`listTmpStageDirs()\` (a glob of \`os.tmpdir()/gsd-minimal-skills-*\`) before and after invoking \`stageSkillsForMode\` with a stubbed copyFileSync that throws mid-copy. Under \`scripts/run-tests.cjs --test-concurrency=4\` (line 24), \`tests/install-minimal-all-runtimes.test.cjs\` runs in a parallel subprocess and ALSO creates \`gsd-minimal-skills-*\` dirs in the shared OS tmpdir. The parallel process's create/remove activity between snapshots caused \`deepStrictEqual(after, before)\` to fail.

Both processes behaved correctly in isolation. The test design was wrong: it observed shared filesystem state without process scoping.

## What this fix does

Replaces the global-snapshot comparison with direct observation of THIS test's own stage dir:

\`\`\`js
const realMkdtemp = fs.mkdtempSync;
let stagedDir = null;
fs.mkdtempSync = (prefix, ...rest) => {
  const out = realMkdtemp(prefix, ...rest);
  if (typeof prefix === 'string' && prefix.endsWith('gsd-minimal-skills-')) {
    stagedDir = out;
  }
  return out;
};
// ... stub copyFileSync to throw, run stageSkillsForMode ...
assert.equal(fs.existsSync(stagedDir), false,
  \`partial staged dir should be removed on throw, but \${stagedDir} still exists\`);
\`\`\`

The stub records the EXACT path \`stageSkillsForMode\` created via \`mkdtempSync\`. Assertion checks that path is gone after the throw. No global tmpdir scan, no parallel-process interference.

## Root cause

\`scripts/run-tests.cjs:24\` runs tests with \`--test-concurrency=4\`. node:test runs each test FILE in its own subprocess. \`tests/install-minimal.test.cjs\` and \`tests/install-minimal-all-runtimes.test.cjs\` both call \`stageSkillsForMode\`, both share \`os.tmpdir()\`. The original test's \`assert.deepStrictEqual(after, before)\` was unsound: it required \`os.tmpdir()\` to be process-private, which it isn't.

## Verified not a regression

- The new assertion is strictly stronger: it directly checks the stageSkillsForMode contract (its mkdtemp'd dir is rmSync'd on throw) instead of a derived equality on a shared snapshot.
- Sibling test at line 244 \`SIGINT triggers cleanup and re-raises the signal\` is unaffected — it spawns a child process and uses the child's stdout to capture the staged path, which is already process-scoped.
- \`stageSkillsForMode\` itself is unchanged. This is a test-only fix.
- Verified the fix passes when \`tests/install-minimal.test.cjs\` is run in isolation: 26/26 tests pass.

## Testing

### How I verified the fix

1. Ran \`node --test --test-concurrency=1 tests/install-minimal.test.cjs\` — 26/26 pass.
2. The new assertion \`fs.existsSync(stagedDir) === false\` catches the underlying invariant directly. If \`stageSkillsForMode\` regresses (stops cleaning up its partial dir on throw), \`stagedDir\` stays on disk and the test fails — same regression coverage as before, without the parallel-process race.
3. The \`stagedDir !== null\` guard catches a different regression: if \`stageSkillsForMode\` ever stops calling \`mkdtempSync\` (e.g., refactored to a different staging mechanism), the test fails with a clear message rather than passing vacuously.

### Regression test added?

- [x] No — this IS the regression test. The change replaces an unsound assertion with a sound one. Same regression coverage, narrower observation surface.

### Platforms tested

- [x] macOS (local)
- [ ] Windows
- [ ] Linux (will exercise via CI re-run)
- [ ] N/A

### Runtimes tested

- [x] N/A — pure unit-test fix; no runtime-specific code touched

---

## Checklist

- [x] Issue linked above with \`Fixes #3008\`
- [x] Linked issue has the \`confirmed-bug\` label
- [x] Fix is scoped to the reported bug — no unrelated changes
- [x] Regression coverage preserved (the test itself IS the regression test for stageSkillsForMode's catch-block cleanup)
- [x] All existing tests pass when this file is run
- [x] Changeset added (\`.changeset/calm-tigers-frolic.md\`)
- [x] No new dependencies

## Breaking changes

None — test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Fixed non-deterministic failures in parallel test execution environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->