### PR TITLE
fix: remove stale /gsd-list-phase-assumptions guidance from progress routing

### DIFF
--- a/.changeset/fix-3094-progress-stale-assumptions.md
+++ b/.changeset/fix-3094-progress-stale-assumptions.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3111
+---
+**Progress routing command guidance remains canonical** — pre-planning assumption checks in progress routing now consistently assert and document `/gsd-discuss-phase` as the replacement path, with tests enforcing structured slash-command token checks.

--- a/get-shit-done/workflows/progress.md
+++ b/get-shit-done/workflows/progress.md
@@ -275,7 +275,7 @@ PHASE_HAS_UI=$(echo "$PHASE_SECTION" | grep -qi "UI hint.*yes" && echo "true" ||
 **Also available:**
 - `/gsd-ui-phase {phase}` — generate UI design contract (recommended for frontend phases)
 - `/gsd-plan-phase {phase}` — skip discussion, plan directly
-- `/gsd-list-phase-assumptions {phase}` — see Claude's assumptions
+- `/gsd-discuss-phase {phase}` — include assumptions check before planning
 
 ---
 ```
@@ -297,7 +297,7 @@ PHASE_HAS_UI=$(echo "$PHASE_SECTION" | grep -qi "UI hint.*yes" && echo "true" ||
 
 **Also available:**
 - `/gsd-plan-phase {phase} ${GSD_WS}` — skip discussion, plan directly
-- `/gsd-list-phase-assumptions {phase} ${GSD_WS}` — see Claude's assumptions
+- `/gsd-discuss-phase {phase} ${GSD_WS}` — include assumptions check before planning
 
 ---
 ```

--- a/tests/bug-3042-3044-research-flag-and-stale-refs.test.cjs
+++ b/tests/bug-3042-3044-research-flag-and-stale-refs.test.cjs
@@ -315,8 +315,10 @@ describe('bug #3094: progress routing does not reference removed /gsd-list-phase
 
   test('progress.md pre-planning guidance uses /gsd-discuss-phase instead', () => {
     const content = read('get-shit-done/workflows/progress.md');
-    assert.ok(
-      /\/gsd-discuss-phase/.test(content),
+    const tokens = extractSlashCommandTokens(content);
+    assert.equal(
+      tokens.has('/gsd-discuss-phase'),
+      true,
       'progress.md should route pre-planning assumption checks via /gsd-discuss-phase'
     );
   });

--- a/tests/bug-3042-3044-research-flag-and-stale-refs.test.cjs
+++ b/tests/bug-3042-3044-research-flag-and-stale-refs.test.cjs
@@ -302,6 +302,26 @@ describe('bug #3044: localized doc sets also scrubbed', () => {
 
 // ─── Replacement commands are documented ────────────────────────────────────
 
+describe('bug #3094: progress routing does not reference removed /gsd-list-phase-assumptions', () => {
+  test('get-shit-done/workflows/progress.md has no /gsd-list-phase-assumptions token', () => {
+    const content = read('get-shit-done/workflows/progress.md');
+    const tokens = extractSlashCommandTokens(content);
+    assert.equal(
+      tokens.has('/gsd-list-phase-assumptions'),
+      false,
+      'progress.md must not recommend removed /gsd-list-phase-assumptions'
+    );
+  });
+
+  test('progress.md pre-planning guidance uses /gsd-discuss-phase instead', () => {
+    const content = read('get-shit-done/workflows/progress.md');
+    assert.ok(
+      /\/gsd-discuss-phase/.test(content),
+      'progress.md should route pre-planning assumption checks via /gsd-discuss-phase'
+    );
+  });
+});
+
 describe('replacement commands appear where the deleted ones used to live', () => {
   test('docs/issue-driven-orchestration.md uses /gsd-workspace --new (not /gsd-new-workspace)', () => {
     const content = read('docs/issue-driven-orchestration.md');


### PR DESCRIPTION
## Summary
Fixes #3094 by removing stale `/gsd-list-phase-assumptions` recommendations from `get-shit-done/workflows/progress.md` and replacing them with supported `/gsd-discuss-phase` guidance.

## Diagnose
- Reproduced by searching workflow routing output: `progress.md` still contained two `/gsd-list-phase-assumptions` references.
- Root cause: stale recommendation text survived command-surface consolidation.

## TDD
### Red
Added regression tests in `tests/bug-3042-3044-research-flag-and-stale-refs.test.cjs`:
- asserts `progress.md` does **not** contain `/gsd-list-phase-assumptions` token
- asserts pre-planning guidance includes `/gsd-discuss-phase`

Observed failure:
- `progress.md must not recommend removed /gsd-list-phase-assumptions`

### Green
Updated `get-shit-done/workflows/progress.md` to replace both stale bullets with `/gsd-discuss-phase` alternatives.

### Refactor
Kept coverage in existing stale-reference regression suite so future command-surface cleanups are caught in one place.

## Rubber Duck Notes
If progress routing tells users to run a command that is not in `commands/gsd/`, users hit a dead path. The safest seam is token-level verification on emitted slash commands in workflow markdown, then updating only the stale routing bullets.

## Verification
- `node --test tests/bug-3042-3044-research-flag-and-stale-refs.test.cjs` (pass)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated workflow phase planning guidance to replace the previously suggested slash-command with a new command that explicitly includes an assumptions check.
* **Tests**
  * Added test validation to ensure the workflow guidance no longer references the old command and enforces the new, assumption-aware guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->