### PR TITLE
fix: make orphaned worktree prune non-destructive by default

### DIFF
--- a/.changeset/fix-3056-worktree-path-assertion.md
+++ b/.changeset/fix-3056-worktree-path-assertion.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3117
+---
+**Worktree prune regression checks are now path-normalized** — pruning safety tests now parse `git worktree list --porcelain` and assert structured normalized paths, preventing path-separator false negatives across platforms while preserving non-destructive prune guarantees.

--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -792,19 +792,13 @@ function parseWorktreePorcelain(porcelain) {
 }
 
 /**
- * Remove linked git worktrees whose branch has already been merged into the
- * current HEAD of the main worktree.  Also runs `git worktree prune` to clear
- * any stale references left by manually-deleted worktree directories.
+ * Clear stale worktree metadata references via `git worktree prune`.
  *
- * Safe guards:
- *  - Never removes the main worktree (first entry in --porcelain output).
- *  - Never removes the worktree at process.cwd().
- *  - Never removes a worktree whose branch has unmerged commits.
- *  - Skips detached-HEAD worktrees (no branch name).
+ * Destructive linked-worktree removal is disabled by default for safety.
  *
  * @param {string} repoRoot - absolute path to the main (or any) worktree of
  *   the repository; used as `cwd` for git commands.
- * @returns {string[]} list of worktree paths that were removed
+ * @returns {string[]} list of worktree paths that were removed (always empty)
  */
 function pruneOrphanedWorktrees(repoRoot) {
   const pruned = [];
@@ -821,37 +815,14 @@ function pruneOrphanedWorktrees(repoRoot) {
       return pruned;
     }
 
-    // 2. First entry is the main worktree — never touch it
-    const mainWorktreePath = worktrees[0].path;
-
-    // 3. Check each non-main worktree
-    for (let i = 1; i < worktrees.length; i++) {
-      const { path: wtPath, branch } = worktrees[i];
-
-      // Never remove the worktree for the current process directory
-      if (wtPath === cwd || cwd.startsWith(wtPath + path.sep)) continue;
-
-      // Check if the branch is fully merged into HEAD (main)
-      // git merge-base --is-ancestor <branch> HEAD exits 0 when merged
-      const ancestorCheck = execGit(repoRoot, [
-        'merge-base', '--is-ancestor', branch, 'HEAD',
-      ]);
-
-      if (ancestorCheck.exitCode !== 0) {
-        // Not yet merged — leave it alone
-        continue;
-      }
-
-      // Remove the worktree and delete the branch
-      const removeResult = execGit(repoRoot, ['worktree', 'remove', '--force', wtPath]);
-      if (removeResult.exitCode === 0) {
-        execGit(repoRoot, ['branch', '-D', branch]);
-        pruned.push(wtPath);
-      }
-    }
+    // Destructive removal of linked worktrees is intentionally disabled.
+    // Keep metadata cleanup only (git worktree prune), which clears stale refs
+    // for manually-deleted directories without removing active sibling worktrees.
+    void cwd;
+    void worktrees;
   } catch { /* never crash the caller */ }
 
-  // 4. Always run prune to clear stale references (e.g. manually-deleted dirs)
+  // Always run prune to clear stale references (e.g. manually-deleted dirs)
   execGit(repoRoot, ['worktree', 'prune']);
 
   return pruned;

--- a/tests/prune-orphaned-worktrees.test.cjs
+++ b/tests/prune-orphaned-worktrees.test.cjs
@@ -49,8 +49,8 @@ describe('pruneOrphanedWorktrees', () => {
     cleanup(tmpBase);
   });
 
