### PR TITLE
fix: respect explicit milestone version in milestone complete

### DIFF
--- a/.changeset/lively-moles-caper.md
+++ b/.changeset/lively-moles-caper.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3043
+---
+milestone complete now scopes phase stats to the explicit version argument and errors when that version is missing from a versioned ROADMAP milestone section.

--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -1895,10 +1895,62 @@ function getMilestoneInfo(cwd) {
  * to the current milestone based on ROADMAP.md phase headings.
  * If no ROADMAP exists or no phases are listed, returns a pass-all filter.
  */
-function getMilestonePhaseFilter(cwd) {
+function getMilestonePhaseFilter(cwd, versionOverride) {
   const milestonePhaseNums = new Set();
+  let missingExplicitVersion = false;
   try {
-    const roadmap = extractCurrentMilestone(fs.readFileSync(path.join(planningDir(cwd), 'ROADMAP.md'), 'utf-8'), cwd);
+    const roadmapPath = path.join(planningDir(cwd), 'ROADMAP.md');
+    const roadmapContent = fs.readFileSync(roadmapPath, 'utf-8');
+    let roadmap = extractCurrentMilestone(roadmapContent, cwd);
+
+    if (versionOverride) {
+      const escapedVersion = escapeRegex(versionOverride);
+      const sectionPattern = new RegExp(`(^#{1,3}\\s+.*${escapedVersion}[^\\n]*)`, 'mi');
+      const sectionMatch = roadmapContent.match(sectionPattern);
+      if (!sectionMatch) {
+        // Only treat this as an error case when the roadmap is milestone-versioned.
+        // Older/flat roadmap formats without vX.Y milestone headings should keep
+        // legacy pass-through behavior for milestone.complete.
+        const hasVersionedMilestones = /^#{1,3}\s+.*v\d+\.\d+/mi.test(roadmapContent);
+        if (hasVersionedMilestones) {
+          roadmap = '';
+          missingExplicitVersion = true;
+        }
+      } else {
+        const sectionStart = sectionMatch.index;
+        const headingLevel = sectionMatch[1].match(/^(#{1,3})\s/)[1].length;
+        const restContent = roadmapContent.slice(sectionStart + sectionMatch[0].length);
+        const nextMilestonePattern = new RegExp(`^#{1,${headingLevel}}\\s+(?!Phase\\s+\\S)(?:.*v\\d+\\.\\d+|✅|📋|🚧)`, 'i');
+
+        let sectionEnd = roadmapContent.length;
+        let fenceChar = null;
+        let fenceLen = 0;
+        let charOffset = 0;
+        for (const line of restContent.split('\n')) {
+          const fenceMatch = line.match(/^\s{0,3}((?:`{3,}|~{3,}))(.*)/);
+          if (fenceMatch) {
+            const char = fenceMatch[1][0];
+            const len = fenceMatch[1].length;
+            const trailing = fenceMatch[2] || '';
+            if (!fenceChar) {
+              fenceChar = char;
+              fenceLen = len;
+            } else if (char === fenceChar && len >= fenceLen && /^\s*$/.test(trailing)) {
+              fenceChar = null;
+              fenceLen = 0;
+            }
+          } else if (!fenceChar && nextMilestonePattern.test(line)) {
+            sectionEnd = sectionStart + sectionMatch[0].length + charOffset;
+            break;
+          }
+          charOffset += line.length + 1;
+        }
+
+        const currentSection = roadmapContent.slice(sectionStart, sectionEnd);
+        roadmap = currentSection;
+      }
+    }
+
     // Match both numeric phases (Phase 1:) and custom IDs (Phase PROJ-42:)
     const phasePattern = /#{2,4}\s*Phase\s+([\w][\w.-]*)\s*:/gi;
     let m;
@@ -1910,6 +1962,7 @@ function getMilestonePhaseFilter(cwd) {
   if (milestonePhaseNums.size === 0) {
     const passAll = () => true;
     passAll.phaseCount = 0;
+    passAll.missingExplicitVersion = missingExplicitVersion;
     return passAll;
   }
 
@@ -1927,6 +1980,7 @@ function getMilestonePhaseFilter(cwd) {
     return false;
   }
   isDirInMilestone.phaseCount = milestonePhaseNums.size;
+  isDirInMilestone.missingExplicitVersion = missingExplicitVersion;
   return isDirInMilestone;
 }
 

--- a/get-shit-done/bin/lib/milestone.cjs
+++ b/get-shit-done/bin/lib/milestone.cjs
@@ -107,7 +107,10 @@ function cmdMilestoneComplete(cwd, version, options, raw) {
   // Scope stats and accomplishments to only the phases belonging to the
   // current milestone's ROADMAP.  Uses the shared filter from core.cjs
   // (same logic used by cmdPhasesList and other callers).
-  const isDirInMilestone = getMilestonePhaseFilter(cwd);
+  const isDirInMilestone = getMilestonePhaseFilter(cwd, version);
+  if (isDirInMilestone.missingExplicitVersion) {
+    error(`no phases found for milestone ${version} in ROADMAP.md`);
+  }
 
   // Gather stats from phases (scoped to current milestone only)
   let phaseCount = 0;

--- a/tests/bug-3043-milestone-complete-scope.test.cjs
+++ b/tests/bug-3043-milestone-complete-scope.test.cjs
@@ -1,0 +1,57 @@
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { createTempProject, cleanup, runGsdTools } = require('./helpers.cjs');
+
+describe('bug #3043: milestone complete respects explicit version scope', () => {
+  test('milestone.complete v3.6 uses v3.6 phases even when STATE milestone is v3.5', () => {
+    const tmpDir = createTempProject('gsd-bug-3043-');
+    try {
+      fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), '---\nmilestone: v3.5\n---\n');
+      fs.writeFileSync(
+        path.join(tmpDir, '.planning', 'ROADMAP.md'),
+        '# Roadmap\n\n## 🚧 v3.5 Paused\n### Phase 103: old\n### Phase 104: old2\n\n## 🚧 v3.6 Current\n### Phase 108: new\n',
+      );
+      fs.writeFileSync(path.join(tmpDir, '.planning', 'REQUIREMENTS.md'), '# Requirements\n');
+
+      const oldDirA = path.join(tmpDir, '.planning', 'phases', '103.old');
+      const oldDirB = path.join(tmpDir, '.planning', 'phases', '104.old');
+      const newDir = path.join(tmpDir, '.planning', 'phases', '108.new');
+      fs.mkdirSync(oldDirA, { recursive: true });
+      fs.mkdirSync(oldDirB, { recursive: true });
+      fs.mkdirSync(newDir, { recursive: true });
+      fs.writeFileSync(path.join(oldDirA, 'SUMMARY.md'), 'one-liner: old milestone A\n\n## Summary\nold\n');
+      fs.writeFileSync(path.join(oldDirB, 'SUMMARY.md'), 'one-liner: old milestone B\n\n## Summary\nold\n');
+      fs.writeFileSync(path.join(newDir, 'SUMMARY.md'), 'one-liner: new milestone\n\n## Summary\nnew\n');
+
+      const result = runGsdTools(['milestone', 'complete', 'v3.6', '--raw'], tmpDir);
+      assert.equal(result.success, true, result.error || result.output);
+      const payload = JSON.parse(result.output);
+
+      assert.equal(payload.version, 'v3.6');
+      assert.equal(payload.phases, 1, `expected v3.6 to scope to one phase, got ${payload.phases}`);
+    } finally {
+      cleanup(tmpDir);
+    }
+  });
+
+  test('milestone.complete fails when explicit milestone version resolves no phases', () => {
+    const tmpDir = createTempProject('gsd-bug-3043-empty-');
+    try {
+      fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), '---\nmilestone: v1.0\n---\n');
+      fs.writeFileSync(
+        path.join(tmpDir, '.planning', 'ROADMAP.md'),
+        '# Roadmap\n\n## 🚧 v1.0\n### Phase 1: foundation\n',
+      );
+      fs.writeFileSync(path.join(tmpDir, '.planning', 'REQUIREMENTS.md'), '# Requirements\n');
+      fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '01-foundation'), { recursive: true });
+
+      const result = runGsdTools(['milestone', 'complete', 'v9.9', '--raw'], tmpDir);
+      assert.equal(result.success, false, 'expected command to fail when no phases match explicit version');
+      assert.match(result.error || '', /no phases|phase/i);
+    } finally {
+      cleanup(tmpDir);
+    }
+  });
+});


### PR DESCRIPTION
## Linked Issue

Fixes #3043

## What was broken

`gsd-tools milestone complete <version>` could scope phase stats/archives using the milestone in `STATE.md` instead of the explicit `<version>` argument. In paused-milestone workflows this could archive/report the wrong milestone data.

## What this fix does

Makes milestone phase filtering version-aware for `milestone complete` by passing the explicit version into milestone scoping. If a versioned ROADMAP is present but the requested milestone version section is missing, the command now fails with a clear error instead of silently producing misleading output.

## Root cause

`cmdMilestoneComplete` called `getMilestonePhaseFilter(cwd)` without propagating the command version. The filter’s section extraction therefore used current milestone context (typically from `STATE.md`), which can diverge from the explicit command target.

## Testing

### How I verified the fix

- Added regression: `tests/bug-3043-milestone-complete-scope.test.cjs`
  - reproduces mismatch (`STATE.md` pinned to v3.5 while command runs `v3.6`) and verifies v3.6-only phase counting
  - verifies explicit error when requested version is absent from a versioned ROADMAP
- Ran:
  - `node --test tests/bug-3043-milestone-complete-scope.test.cjs`
  - `node --test tests/bug-3043-milestone-complete-scope.test.cjs tests/milestone.test.cjs`
  - `npm test`

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Milestone completion now requires an explicit version argument and validates its existence in the ROADMAP file. The command properly scopes phase statistics to the specified version and throws an error if the version is not found, preventing silent fallback behavior that could lead to incorrect phase tracking or misleading project status reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->