### PR TITLE
docs(mvp): canary-prep concept cleanup — CONTEXT.md, mvp-concepts index, --prd interaction

### DIFF
--- a/.changeset/mvp-concept-cleanup-canary-prep.md
+++ b/.changeset/mvp-concept-cleanup-canary-prep.md
@@ -1,0 +1,5 @@
+---
+type: Changed
+pr: 0
+---
+**MVP umbrella concept cleanup for v1.50.0-canary.2** — adds the seven MVP-related domain terms (MVP Mode, User Story, Walking Skeleton, Vertical Slice, Behavior-Adding Task, MVP+TDD Gate, SPIDR Splitting) to `CONTEXT.md` so the project's domain glossary is consistent with the shipped surface; adds `references/mvp-concepts.md` as a single index for the six MVP reference files (planner-mvp-mode, skeleton-template, user-story-template, spidr-splitting, execute-mvp-tdd, verify-mvp-mode); clarifies the `--mvp` + `--prd` interaction in the plan-phase Walking Skeleton block. No behavior change.

--- a/.changeset/mvp-concept-cleanup-canary-prep.md
+++ b/.changeset/mvp-concept-cleanup-canary-prep.md
@@ -1,5 +1,5 @@
 ---
 type: Changed
-pr: 0
+pr: 3176
 ---
 **MVP umbrella concept cleanup for v1.50.0-canary.2** — adds the seven MVP-related domain terms (MVP Mode, User Story, Walking Skeleton, Vertical Slice, Behavior-Adding Task, MVP+TDD Gate, SPIDR Splitting) to `CONTEXT.md` so the project's domain glossary is consistent with the shipped surface; adds `references/mvp-concepts.md` as a single index for the six MVP reference files (planner-mvp-mode, skeleton-template, user-story-template, spidr-splitting, execute-mvp-tdd, verify-mvp-mode); clarifies the `--mvp` + `--prd` interaction in the plan-phase Walking Skeleton block. No behavior change.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -40,6 +40,27 @@ Module owning command resolution, policy projection (`mutation`, `output_mode`),
 ### Query Pre-Project Config Policy Module
 Module policy that defines query-time behavior when `.planning/config.json` is absent: use built-in defaults for parity-sensitive query Interfaces, and emit parity-aligned empty model ids for pre-project model resolution surfaces.
 
