### PR TITLE
fix(graphify): run /gsd-graphify build inline instead of spawning a sub-agent

### DIFF
--- a/.changeset/graphify-build-inline.md
+++ b/.changeset/graphify-build-inline.md
@@ -1,0 +1,4 @@
+---
+type: Fixed
+---
+**`/gsd-graphify build` now runs inline instead of spawning a sub-agent** — required by graphify v0.7+, which split the build into a fast AST-extraction phase followed by a separate clustering + report-write phase. The cached AST phase survived sub-agent isolation, but the post-extraction phase was being SIGTERM'd when the agent exited, leaving only the cache populated and no `graph.json` / `graph.html` / `GRAPH_REPORT.md` artifacts. The skill now runs `graphify update .`, the three artifact copies, the snapshot, and the status report as a single foreground Bash call, surviving to completion. The CLI's `graphify build` pre-flight still returns `action: "spawn_agent"` so external callers and existing tests keep working.

--- a/commands/gsd/graphify.md
+++ b/commands/gsd/graphify.md
@@ -138,7 +138,7 @@ Parse the JSON output:
 
 Display:
 
-```
+```text
 GSD > Building knowledge graph...
 ```
 

--- a/commands/gsd/graphify.md
+++ b/commands/gsd/graphify.md
@@ -5,7 +5,6 @@ argument-hint: "[build|query <term>|status|diff]"
 allowed-tools:
   - Read
   - Bash
-  - Task
 ---
 
 **STOP -- DO NOT READ THIS FILE. You are already reading it. This prompt was injected into your context by Claude Code's command system. Using the Read tool on this file wastes tokens. Begin executing Step 0 immediately.**
@@ -54,7 +53,7 @@ Parse `$ARGUMENTS` to determine the operation mode:
 
 | Argument | Action |
 |----------|--------|
-| `build` | Spawn graphify-builder agent (Step 3) |
+| `build` | Run inline build (Step 3) |
 | `query <term>` | Run inline query (Step 2a) |
 | `status` | Run inline status check (Step 2b) |
 | `diff` | Run inline diff check (Step 2c) |
@@ -122,80 +121,55 @@ If no snapshot exists, suggest running `build` twice (first to create, second to
 
 ---
 
-## Step 3 -- Build (Agent Spawn)
+## Step 3 -- Build (Inline)
 
-Run pre-flight check first:
+Run the pre-flight check first:
 
-```
-PREFLIGHT=$(node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" graphify build)
-```
-
-If pre-flight returns `disabled: true` or `error`, display the message and **STOP**.
-
-If pre-flight returns `action: "spawn_agent"`, display:
-
-```
-GSD > Spawning graphify-builder agent...
+```bash
+node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" graphify build
 ```
 
-Spawn a Task:
+Parse the JSON output:
+- If `disabled: true`: display the disabled message from Step 1 and **STOP**
+- If `error`: display the error message and **STOP**
+- If `action: "spawn_agent"`: pre-flight passed -- proceed with the inline build below
+
+(The `spawn_agent` action name is historical. The skill now performs the build inline because graphify v0.7+ split the build into a fast AST-extraction phase and a separate clustering + report-write phase. Sub-agent isolation kept the cached extraction phase alive but SIGTERM'd the post-extraction phase when the agent exited, leaving the cache populated but no `graph.json` artifacts written. The CLI still emits the `spawn_agent` signal so external callers and tests keep working.)
+
+Display:
 
 ```
-Task(
-  description="Build or rebuild the project knowledge graph",
-  prompt="You are the graphify-builder agent. Your job is to build or rebuild the project knowledge graph using the graphify CLI.
-
-Project root: ${CWD}
-gsd-tools path: $HOME/.claude/get-shit-done/bin/gsd-tools.cjs
-
-## Instructions
-
-1. **Invoke graphify:**
-   Run from the project root:
-   ```
-   graphify update .
-   ```
-   This builds the knowledge graph with SHA256 incremental caching.
-   Timeout: up to 5 minutes (or as configured via graphify.build_timeout).
-
-2. **Validate output:**
-   Check that graphify-out/graph.json exists and is valid JSON with nodes[] and edges[] arrays.
-   If graphify exited non-zero or graph.json is not parseable, output:
-   ## GRAPHIFY BUILD FAILED
-   Include the stderr output for debugging. Do NOT delete .planning/graphs/ -- prior valid graph remains available.
-
-3. **Copy artifacts to .planning/graphs/:**
-   ```
-   cp graphify-out/graph.json .planning/graphs/graph.json
-   cp graphify-out/graph.html .planning/graphs/graph.html
-   cp graphify-out/GRAPH_REPORT.md .planning/graphs/GRAPH_REPORT.md
-   ```
-   These three files are the build output consumed by query, status, and diff commands.
-
-4. **Write diff snapshot:**
-   ```
-   node \"$HOME/.claude/get-shit-done/bin/gsd-tools.cjs\" graphify build snapshot
-   ```
-   This creates .planning/graphs/.last-build-snapshot.json for future diff comparisons.
-
-5. **Report build summary:**
-   ```
-   node \"$HOME/.claude/get-shit-done/bin/gsd-tools.cjs\" graphify status
-   ```
-   Display the node count, edge count, and hyperedge count from the status output.
-
-When complete, output: ## GRAPHIFY BUILD COMPLETE with the summary counts.
-If something fails at any step, output: ## GRAPHIFY BUILD FAILED with details."
-)
+GSD > Building knowledge graph...
 ```
 
-Wait for the agent to complete.
+Run the build, copy artifacts, write the diff snapshot, and report the summary in a single foreground Bash call so the whole pipeline survives to completion. Use a `timeout` of `600000` ms (10 minutes), which covers the `graphify.build_timeout` ceiling (default 300 s) with margin:
+
+```bash
+graphify update . \
+  && cp graphify-out/graph.json .planning/graphs/graph.json \
+  && cp graphify-out/graph.html .planning/graphs/graph.html \
+  && cp graphify-out/GRAPH_REPORT.md .planning/graphs/GRAPH_REPORT.md \
+  && node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" graphify build snapshot \
+  && node "$HOME/.claude/get-shit-done/bin/gsd-tools.cjs" graphify status
+```
+
+Do NOT pass `run_in_background: true`. Typical builds complete in 15-60 seconds and the entire chain must run foreground.
+
+If the chain fails (non-zero exit):
+- Display: `## GRAPHIFY BUILD FAILED` followed by the captured stderr
+- Do NOT delete `.planning/graphs/` -- the prior valid graph remains available
+- **STOP**
+
+If the chain succeeds:
+- Parse the trailing `graphify status` JSON
+- Display: `## GRAPHIFY BUILD COMPLETE` with the node, edge, and hyperedge counts
 
 ---
 
 ## Anti-Patterns
 
-1. DO NOT spawn an agent for query/status/diff operations -- these are inline CLI calls
-2. DO NOT modify graph files directly -- the build agent handles writes
-3. DO NOT skip the config gate check
-4. DO NOT use gsd-tools config get-value for the config gate -- it exits on missing keys
+1. DO NOT spawn an agent for any operation -- build, query, status, and diff all run inline. Sub-agent isolation terminates background bash when the agent exits, which previously truncated graphify builds mid-write and left only the cache populated.
+2. DO NOT pass `run_in_background: true` for the build chain -- the operation is fast and must complete in the foreground.
+3. DO NOT modify graph files directly -- always go through `graphify update .` and the snapshot CLI.
+4. DO NOT skip the config gate check.
+5. DO NOT use `gsd-tools config get-value` for the config gate -- it exits on missing keys.

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -981,7 +981,7 @@ Build, query, and inspect the project knowledge graph stored in `.planning/graph
 
 | Subcommand | Description |
 |------------|-------------|
-| `build` | Build or rebuild the knowledge graph (spawns the graphify-builder agent) |
+| `build` | Build or rebuild the knowledge graph (runs `graphify update .` inline and refreshes `.planning/graphs/`) |
 | `query <term>` | Search the graph for a term |
 | `status` | Show graph freshness and statistics |
 | `diff` | Show changes since the last build |


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #3166

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

`/gsd-graphify build` spawned a sub-agent that ran `graphify update .` as a background bash process. With graphify v0.7+, the build split into a fast AST-extraction phase followed by a separate clustering + report-write phase. The post-extraction phase was SIGTERM'd when the sub-agent exited, leaving only the cache populated — no `graph.json`, `graph.html`, or `GRAPH_REPORT.md` artifacts were written to `.planning/graphs/`.

## What this fix does

Converts the build to run inline as a single foreground Bash call (no sub-agent), so `graphify update .`, the three artifact copies, the snapshot, and the status report all complete before the command returns.

## Root cause

Sub-agent isolation terminates any background bash left running when the agent exits. Pre-v0.7 graphify completed its work during the AST-extraction phase, which survived long enough. v0.7+ deferred clustering and report writing to a second phase that outlived the agent boundary.

## Testing

### How I verified the fix

Ran `graphify update .` directly in the main shell — completed in 16 seconds with 369 MB peak memory and produced all three artifacts under `.planning/graphs/`.

### Regression test added?

- [ ] Yes — added a test that would have caught this bug
- [x] No — the fix is in the skill's instruction text (`commands/gsd/graphify.md`), not in CJS code. Runtime orchestration of a CLI tool is not covered by the existing test suite.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [ ] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None