### PR TITLE
fix: remove /clear then from resume route templates

### DIFF
--- a/.changeset/pr-3113-release-note.md
+++ b/.changeset/pr-3113-release-note.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3113
+---
+Fixes for issue #3113 were applied to keep command/workflow behavior and SDK parity aligned with current documented usage.

--- a/get-shit-done/workflows/resume-project.md
+++ b/get-shit-done/workflows/resume-project.md
@@ -225,9 +225,11 @@ Wait for user selection.
 </step>
 
 <step name="route_to_workflow">
-Based on user selection, route to appropriate workflow:
+Based on user selection, route to appropriate workflow.
 
-- **Execute plan** → Show command for user to run after clearing:
+Resume-specific exception: do **not** emit `/clear then:` here. Resume is already a session-entry flow, so the next command should be shown directly.
+
+- **Execute plan** → Show direct next command:
   ```
   ---
 
@@ -235,21 +237,17 @@ Based on user selection, route to appropriate workflow:
 
   **{phase}-{plan}: [Plan Name]** — [objective from PLAN.md]
 
-  `/clear` then:
-
   `/gsd-execute-phase {phase} ${GSD_WS}`
 
   ---
   ```
-- **Plan phase** → Show command for user to run after clearing:
+- **Plan phase** → Show direct next command:
   ```
   ---
 
   ## ▶ Next Up — [${PROJECT_CODE}] ${PROJECT_TITLE}
 
   **Phase [N]: [Name]** — [Goal from ROADMAP.md]
-
-  `/clear` then:
 
   `/gsd-plan-phase [phase-number] ${GSD_WS}`
 

--- a/tests/bug-3083-resume-route-clear.test.cjs
+++ b/tests/bug-3083-resume-route-clear.test.cjs
@@ -1,0 +1,28 @@
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+describe('bug #3083: resume-project next-step routing should not include /clear then:', () => {
+  test('route_to_workflow block omits /clear then: in resume templates', () => {
+    const workflowPath = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'resume-project.md');
+    const content = fs.readFileSync(workflowPath, 'utf-8');
+    const routeStart = content.indexOf('<step name="route_to_workflow">');
+    const routeEnd = content.indexOf('</step>', routeStart);
+    const routeBlock = content.slice(routeStart, routeEnd);
+
+    assert.equal(routeBlock.includes('/clear` then:'), false, 'resume route templates must not include `/clear` then:');
+  });
+
+  test('route_to_workflow block includes exception note explaining resume behavior', () => {
+    const workflowPath = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'resume-project.md');
+    const content = fs.readFileSync(workflowPath, 'utf-8');
+    const routeStart = content.indexOf('<step name="route_to_workflow">');
+    const routeEnd = content.indexOf('</step>', routeStart);
+    const routeBlock = content.slice(routeStart, routeEnd);
+
+    assert.match(routeBlock, /resume.*exception|exception.*resume/i);
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #3083 by making `resume-project` a session-entry exception to generic continuation formatting:
- Removed `/clear then:` from `route_to_workflow` Next Up templates
- Kept same command routing semantics
- Added an inline note documenting why resume is an exception

## Diagnose
Reproduced from `get-shit-done/workflows/resume-project.md` route templates:
- Both execute and plan routes included `/clear then:` text
- This is redundant for resume because user has already started a fresh continuation flow

## TDD
### Red
Added regression test file first:
- `tests/bug-3083-resume-route-clear.test.cjs`
  - fails if `route_to_workflow` contains `/clear then:`
  - fails if no explicit resume-exception note exists

Test failed before fix.

### Green
Updated `get-shit-done/workflows/resume-project.md`:
- removed `/clear then:` lines
- switched phrasing to “Show direct next command”
- added explicit “resume-specific exception” note

Tests now pass.

## Rubber Duck Notes
The bug was a UX/context mismatch, not command correctness. Continuation templates are correct at end-of-workflow handoff, but resume is already a new-session handoff. So the right behavior is to output the direct command, not instruct another clear.

## Verification
- `node --test tests/bug-3083-resume-route-clear.test.cjs` ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified command output display in the resume project workflow—"Execute plan" and "Plan phase" steps now show commands directly without unnecessary prefixes.

* **Tests**
  * Added test suite to validate resume project workflow content and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->