-  // Test 1: removes a worktree whose branch is merged into main
-  test('removes a worktree whose branch is merged into main', () => {
+  // Test 1: keeps a merged worktree (destructive removal disabled by default)
+  test('keeps a worktree whose branch is merged into main', () => {
     const repoDir = path.join(tmpBase, 'repo');
     const worktreeDir = path.join(tmpBase, 'wt-merged');
 
@@ -72,17 +72,17 @@ describe('pruneOrphanedWorktrees', () => {
     const pruneOrphanedWorktrees = getPruneOrphanedWorktrees();
     pruneOrphanedWorktrees(repoDir);
 
-    // Assert: worktree directory no longer exists
+    // Assert: worktree directory still exists
     assert.ok(
-      !fs.existsSync(worktreeDir),
-      'worktree directory should have been removed but still exists: ' + worktreeDir
+      fs.existsSync(worktreeDir),
+      'merged worktree should not be removed by default: ' + worktreeDir
     );
 
-    // Assert: git worktree list no longer shows it
+    // Assert: git worktree list still shows it
     const listOut = execSync('git worktree list', { cwd: repoDir, encoding: 'utf8' });
     assert.ok(
-      !listOut.includes(worktreeDir),
-      'git worktree list still references removed worktree:\n' + listOut
+      listOut.includes(worktreeDir),
+      'git worktree list should still reference merged worktree:\n' + listOut
     );
   });
 
@@ -132,11 +132,8 @@ describe('pruneOrphanedWorktrees', () => {
     const pruneOrphanedWorktrees = getPruneOrphanedWorktrees();
     const pruned = pruneOrphanedWorktrees(repoDir);
 
-    // process.cwd() must not appear in pruned paths
-    assert.ok(
-      !pruned.includes(process.cwd()),
-      'process.cwd() should never be pruned, but found in: ' + JSON.stringify(pruned)
-    );
+    // No destructive removals are performed by default
+    assert.deepStrictEqual(pruned, []);
 
     // The main worktree (repoDir) itself must still exist
     assert.ok(

--- a/tests/prune-orphaned-worktrees.test.cjs
+++ b/tests/prune-orphaned-worktrees.test.cjs
@@ -21,6 +21,24 @@ function getPruneOrphanedWorktrees() {
 }
 
 // Create a minimal git repo with an initial commit on main.
+function canonicalPath(p) {
+  try {
+    return fs.realpathSync.native(path.resolve(p));
+  } catch {
+    return path.resolve(p);
+  }
+}
+
+function listedWorktreePaths(repoDir) {
+  const out = execSync('git worktree list --porcelain', { cwd: repoDir, encoding: 'utf8' });
+  return new Set(
+    out
+      .split('\n')
+      .filter((line) => line.startsWith('worktree '))
+      .map((line) => canonicalPath(line.slice('worktree '.length).trim()))
+  );
+}
+
 function createGitRepo(dir) {
   fs.mkdirSync(dir, { recursive: true });
   execSync('git init', { cwd: dir, stdio: 'pipe' });
@@ -79,10 +97,10 @@ describe('pruneOrphanedWorktrees', () => {
     );
 
     // Assert: git worktree list still shows it
-    const listOut = execSync('git worktree list', { cwd: repoDir, encoding: 'utf8' });
+    const listed = listedWorktreePaths(repoDir);
     assert.ok(
-      listOut.includes(worktreeDir),
-      'git worktree list should still reference merged worktree:\n' + listOut
+      listed.has(canonicalPath(worktreeDir)),
+      'git worktree list should still reference merged worktree'
     );
   });
 


### PR DESCRIPTION
## Summary
Fixes #3056 by making `pruneOrphanedWorktrees()` non-destructive by default.

Behavior change:
- Keep `git worktree prune` metadata cleanup
- Disable `git worktree remove --force` / branch deletion loop entirely

This prevents routine informational flows from deleting active sibling linked worktrees.

## Diagnose
The previous implementation could force-remove linked worktrees based on branch ancestry heuristics and path-string checks. In practice, that allowed sibling worktrees to be removed during normal init/progress flows.

## TDD
### Red
Updated regression expectations in `tests/prune-orphaned-worktrees.test.cjs`:
- merged worktrees are **kept**
- unmerged worktrees are **kept**
- return value is empty (no destructive removals)
- stale metadata is still pruned

### Green
Updated `get-shit-done/bin/lib/core.cjs` `pruneOrphanedWorktrees()`:
- removed destructive removal loop
- retained `git worktree prune`
- clarified function contract/docs

## Rubber Duck Notes
For this code path, safe default is “never delete user worktrees”. Metadata prune is enough for stale refs and avoids irreversible data loss from heuristic misclassification.

## Verification
- `node --test tests/prune-orphaned-worktrees.test.cjs` ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved worktree maintenance to be non-destructive. Merged worktrees are no longer automatically removed, branch deletions have been eliminated, and the operation gracefully handles errors without interruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->