### PR TITLE
fix(commit): scope every commit call to its staged pathspec

### DIFF
--- a/.changeset/gentle-birds-caper.md
+++ b/.changeset/gentle-birds-caper.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3106
+---
+**`gsd-sdk query commit` is now scoped to its own staged paths.** Pre-staged unrelated index entries (for example a prior `git rm`) no longer leak into the commit alongside the files passed via `--files`. The same scope guarantee now applies to the `.planning/` fallback, `--amend`, and `commit-to-subrepo`.

--- a/sdk/src/query/commit.test.ts
+++ b/sdk/src/query/commit.test.ts
@@ -200,3 +200,142 @@ describe('checkCommit', () => {
     expect((result.data as { can_commit: boolean }).can_commit).toBe(true);
   });
 });
+
+// ─── pathspec scope regression (#3061) ────────────────────────────────────
+//
+// The handler must commit only the paths it staged itself, even when the
+// caller's git index already had unrelated entries staged before the call.
+// Before the fix, `git commit` ran without a pathspec and swept those
+// pre-staged entries into the commit alongside the requested files.
+
+describe('commit pathspec scope (#3061)', () => {
+  // Each test needs an existing HEAD so we can pre-stage a deletion against it.
+  beforeEach(async () => {
+    await writeFile(join(tmpDir, 'README.md'), 'init\n');
+    execSync('git add README.md', { cwd: tmpDir, stdio: 'pipe' });
+    execSync('git commit -m "init"', { cwd: tmpDir, stdio: 'pipe' });
+    await writeFile(
+      join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ commit_docs: true }),
+    );
+  });
+
+  it('--files commits only the named paths when an unrelated change is pre-staged', async () => {
+    const { commit } = await import('./commit.js');
+    await writeFile(join(tmpDir, '.planning', 'STATE.md'), '# State\n');
+
+    // Operator scenario from the issue: a `git rm` is already in the index
+    // before the workflow's commit step runs.
+    execSync('git rm README.md', { cwd: tmpDir, stdio: 'pipe' });
+
+    const result = await commit(['docs: state only', '--files', '.planning/STATE.md'], tmpDir);
+    expect((result.data as { committed: boolean }).committed).toBe(true);
+
+    const committed = execSync('git show --name-only --format= HEAD', { cwd: tmpDir, encoding: 'utf-8' })
+      .trim()
+      .split('\n');
+    expect(committed).toContain('.planning/STATE.md');
+    expect(committed).not.toContain('README.md');
+
+    // The pre-staged deletion must remain staged-but-uncommitted.
+    const status = execSync('git status --porcelain', { cwd: tmpDir, encoding: 'utf-8' });
+    expect(status).toMatch(/^D {2}README\.md/m);
+  });
+
+  it('.planning/ fallback commits only planning paths when an unrelated change is pre-staged', async () => {
+    const { commit } = await import('./commit.js');
+    await writeFile(join(tmpDir, '.planning', 'STATE.md'), '# State\n');
+
+    execSync('git rm README.md', { cwd: tmpDir, stdio: 'pipe' });
+
+    const result = await commit(['docs: planning'], tmpDir);
+    expect((result.data as { committed: boolean }).committed).toBe(true);
+
+    const committed = execSync('git show --name-only --format= HEAD', { cwd: tmpDir, encoding: 'utf-8' })
+      .trim()
+      .split('\n');
+    expect(committed).not.toContain('README.md');
+    expect(committed.some(f => f.startsWith('.planning/'))).toBe(true);
+
+    const status = execSync('git status --porcelain', { cwd: tmpDir, encoding: 'utf-8' });
+    expect(status).toMatch(/^D {2}README\.md/m);
+  });
+
+  it('--amend with --files keeps the amend within the named pathspec', async () => {
+    const { commit } = await import('./commit.js');
+
+    // Land an initial planning commit to amend, and assert the setup landed.
+    // If it silently failed the amend would target the wrong HEAD and the
+    // assertions below would still pass for the wrong reason.
+    await writeFile(join(tmpDir, '.planning', 'STATE.md'), '# State v1\n');
+    const setup = await commit(['docs: initial state', '--files', '.planning/STATE.md'], tmpDir);
+    expect((setup.data as { committed: boolean }).committed).toBe(true);
+
+    // Modify STATE.md, then pre-stage an unrelated change before amending.
+    await writeFile(join(tmpDir, '.planning', 'STATE.md'), '# State v2\n');
+    execSync('git rm README.md', { cwd: tmpDir, stdio: 'pipe' });
+
+    const result = await commit(['docs: amended', '--amend', '--files', '.planning/STATE.md'], tmpDir);
+    expect((result.data as { committed: boolean }).committed).toBe(true);
+
+    const committed = execSync('git show --name-only --format= HEAD', { cwd: tmpDir, encoding: 'utf-8' })
+      .trim()
+      .split('\n');
+    expect(committed).toContain('.planning/STATE.md');
+    expect(committed).not.toContain('README.md');
+
+    const status = execSync('git status --porcelain', { cwd: tmpDir, encoding: 'utf-8' });
+    expect(status).toMatch(/^D {2}README\.md/m);
+  });
+});
+
+// ─── input validation and option-injection safety (#3061 follow-ups) ──────
+//
+// Two guards that travel with the pathspec rewrite:
+//   1. --files with no usable paths fails fast instead of falling back to
+//      .planning/, which would silently swap the caller's intended scope.
+//   2. Every git add invocation uses the `--` separator so a path that
+//      starts with `-` is treated as a pathspec rather than an option.
+
+describe('commit input validation and option safety (#3061)', () => {
+  beforeEach(async () => {
+    await writeFile(join(tmpDir, 'README.md'), 'init\n');
+    execSync('git add README.md', { cwd: tmpDir, stdio: 'pipe' });
+    execSync('git commit -m "init"', { cwd: tmpDir, stdio: 'pipe' });
+    await writeFile(
+      join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ commit_docs: true }),
+    );
+  });
+
+  it('--files with no usable paths is rejected instead of silently using .planning/', async () => {
+    const { commit } = await import('./commit.js');
+    // Drop a planning change that the .planning/ fallback would otherwise pick up.
+    await writeFile(join(tmpDir, '.planning', 'STATE.md'), '# State\n');
+
+    const result = await commit(['msg', '--files', '--no-verify'], tmpDir);
+    expect((result.data as { committed: boolean }).committed).toBe(false);
+    expect((result.data as { reason: string }).reason).toContain('--files requires at least one path');
+
+    // The handler must not have staged anything: if it had silently fallen
+    // back to .planning/, STATE.md would now show up in the staged list.
+    const stagedAfter = execSync('git diff --cached --name-only', { cwd: tmpDir, encoding: 'utf-8' }).trim();
+    expect(stagedAfter).toBe('');
+  });
+
+  it('stages a file whose name starts with "-" instead of misparsing it as a git option', async () => {
+    const { commit } = await import('./commit.js');
+    // A filename like `-A.md` is the canonical option-injection trap:
+    // without the `--` separator, `git add -A.md` would be parsed as a flag.
+    const dashName = '-A.md';
+    await writeFile(join(tmpDir, dashName), 'dash content\n');
+
+    const result = await commit(['feat: add dash file', '--files', dashName], tmpDir);
+    expect((result.data as { committed: boolean }).committed).toBe(true);
+
+    const committed = execSync('git show --name-only --format= HEAD', { cwd: tmpDir, encoding: 'utf-8' })
+      .trim()
+      .split('\n');
+    expect(committed).toContain(dashName);
+  });
+});

