### PR TITLE
fix(hooks): gsd-check-update-worker — execFileSync 'npm' needs shell:true on Windows

### DIFF
--- a/.changeset/windows-npm-shell-fix.md
+++ b/.changeset/windows-npm-shell-fix.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+---
+
+**Windows update-check no longer silently fails** — `gsd-check-update-worker` now passes `shell: true` only on Windows, allowing `execFileSync('npm', ...)` to resolve `npm.cmd` via PATHEXT. POSIX path (Linux/macOS) is unchanged. Without this fix, the worker failed with ENOENT, `latest` stayed `null`, `update_available` became `null`, and the statusline `⬆ /gsd-update` indicator never rendered for Windows users. Fixes #3103.

--- a/hooks/gsd-check-update-worker.js
+++ b/hooks/gsd-check-update-worker.js
@@ -93,11 +93,13 @@ try {
     encoding: 'utf8',
     timeout: 10000,
     windowsHide: true,
-    // shell:true is required on Windows so 'npm' resolves to npm.cmd via PATHEXT.
-    // Without it, execFileSync looks for a literal 'npm' binary, fails with ENOENT,
-    // the catch swallows the error, latest stays null, and the statusline never shows
-    // the "⬆ /gsd-update" indicator on Windows.
-    shell: true,
+    // On Windows, 'npm' is distributed as npm.cmd. Node's execFileSync does
+    // not apply PATHEXT resolution and looks for a literal 'npm' binary,
+    // failing with ENOENT. Setting shell:true on Windows routes through
+    // cmd.exe which resolves npm.cmd via PATHEXT.
+    // POSIX (Linux/macOS) is left untouched — no shell spawn, no extra
+    // signal/exit-code semantics, no overhead.
+    shell: process.platform === 'win32',
   }).trim();
 } catch (e) {}
 

--- a/hooks/gsd-check-update-worker.js
+++ b/hooks/gsd-check-update-worker.js
@@ -93,6 +93,11 @@ try {
     encoding: 'utf8',
     timeout: 10000,
     windowsHide: true,
+    // shell:true is required on Windows so 'npm' resolves to npm.cmd via PATHEXT.
+    // Without it, execFileSync looks for a literal 'npm' binary, fails with ENOENT,
+    // the catch swallows the error, latest stays null, and the statusline never shows
+    // the "⬆ /gsd-update" indicator on Windows.
+    shell: true,
   }).trim();
 } catch (e) {}
 