+### MVP Mode
+Phase-level planning mode that frames work as a vertical slice (UI → API → DB) of one user-visible capability instead of horizontal layers. Resolved at workflow init via the precedence chain: `--mvp` CLI flag → ROADMAP.md `**Mode:** mvp` field → `workflow.mvp_mode` config → false. All-or-nothing per phase (PRD #2826 Q1). Surfaced as `MVP_MODE=true|false` to the planner, executor, verifier, and discovery surfaces (progress, stats, graphify). Canonical parser: `roadmap.cjs` `**Mode:**` field; canonical resolution chain documented in `workflows/plan-phase.md`. Concept index: `references/mvp-concepts.md`.
+
+### User Story
+Phase-goal format under MVP Mode: `As a [role], I want to [capability], so that [outcome].` Required regex shape: `/^As a .+, I want to .+, so that .+\.$/`. Used as the framing input by `gsd-planner` (emits as bolded `## Phase Goal` header in PLAN.md) and as the verification target by `gsd-verifier` (the `[outcome]` clause is the goal-backward verification anchor). Authored interactively by `/gsd-mvp-phase`, validated by SPIDR Splitting when too large.
+
+### Walking Skeleton
+Phase 1 deliverable under `--mvp` on a new project: the thinnest end-to-end stack proving every layer (framework, DB, routing, deployment) works together. Emitted as `SKELETON.md` capturing the architectural decisions subsequent vertical slices inherit. Gate fires when `phase_number == "01"` AND `prior_summaries == 0` AND `MVP_MODE=true`. Scope intentionally narrow (PRD #2826 Q2) — does not retrofit existing projects.
+
+### Vertical Slice
+Single-feature task that moves one user capability from open-to-close (happy path) end-to-end. Contrast with the horizontal layer (all models, then all APIs, then all UI). The MVP Mode planning unit; SPIDR Splitting axes (Spike, Paths, Interfaces, Data, Rules) are the canonical decomposition tools when a slice is too large for one phase.
+
+### Behavior-Adding Task
+Predicate over a PLAN.md task: `tdd="true"` frontmatter AND `<behavior>` block names a user-visible outcome AND `<files>` includes at least one non-`*.md` / non-`*.json` / non-`*.test.*` source file. Pure doc/config/test-only tasks are exempt. The MVP+TDD Gate (in `references/execute-mvp-tdd.md`) only halts execution on this predicate; the gsd-executor agent applies all three checks at runtime. Currently a prose-only specification — no shared utility.
+
+### MVP+TDD Gate
+Per-task runtime gate in `/gsd-execute-phase` that, when both `MVP_MODE` and `TDD_MODE` are true, refuses to advance a Behavior-Adding Task until a failing-test commit (`test({phase}-{plan})`) exists for it. The `tdd_review_checkpoint` end-of-phase review escalates from advisory to blocking under the same condition. Documented contract: `references/execute-mvp-tdd.md`. Reserved escape hatch `--force-mvp-gate` is documented but not implemented.
+
+### SPIDR Splitting
+Five-axis story decomposition discipline (**S**pike, **P**aths, **I**nterfaces, **D**ata, **R**ules) used by `/gsd-mvp-phase` when a User Story is too large for one phase. Full interactive flow per PRD #2826 Q3 (not a lightweight filter). Reference: `get-shit-done/references/spidr-splitting.md`.
+
 ---
 
 ## Recurring PR mistakes (distilled from CodeRabbit reviews, 2026-05-05)

--- a/docs/INVENTORY-MANIFEST.json
+++ b/docs/INVENTORY-MANIFEST.json
@@ -218,6 +218,7 @@
       "mandatory-initial-read.md",
       "model-profile-resolution.md",
       "model-profiles.md",
+      "mvp-concepts.md",
       "phase-argument-parsing.md",
       "planner-antipatterns.md",
       "planner-chunked.md",

--- a/docs/INVENTORY.md
+++ b/docs/INVENTORY.md
@@ -261,7 +261,7 @@ Full roster at `get-shit-done/workflows/*.md`. Workflows are thin orchestrators 
 
 ---
 
-## References (58 shipped)
+## References (59 shipped)
 
 Full roster at `get-shit-done/references/*.md`. References are shared knowledge documents that workflows and agents `@-reference`. The groupings below match [`docs/ARCHITECTURE.md`](ARCHITECTURE.md#references-get-shit-donereferencesmd) — core, workflow, thinking-model clusters, and the modular planner decomposition.
 
@@ -354,7 +354,7 @@ The `gsd-planner` agent is decomposed into a core agent plus reference modules t
 | `user-story-template.md` | User story format for MVP planning — "As a / I want to / So that" structured fields. |
 | `spidr-splitting.md` | SPIDR splitting decomposition rules for handling large user stories in MVP mode. |
 
-> **Subdirectory:** `get-shit-done/references/few-shot-examples/` contains additional few-shot examples (`plan-checker.md`, `verifier.md`) that are referenced from specific agents. These are not counted in the 58 top-level references.
+> **Subdirectory:** `get-shit-done/references/few-shot-examples/` contains additional few-shot examples (`plan-checker.md`, `verifier.md`) that are referenced from specific agents. These are not counted in the 59 top-level references.
 
 ---
 

--- a/get-shit-done/references/mvp-concepts.md
+++ b/get-shit-done/references/mvp-concepts.md
@@ -1,0 +1,49 @@
+# MVP Concepts — index
+
+Cross-reference for the six MVP-related reference files. Each file has a single, narrow purpose. This index exists so future readers (and agents resolving `@`-refs) can find the right file without grepping the directory.
+
+Canonical domain terms for the concepts named below live in [CONTEXT.md](../../CONTEXT.md) under "Domain terms" — start there if you need a precise definition.
+
+## File map
+
+| File | Purpose | Loaded by |
+|---|---|---|
+| `references/planner-mvp-mode.md` | **Rules.** Vertical-slice planning rules, slice ordering, Walking Skeleton constraints. | `gsd-planner` agent when `MVP_MODE=true` |
+| `references/skeleton-template.md` | **Template.** Shape of `SKELETON.md` for new-project Phase 1 under `--mvp`. | `gsd-planner` agent when the Walking Skeleton gate fires |
+| `references/user-story-template.md` | **Template.** Format and slot definitions for `As a / I want to / So that`. | `gsd-mvp-phase` workflow during interactive prompting; `gsd-planner` when emitting the `## Phase Goal` header |
+| `references/spidr-splitting.md` | **Splitting discipline.** Five-axis decomposition (Spike, Paths, Interfaces, Data, Rules) for stories too large for one phase. | `gsd-mvp-phase` workflow when the user story exceeds size threshold |
+| `references/execute-mvp-tdd.md` | **Gate.** MVP+TDD runtime gate semantics: when it fires, what it checks, halt-and-report protocol, end-of-phase blocking escalation, Behavior-Adding Task definition. | `gsd-executor` agent when `MVP_MODE=true && TDD_MODE=true` |
+| `references/verify-mvp-mode.md` | **UAT framing.** Three-section UAT structure (user-flow → technical → coverage), anti-patterns, `User Flow Coverage` section in VERIFICATION.md. | `gsd-verifier` agent when the phase under verification has `mode: mvp` |
+
+## Concept-to-file map
+
+If you're looking for the canonical statement of a concept, this is where to find it:
+
+- **MVP Mode resolution chain** — `workflows/plan-phase.md` Step 1 (CLI flag → roadmap → config → false). Mirrored in `execute-phase.md` and `verify-work.md`.
+- **`**Mode:** mvp` parser** — `get-shit-done/bin/lib/roadmap.cjs` (`searchPhaseInContent` + `cmdRoadmapAnalyze`). Workflows compare against the parser output, never re-parse.
+- **User Story regex** — `/^As a .+, I want to .+, so that .+\.$/` — applied at runtime by `gsd-verifier` (the user-story-format guard) and `gsd-mvp-phase` (interactive validation).
+- **Behavior-Adding Task predicate** — `references/execute-mvp-tdd.md` (the canonical three-check definition). Applied at runtime by `gsd-executor`.
+- **Walking Skeleton gate condition** — `workflows/plan-phase.md` (Phase 1 + new project + `--mvp` + no prior summaries → emit `SKELETON.md`).
+- **MVP+TDD Gate** (RED→GREEN enforcement) — `references/execute-mvp-tdd.md`.
+- **MVP-mode UAT framing** (user-flow first, technical deferred) — `references/verify-mvp-mode.md`.
+- **Per-phase mode authoring** — `workflows/mvp-phase.md` (writes `**Mode:** mvp` to ROADMAP.md after collecting the user story).
+- **Project-wide mode prompt at init** — `workflows/new-project.md` (Vertical MVP vs Horizontal Layers question).
+
+## Interactions worth knowing
+
+- **`--mvp` and `--prd <file>` together on Phase 1.** Both paths converge at the planner spawn. The PRD express path creates `CONTEXT.md` from the PRD file and continues to the research step; the Walking Skeleton gate fires independently when Phase 1 + new project + `--mvp`. The planner therefore receives both `WALKING_SKELETON=true` and PRD-derived context. This is intentional: the PRD informs what the skeleton should prove.
+- **`MVP_MODE` is all-or-nothing per phase, not per task.** A phase is either MVP-mode or standard. Mixed-mode phases are not supported (PRD #2826 Q1).
+- **`TDD_MODE` is independent of `MVP_MODE`.** TDD can be on without MVP, MVP can be on without TDD. Only the *intersection* (both true) activates the MVP+TDD Gate.
+- **The `gsd-roadmapper` agent makes the MVP/standard decision once at project init** based on `PROJECT_MODE`. Per-phase opt-in/out happens later via `/gsd-mvp-phase` or `/gsd-edit-phase`.
+
+## Tests
+
+Structural contract tests for each integration site live under `tests/`:
+
+- `plan-phase-mvp-flag.test.cjs` — plan-phase MVP_MODE resolution chain
+- `planner-mvp-mode.test.cjs` — gsd-planner agent MVP section
+- `mvp-phase-command.test.cjs`, `mvp-phase-integration.test.cjs`, `mvp-phase-spidr.test.cjs` — `/gsd-mvp-phase`
+- `execute-mvp-tdd-gate.test.cjs`, `executor-mvp-tdd-section.test.cjs` — MVP+TDD Gate
+- `verifier-mvp-section.test.cjs`, `verify-mvp-uat.test.cjs` — verifier UAT framing
+- `new-project-mvp-prompt.test.cjs` — mode prompt at init
+- `progress-mvp-display.test.cjs`, `stats-mvp-display.test.cjs`, `graphify-mvp-viz.test.cjs` — discovery surfaces

--- a/get-shit-done/workflows/plan-phase.md
+++ b/get-shit-done/workflows/plan-phase.md
@@ -105,6 +105,8 @@ When `WALKING_SKELETON=true`:
 - Planner is instructed to produce `SKELETON.md` in the phase directory alongside `PLAN.md`. The template lives at `@~/.claude/get-shit-done/references/skeleton-template.md`.
 - The plan must scaffold project + routing + one real DB read/write + one real UI interaction + dev deployment — the thinnest possible end-to-end working slice.
 
+**Interaction with `--prd <filepath>`.** `--mvp` and `--prd` compose. The PRD express path (Step 3.5) creates `CONTEXT.md` from the PRD file and continues to research; the Walking Skeleton gate fires independently from the conditions above. When both are active on Phase 1 of a new project, the planner receives `WALKING_SKELETON=true` and PRD-derived context simultaneously — the PRD informs *what the skeleton should prove*. No precedence is needed; the two signals are orthogonal. See [`references/mvp-concepts.md`](../references/mvp-concepts.md) for the broader interaction map.
+
 Extract `--prd <filepath>` from $ARGUMENTS. If present, set PRD_FILE to the filepath.
 
 **If no phase number:** Detect next unplanned phase from roadmap.


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #3175

The linked issue carries the `approved-enhancement` label.

---

## What this enhancement improves

Concept-surface cleanup for the MVP umbrella feature (#2826) ahead of `v1.50.0-canary.2`. Three docs gaps surfaced by `/improve-codebase-architecture` against the freshly-merged dev (`12c4e565`):

1. `CONTEXT.md` had zero MVP domain terms.
2. The six MVP reference files had no index.
3. `plan-phase.md` Walking Skeleton block didn't document `--mvp` + `--prd` composition.

## Before / After

**Before:** MVP concepts (MVP Mode, Walking Skeleton, User Story, Vertical Slice, Behavior-Adding Task, MVP+TDD Gate, SPIDR Splitting) live only in their respective reference files; no canonical glossary; no concept-to-file map. Anyone landing on the codebase has to grep six files to find where a concept is defined.

**After:** Seven new entries in `CONTEXT.md` give canonical definitions. New `references/mvp-concepts.md` indexes the six MVP reference files (purpose + loaded-by per file) and maps each concept to its canonical statement location. Plan-phase Walking Skeleton block documents `--mvp` + `--prd` orthogonality.

## How it was implemented

- `CONTEXT.md` — appended 7 domain term entries to the "Domain terms" section, between `Query Pre-Project Config Policy Module` and the `---` divider. Wording matches the canonical statements in the corresponding reference files.
- `get-shit-done/references/mvp-concepts.md` — new file. File map (table), concept-to-file map (bullets), interaction notes (composability with `--prd`, all-or-nothing per phase, TDD independence, gsd-roadmapper init flow), test list.
- `get-shit-done/workflows/plan-phase.md` — added three-sentence note inside the existing Walking Skeleton block, just before the `--prd` parser. Cross-links to `references/mvp-concepts.md`.
- `docs/INVENTORY.md` + `docs/INVENTORY-MANIFEST.json` — refreshed references count (58 → 59).

## Testing

### How I verified the enhancement works

Docs-only change. Verified by:
- Re-reading the new `CONTEXT.md` entries against the corresponding reference files for accuracy.
- Confirming each `concept-to-file` map entry resolves to an actual canonical statement at the cited location.
- `node scripts/gen-inventory-manifest.cjs --write` to regenerate the manifest from the filesystem.

### Platforms tested

- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

---

## Checklist

- [x] Issue linked above with `Closes #NNN`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass — N/A, docs-only change with no test impact
- [x] New or updated tests cover the enhanced behavior — N/A, docs-only
- [x] `.changeset/` fragment added (`mvp-concept-cleanup-canary-prep.md`, type `Changed`)
- [x] Documentation updated if behavior or output changed — this PR *is* the docs update
- [x] No unnecessary dependencies added

## Breaking changes

None. Documentation addition only.

---

## Surfaced for follow-up (NOT in this PR)

The `/improve-codebase-architecture` review against `12c4e565` also surfaced three structural items that should be filed as separate enhancement issues — not landed before canary:

1. **MVP_MODE resolution shell block duplicated across `plan-phase.md`, `execute-phase.md`, `verify-work.md`.** Same precedence-chain bash repeats in 3 workflow files. Extracting needs a shared workflow-include mechanism the project doesn't have today; structural change with broader implications.
2. **Behavior-Adding Task predicate is prose-only** (`references/execute-mvp-tdd.md`). The three-check definition (tdd=true + `<behavior>` block + non-test source files) is implemented inline in the gsd-executor agent at runtime; no shared utility. Centralizing requires changing how agents consume utilities.
3. **User Story regex hardcoded in `verify-work.md`** (`/^As a .+, I want to .+, so that .+\.$/`). Same pattern is also applied by `/gsd-mvp-phase` interactive validation; one canonical definition would prevent future drift.

Each of these is a real depth opportunity but is bigger than canary-prep scope.

## Targeting `dev`

This PR targets `dev`, not `main`, as part of v1.50.0-canary.2 prep. `dev` is the canary publish stream per project release-stream policy (#2828).
