### PR TITLE
fix: make phase insert placeholder/dry-run preconditions explicit

### DIFF
--- a/.changeset/pr-3125-release-note.md
+++ b/.changeset/pr-3125-release-note.md
@@ -2,4 +2,4 @@
 type: Fixed
 pr: 3125
 ---
-Fixes for issue #3125 were applied to keep command/workflow behavior and SDK parity aligned with current documented usage.
+Fixes for issue #3098 were applied to keep command/workflow behavior and SDK parity aligned with current documented usage.

--- a/.changeset/pr-3125-release-note.md
+++ b/.changeset/pr-3125-release-note.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3125
+---
+Fixes for issue #3125 were applied to keep command/workflow behavior and SDK parity aligned with current documented usage.

--- a/get-shit-done/bin/lib/phase-command-router.cjs
+++ b/get-shit-done/bin/lib/phase-command-router.cjs
@@ -33,6 +33,9 @@ function routePhaseCommand({ phase, args, cwd, raw, error }) {
     }
     phase.cmdPhaseAddBatch(cwd, descriptions, raw);
   } else if (subcommand === 'insert') {
+    if (args.includes('--dry-run')) {
+      error('phase insert does not support --dry-run');
+    }
     phase.cmdPhaseInsert(cwd, args[2], args.slice(3).join(' '), raw);
   } else if (subcommand === 'remove') {
     const forceFlag = args.includes('--force');

--- a/get-shit-done/bin/lib/phase.cjs
+++ b/get-shit-done/bin/lib/phase.cjs
@@ -556,6 +556,10 @@ function cmdPhaseInsert(cwd, afterPhase, description, raw) {
     const afterPhaseEscaped = unpadded.replace(/\./g, '\\.');
     const targetPattern = new RegExp(`#{2,4}\\s*Phase\\s+0*${afterPhaseEscaped}:`, 'i');
     if (!targetPattern.test(content)) {
+      const checklistPattern = new RegExp(`-\\s*\\[[ x]\\]\\s*\\*\\*Phase\\s+0*${afterPhaseEscaped}:`, 'i');
+      if (checklistPattern.test(content)) {
+        error(`Phase ${afterPhase} exists in roadmap summary but is missing a detail section (### Phase ${afterPhase}: ...).`);
+      }
       error(`Phase ${afterPhase} not found in ROADMAP.md`);
     }
 

--- a/tests/phase.test.cjs
+++ b/tests/phase.test.cjs
@@ -1237,6 +1237,28 @@ describe('phase insert command', () => {
     assert.ok(roadmap.includes('**Requirements**: TBD'), 'inserted phase entry should include Requirements TBD');
   });
 
+  test('reports actionable error for summary-only placeholder phase without detail section (#3098)', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      `# Roadmap\n\n- [ ] **Phase 5: Placeholder**\n`
+    );
+
+    const result = runGsdTools('phase insert 5 Hotfix', tmpDir);
+    assert.ok(!result.success, 'should fail when phase is summary-only placeholder');
+    assert.ok(result.error.includes('missing a detail section'));
+  });
+
+  test('phase insert rejects unsupported --dry-run flag explicitly (#3098)', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      `# Roadmap\n\n### Phase 1: Foundation\n**Goal:** Setup\n`
+    );
+
+    const result = runGsdTools('phase insert 1 Hotfix --dry-run', tmpDir);
+    assert.ok(!result.success, 'phase insert should reject unsupported --dry-run');
+    assert.ok(result.error.includes('does not support --dry-run'));
+  });
+
   test('handles #### heading depth from multi-milestone roadmaps', () => {
     fs.writeFileSync(
       path.join(tmpDir, '.planning', 'ROADMAP.md'),


### PR DESCRIPTION
## Summary
Fixes #3098 precondition ambiguity around `phase insert` by making failure causes explicit and rejecting unsupported flags clearly.

Changes:
- `phase insert --dry-run` now fails fast with explicit unsupported-flag error.
- If target phase appears in roadmap summary checklist but lacks a detail section,
  `phase insert` now returns an actionable error naming the missing detail-section precondition.

## Diagnose
Mismatch surfaced as contradictory UX:
- init/read paths can expose roadmap placeholder presence
- insert path failed with generic "not found" message even when a summary placeholder existed
- `--dry-run` was silently treated as description text

## TDD
### Red
Added regression tests in `tests/phase.test.cjs`:
- `reports actionable error for summary-only placeholder phase without detail section (#3098)`
- `phase insert rejects unsupported --dry-run flag explicitly (#3098)`

### Green
Implemented:
- `phase-command-router.cjs`: reject `--dry-run` for `phase insert`
- `phase.cjs` (`cmdPhaseInsert`): detect checklist-only placeholder and emit specific precondition error

## Rubber Duck Notes
The core issue here is semantic clarity: distinguish "missing phase" from "placeholder exists but detail section missing" and distinguish "unsupported flag" from "description text".

## Verification
- `node --test tests/phase.test.cjs` ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `phase insert` now rejects the unsupported `--dry-run` flag with a clear error.
  * Improved error messaging when a roadmap phase appears only in the summary but lacks its detailed section.

* **Tests**
  * Added tests covering `--dry-run` validation and the missing-phase-detail error scenario.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->