--- a/tests/gsd-check-update-worker-platform-gate.test.cjs
+++ b/tests/gsd-check-update-worker-platform-gate.test.cjs
@@ -1,0 +1,99 @@
+/**
+ * Tests for gsd-check-update-worker.js — Windows npm resolution platform gate.
+ *
+ * Background (issue #3103, PR #3102):
+ *   On Windows, `npm` ships as `npm.cmd`. Node's execFileSync does not apply
+ *   PATHEXT resolution (unlike execSync/exec) and fails with ENOENT. The fix
+ *   is to spawn through a shell on Windows (cmd.exe resolves npm.cmd via
+ *   PATHEXT). On POSIX, `npm` is a node-script symlink and resolves without
+ *   a shell, so spawning `/bin/sh -c` is pure overhead and changes signal /
+ *   exit-code semantics — undesirable.
+ *
+ * This test locks the contract: shell must be platform-gated to win32 only,
+ * never an unconditional `shell: true`. A regression that re-introduces
+ * `shell: true` would change POSIX runtime behavior silently — exactly the
+ * cross-platform risk that adversarial review on PR #3102 flagged.
+ *
+ * Source-grep policy: this test reads the worker source via readFileSync.
+ * The repo's lint-no-source-grep rule (scripts/lint-no-source-grep.cjs)
+ * targets `.cjs` files in bin/lib/get-shit-done — `hooks/*.js` is out of
+ * scope. The behavior we need to lock is a single static-spawn-options
+ * shape, which only manifests at runtime under Windows; runtime testing
+ * would require a Windows CI lane. A structural assertion is the
+ * minimum-cost contract.
+ */
+
+// allow-test-rule: structural assertion on hook spawn-options shape; the
+// behavior being tested (Windows-only shell resolution) is platform-gated
+// at runtime and cannot be reached on POSIX CI without a Windows lane.
+
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const WORKER_PATH = path.join(__dirname, '..', 'hooks', 'gsd-check-update-worker.js');
+
+describe('gsd-check-update-worker: Windows npm spawn platform gate', () => {
+  test('worker file exists', () => {
+    assert.ok(fs.existsSync(WORKER_PATH), `worker not found at ${WORKER_PATH}`);
+  });
+
+  test('shell option is gated to process.platform === "win32"', () => {
+    const src = fs.readFileSync(WORKER_PATH, 'utf8');
+
+    // Locks the platform gate. Allows whitespace/quote variation around
+    // the comparison so trivial style fixes do not break the contract.
+    const platformGate =
+      /shell:\s*process\.platform\s*===\s*['"]win32['"]/;
+
+    assert.match(
+      src,
+      platformGate,
+      [
+        'shell option must be `process.platform === "win32"`.',
+        'A regression to `shell: true` would spawn /bin/sh -c on POSIX',
+        '(adds shell overhead, changes signal/exit semantics, can mask',
+        'windowsHide on some Node versions). See PR #3102.',
+      ].join(' '),
+    );
+  });
+
+  test('no unconditional shell: true on the npm spawn', () => {
+    const src = fs.readFileSync(WORKER_PATH, 'utf8');
+
+    // Strip line and block comments so prose mentions of "shell:true" in
+    // documentation comments do not trigger the regression check.
+    const codeOnly = src
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+
+    // Reject literal `shell: true` in CODE only. The correct fix uses
+    // `shell: process.platform === 'win32'` (an expression, not the
+    // literal `true`), so this never matches the platform-gated form.
+    // Trailing `[,\s}]` ensures we match an object-property assignment,
+    // not an unrelated identifier.
+    const naiveShell = /shell\s*:\s*true\s*[,\s}]/;
+
+    assert.doesNotMatch(
+      codeOnly,
+      naiveShell,
+      'shell: true is forbidden — use `process.platform === "win32"` gate.',
+    );
+  });
+
+  test('execFileSync is still the spawn primitive (not exec/execSync)', () => {
+    const src = fs.readFileSync(WORKER_PATH, 'utf8');
+
+    // execFileSync is intentional: it does not invoke a shell on POSIX,
+    // unlike exec/execSync. A regression that swaps to execSync would
+    // silently always spawn a shell, defeating the platform gate.
+    assert.match(
+      src,
+      /execFileSync\s*\(\s*['"]npm['"]/,
+      'npm spawn must use execFileSync (not exec/execSync) to keep POSIX shell-free.',
+    );
+  });
+});


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #3103

---

## What was broken

On Windows, `gsd-check-update-worker.js` silently fails to fetch the latest npm version. `update_available` stays `null` and the statusline never shows the `⬆ /gsd-update` indicator — Windows users miss every release.

## What this fix does

Adds `shell: process.platform === 'win32'` to the `execFileSync('npm', ...)` call so Node routes through `cmd.exe` on Windows (which resolves `npm.cmd` via `PATHEXT`). On POSIX the option is `false`, so the spawn path is byte-identical to before — no shell process, no quoting-semantics shift, no `windowsHide` regression.

## Root cause

Node's `execFileSync` (unlike `execSync`/`exec`) does not spawn a shell by default and does not apply `PATHEXT` resolution. On Windows, npm ships as `npm.cmd`, not as a literal `npm` binary, so `execFileSync('npm', ...)` fails with `ENOENT`. The surrounding silent `try { ... } catch (e) {}` swallows the error, leaving `latest = null` and breaking the entire update-check pipeline.

POSIX is unaffected because `npm` is a symlink to a node script with shebang, resolvable without shell.

## Testing

### How I verified the fix

Manual repro on Windows 11 + Node 22 + npm 10 (PowerShell + Git Bash):

```powershell
$env:GSD_CACHE_FILE = "$env:USERPROFILE\.cache\gsd\gsd-update-check.json"
$env:GSD_PROJECT_VERSION_FILE = "$env:USERPROFILE\.claude\get-shit-done\VERSION"
$env:GSD_GLOBAL_VERSION_FILE = "$env:USERPROFILE\.claude\get-shit-done\VERSION"
node "$env:USERPROFILE\.claude\hooks\gsd-check-update-worker.js"
Get-Content "$env:USERPROFILE\.cache\gsd\gsd-update-check.json"
```

**Before:** `{"update_available":null,"installed":"1.40.0","latest":"unknown",...}`
**After:** `{"update_available":false,"installed":"1.40.0","latest":"1.40.0",...}`

Same `latest:"1.40.0"` value POSIX produces.

### Regression test added?

- [x] Yes — `tests/gsd-check-update-worker-platform-gate.test.cjs`
- [ ] No

Locks the contract that `shell` is platform-gated to win32 only (rejects unconditional `shell: true`), and that `execFileSync` remains the spawn primitive (a swap to `execSync` would silently shell-spawn on POSIX and defeat the gate). All 4 subtests pass; `lint-no-source-grep` clean.

The test is structural (reads worker source via `readFileSync`) because the win32 branch only manifests on a Windows runner and the repo's CI is POSIX-only. The file targeted is `hooks/*.js`, outside the `lint-no-source-grep` `.cjs` scope, and the test carries an `allow-test-rule` annotation with rationale.

### Platforms tested

- [ ] macOS
- [x] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A

---

## Checklist

- [x] Issue linked above with `Fixes #3103`
- [x] Linked issue has the `confirmed` and `bug` labels (added by maintainer during triage)
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added — `tests/gsd-check-update-worker-platform-gate.test.cjs`
- [x] All existing tests pass — `node --test` on the new file passes 4/4; `node scripts/lint-no-source-grep.cjs` clean
- [x] `.changeset/windows-npm-shell-fix.md` added (Fixed type)
- [x] No unnecessary dependencies added

## Breaking changes

None. POSIX behavior is byte-identical to before (no shell spawn, original signal/exit-code semantics, `windowsHide` retained). Windows behavior moves from broken (ENOENT) to working.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Update checker now works on Windows so the update-available indicator displays correctly.

* **Documentation**
  * Added a changeset entry describing the Windows-specific fix to the update check behavior.

* **Tests**
  * Added tests validating the platform-specific handling of the update check to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
