### PR TITLE
fix: normalize stale STATE narrative tails on milestone completion

### DIFF
--- a/.changeset/fix-3088-milestone-state-fallback-sections.md
+++ b/.changeset/fix-3088-milestone-state-fallback-sections.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3122
+---
+**Milestone close now repairs missing STATE narrative sections** — when `## Current Position` or `## Operator Next Steps` headings are absent, milestone completion appends canonical sections so state remains deterministic and consistently points operators to `/gsd-new-milestone`.

--- a/get-shit-done/bin/lib/milestone.cjs
+++ b/get-shit-done/bin/lib/milestone.cjs
@@ -215,13 +215,20 @@ function cmdMilestoneComplete(cwd, version, options, raw) {
       `Last activity: ${today} — Milestone ${version} completed and archived\n\n`;
     if (positionPattern.test(stateContent)) {
       stateContent = stateContent.replace(positionPattern, (_m, header) => `${header}${closedPositionBody}`);
+    } else {
+      stateContent = `${stateContent.trimEnd()}\n\n## Current Position\n${closedPositionBody}`;
     }
 
     // Normalize operator-next-step tails that can become stale after close.
-    stateContent = stateContent.replace(
-      /(##\s*Operator Next Steps\s*\n)([\s\S]*?)(?=\n##|$)/i,
-      `$1\n- Start the next milestone with /gsd-new-milestone\n\n`,
-    );
+    const operatorPattern = /(##\s*Operator Next Steps\s*\n)([\s\S]*?)(?=\n##|$)/i;
+    if (operatorPattern.test(stateContent)) {
+      stateContent = stateContent.replace(
+        operatorPattern,
+        `$1\n- Start the next milestone with /gsd-new-milestone\n\n`,
+      );
+    } else {
+      stateContent = `${stateContent.trimEnd()}\n\n## Operator Next Steps\n\n- Start the next milestone with /gsd-new-milestone\n`;
+    }
 
     writeStateMd(statePath, stateContent, cwd);
   }

--- a/get-shit-done/bin/lib/milestone.cjs
+++ b/get-shit-done/bin/lib/milestone.cjs
@@ -196,7 +196,7 @@ function cmdMilestoneComplete(cwd, version, options, raw) {
     atomicWriteFileSync(milestonesPath, normalizeMd(`# Milestones\n\n${milestoneEntry}`));
   }
 
-  // Update STATE.md — use shared helpers that handle both **bold:** and plain Field: formats
+  // Update STATE.md — keep frontmatter/body semantically aligned after closure
   if (fs.existsSync(statePath)) {
     let stateContent = fs.readFileSync(statePath, 'utf-8');
 
@@ -204,6 +204,24 @@ function cmdMilestoneComplete(cwd, version, options, raw) {
     stateContent = stateReplaceFieldWithFallback(stateContent, 'Last Activity', 'Last activity', today);
     stateContent = stateReplaceFieldWithFallback(stateContent, 'Last Activity Description', null,
       `${version} milestone completed and archived`);
+
+    // Reset Current Position narrative so resume/progress flows do not keep
+    // pointing at closed-phase execution instructions.
+    const positionPattern = /(##\s*Current Position\s*\n)([\s\S]*?)(?=\n##|$)/i;
+    const closedPositionBody =
+      `\nPhase: Milestone ${version} complete\n` +
+      `Plan: —\n` +
+      `Status: Awaiting next milestone\n` +
+      `Last activity: ${today} — Milestone ${version} completed and archived\n\n`;
+    if (positionPattern.test(stateContent)) {
+      stateContent = stateContent.replace(positionPattern, (_m, header) => `${header}${closedPositionBody}`);
+    }
+
+    // Normalize operator-next-step tails that can become stale after close.
+    stateContent = stateContent.replace(
+      /(##\s*Operator Next Steps\s*\n)([\s\S]*?)(?=\n##|$)/i,
+      `$1\n- Start the next milestone with /gsd-new-milestone\n\n`,
+    );
 
     writeStateMd(statePath, stateContent, cwd);
   }

--- a/sdk/src/query/phase-lifecycle.ts
+++ b/sdk/src/query/phase-lifecycle.ts
@@ -1841,6 +1841,22 @@ export const milestoneComplete: QueryHandler = async (args, projectDir, workstre
         null,
         `${version} milestone completed and archived`,
       );
+
+      const positionPattern = /(##\s*Current Position\s*\n)([\s\S]*?)(?=\n##|$)/i;
+      const closedPositionBody =
+        `\nPhase: Milestone ${version} complete\n` +
+        `Plan: —\n` +
+        `Status: Awaiting next milestone\n` +
+        `Last activity: ${today} — Milestone ${version} completed and archived\n\n`;
+      if (positionPattern.test(next)) {
+        next = next.replace(positionPattern, (_m, header) => `${header}${closedPositionBody}`);
+      }
+
+      next = next.replace(
+        /(##\s*Operator Next Steps\s*\n)([\s\S]*?)(?=\n##|$)/i,
+        `$1\n- Start the next milestone with /gsd-new-milestone\n\n`,
+      );
+
       return next;
     }, workstream);
   }

--- a/sdk/src/query/phase-lifecycle.ts
+++ b/sdk/src/query/phase-lifecycle.ts
@@ -1850,12 +1850,19 @@ export const milestoneComplete: QueryHandler = async (args, projectDir, workstre
         `Last activity: ${today} — Milestone ${version} completed and archived\n\n`;
       if (positionPattern.test(next)) {
         next = next.replace(positionPattern, (_m, header) => `${header}${closedPositionBody}`);
+      } else {
+        next = `${next.trimEnd()}\n\n## Current Position\n${closedPositionBody}`;
       }
 
-      next = next.replace(
-        /(##\s*Operator Next Steps\s*\n)([\s\S]*?)(?=\n##|$)/i,
-        `$1\n- Start the next milestone with /gsd-new-milestone\n\n`,
-      );
+      const operatorPattern = /(##\s*Operator Next Steps\s*\n)([\s\S]*?)(?=\n##|$)/i;
+      if (operatorPattern.test(next)) {
+        next = next.replace(
+          operatorPattern,
+          `$1\n- Start the next milestone with /gsd-new-milestone\n\n`,
+        );
+      } else {
+        next = `${next.trimEnd()}\n\n## Operator Next Steps\n\n- Start the next milestone with /gsd-new-milestone\n`;
+      }
 
       return next;
     }, workstream);

--- a/tests/milestone.test.cjs
+++ b/tests/milestone.test.cjs
@@ -247,6 +247,23 @@ describe('milestone complete command', () => {
     assert.ok(state.includes('/gsd-new-milestone'));
   });
 
+  test('appends canonical narrative sections when STATE.md headings are missing (#3088)', () => {
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), `# Roadmap v1.0\n`);
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      `# State\n\n**Status:** In progress\n**Last Activity:** 2025-01-01\n**Last Activity Description:** Working\n`
+    );
+
+    const result = runGsdTools('milestone complete v1.0 --name Test', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const state = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    assert.ok(state.includes('## Current Position'));
+    assert.ok(state.includes('Phase: Milestone v1.0 complete'));
+    assert.ok(state.includes('## Operator Next Steps'));
+    assert.ok(state.includes('/gsd-new-milestone'));
+  });
+
   test('handles missing ROADMAP.md gracefully', () => {
     // Only STATE.md — no ROADMAP.md, no REQUIREMENTS.md
     fs.writeFileSync(

--- a/tests/milestone.test.cjs
+++ b/tests/milestone.test.cjs
@@ -227,6 +227,26 @@ describe('milestone complete command', () => {
     );
   });
 
+  test('normalizes stale STATE.md narrative tails after milestone complete (#3088)', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      `# Roadmap v1.0\n`
+    );
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      `# State\n\n**Status:** In progress\n**Last Activity:** 2025-01-01\n**Last Activity Description:** Working\n\n## Current Position\n\nPhase: 03 — EXECUTING\nPlan: 03-02\nStatus: Executing\nLast activity: 2025-01-01 — Running phase\n\n## Operator Next Steps\n\n- Re-run /gsd-complete-milestone v1.0\n`
+    );
+
+    const result = runGsdTools('milestone complete v1.0 --name Test', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const state = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    assert.ok(state.includes('Phase: Milestone v1.0 complete'));
+    assert.ok(state.includes('Status: Awaiting next milestone'));
+    assert.ok(!state.includes('Re-run /gsd-complete-milestone'));
+    assert.ok(state.includes('/gsd-new-milestone'));
+  });
+
   test('handles missing ROADMAP.md gracefully', () => {
     // Only STATE.md — no ROADMAP.md, no REQUIREMENTS.md
     fs.writeFileSync(


### PR DESCRIPTION
## Summary
Fixes #3088 by normalizing `STATE.md` narrative sections when milestone completion succeeds.

Updated both CJS and SDK milestone-complete paths to keep body/frontmatter aligned.

## Diagnose
Root cause: milestone completion updated key state fields but could leave narrative tails (`## Current Position`, `## Operator Next Steps`) referencing closed execution context, creating contradictory routing signals.

## TDD
### Red
Added regression test in `tests/milestone.test.cjs`:
- `normalizes stale STATE.md narrative tails after milestone complete (#3088)`
- starts from stale execution-tail content
- asserts post-close normalization of Current Position and operator guidance

### Green
Implemented normalization in:
- `get-shit-done/bin/lib/milestone.cjs`
- `sdk/src/query/phase-lifecycle.ts`

Behavior after close now sets:
- `Phase: Milestone <version> complete`
- `Status: Awaiting next milestone`
- normalized operator next step to `/gsd-new-milestone`

### Refactor
Kept existing status/activity field updates intact; added deterministic body normalization as a bounded post-close step.

## Rubber Duck Notes
Machine-readable state and narrative state must agree. If close succeeds but narrative still points to in-flight phase commands, resume/next-step routing becomes ambiguous. Deterministic reset removes that ambiguity.

## Verification
- `node --test tests/milestone.test.cjs` ✅
- `npm test -- sdk/src/query/phase-lifecycle.test.ts` ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Milestone completion now automatically updates project status documentation to reflect completion and provide guidance for initiating the next milestone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->