### PR TITLE
docs: add Prerelease editions install guidance (Next/Nightly/Insiders/Preview)

### DIFF
--- a/.changeset/swift-coyotes-document.md
+++ b/.changeset/swift-coyotes-document.md
@@ -1,0 +1,5 @@
+---
+type: Changed
+pr: 0
+---
+**USER-GUIDE now documents installing for prerelease runtime editions** — adds a "Installing for Prerelease Editions (Next / Nightly / Insiders / Preview)" section with the `<RUNTIME>_CONFIG_DIR` env-var reference for every supported runtime. Resolves the discoverability gap behind requests like #3161 (Windsurf Next) without enumerating each prerelease channel as a separately tested runtime. Closes #3172.

--- a/.changeset/swift-coyotes-document.md
+++ b/.changeset/swift-coyotes-document.md
@@ -1,5 +1,5 @@
 ---
 type: Changed
-pr: 0
+pr: 3173
 ---
 **USER-GUIDE now documents installing for prerelease runtime editions** — adds a "Installing for Prerelease Editions (Next / Nightly / Insiders / Preview)" section with the `<RUNTIME>_CONFIG_DIR` env-var reference for every supported runtime. Resolves the discoverability gap behind requests like #3161 (Windsurf Next) without enumerating each prerelease channel as a separately tested runtime. Closes #3172.

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -1200,6 +1200,41 @@ npx get-shit-done-cc --qwen --global
 
 Skills are installed to `~/.qwen/skills/gsd-*/SKILL.md`. Use the `QWEN_CONFIG_DIR` environment variable to override the default install path.
 
+### Installing for Prerelease Editions (Next / Nightly / Insiders / Preview)
+
+Many supported runtimes ship a prerelease edition alongside their stable release — Windsurf Next, Cursor Nightly, VS Code Insiders, Codex preview channels, JetBrains EAP, and so on. Prerelease editions read from a sibling configuration directory, so the default install path won't reach them.
+
+GSD does not enumerate prerelease editions as separate named runtimes. They are accommodated through the existing `<RUNTIME>_CONFIG_DIR` environment variables and the free-string runtime policy (see [#2517](https://github.com/gsd-build/get-shit-done/issues/2517)) — installs work, paths resolve, GSD operates. Prerelease editions are **best-effort and not separately tested** as part of release CI.
+
+**Pattern.** Set the runtime's `*_CONFIG_DIR` env var to the prerelease directory before running the installer:
+
+```bash
+WINDSURF_CONFIG_DIR=~/.codeium/windsurf-next npx get-shit-done-cc@latest --windsurf --global
+```
+
+Select the corresponding stable runtime in the installer prompt. Skills land in the prerelease directory; commands appear in the prerelease editor.
+
+**Env-var reference for supported runtimes:**
+
+| Runtime | Stable default | Override env var |
+|---|---|---|
+| Claude Code | `~/.claude` | `CLAUDE_CONFIG_DIR` |
+| Gemini CLI | `~/.gemini` | `GEMINI_CONFIG_DIR` |
+| OpenCode | `XDG_CONFIG_HOME/opencode` | `OPENCODE_CONFIG_DIR` |
+| Codex | (per Codex CLI) | `--config-dir` flag |
+| Copilot | `~/.copilot` | `COPILOT_CONFIG_DIR` |
+| Cursor | `~/.cursor` | `CURSOR_CONFIG_DIR` |
+| Windsurf | `~/.codeium/windsurf` | `WINDSURF_CONFIG_DIR` |
+| Antigravity | `~/.gemini/antigravity` | `ANTIGRAVITY_CONFIG_DIR` |
+| Augment | `~/.augment` | `AUGMENT_CONFIG_DIR` |
+| Trae | `~/.trae` | `TRAE_CONFIG_DIR` |
+| Qwen Code | `~/.qwen` | `QWEN_CONFIG_DIR` |
+| Kilo | `~/.config/kilo` | `KILO_CONFIG_DIR` |
+| CodeBuddy | `~/.codebuddy` | `CODEBUDDY_CONFIG_DIR` |
+| Cline | `~/.cline` | `CLINE_CONFIG_DIR` |
+
+If your runtime's prerelease channel is not listed, point the matching env var at its config directory and file an issue if the install fails for any reason other than the path mapping.
+
 ### Using Claude Code with Non-Anthropic Providers (OpenRouter, Local)
 
 If GSD subagents call Anthropic models and you're paying through OpenRouter or a local provider, switch to the `inherit` profile: `/gsd-config --profile inherit`. This makes all agents use your current session model instead of specific Anthropic models. See also `/gsd-settings` → Model Profile → Inherit.


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #3172

The linked issue carries the `approved-enhancement` label.

---

## What this enhancement improves

`docs/USER-GUIDE.md` — installer guidance for users running prerelease editions of supported runtimes (Windsurf Next, Cursor Nightly, VS Code Insiders, Codex preview, JetBrains EAP, etc.).

## Before / After

**Before:** Users on prerelease runtime editions hit a silent install failure (skills go to the stable directory the prerelease editor doesn't read), then file an issue per edition asking GSD to "support" their channel — most recently #3161 for Windsurf Next. The `<RUNTIME>_CONFIG_DIR` override exists in `bin/install.js` and works today, but users have to read the source to find it.

**After:** A new "Installing for Prerelease Editions (Next / Nightly / Insiders / Preview)" subsection in USER-GUIDE.md states the general pattern, gives a concrete Windsurf Next example, and tabulates the override env var for every supported runtime. Maintainers can redirect future "add `<runtime>-next/-nightly/-insiders`" requests to one section instead of evaluating each as a runtime-addition feature ask.

## How it was implemented

One subsection inserted in `docs/USER-GUIDE.md` between the existing "Installing for Qwen Code" and "Using Claude Code with Non-Anthropic Providers" sections. Env-var names sourced directly from the `getDirName` switch in `bin/install.js`. Section explicitly states that prerelease editions are best-effort and not separately tested under release CI — consistent with the free-string runtime policy documented at #2517.

No code changes. No new files (beyond the changeset fragment). No tests required.

## Testing

### How I verified the enhancement works

Docs-only change. Verified by re-reading the inserted section against `bin/install.js` env-var resolution (lines 230-450) to confirm every runtime's stable default and override env var match the table.

### Platforms tested

- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

---

## Checklist

- [x] Issue linked above with `Closes #NNN`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass — N/A, docs-only change with no test impact
- [x] New or updated tests cover the enhanced behavior — N/A, docs-only
- [x] `.changeset/` fragment added (`swift-coyotes-document.md`, type `Changed`)
- [x] Documentation updated if behavior or output changed — this PR *is* the docs update
- [x] No unnecessary dependencies added

## Breaking changes

None. Documentation addition only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new installation guide section covering prerelease runtime editions (Windsurf Next, Cursor Nightly, and similar channels), including configuration directory setup, installer behavior, and environment variable configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->