### PR TITLE
fix: use #!/usr/bin/env bash in community .sh hooks for distro portability

### DIFF
--- a/.changeset/portable-bash-shebang-hooks.md
+++ b/.changeset/portable-bash-shebang-hooks.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3105
+---
+**Community .sh hooks now use `#!/usr/bin/env bash` for cross-distro portability.** The three opt-in bash hooks (`gsd-phase-boundary.sh`, `gsd-session-state.sh`, `gsd-validate-commit.sh`) shipped with `#!/bin/bash`, which fails on distros that don't ship bash at `/bin/bash` (NixOS, minimal Alpine images, some container runtimes). POSIX guarantees `/bin/sh` but not `/bin/bash`. The fix matches the convention already used in `scripts/*.sh`. Latent in the default install path because Claude Code wires hooks as `bash <path>` from `settings.json` (PATH-resolved — the script's own shebang is read as a comment), but the bug surfaces immediately if a hook is run directly (tests, future installer changes, manual debugging). Comment in `bin/install.js::buildHookCommand` updated to clarify that the runner is PATH-resolved bare `bash`, not `/bin/bash` — POSIX std PATH guarantee was the wrong rationale.

--- a/bin/install.js
+++ b/bin/install.js
@@ -709,10 +709,16 @@ function rewriteLegacyCodexHookBlock(content, absoluteRunner) {
  */
 function buildHookCommand(configDir, hookName, opts) {
   if (!opts) opts = {};
-  // .sh hooks run under /bin/bash (POSIX std PATH always includes /bin),
-  // so bare `bash` is fine. .js hooks need the absolute node path because
-  // GUI-launched runtimes start with a minimal PATH that does not include
-  // nvm/Homebrew/Volta-installed node binaries (#2979).
+  // .sh hooks run under bare `bash` (PATH-resolved). POSIX guarantees
+  // /bin/sh but not /bin/bash, and distros like NixOS do not ship
+  // /bin/bash by default — so PATH-resolved `bash` is more portable than
+  // an absolute /bin/bash. The wrapping `bash <path>` invocation also
+  // means the script's own shebang (#!/usr/bin/env bash) is read as a
+  // comment in this code path; it only matters when the script is run
+  // directly (e.g. tests or future installer changes). .js hooks still
+  // need the absolute node path because GUI-launched runtimes start with
+  // a minimal PATH that does not include nvm/Homebrew/Volta-installed
+  // node binaries (#2979).
   const nodeRunner = resolveNodeRunner();
   const runner = hookName.endsWith('.sh') ? 'bash' : nodeRunner;
   // resolveNodeRunner returns null when process.execPath is unavailable.

--- a/hooks/gsd-phase-boundary.sh
+++ b/hooks/gsd-phase-boundary.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # gsd-hook-version: {{GSD_VERSION}}
 # gsd-phase-boundary.sh — PostToolUse hook: detect .planning/ file writes
 # Outputs a reminder when planning files are modified outside normal workflow.

--- a/hooks/gsd-session-state.sh
+++ b/hooks/gsd-session-state.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # gsd-hook-version: {{GSD_VERSION}}
 # gsd-session-state.sh — SessionStart hook: inject project state reminder
 # Outputs STATE.md head on every session start for orientation.

--- a/hooks/gsd-validate-commit.sh
+++ b/hooks/gsd-validate-commit.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # gsd-hook-version: {{GSD_VERSION}}
 # gsd-validate-commit.sh — PreToolUse hook: enforce Conventional Commits format
 # Blocks git commit commands with non-conforming messages (exit 2).

--- a/tests/bug-2136-sh-hook-version.test.cjs
+++ b/tests/bug-2136-sh-hook-version.test.cjs
@@ -100,11 +100,18 @@ describe('bug #2136 part 1: bash hook sources carry gsd-hook-version placeholder
   }
 
   test('version header is on line 2 (immediately after shebang)', () => {
-    // Placing the header immediately after #!/bin/bash ensures it is always
-    // found regardless of how much of the file is read.
+    // Placing the header immediately after the shebang ensures it is always
+    // found regardless of how much of the file is read. The shebang itself
+    // must use `#!/usr/bin/env bash` (PATH-resolved) rather than `#!/bin/bash`
+    // — POSIX guarantees /bin/sh but not /bin/bash, and distros like NixOS
+    // do not ship /bin/bash by default.
     for (const sh of SH_HOOKS) {
       const lines = fs.readFileSync(path.join(HOOKS_DIR, sh), 'utf8').split('\n');
-      assert.strictEqual(lines[0], '#!/bin/bash', `${sh} line 1 must be #!/bin/bash`);
+      assert.strictEqual(
+        lines[0],
+        '#!/usr/bin/env bash',
+        `${sh} line 1 must be "#!/usr/bin/env bash" for cross-distro portability`
+      );
       assert.ok(
         lines[1].startsWith('# gsd-hook-version:'),
         `${sh} line 2 must be the gsd-hook-version header (got: "${lines[1]}")`

--- a/tests/bug-2979-hook-absolute-node.test.cjs
+++ b/tests/bug-2979-hook-absolute-node.test.cjs
@@ -20,7 +20,8 @@ process.env.GSD_TEST_MODE = '1';
  * resolveNodeRunner helper, asserting on structured records:
  *  - the runner field is an absolute path (not bare 'node')
  *  - it ends with /node or \\node (or .exe on Windows simulation)
- *  - .sh hooks still use bare 'bash' (POSIX std PATH always has /bin)
+ *  - .sh hooks still use bare 'bash' (PATH-resolved; portable across
+ *    distros that don't ship /bin/bash, like NixOS)
  *
  * No source-grep on install.js content — assertions go against the
  * value returned by the exported function and the parsed structure of


### PR DESCRIPTION
## Linked Issue

Fixes #3104

## What was broken

The three community .sh hooks (`gsd-phase-boundary.sh`, `gsd-session-state.sh`, `gsd-validate-commit.sh`) ship with `#!/bin/bash`, which fails on distros that don't ship bash at `/bin/bash` (NixOS, minimal Alpine, some container runtimes). POSIX guarantees `/bin/sh` but not `/bin/bash`.

## What this fix does

Switches the three hook shebangs to `#!/usr/bin/env bash`, matching the convention already used in `scripts/*.sh`. Updates two test assertions and a misleading comment in `bin/install.js` that cited "POSIX std PATH always includes /bin" as the rationale (the actual rationale is that bare `bash` is PATH-resolved, which is what makes it portable).

## Root cause

Two separate things came together:

1. The hook .sh files inherited the `#!/bin/bash` form from when they were first added, before `scripts/*.sh` settled on `#!/usr/bin/env bash`.
2. The bug is **latent** in the default install path because `settings.json` wires hooks as `bash "<path>"` (PATH-resolved). When `bash` is invoked with a script argument, it reads the file internally and the shebang is treated as a comment. So on NixOS today, hooks work via the wrapping invocation even though the shebang is wrong.

The latent bug surfaces if a hook is run directly: tests, manual debugging, or any future installer change that exec's the script.

## Testing

### How I verified the fix

On NixOS 26.05 with Node v24.14.0:

- `npm run build:hooks`: `hooks/dist/*.sh` shebangs propagate correctly.
- `node --test tests/bug-2136-sh-hook-version.test.cjs tests/bug-2979-hook-absolute-node.test.cjs tests/bug-1817-sh-hook-guard.test.cjs tests/bug-1834-sh-hooks-installed.test.cjs tests/bug-1906-hook-relative-paths.test.cjs tests/bug-2557-gemini-local-hook-paths.test.cjs tests/bug-3017-codex-hook-absolute-node.test.cjs tests/security-scan.test.cjs tests/hooks-doc-parity.test.cjs`: 126/126 pass.
- `node scripts/run-tests.cjs` (full suite): 6944 pass / 0 fail / 5 skip.
- Manually executed each hook directly with the new shebang on a NixOS shell — all three resolve and execute (previously: `bad interpreter: /bin/bash: no such file or directory`).

### Regression test added?

- [x] Yes — `tests/bug-2136-sh-hook-version.test.cjs::version header is on line 2 (immediately after shebang)` already asserts the exact shebang on line 1; updated to expect `#!/usr/bin/env bash` so any future regression to `#!/bin/bash` will fail the test.

### Platforms tested

- [x] Linux (NixOS — the affected platform; also benchmarked behavior matches upstream main on Linux x86_64)
- [ ] macOS (no behavior change expected — `/bin/bash` exists everywhere on macOS, so the new env-bash shebang resolves identically)
- [ ] Windows (no behavior change — Git Bash + Windows install path use `bash <path>` PATH lookup; shebang is comment in this path)

### Runtimes tested

- [x] Claude Code

## Checklist

- [x] Linked issue exists and (will) carry the `confirmed-bug` label.
- [x] Single conceptual change, atomic commit.
- [x] Changeset entry under `.changeset/portable-bash-shebang-hooks.md`.
- [x] Tests updated to reflect new expectation.
- [x] Comment cleanup in `bin/install.js::buildHookCommand` aligned with reality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified hook execution environment and shell portability across distributions.

* **Chores**
  * Updated hook script interpreter lines to use PATH-resolved bash for improved cross-platform compatibility.

* **Tests**
  * Adjusted tests to require the portable shebang and updated test comments to match the clarified behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->