### PR TITLE
feat: post-push pipeline polling for /gsd-ship and /gsd-complete-milestone

### DIFF
--- a/.changeset/post-push-pipeline-polling.md
+++ b/.changeset/post-push-pipeline-polling.md
@@ -1,0 +1,5 @@
+---
+type: Added
+pr: TBD
+---
+**Post-push pipeline polling for `/gsd-ship` and `/gsd-complete-milestone`** — `/gsd-ship` now captures the new pipeline ID after `git push`, polls via `ScheduleWakeup` (30s × 30 max, 15-min cap), and refuses to mark the phase shipped if the pipeline ends in `failed`/`canceled`. Failed-job names + last ~50 lines of trace are surfaced inline. Override available via `/gsd-ship --ignore-pipeline` (auditable in SUMMARY.md). `/gsd-complete-milestone` adds a strict tag-push gate: refuses to push a `vX.Y.0` tag while the most recent `main` pipeline is non-success — no override (tags trigger prod deploys in many setups). Backwards-compatible — old phases without pipeline state still ship; commits with `[ci skip]` skip polling.

--- a/get-shit-done/workflows/complete-milestone.md
+++ b/get-shit-done/workflows/complete-milestone.md
@@ -722,6 +722,54 @@ fi
 
 </step>
 
+<step name="check_main_pipeline_green">
+**Purpose (HK-04):** Refuse to push a `vX.Y.0` tag while the most recent `main` pipeline is in a non-success state. This prevents the v1.3 close anti-pattern (pipeline #236 went red post-merge, but the close was already in flight, so `v1.3.0` shipped over a red main).
+
+**No `--ignore-pipeline` override at the milestone level (D-07): pushing tags deploys to prod in many setups; this guard is strict.**
+
+```bash
+# Skip if glab unavailable / not authenticated
+if ! command -v glab >/dev/null 2>&1 || ! glab auth status >/dev/null 2>&1; then
+  echo "glab not configured — skipping main-pipeline gate. Confirm CI is green manually before tagging."
+else
+  REMOTE_URL=$(git remote get-url origin)
+  PROJECT_PATH=$(echo "$REMOTE_URL" | sed -E 's|^https?://[^/]+/||; s|^git@[^:]+:||; s|\.git$||')
+  ENCODED_PROJECT=$(echo "$PROJECT_PATH" | sed 's|/|%2F|g')
+
+  PIPELINE_STATUS=$(glab api "projects/${ENCODED_PROJECT}/pipelines?ref=main&order_by=id&sort=desc&per_page=1" \
+    | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{const r=JSON.parse(d);if(r[0])console.log(r[0].status)}catch(e){}})")
+
+  PIPELINE_ID=$(glab api "projects/${ENCODED_PROJECT}/pipelines?ref=main&order_by=id&sort=desc&per_page=1" \
+    | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{const r=JSON.parse(d);if(r[0])console.log(r[0].id)}catch(e){}})")
+
+  if [ -z "$PIPELINE_STATUS" ]; then
+    echo "No pipeline found on main — confirm manually before tagging."
+  elif [ "$PIPELINE_STATUS" != "success" ]; then
+    echo ""
+    echo "═══════════════════════════════════════════════════════════════"
+    echo "  REFUSING to tag — main pipeline #${PIPELINE_ID} is ${PIPELINE_STATUS}"
+    echo "═══════════════════════════════════════════════════════════════"
+    echo ""
+    echo "Tags trigger production deploys in many setups. Pushing v[X.Y] over a"
+    echo "${PIPELINE_STATUS} pipeline could deploy broken code to prod."
+    echo ""
+    echo "Required actions:"
+    echo "  1. Investigate https://<gitlab>/${PROJECT_PATH}/-/pipelines/${PIPELINE_ID}"
+    echo "  2. Fix the underlying issue + push to main"
+    echo "  3. Wait for the next main pipeline to succeed"
+    echo "  4. Re-run /gsd-complete-milestone"
+    echo ""
+    echo "There is no --ignore-pipeline override for milestone tagging (HK-04 D-07)."
+    echo ""
+    exit 1
+  else
+    echo "✓ main pipeline #${PIPELINE_ID} is success — proceeding to tag"
+  fi
+fi
+```
+
+</step>
+
 <step name="git_tag">
 
 Create git tag:

--- a/get-shit-done/workflows/ship.md
+++ b/get-shit-done/workflows/ship.md
@@ -8,6 +8,21 @@ Read all files referenced by the invoking prompt's execution_context before star
 
 <process>
 
+<step name="parse_flags">
+Parse $ARGUMENTS for the polling override flag:
+
+```bash
+IGNORE_PIPELINE=false
+for arg in $ARGUMENTS; do
+  if [ "$arg" = "--ignore-pipeline" ]; then
+    IGNORE_PIPELINE=true
+  fi
+done
+```
+
+When `IGNORE_PIPELINE` is true, the `poll_post_push_pipeline` step records a `pipeline_override` block in the SUMMARY.md instead of refusing on a failed pipeline. Override is auditable.
+</step>
+
 <step name="initialize">
 Parse arguments and load project state:
 
@@ -247,6 +262,114 @@ gh pr edit ${PR_NUMBER} --add-reviewer "${REVIEWER}"
 Report the PR URL and suggest: "Review the diff at {url}/files"
 </step>
 
+<step name="poll_post_push_pipeline">
+**Purpose (HK-04):** After `git push`, capture the new pipeline ID, poll until terminal, and refuse to mark the phase shipped if the pipeline ends in `failed` or `canceled`. Override available via `--ignore-pipeline` (parsed in `parse_flags`).
+
+**Skip if:** the platform isn't GitLab, `glab` isn't authenticated, or no pipeline triggered (e.g., docs-only commit with `[ci skip]`).
+
+```bash
+# Pre-flight
+if ! command -v glab >/dev/null 2>&1; then
+  echo "glab not installed — skipping pipeline polling"
+elif ! glab auth status >/dev/null 2>&1; then
+  echo "glab not authenticated — skipping pipeline polling. Run \`glab auth login\` to enable."
+else
+  # Resolve URL-encoded project path from `git remote get-url origin`
+  REMOTE_URL=$(git remote get-url origin)
+  # Strip protocol + .git; URL-encode slashes
+  PROJECT_PATH=$(echo "$REMOTE_URL" | sed -E 's|^https?://[^/]+/||; s|^git@[^:]+:||; s|\.git$||')
+  ENCODED_PROJECT=$(echo "$PROJECT_PATH" | sed 's|/|%2F|g')
+
+  # Capture the pipeline ID. Retry up to 3× because GitLab may not have created
+  # the pipeline yet immediately after push.
+  PIPELINE_ID=""
+  for attempt in 1 2 3; do
+    PIPELINE_ID=$(glab api "projects/${ENCODED_PROJECT}/pipelines?ref=${CURRENT_BRANCH}&order_by=id&sort=desc&per_page=1" \
+      | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{try{const r=JSON.parse(d);if(r[0])console.log(r[0].id)}catch(e){}})")
+    if [ -n "$PIPELINE_ID" ]; then break; fi
+    sleep 5
+  done
+
+  if [ -z "$PIPELINE_ID" ]; then
+    echo "No pipeline triggered for ${CURRENT_BRANCH} — proceeding without polling."
+  fi
+fi
+```
+
+**Polling loop (only if PIPELINE_ID was captured):**
+
+The polling uses `ScheduleWakeup` — never an in-context `sleep` loop. Each tick:
+
+1. Query: `glab api "projects/${ENCODED_PROJECT}/pipelines/${PIPELINE_ID}"`.
+2. Parse `status`. Branches:
+   - `success` → exit polling, proceed to `track_shipping`.
+   - `failed` or `canceled` → enter `surface_failed_traces` substep.
+   - `pending`, `running`, `waiting_for_resource`, `preparing` → schedule next wakeup at 30s, increment tick counter.
+3. Cap at 30 ticks (15-minute total). On cap reached:
+   ```
+   AskUserQuestion:
+     question: "Pipeline ${PIPELINE_ID} still running after 15 minutes. Continue waiting, skip polling, or fail?"
+     options: ["Continue another 15 min", "Skip — assume green", "Fail — refuse to ship"]
+   ```
+
+**ScheduleWakeup pattern:**
+
+```
+ScheduleWakeup({
+  delaySeconds: 30,
+  reason: "polling pipeline #${PIPELINE_ID} (tick ${tickN}/30) — current status: ${prevStatus}",
+  prompt: "/gsd-ship --resume-poll-tick=${nextTick} --pipeline-id=${PIPELINE_ID} <original args>"
+})
+```
+
+**`surface_failed_traces` substep (only on failed/canceled):**
+
+```bash
+JOBS=$(glab api "projects/${ENCODED_PROJECT}/pipelines/${PIPELINE_ID}/jobs")
+# Filter status==failed and ALSO status==canceled (different from pipeline-cancelled)
+FAILED_JOB_IDS=$(echo "$JOBS" | node -e "let d='';process.stdin.on('data',c=>d+=c);process.stdin.on('end',()=>{const r=JSON.parse(d);console.log(r.filter(j=>j.status==='failed').map(j=>j.id+':'+j.name).join('\\n'))}")
+```
+
+For each failed job ID:
+```bash
+echo "## Job: ${JOB_NAME} (failed)"
+glab ci trace "${JOB_ID}" -p "${PIPELINE_ID}" 2>&1 | tail -50
+```
+
+Surface in user prompt:
+
+```
+## Pipeline #${PIPELINE_ID} failed
+
+Branch: ${CURRENT_BRANCH}
+Status: failed
+Failed jobs (${count}):
+
+[per-job ## blocks with last 50 lines of trace]
+
+──────────────────────────────────────────────────────────────────
+```
+
+If `IGNORE_PIPELINE=true`:
+- Skip the refusal; record an override block in the next `track_shipping` step's SUMMARY:
+  ```yaml
+  pipeline_override:
+    pipeline_id: ${PIPELINE_ID}
+    status: failed
+    failed_jobs: [list]
+    overridden_by: $(git config user.email)
+    overridden_at: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+    reason: "user-supplied or 'unspecified'"
+  ```
+
+If `IGNORE_PIPELINE=false` (default):
+- REFUSE: print "Phase NOT marked shipped. Pipeline #${PIPELINE_ID} ended in failed."
+- Suggest options: "Fix the failure and re-push (recommended); rerun the failed jobs via GitLab UI; OR re-run /gsd-ship --ignore-pipeline (records audit trail)."
+- Exit workflow.
+
+**Backwards compatibility (D-10):** if no pipeline was triggered (e.g., `[ci skip]` commit, or platform isn't GitLab), the entire polling block becomes a no-op and the workflow proceeds to `track_shipping` as before.
+</step>
+
 <step name="track_shipping">
 Update STATE.md to reflect the shipping action:
 
@@ -259,6 +382,8 @@ If `commit_docs` is true:
 ```bash
 gsd-sdk query commit "docs(${padded_phase}): ship phase ${PHASE_NUMBER} — PR #${PR_NUMBER}" --files .planning/STATE.md
 ```
+
+**If `IGNORE_PIPELINE=true`** (an override happened in `poll_post_push_pipeline`), append the `pipeline_override` block to the phase's SUMMARY.md as documented in that step. This block becomes a permanent audit record.
 </step>
 
 <step name="report">


### PR DESCRIPTION
## Summary

Closes the v1.3-style anti-pattern where a `vX.Y.0` tag (= prod deploy in most setups) ships over a red `main` because `/gsd-complete-milestone` never checked the post-merge pipeline status. Symmetric gap on `/gsd-ship`: a phase could be marked shipped while CI was still red on the feature branch.

This is captured as **HK-04** in a downstream sweet-and-salted project; surfacing as an upstream contribution because the tooling gap is general.

## Changes

### `/gsd-ship` — `poll_post_push_pipeline` step (between `optional_review` and `track_shipping`)

After `git push`, capture the new pipeline ID via:
\`\`\`
glab api "projects/{enc}/pipelines?ref={branch}&order_by=id&sort=desc&per_page=1"
\`\`\`
Retried 3× with 5s backoff because GitLab may not yet have created the pipeline immediately after push (race window observed in practice).

Polling loop uses **`ScheduleWakeup`** (no in-context sleep loop) at 30s intervals, capped at 30 ticks (15 minutes). Each tick:
- \`success\` → exit poll, proceed to \`track_shipping\`
- \`failed\` / \`canceled\` → surface failed-job traces (last ~50 lines per job via \`glab ci trace\`); refuse phase ship unless \`--ignore-pipeline\` flag was passed
- \`pending\` / \`running\` / \`preparing\` / \`waiting_for_resource\` → schedule next tick

Override via \`/gsd-ship --ignore-pipeline\`. Records a structured \`pipeline_override\` block in the phase SUMMARY.md (\`overridden_by\` from \`git config user.email\`, \`overridden_at\`, optional reason) so the override is permanent + auditable.

### `/gsd-complete-milestone` — `check_main_pipeline_green` step (before `git_tag`)

Before \`git_tag\`, query the most recent \`main\` pipeline. If status != \`success\`, REFUSE with remediation steps and the GitLab pipeline URL.

**No \`--ignore-pipeline\` override at the milestone level** — tag pushes deploy to prod in many setups; deploying broken code is the worst-case incident this gate prevents. If the user has a genuine emergency need to tag despite a red main, manual \`git tag\` + \`git push origin\` remains available outside the workflow.

## Backwards compatibility

- If \`glab\` is missing or unauthenticated → both steps log "skipping pipeline polling/gate" and proceed (warns user to confirm manually). No hard fail for non-glab users.
- If no pipeline triggered (e.g., \`[ci skip]\` commit) → poll step becomes a no-op.
- Non-GitLab platforms (GitHub Actions, etc.) → both steps no-op silently. (GitHub Actions equivalent could be added in a follow-up using \`gh run list\`.)
- Old phase state without pipeline metadata → both steps additive; existing phases ship as before.

## Driving incident

In a downstream project's v1.3 milestone close (2026-05-01), pipeline #236 went red on \`main\` AFTER the merge but BEFORE the close completed. Tag \`v1.3.0\` shipped over a red main; the close artifacts were finalized with no signal to the operator that prod had just received broken code. The gap was tracked as HK-04 in that project's backlog and now surfaces here as a general fix.

## Testing

This is a markdown-driven workflow change (no executable test infrastructure exists in this repo for workflows). Live verification approach used downstream:

1. Create throwaway branch with deliberate failing test, push.
2. Run patched \`/gsd-ship\` against it.
3. Observe pipeline ID capture, ScheduleWakeup-driven polling cadence, failed-job trace surfacing, refusal message, and \`--ignore-pipeline\` override path.
4. Cleanup throwaway branch.

Happy to add automated coverage if there's an established pattern in this repo for testing workflow markdown.

## Changeset

\`.changeset/post-push-pipeline-polling.md\` added per repo convention; PR number left as \`TBD\` for maintainer to update on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pipeline polling after git push that detects failed or canceled states with job failure details
  * Added `--ignore-pipeline` flag to override pipeline checks with audit trail
  * Added main pipeline status verification before creating release tags

* **Bug Fixes**
  * Prevents marking phases as shipped when pipelines fail or are canceled
  * Prevents version tag creation when main pipeline is not successful

* **Documentation**
  * Updated CI/release workflow documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->