### PR TITLE
fix(capture): restore backlog workflow route

### DIFF
--- a/.changeset/fix-3137-capture-backlog-workflow.md
+++ b/.changeset/fix-3137-capture-backlog-workflow.md
@@ -1,0 +1,6 @@
+---
+type: Fixed
+pr: 3137
+---
+
+Restores the `/gsd-capture --backlog` workflow implementation so the consolidated capture command no longer routes to a missing `add-backlog.md` workflow. Fixes #3135.

--- a/docs/INVENTORY-MANIFEST.json
+++ b/docs/INVENTORY-MANIFEST.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-05-03",
+  "generated": "2026-05-05",
   "families": {
     "agents": [
       "gsd-advisor-researcher",
@@ -104,6 +104,7 @@
       "/gsd-workstreams"
     ],
     "workflows": [
+      "add-backlog.md",
       "add-phase.md",
       "add-tests.md",
       "add-todo.md",

--- a/docs/INVENTORY.md
+++ b/docs/INVENTORY.md
@@ -162,15 +162,16 @@ These six routers are descriptor-only entries that the model picks first; the bo
 
 ---
 
-## Workflows (84 shipped)
+## Workflows (85 shipped)
 
 Full roster at `get-shit-done/workflows/*.md`. Workflows are thin orchestrators that commands reference internally; most are not read directly by end users. Rows below map each workflow file to its role (derived from the `<purpose>` block) and, where applicable, to the command that invokes it.
 
 | Workflow | Role | Invoked by |
 |----------|------|------------|
+| `add-backlog.md` | Add an idea to the roadmap backlog parking lot using 999.x numbering. | `/gsd-capture --backlog` |
 | `add-phase.md` | Add a new integer phase to the end of the current milestone in the roadmap. | `/gsd-phase` (default) |
 | `add-tests.md` | Generate unit and E2E tests for a completed phase based on its artifacts. | `/gsd-add-tests` |
-| `add-todo.md` | Capture an idea or task that surfaces during a session as a structured todo. | `/gsd-capture` (default), `/gsd-capture --backlog` |
+| `add-todo.md` | Capture an idea or task that surfaces during a session as a structured todo. | `/gsd-capture` (default) |
 | `ai-integration-phase.md` | Orchestrate framework selection → AI research → domain research → eval planning into AI-SPEC.md. | `/gsd-ai-integration-phase` |
 | `analyze-dependencies.md` | Analyze ROADMAP.md phases for file overlap and semantic dependencies; suggest `Depends on` edges. | `/gsd-manager --analyze-deps` |
 | `audit-fix.md` | Autonomous audit-to-fix pipeline — run audit, parse, classify, fix, test, commit. | `/gsd-audit-fix` |

--- a/get-shit-done/workflows/add-backlog.md
+++ b/get-shit-done/workflows/add-backlog.md
@@ -1,0 +1,73 @@
+<purpose>
+Add a backlog item to the roadmap using 999.x numbering. Backlog items are
+unsequenced ideas that are not ready for active planning - they live outside
+the normal phase sequence and accumulate context over time.
+</purpose>
+
+<required_reading>
+Read all files referenced by the invoking prompt's execution_context before starting.
+</required_reading>
+
+<process>
+
+1. **Read ROADMAP.md** to find existing backlog entries:
+   ```bash
+   cat .planning/ROADMAP.md
+   ```
+
+2. **Find next backlog number:**
+   ```bash
+   NEXT=$(gsd-sdk query phase.next-decimal 999 --raw)
+   ```
+   If no 999.x phases exist, start at 999.1.
+
+3. **Add to ROADMAP.md** under a `## Backlog` section. If the section doesn't exist, create it at the end.
+   Write the ROADMAP entry BEFORE creating the directory - this ensures directory existence is always
+   a reliable indicator that the phase is already registered, which prevents false duplicate detection
+   in any hook that checks for existing 999.x directories (#2280):
+
+   ```markdown
+   ## Backlog
+
+   ### Phase {NEXT}: {description} (BACKLOG)
+
+   **Goal:** [Captured for future planning]
+   **Requirements:** TBD
+   **Plans:** 0 plans
+
+   Plans:
+   - [ ] TBD (promote with /gsd-review-backlog when ready)
+   ```
+
+4. **Create the phase directory:**
+   ```bash
+   SLUG=$(gsd-sdk query generate-slug "$ARGUMENTS" --raw)
+   mkdir -p ".planning/phases/${NEXT}-${SLUG}"
+   touch ".planning/phases/${NEXT}-${SLUG}/.gitkeep"
+   ```
+
+5. **Commit:**
+   ```bash
+   gsd-sdk query commit "docs: add backlog item ${NEXT} - ${ARGUMENTS}" --files .planning/ROADMAP.md ".planning/phases/${NEXT}-${SLUG}/.gitkeep"
+   ```
+
+6. **Report:**
+   ```
+   ## Backlog Item Added
+
+   Phase {NEXT}: {description}
+   Directory: .planning/phases/{NEXT}-{slug}/
+
+   This item lives in the backlog parking lot.
+   Use /gsd-discuss-phase {NEXT} to explore it further.
+   Use /gsd-review-backlog to promote items to active milestone.
+   ```
+
+</process>
+
+<notes>
+- 999.x numbering keeps backlog items out of the active phase sequence
+- Phase directories are created immediately, so /gsd-discuss-phase and /gsd-plan-phase work on them
+- No `Depends on:` field - backlog items are unsequenced by definition
+- Sparse numbering is fine (999.1, 999.3) - always uses next-decimal
+</notes>

--- a/get-shit-done/workflows/add-backlog.md
+++ b/get-shit-done/workflows/add-backlog.md
@@ -52,7 +52,7 @@ Read all files referenced by the invoking prompt's execution_context before star
    ```
 
 6. **Report:**
-   ```
+   ```text
    ## Backlog Item Added
 
    Phase {NEXT}: {description}

--- a/tests/enh-2790-skill-consolidation.test.cjs
+++ b/tests/enh-2790-skill-consolidation.test.cjs
@@ -10,6 +10,7 @@ const fs = require('fs');
 const path = require('path');
 
 const COMMANDS_DIR = path.join(__dirname, '..', 'commands', 'gsd');
+const WORKFLOWS_DIR = path.join(__dirname, '..', 'get-shit-done', 'workflows');
 
 /**
  * Parse the YAML frontmatter from a skill .md file.
@@ -238,6 +239,35 @@ describe('#3131 re-wired workflows: parent command bodies dispatch to workflow f
     assert.ok(
       bodyContains('import', 'from-gsd2'),
       'import.md body does not reference from-gsd2 — --from-gsd2 flag dispatch is missing',
+    );
+  });
+});
+
+describe('command execution_context workflow references are loadable', () => {
+  test('every workflow referenced from commands/gsd/*.md exists', () => {
+    const missing = [];
+    const commandFiles = fs.readdirSync(COMMANDS_DIR)
+      .filter((file) => file.endsWith('.md'));
+
+    for (const file of commandFiles) {
+      const raw = fs.readFileSync(path.join(COMMANDS_DIR, file), 'utf8');
+      const blocks = [...raw.matchAll(/<execution_context(?:_extended)?>([\s\S]*?)<\/execution_context(?:_extended)?>/g)];
+
+      for (const block of blocks) {
+        const refs = [...block[1].matchAll(/get-shit-done\/workflows\/([^\s`]+?\.md)/g)];
+        for (const ref of refs) {
+          const workflowPath = path.join(WORKFLOWS_DIR, ref[1]);
+          if (!fs.existsSync(workflowPath)) {
+            missing.push(`${file} -> get-shit-done/workflows/${ref[1]}`);
+          }
+        }
+      }
+    }
+
+    assert.deepStrictEqual(
+      missing,
+      [],
+      'commands reference missing workflow files: ' + missing.join(', '),
     );
   });
 });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3135