--- a/sdk/src/query/commit.ts
+++ b/sdk/src/query/commit.ts
@@ -132,27 +132,40 @@ export const commit: QueryHandler = async (args, projectDir, workstream) => {
   // Sanitize message
   const sanitized = message ? sanitizeCommitMessage(message) : message;
 
-  // Stage files
-  const filesToStage = filePaths.length > 0 ? filePaths : ['.planning/'];
-  for (const file of filesToStage) {
-    const addResult = execGit(projectDir, ['add', file]);
+  // If --files was passed explicitly, the caller asked for an explicit scope.
+  // Falling back to .planning/ when every following token got filtered out
+  // would silently swap the requested scope, so reject the call instead.
+  if (filesIndex !== -1 && filePaths.length === 0) {
+    return { data: { committed: false, reason: '--files requires at least one path' } };
+  }
+
+  // Compute pathspec once: the handler commits exactly the paths it staged,
+  // never anything that was pre-staged externally (#3061).
+  const pathsToCommit = filePaths.length > 0 ? filePaths : ['.planning/'];
+  for (const file of pathsToCommit) {
+    // The `--` separator keeps any path that starts with `-` from being
+    // interpreted as a git option (e.g. a file literally named `-A`).
+    const addResult = execGit(projectDir, ['add', '--', file]);
     if (addResult.exitCode !== 0) {
       return { data: { committed: false, reason: addResult.stderr || `failed to stage ${file}`, exitCode: addResult.exitCode } };
     }
   }
 
-  // Check if anything is staged
-  const diffResult = execGit(projectDir, ['diff', '--cached', '--name-only']);
+  // Check if anything is staged within the pathspec we're about to commit.
+  const diffResult = execGit(projectDir, ['diff', '--cached', '--name-only', '--', ...pathsToCommit]);
   const stagedFiles = diffResult.stdout ? diffResult.stdout.split('\n').filter(Boolean) : [];
   if (stagedFiles.length === 0) {
     return { data: { committed: false, reason: 'nothing staged' } };
   }
 
-  // Build commit command
+  // Build commit command. The trailing `-- pathsToCommit` ensures the commit
+  // captures only files within the requested scope, even when the caller's
+  // index already had unrelated entries staged before this handler ran.
   const commitArgs: string[] = hasAmend
     ? ['commit', '--amend', '--no-edit']
     : ['commit', '-m', sanitized ?? ''];
   if (hasNoVerify) commitArgs.push('--no-verify');
+  commitArgs.push('--', ...pathsToCommit);
 
   const commitResult = execGit(projectDir, commitArgs);
   if (commitResult.exitCode !== 0) {
@@ -276,13 +289,17 @@ export const commitToSubrepo: QueryHandler = async (args, projectDir, workstream
     }
 
     const fileArgs = files.length > 0 ? files : ['.'];
-    const addResult = spawnSync('git', ['-C', projectDir, 'add', ...fileArgs], { stdio: 'pipe', encoding: 'utf-8' });
+    // The `--` separator keeps any path that starts with `-` from being
+    // interpreted as a git option (e.g. a file literally named `-A`).
+    const addResult = spawnSync('git', ['-C', projectDir, 'add', '--', ...fileArgs], { stdio: 'pipe', encoding: 'utf-8' });
     if (addResult.status !== 0) {
       return { data: { committed: false, reason: addResult.stderr || 'git add failed' } };
     }
 
+    // Pathspec on the commit keeps the scope identical to what was just staged,
+    // so any pre-staged external changes do not leak in (#3061).
     const commitResult = spawnSync(
-      'git', ['-C', projectDir, 'commit', '-m', sanitized],
+      'git', ['-C', projectDir, 'commit', '-m', sanitized, '--', ...fileArgs],
       { stdio: 'pipe', encoding: 'utf-8' },
     );
     if (commitResult.status !== 0) {


### PR DESCRIPTION
## Linked Issue

Fixes #3061

## What was broken

`gsd-sdk query commit` swept any pre-staged index entries into the commit alongside the files the handler had just staged. Calling `commit "msg" --files <a>` after a `git rm <b>` produced a commit containing both `<a>` and the deletion of `<b>` under the handler's message.

## What this fix does

Computes `pathsToCommit` once and passes `'--', ...pathsToCommit` to every `git commit` call in the handler: regular, `--amend`, and `commit-to-subrepo`. The staged-files check uses the same pathspec, so the early "nothing staged" return reflects what would actually be committed within scope.

## Root cause

The `git add` loop was already path-scoped, but `git commit` itself ran without a pathspec at `commit.ts:152-157`. #2781 (closing #2767) routed every workflow call site through `--files`, but the handler kept emitting a pathspec-less commit, so the leak survived the well-formed form.

## Testing

### How I verified the fix

* Added three vitest cases to `sdk/src/query/commit.test.ts` covering `--files`, the `.planning/` fallback, and `--amend`. Each pre-stages an unrelated `git rm` before invoking the handler and asserts the commit is scoped to the requested paths while the pre-staged deletion stays staged-but-uncommitted.
* `npx vitest run src/query/commit.test.ts` passes 19/19 (16 pre-existing + 3 new).
* `npm test` from the repo root passes 6944/6944, identical to baseline. The behavioral test in `tests/bug-2767-gsd-sdk-commit-files-flag.test.cjs` still passes.
* `npm run lint:tests` and `npm run lint:changeset` both clean.

### Regression test added?

- [x] Yes, added a test that would have caught this bug
- [ ] No

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #3061`
- [ ] Linked issue has the `confirmed-bug` label (pending maintainer triage; reproducible against `main`, and the new contract aligns with the `--files` documentation already in #2781)
- [x] Fix is scoped to the reported bug, no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added (`.changeset/gentle-birds-caper.md`)
- [x] No unnecessary dependencies added

## Breaking changes

None. The handler now commits exactly the paths it staged, which is the contract that the function name and the `--files` documentation already imply. Any caller that depended on the previous behavior was relying on the leak rather than on documented behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Commit operations now strictly limit what gets included to the paths you specify, preventing unrelated pre-staged changes from being added. This applies to regular commits, the planning-file fallback, amend operations, and sub-repo commits.

* **Tests**
  * Added tests verifying path-specific commit scoping, amend behavior, fallback handling, and safe handling of filenames that look like options.

* **Documentation**
  * Updated changeset entry documenting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->