### PR TITLE
fix(statusline): accept numeric 100 and block-list next_phases parsing

### DIFF
--- a/.changeset/fix-3153-statusline-percent-next-phases.md
+++ b/.changeset/fix-3153-statusline-percent-next-phases.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3153
+---
+**Statusline state rendering is now type-robust and YAML-list compatible** — milestone completion now renders for numeric and string `percent` values, and `next_phases` parsing supports both flow-array and block-list YAML forms.

--- a/hooks/gsd-statusline.js
+++ b/hooks/gsd-statusline.js
@@ -157,13 +157,22 @@ function parseStateMd(content) {
       // next_action: recommended command when idle (discuss-phase / plan-phase / execute-phase / verify-phase)
       if (key === 'next_action') state.nextAction = (v === 'null' || v === '') ? null : v;
     }
-    // next_phases YAML flow array: ["4.5", "4.6"] — single-line flow only
-    // Block sequences (- 4.5 / - 4.6 over multiple lines) are intentionally
-    // not parsed here; statusline only needs the primary recommendation.
-    const npMatch = fm.match(/^next_phases:\s*\[([^\]]*)\]/m);
-    if (npMatch) {
-      const items = npMatch[1].split(',').map(s => s.trim().replace(/^["']|["']$/g, '')).filter(Boolean);
+    // next_phases supports both flow array and block-list YAML forms.
+    const npFlowMatch = fm.match(/^next_phases:\s*\[([^\]]*)\]/m);
+    if (npFlowMatch) {
+      const items = npFlowMatch[1].split(',').map(s => s.trim().replace(/^["']|["']$/g, '')).filter(Boolean);
       state.nextPhases = items.length > 0 ? items : null;
+    } else {
+      const npBlockMatch = fm.match(/^next_phases:\s*\n((?:[ \t]*-[ \t]*[^\n]+\n?)*)/m);
+      if (npBlockMatch) {
+        const items = npBlockMatch[1]
+          .split('\n')
+          .map(line => line.match(/^[ \t]*-[ \t]*(.+)$/))
+          .filter(Boolean)
+          .map(m => m[1].trim().replace(/^["']|["']$/g, ''))
+          .filter(Boolean);
+        state.nextPhases = items.length > 0 ? items : null;
+      }
     }
     // progress nested block: completed_phases / total_phases / percent (2-space indent)
     const progMatch = fm.match(/^progress:\s*\n((?:[ \t]+\w+:.+\n?)+)/m);
@@ -256,7 +265,7 @@ function formatGsdState(s) {
     // Scene 2: idle + a recommended next command is visible to the user.
     // Surfaces "what to run next" without the user opening STATE.md.
     parts.push(`next ${s.nextAction} ${phasesStr}`);
-  } else if (s.percent === '100' || (s.completedPhases && s.totalPhases && s.completedPhases === s.totalPhases)) {
+  } else if (Number(s.percent) === 100 || (s.completedPhases && s.totalPhases && s.completedPhases === s.totalPhases)) {
     // Scene 3: milestone complete (every phase done).
     parts.push('milestone complete');
   } else {

--- a/tests/gsd-statusline.test.cjs
+++ b/tests/gsd-statusline.test.cjs
@@ -125,6 +125,21 @@ describe('parseStateMd', () => {
     assert.equal(s.status, undefined);
     assert.equal(s.phaseNum, undefined);
   });
+
+  test('parses next_phases from YAML block-list form (#3153)', () => {
+    const content = [
+      '---',
+      'next_action: execute',
+      'next_phases:',
+      '  - 4.5',
+      '  - 4.6',
+      '---',
+    ].join('\n');
+
+    const s = parseStateMd(content);
+    assert.equal(s.nextAction, 'execute');
+    assert.deepEqual(s.nextPhases, ['4.5', '4.6']);
+  });
 });
 
 // ─── formatGsdState ─────────────────────────────────────────────────────────
@@ -183,6 +198,14 @@ describe('formatGsdState', () => {
       status: 'planning',
     });
     assert.equal(out, 'Foundations · planning');
+  });
+
+  test('treats numeric 100 percent as milestone complete (#3153)', () => {
+    const out = formatGsdState({
+      milestone: 'v2.0',
+      percent: 100,
+    });
+    assert.equal(out, 'v2.0 [██████████] 100% · milestone complete');
   });
 
   test('returns empty string for empty state', () => {


### PR DESCRIPTION
## Summary
Fixes #3153.

- `formatGsdState` now treats numeric `percent=100` the same as string `'100'` for milestone-complete rendering.
- `parseStateMd` now parses `next_phases` from both YAML flow-array and block-list forms.
- Added regression tests covering both defects.

## Root Cause Analysis
1. **Type-coupled completion check**: completion scene logic used strict string equality (`s.percent === '100'`) while the progress bar path already accepted numeric input.
2. **Parser format asymmetry**: `next_phases` extraction only handled single-line flow arrays and ignored block-list YAML, so valid frontmatter emitted by other writers was dropped.

## TDD
### Red
Added failing tests in `tests/gsd-statusline.test.cjs`:
- `parses next_phases from YAML block-list form (#3153)`
- `treats numeric 100 percent as milestone complete (#3153)`

Observed failures before implementation:
- `nextPhases` was `undefined` for block-list input.
- output missed `· milestone complete` for numeric `percent: 100`.

### Green
Implemented minimal fixes in `hooks/gsd-statusline.js`:
- use `Number(s.percent) === 100` in completion branch
- add block-list fallback parser for `next_phases` when flow-array is absent

## Rubber-Duck Notes
The bug came from treating parsing and rendering as if they shared identical input shape. They don’t: rendering receives normalized values from multiple paths, while parsing only recognized one YAML list syntax. Making both code paths input-tolerant (without changing output contract) removes the mismatch.

## Verification
- `node --test tests/gsd-statusline.test.cjs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed milestone completion detection to properly handle numeric percent values.

* **New Features**
  * Added support for next_phases in multiple YAML formats (flow-style arrays and block-list form).

* **Tests**
  * Added validation tests for YAML frontmatter parsing and milestone completion rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->