### PR TITLE
fix: normalize legacy top-level branching_strategy into git config

### DIFF
--- a/.changeset/pr-3116-release-note.md
+++ b/.changeset/pr-3116-release-note.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3116
+---
+Fixes for issue #3116 were applied to keep command/workflow behavior and SDK parity aligned with current documented usage.

--- a/sdk/src/config.test.ts
+++ b/sdk/src/config.test.ts
@@ -237,6 +237,26 @@ describe('loadConfig', () => {
     expect(config).toEqual(CONFIG_DEFAULTS);
   });
 
+  it('maps legacy top-level branching_strategy into git.branching_strategy', async () => {
+    await writeFile(
+      join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ branching_strategy: 'phase' }),
+    );
+
+    const config = await loadConfig(tmpDir);
+    expect(config.git.branching_strategy).toBe('phase');
+  });
+
+  it('git.branching_strategy overrides legacy top-level branching_strategy when both are present', async () => {
+    await writeFile(
+      join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ branching_strategy: 'phase', git: { branching_strategy: 'milestone' } }),
+    );
+
+    const config = await loadConfig(tmpDir);
+    expect(config.git.branching_strategy).toBe('milestone');
+  });
+
   it('does not mutate CONFIG_DEFAULTS between calls', async () => {
     const before = structuredClone(CONFIG_DEFAULTS);
 

--- a/sdk/src/config.ts
+++ b/sdk/src/config.ts
@@ -177,11 +177,16 @@ export async function loadConfig(projectDir: string, workstream?: string): Promi
 }
 
 function mergeDefaults(parsed: Record<string, unknown>): GSDConfig {
+  const legacyBranchingStrategy = typeof parsed.branching_strategy === 'string'
+    ? parsed.branching_strategy
+    : undefined;
+
   return {
     ...structuredClone(CONFIG_DEFAULTS),
     ...parsed,
     git: {
       ...CONFIG_DEFAULTS.git,
+      ...(legacyBranchingStrategy ? { branching_strategy: legacyBranchingStrategy } : {}),
       ...(parsed.git as Partial<GitConfig> ?? {}),
     },
     workflow: {

--- a/sdk/src/query/init.test.ts
+++ b/sdk/src/query/init.test.ts
@@ -330,6 +330,20 @@ describe('initExecutePhase', () => {
     const data = result.data as Record<string, unknown>;
     expect(data.error).toBeDefined();
   });
+
+  it('honors legacy top-level branching_strategy in config for execute-phase init (#3055)', async () => {
+    await writeFile(join(tmpDir, '.planning', 'config.json'), JSON.stringify({
+      model_profile: 'balanced',
+      commit_docs: false,
+      branching_strategy: 'phase',
+      workflow: { research: true, plan_check: true, verifier: true, nyquist_validation: true },
+    }));
+
+    const result = await initExecutePhase(['9'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+    expect(data.branching_strategy).toBe('phase');
+    expect(typeof data.branch_name).toBe('string');
+  });
 });
 
 describe('initPlanPhase', () => {


### PR DESCRIPTION
## Summary
Fixes #3055 by making SDK config normalization honor legacy top-level `branching_strategy` so `init.execute-phase` no longer silently resolves to `none`.

## Diagnose
Repro class:
- `config-get branching_strategy` reflected top-level value
- `init.execute-phase` consumed `config.git.branching_strategy` and fell back to `none`

Root cause:
SDK `mergeDefaults()` did not map legacy top-level `branching_strategy` into `git.branching_strategy`.

## TDD
### Red
Added tests first:
- `sdk/src/config.test.ts`
  - maps top-level `branching_strategy` into `git.branching_strategy`
  - nested `git.branching_strategy` wins when both exist
- `sdk/src/query/init.test.ts`
  - `initExecutePhase` honors top-level `branching_strategy: "phase"`

### Green
Implemented legacy mapping in `sdk/src/config.ts`:
- If `parsed.branching_strategy` is a string, use it as fallback for `git.branching_strategy`
- Keep canonical nested `git.branching_strategy` precedence when present

## Rubber Duck Notes
This was a config-shape drift bug. Runtime consumers were correct to read canonical `git.branching_strategy`; loader needed to normalize legacy shape into that canonical slot.

## Verification
- `npm test -- sdk/src/config.test.ts sdk/src/query/init.test.ts` ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Enhancement**
  * Added support for legacy configuration files with top-level `branching_strategy` fields, ensuring backward compatibility with older config formats.

* **Tests**
  * Added test coverage for legacy branching strategy configuration handling and precedence rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->