### PR TITLE
test(stats): lock decimal phase continuity when .10 exists

### DIFF
--- a/.changeset/fix-3150-stats-json-decimal-gap-regression.md
+++ b/.changeset/fix-3150-stats-json-decimal-gap-regression.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3150
+---
+**`stats.json` decimal phase ordering now has explicit regression coverage** — added a fixture ensuring `06.7/06.8/06.9` remain present when `06.10` exists, preventing dropped-phase regressions in mixed decimal phase ranges.

--- a/.changeset/fix-3150-stats-json-decimal-gap-regression.md
+++ b/.changeset/fix-3150-stats-json-decimal-gap-regression.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 3150
+pr: 3155
 ---
 **`stats.json` decimal phase ordering now has explicit regression coverage** — added a fixture ensuring `06.7/06.8/06.9` remain present when `06.10` exists, preventing dropped-phase regressions in mixed decimal phase ranges.

--- a/tests/bug-3150-stats-json-decimal-phase-gaps.test.cjs
+++ b/tests/bug-3150-stats-json-decimal-phase-gaps.test.cjs
@@ -26,7 +26,21 @@ describe('bug #3150: stats.json includes contiguous decimal phases when .10 exis
       const result = runGsdTools('stats json', tmpDir);
       assert.ok(result.success, `Command failed: ${result.error}`);
 
-      const output = JSON.parse(result.output);
+      let output;
+      assert.doesNotThrow(
+        () => {
+          output = JSON.parse(result.output);
+        },
+        `Command output must be valid JSON. Raw output prefix: ${result.output.slice(0, 200)}`
+      );
+      assert.ok(
+        output && typeof output === 'object' && !Array.isArray(output),
+        `Expected object output, got: ${typeof output}`
+      );
+      assert.ok(
+        Array.isArray(output.phases),
+        `Expected output.phases array. Raw output prefix: ${result.output.slice(0, 200)}`
+      );
       const phaseNumbers = output.phases.map((p) => p.number);
 
       assert.deepStrictEqual(

--- a/tests/bug-3150-stats-json-decimal-phase-gaps.test.cjs
+++ b/tests/bug-3150-stats-json-decimal-phase-gaps.test.cjs
@@ -1,0 +1,44 @@
+'use strict';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { createTempProject, cleanup, runGsdTools } = require('./helpers.cjs');
+
+describe('bug #3150: stats.json includes contiguous decimal phases when .10 exists', () => {
+  test('stats json preserves 06.7/06.8/06.9 alongside 06.10', () => {
+    const tmpDir = createTempProject('gsd-bug-3150-');
+    try {
+      fs.writeFileSync(
+        path.join(tmpDir, '.planning', 'ROADMAP.md'),
+        `# Roadmap\n\n### Phase 06.6: P06.6\n**Goal:** G\n\n### Phase 06.7: P06.7\n**Goal:** G\n\n### Phase 06.8: P06.8\n**Goal:** G\n\n### Phase 06.9: P06.9\n**Goal:** G\n\n### Phase 06.10: P06.10\n**Goal:** G\n`
+      );
+
+      const dirs = ['06.6-a', '06.7-b', '06.8-c', '06.9-d', '06.10-e'];
+      for (const dirName of dirs) {
+        const phaseDir = path.join(tmpDir, '.planning', 'phases', dirName);
+        fs.mkdirSync(phaseDir, { recursive: true });
+        fs.writeFileSync(path.join(phaseDir, 'PLAN.md'), '# plan\n');
+        fs.writeFileSync(path.join(phaseDir, 'SUMMARY.md'), '# summary\n');
+      }
+
+      const result = runGsdTools('stats json', tmpDir);
+      assert.ok(result.success, `Command failed: ${result.error}`);
+
+      const output = JSON.parse(result.output);
+      const phaseNumbers = output.phases.map((p) => p.number);
+
+      assert.deepStrictEqual(
+        phaseNumbers,
+        ['06.6', '06.7', '06.8', '06.9', '06.10'],
+        'stats.json must not skip 06.7/06.8/06.9 when 06.10 exists'
+      );
+      assert.equal(output.phases_total, 5);
+      assert.equal(output.total_plans, 5);
+      assert.equal(output.total_summaries, 5);
+    } finally {
+      cleanup(tmpDir);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #3150 by adding a targeted regression guard for the reported decimal-phase omission pattern in `stats.json`.

## Diagnose
I attempted to reproduce the reported jump (`06.6 -> 06.10` while dropping `06.7/06.8/06.9`) against current `main` behavior in the issue branch and could not reproduce it. Current aggregation returns all decimal phases correctly in mixed ranges.

Given the report was from `v1.40.0`, this indicates the defect was likely fixed indirectly by subsequent stats/phase-indexing changes, but lacked a focused regression test for the exact pattern.

## Root Cause Analysis
- **Observed defect (reported):** `stats.json` omitted intermediate decimal phases when a higher minor like `.10` existed.
- **Most likely historical cause:** fragile phase aggregation logic around decimal-phase normalization/sorting/keying in older builds.
- **Current state:** logic now handles this sequence correctly, but without a specific test the behavior could regress unnoticed.

## TDD
### Red intent
Added a fixture matching the exact failing shape from the issue:
- phases `06.6`, `06.7`, `06.8`, `06.9`, `06.10`
- roadmap + on-disk directories + PLAN/SUMMARY artifacts

### Green result
The new test passes on current code, demonstrating the regression is currently fixed and now protected:
- `tests/bug-3150-stats-json-decimal-phase-gaps.test.cjs`

## Rubber Duck Notes
The key insight is that this issue is less about adding new behavior and more about preserving correctness already achieved. The safest fix is a narrow regression test that encodes the reporter’s exact sequence (`.7/.8/.9` plus `.10`) so future refactors can’t silently reintroduce the omission.

## Verification
- `node --test tests/bug-3150-stats-json-decimal-phase-gaps.test.cjs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents decimal-phase regressions in stats.json so phases like 06.7/06.8/06.9 are preserved when a later phase (e.g., 06.10) exists.

* **Tests**
  * Added end-to-end test coverage validating correct decimal phase ordering and accurate phase/plan/summary counts in stats.json.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->