## What was broken

`/gsd-capture --backlog` routes to `get-shit-done/workflows/add-backlog.md`, but that workflow file was missing after the command consolidation.

## What this fix does

Restores `add-backlog.md` as an internal workflow, updates the workflow inventory, and adds a regression test that verifies command execution-context workflow references resolve to shipped files.

## Root cause

The standalone `commands/gsd/add-backlog.md` command was removed during the #2790 consolidation, but its implementation was not preserved as a workflow for the consolidated `capture.md` route.

## Testing

### How I verified the fix

- `node --test tests/enh-2790-skill-consolidation.test.cjs`
- `node --test tests/inventory-counts.test.cjs tests/inventory-manifest-sync.test.cjs tests/enh-2790-skill-consolidation.test.cjs`
- `node scripts/gen-inventory-manifest.cjs --check`
- `git diff --check`

### Regression test added?

- [x] Yes - added a command execution-context workflow reference scan that would have caught the missing `add-backlog.md` route.
- [ ] No - explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` - **PR will be auto-closed if missing**
- [ ] Linked issue has the `confirmed-bug` label - currently `needs-triage`; maintainer confirmation needed.
- [x] Fix is scoped to the reported bug - no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`) - targeted regression/inventory tests passed; full suite not run locally.
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`)
- [x] No unnecessary dependencies added

## Breaking changes

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored the backlog capture workflow so the consolidated capture command correctly supports the `--backlog` flag.

* **Documentation**
  * Updated workflow inventory and manifest to add the backlog workflow and clarify its invocation and counts.

* **Tests**
  * Added a test to validate that command references to workflows resolve to existing workflow files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->