### PR TITLE
fix: make update custom-file backup resilient to EACCES

### DIFF
--- a/.changeset/pr-3124-release-note.md
+++ b/.changeset/pr-3124-release-note.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3124
+---
+Fixes for issue #3124 were applied to keep command/workflow behavior and SDK parity aligned with current documented usage.

--- a/get-shit-done/workflows/update.md
+++ b/get-shit-done/workflows/update.md
@@ -486,10 +486,15 @@ const path = require('path');
 for (const relPath of custom_files) {
   const src = path.join(runtimeDir, relPath);
   const dst = path.join(backupDir, relPath);
-  if (fs.existsSync(src)) {
+  if (!fs.existsSync(src)) continue;
+
+  try {
     fs.mkdirSync(path.dirname(dst), { recursive: true });
     fs.copyFileSync(src, dst);
     console.log('  Backed up: ' + relPath);
+  } catch (err) {
+    const code = err && err.code ? String(err.code) : 'ERROR';
+    console.log('  Skipped (non-fatal): ' + relPath + ' [' + code + ']');
   }
 }
 JSEOF

--- a/tests/bug-3050-update-backup-eacces-nonfatal.test.cjs
+++ b/tests/bug-3050-update-backup-eacces-nonfatal.test.cjs
@@ -15,8 +15,9 @@ describe('bug #3050: update backup skips unreadable files non-fatally', () => {
     const hasTryCatch = /try\s*\{[\s\S]*copyFileSync\([\s\S]*\}[\s\S]*catch\s*\(err\)/.test(content);
     assert.ok(hasTryCatch, 'backup copy loop must catch per-file copy errors');
 
+    const hasNonFatalSkipMessage = /Skipped \(non-fatal\):/.test(content);
     assert.ok(
-      content.includes('Skipped (non-fatal):'),
+      hasNonFatalSkipMessage,
       'workflow must log a non-fatal skip message for unreadable custom files',
     );
   });

--- a/tests/bug-3050-update-backup-eacces-nonfatal.test.cjs
+++ b/tests/bug-3050-update-backup-eacces-nonfatal.test.cjs
@@ -1,0 +1,23 @@
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+describe('bug #3050: update backup skips unreadable files non-fatally', () => {
+  test('update workflow backup loop wraps copyFileSync in try/catch and logs non-fatal skip', () => {
+    const content = fs.readFileSync(
+      path.join(__dirname, '..', 'get-shit-done', 'workflows', 'update.md'),
+      'utf8',
+    );
+
+    const hasTryCatch = /try\s*\{[\s\S]*copyFileSync\([\s\S]*\}[\s\S]*catch\s*\(err\)/.test(content);
+    assert.ok(hasTryCatch, 'backup copy loop must catch per-file copy errors');
+
+    assert.ok(
+      content.includes('Skipped (non-fatal):'),
+      'workflow must log a non-fatal skip message for unreadable custom files',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #3050 by making `/gsd-update` custom-file backup best-effort per file.

`backup_custom_files` now:
- wraps each `copyFileSync` in `try/catch`
- logs `Skipped (non-fatal): <path> [<code>]` on read/copy errors (e.g. EACCES)
- continues backing up other files instead of aborting the update

## Diagnose
Root cause: backup loop performed direct `copyFileSync` with no per-file error handling; one unreadable file threw and terminated the entire update flow.

## TDD
### Red
Added regression guard:
- `tests/bug-3050-update-backup-eacces-nonfatal.test.cjs`
- asserts update workflow backup snippet catches copy errors and logs non-fatal skip

### Green
Updated backup loop in `get-shit-done/workflows/update.md` to catch and continue per file.

## Rubber Duck Notes
Backup should be durability-oriented, not brittle. A single permission-denied file is a partial backup condition, not a fatal installation blocker.

## Verification
- `node --test tests/bug-3050-update-backup-eacces-nonfatal.test.cjs` ✅
