### PR TITLE
fix: guard optional sketch-findings probes from non-zero ls exits

### DIFF
--- a/.changeset/fix-3072-findings-probe-assertions.md
+++ b/.changeset/fix-3072-findings-probe-assertions.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3119
+---
+**Optional findings probe guard checks now use structured parsing** — regression tests now parse fenced bash blocks and validate sketch/spike findings probes as structured command records, ensuring non-fatal `|| true` guards are enforced without raw source grep assertions.

--- a/get-shit-done/workflows/discuss-phase.md
+++ b/get-shit-done/workflows/discuss-phase.md
@@ -244,8 +244,8 @@ For each CONTEXT.md read: extract `<decisions>` (locked preferences), `<specific
 
 **Spike/sketch findings:** Check for project-local skills:
 ```bash
-SPIKE_FINDINGS=$(ls ./.claude/skills/spike-findings-*/SKILL.md 2>/dev/null | head -1)
-SKETCH_FINDINGS=$(ls ./.claude/skills/sketch-findings-*/SKILL.md 2>/dev/null | head -1)
+SPIKE_FINDINGS=$(ls ./.claude/skills/spike-findings-*/SKILL.md 2>/dev/null | head -1 || true)
+SKETCH_FINDINGS=$(ls ./.claude/skills/sketch-findings-*/SKILL.md 2>/dev/null | head -1 || true)
 RAW_SPIKES=$(ls .planning/spikes/MANIFEST.md 2>/dev/null)
 RAW_SKETCHES=$(ls .planning/sketches/MANIFEST.md 2>/dev/null)
 ```

--- a/get-shit-done/workflows/new-project.md
+++ b/get-shit-done/workflows/new-project.md
@@ -253,10 +253,10 @@ Check for existing spike and sketch work that should inform project setup:
 
 ```bash
 # Check for spike findings skill (project-local)
-SPIKE_SKILL=$(ls ./.claude/skills/spike-findings-*/SKILL.md 2>/dev/null | head -1)
+SPIKE_SKILL=$(ls ./.claude/skills/spike-findings-*/SKILL.md 2>/dev/null | head -1 || true)
 
 # Check for sketch findings skill (project-local)
-SKETCH_SKILL=$(ls ./.claude/skills/sketch-findings-*/SKILL.md 2>/dev/null | head -1)
+SKETCH_SKILL=$(ls ./.claude/skills/sketch-findings-*/SKILL.md 2>/dev/null | head -1 || true)
 
 # Check for raw spikes/sketches in .planning/
 HAS_SPIKES=$(ls .planning/spikes/MANIFEST.md 2>/dev/null)

--- a/get-shit-done/workflows/plan-phase.md
+++ b/get-shit-done/workflows/plan-phase.md
@@ -668,8 +668,8 @@ REVIEWS_PATH=$(_gsd_field "$INIT" reviews_path)
 PATTERNS_PATH=$(_gsd_field "$INIT" patterns_path)
 
 # Detect spike/sketch findings skills (project-local)
-SPIKE_FINDINGS_PATH=$(ls ./.claude/skills/spike-findings-*/SKILL.md 2>/dev/null | head -1)
-SKETCH_FINDINGS_PATH=$(ls ./.claude/skills/sketch-findings-*/SKILL.md 2>/dev/null | head -1)
+SPIKE_FINDINGS_PATH=$(ls ./.claude/skills/spike-findings-*/SKILL.md 2>/dev/null | head -1 || true)
+SKETCH_FINDINGS_PATH=$(ls ./.claude/skills/sketch-findings-*/SKILL.md 2>/dev/null | head -1 || true)
 ```
 
 ## 7.5. Verify Nyquist Artifacts

--- a/get-shit-done/workflows/ui-phase.md
+++ b/get-shit-done/workflows/ui-phase.md
@@ -31,7 +31,7 @@ Parse JSON for: `phase_dir`, `phase_number`, `phase_name`, `phase_slug`, `padded
 
 Detect sketch findings:
 ```bash
-SKETCH_FINDINGS_PATH=$(ls ./.claude/skills/sketch-findings-*/SKILL.md 2>/dev/null | head -1)
+SKETCH_FINDINGS_PATH=$(ls ./.claude/skills/sketch-findings-*/SKILL.md 2>/dev/null | head -1 || true)
 ```
 
 Resolve UI agent models:

--- a/tests/bug-3072-optional-sketch-findings-guard.test.cjs
+++ b/tests/bug-3072-optional-sketch-findings-guard.test.cjs
@@ -1,0 +1,31 @@
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..', 'get-shit-done', 'workflows');
+
+function read(rel) {
+  return fs.readFileSync(path.join(ROOT, rel), 'utf8');
+}
+
+describe('bug #3072: optional sketch/spike findings probes are non-fatal', () => {
+  test('all sketch/spike findings SKILL.md ls probes include || true', () => {
+    const files = ['ui-phase.md', 'plan-phase.md', 'discuss-phase.md', 'new-project.md'];
+    const offenders = [];
+
+    for (const file of files) {
+      const content = read(file);
+      const lines = content.split('\n');
+      for (const line of lines) {
+        if (/\.claude\/skills\/(?:sketch|spike)-findings-\*\/SKILL\.md/.test(line) && !/\|\|\s*true/.test(line)) {
+          offenders.push(`${file}: ${line.trim()}`);
+        }
+      }
+    }
+
+    assert.deepStrictEqual(offenders, [], `missing non-fatal guard on optional findings probe:\n${offenders.join('\n')}`);
+  });
+});

--- a/tests/bug-3072-optional-sketch-findings-guard.test.cjs
+++ b/tests/bug-3072-optional-sketch-findings-guard.test.cjs
@@ -11,6 +11,37 @@ function read(rel) {
   return fs.readFileSync(path.join(ROOT, rel), 'utf8');
 }
 
+function extractFindingsProbesFromBashBlocks(markdown) {
+  const probes = [];
+  const fenceRe = /```bash\n([\s\S]*?)```/g;
+  let fenceMatch;
+
+  while ((fenceMatch = fenceRe.exec(markdown)) !== null) {
+    const block = fenceMatch[1];
+    const baseLine = markdown.slice(0, fenceMatch.index).split('\n').length;
+    const lines = block.split('\n');
+
+    lines.forEach((line, idx) => {
+      if (!line.includes('.claude/skills/')) return;
+      const kind = line.includes('sketch-findings-*/SKILL.md')
+        ? 'sketch'
+        : line.includes('spike-findings-*/SKILL.md')
+          ? 'spike'
+          : null;
+      if (!kind) return;
+
+      probes.push({
+        lineNumber: baseLine + idx,
+        commandText: line.trim(),
+        kind,
+        hasNonFatalGuard: /\|\|\s*true/.test(line),
+      });
+    });
+  }
+
+  return probes;
+}
+
 describe('bug #3072: optional sketch/spike findings probes are non-fatal', () => {
   test('all sketch/spike findings SKILL.md ls probes include || true', () => {
     const files = ['ui-phase.md', 'plan-phase.md', 'discuss-phase.md', 'new-project.md'];
@@ -18,10 +49,10 @@ describe('bug #3072: optional sketch/spike findings probes are non-fatal', () =>
 
     for (const file of files) {
       const content = read(file);
-      const lines = content.split('\n');
-      for (const line of lines) {
-        if (/\.claude\/skills\/(?:sketch|spike)-findings-\*\/SKILL\.md/.test(line) && !/\|\|\s*true/.test(line)) {
-          offenders.push(`${file}: ${line.trim()}`);
+      const probes = extractFindingsProbesFromBashBlocks(content);
+      for (const probe of probes) {
+        if (!probe.hasNonFatalGuard) {
+          offenders.push(`${file}:${probe.lineNumber} ${probe.commandText}`);
         }
       }
     }


### PR DESCRIPTION
## Summary
Fixes #3072 by making optional sketch/spike findings skill probes non-fatal in workflow preflight logic.

Updated workflows:
- `get-shit-done/workflows/ui-phase.md`
- `get-shit-done/workflows/plan-phase.md`
- `get-shit-done/workflows/discuss-phase.md`
- `get-shit-done/workflows/new-project.md`

All `ls ./.claude/skills/(sketch|spike)-findings-*/SKILL.md` probes now include `|| true`.

## Diagnose
Root cause: optional skill detection used `ls` glob probes that can exit non-zero when no match exists. In strict preflight shells this can surface noisy/misleading failure output despite the path being optional.

## TDD
### Red
Added regression test first:
- `tests/bug-3072-optional-sketch-findings-guard.test.cjs`
- Asserts all findings-skill `ls` probes include non-fatal guard (`|| true`).

### Green
Patched all affected workflow probe lines to include `|| true`.

## Rubber Duck Notes
Optional inputs must not control command exit semantics. Guarding these probes keeps error output meaningful: only real blockers should fail preflight.

## Verification
- `node --test tests/bug-3072-optional-sketch-findings-guard.test.cjs` ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced workflow stability by making skill directory detection more tolerant of missing optional directories, preventing unexpected failures across discussion, planning, UI, and project creation phases.

* **Tests**
  * Added validation tests to verify workflows correctly handle missing optional skill files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->