### PR TITLE
docs(canary.2): user-facing MVP feature docs + canary.2 release notes

### DIFF
--- a/.changeset/canary-2-mvp-feature-docs.md
+++ b/.changeset/canary-2-mvp-feature-docs.md
@@ -1,0 +1,5 @@
+---
+type: Changed
+pr: 0
+---
+**First end-to-end user-facing docs for the MVP umbrella feature** — `docs/USER-GUIDE.md` gains an "MVP Mode" walkthrough section (when to pick it, 5-row diff table vs standard mode, worked example with the same webhook-validator scenario as the standard walkthrough, "how to confirm MVP mode is on" recipe, configuration knobs, links to all reference docs); `docs/COMMANDS.md` gains a full `### /gsd-mvp-phase` entry, the `--mvp` flag row on `/gsd-plan-phase`, and the Vertical MVP / Horizontal Layers mode prompt on `/gsd-new-project`; `docs/CLI-TOOLS.md` gains a "MVP Commands" section documenting the three new query verbs (`phase.mvp-mode`, `task.is-behavior-adding`, `user-story.validate`) with input forms, return shapes, per-field tables. New `docs/RELEASE-v1.50.0-canary.2.md` cross-links into all of the above as the canary release notes. Closes the docs gap between canary.1 (feature shipped) and canary.2 (feature documented).

--- a/.changeset/canary-2-mvp-feature-docs.md
+++ b/.changeset/canary-2-mvp-feature-docs.md
@@ -1,5 +1,5 @@
 ---
 type: Changed
-pr: 0
+pr: 3180
 ---
 **First end-to-end user-facing docs for the MVP umbrella feature** — `docs/USER-GUIDE.md` gains an "MVP Mode" walkthrough section (when to pick it, 5-row diff table vs standard mode, worked example with the same webhook-validator scenario as the standard walkthrough, "how to confirm MVP mode is on" recipe, configuration knobs, links to all reference docs); `docs/COMMANDS.md` gains a full `### /gsd-mvp-phase` entry, the `--mvp` flag row on `/gsd-plan-phase`, and the Vertical MVP / Horizontal Layers mode prompt on `/gsd-new-project`; `docs/CLI-TOOLS.md` gains a "MVP Commands" section documenting the three new query verbs (`phase.mvp-mode`, `task.is-behavior-adding`, `user-story.validate`) with input forms, return shapes, per-field tables. New `docs/RELEASE-v1.50.0-canary.2.md` cross-links into all of the above as the canary release notes. Closes the docs gap between canary.1 (feature shipped) and canary.2 (feature documented).

--- a/docs/CLI-TOOLS.md
+++ b/docs/CLI-TOOLS.md
@@ -180,6 +180,119 @@ node gsd-tools.cjs roadmap analyze
 node gsd-tools.cjs roadmap update-plan-progress <N>
 ```
 
+> **Mode field (v1.50.0+).** `roadmap get-phase` returns a `mode` field extracted from `**Mode:**` (e.g. `"mvp"`). Lowercased + trimmed; unrecognized values preserved verbatim for forward-compat. The companion `gsd-sdk query phase.mvp-mode <N>` ([MVP Commands](#mvp-commands)) wraps this with the full precedence chain.
+
+---
+
+## MVP Commands
+
+SDK-only verbs that centralize MVP-mode resolution and validation. Three small focused queries; consumed by `/gsd-plan-phase`, `/gsd-execute-phase`, `/gsd-verify-work`, `/gsd-progress`, `/gsd-mvp-phase` and the gsd-executor and gsd-verifier agents. No `gsd-tools.cjs` mirror — these are native SDK handlers (registered in `NO_CJS_SUBPROCESS_REASON`).
+
+### `phase.mvp-mode`
+
+Resolve whether MVP mode applies to a phase. Single canonical seam — workflows call this verb instead of inlining the precedence chain.
+
+**Precedence (first hit wins):**
+1. `--cli-flag` arg (caller asserts the user passed `--mvp` on the CLI)
+2. ROADMAP.md `**Mode:** mvp` for the phase
+3. `workflow.mvp_mode` config (project-wide default)
+4. `false`
+
+```bash
+# Roadmap + config check (no CLI override)
+gsd-sdk query phase.mvp-mode 1
+
+# Caller saw --mvp on CLI — flag wins
+gsd-sdk query phase.mvp-mode 1 --cli-flag
+
+# Pluck just the boolean for shell composition
+MVP_MODE=$(gsd-sdk query phase.mvp-mode 1 --pick active)
+```
+
+**Returns** (`{ data: ... }`):
+```json
+{
+  "active": true,
+  "source": "roadmap",
+  "roadmap_mode": "mvp",
+  "config_mvp_mode": false,
+  "cli_flag_present": false
+}
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `active` | boolean | True when MVP mode applies. |
+| `source` | `cli_flag` \| `roadmap` \| `config` \| `none` | Which signal in the chain decided. |
+| `roadmap_mode` | string \| null | Literal value from `**Mode:**` (lowercased), or null when absent. |
+| `config_mvp_mode` | boolean | The `workflow.mvp_mode` config value at resolution time. |
+| `cli_flag_present` | boolean | True when `--cli-flag` was passed. |
+
+### `task.is-behavior-adding`
+
+Predicate: does this PLAN.md task add user-visible behavior under the MVP+TDD Gate? Three checks, all required: (1) `tdd="true"` frontmatter, (2) non-empty `<behavior>` block, (3) `<files>` includes at least one non-test source file (excludes `*.md`, `*.json`, `*.test.*`, `*.spec.*`). Pure doc-only / config-only / test-only tasks return `false` and are exempt from the gate.
+
+```bash
+# From a plan file on disk
+gsd-sdk query task.is-behavior-adding ./plans/01-PLAN-auth.md
+
+# From an inline XML snippet
+gsd-sdk query task.is-behavior-adding --task-content '<task tdd="true"><behavior>User can log in</behavior><files>src/auth.ts</files></task>'
+```
+
+**Returns:**
+```json
+{
+  "is_behavior_adding": true,
+  "checks": {
+    "tdd_true": true,
+    "has_behavior_block": true,
+    "has_source_files": true
+  },
+  "reason": null
+}
+```
+
+When `is_behavior_adding` is `false`, `reason` is a human-readable diagnostic listing which of the three checks failed — used by the executor's halt-and-report message. Canonical specification: [`get-shit-done/references/execute-mvp-tdd.md`](../get-shit-done/references/execute-mvp-tdd.md).
+
+### `user-story.validate`
+
+Validate that a string matches the canonical User Story format used by MVP-mode phases. Owns the regex `/^As a .+, I want to .+, so that .+\.$/`. Consumed by `gsd-verifier` (phase-goal guard) and `/gsd-mvp-phase` (interactive-prompt validation) — single source of truth so the validator the user sees during `/gsd-mvp-phase` matches the validator the verifier applies later.
+
+```bash
+# Positional form
+gsd-sdk query user-story.validate "As a user, I want to log in, so that I see my data."
+
+# Flag form (when the story might contain shell metacharacters)
+gsd-sdk query user-story.validate --story "As a user, I want to log in, so that I see my data."
+```
+
+**Returns when valid:**
+```json
+{
+  "valid": true,
+  "input": "As a user, I want to log in, so that I see my data.",
+  "slots": {
+    "role": "user",
+    "capability": "log in",
+    "outcome": "I see my data"
+  },
+  "errors": []
+}
+```
+
+**Returns when invalid** (e.g. missing the terminal period):
+```json
+{
+  "valid": false,
+  "input": "As a user, I want to log in, so that I see my data",
+  "slots": null,
+  "errors": ["Must end with a period."]
+}
+```
+
+The `errors[]` array contains specific guidance per missing element (`Must begin with "As a "`, `Must contain ", I want to "`, `Must contain ", so that "`, `Must end with a period.`) so callers can surface targeted re-prompts.
+
 ---
 
 ## Config Commands

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -44,8 +44,10 @@ Initialize a new project with deep context gathering.
 **Prerequisites:** No existing `.planning/PROJECT.md`
 **Produces:** `PROJECT.md`, `REQUIREMENTS.md`, `ROADMAP.md`, `STATE.md`, `config.json`, `research/`, `CLAUDE.md`
 
+**Project mode prompt (v1.50.0+).** During the interactive flow, GSD asks whether the project follows the **Vertical MVP** discipline (each phase delivers an end-to-end user capability — recommended for new products) or **Horizontal Layers** (build complete technical layers, assemble at the end — better for infrastructure-heavy projects). Picking Vertical MVP writes `**Mode:** mvp` on every initial roadmap phase, which downstream commands (`/gsd-plan-phase`, `/gsd-execute-phase`, `/gsd-verify-work`, `/gsd-progress`, `/gsd-stats`, `/gsd-graphify`) detect automatically. See [docs/USER-GUIDE.md → MVP Mode](USER-GUIDE.md#mvp-mode) for the full walkthrough.
+
 ```bash
-/gsd-new-project                    # Interactive mode
+/gsd-new-project                    # Interactive mode (includes mode prompt)
 /gsd-new-project --auto @prd.md     # Auto-extract from PRD
 ```
 
@@ -153,9 +155,10 @@ Research, plan, and verify a phase.
 | `--validate` | Run state validation before planning begins |
 | `--bounce` | Run external plan bounce validation after planning (uses `workflow.plan_bounce_script`) |
 | `--skip-bounce` | Skip plan bounce even if enabled in config |
+| `--mvp` | Plan as a vertical MVP slice (UI → API → DB per task) instead of horizontal layers. Resolution chain: this flag → ROADMAP `**Mode:** mvp` → `workflow.mvp_mode` config → false. On Phase 1 of a new project, also triggers the **Walking Skeleton** gate — produces `SKELETON.md` capturing the thinnest end-to-end stack. See [`/gsd-mvp-phase`](#gsd-mvp-phase) for the guided entry point. |
 
 **Prerequisites:** `.planning/ROADMAP.md` exists
-**Produces:** `{phase}-RESEARCH.md`, `{phase}-{N}-PLAN.md`, `{phase}-VALIDATION.md`
+**Produces:** `{phase}-RESEARCH.md`, `{phase}-{N}-PLAN.md`, `{phase}-VALIDATION.md`. Under `--mvp` on a new-project Phase 1, also produces `SKELETON.md`.
 
 **Research-only mode (`--research-phase <N>`):**
 - No modifier: prompts `update / view / skip` if RESEARCH.md already exists.
@@ -171,7 +174,45 @@ Research, plan, and verify a phase.
 /gsd-plan-phase --research-phase 4             # Research only on phase 4 (prompts if RESEARCH.md exists)
 /gsd-plan-phase --research-phase 4 --view      # Print existing RESEARCH.md, no spawn
 /gsd-plan-phase --research-phase 4 --research  # Force-refresh research, no prompt
+/gsd-plan-phase 1 --mvp                        # Vertical-slice plan; on new-project Phase 1, emits SKELETON.md
 ```
+
+---
+
+### `/gsd-mvp-phase`
+
+Plan a phase as a vertical MVP slice — three structured user-story prompts → SPIDR splitting check → ROADMAP mutation → delegates to `/gsd-plan-phase` with MVP mode active.
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `N` | **Yes** | Phase number to convert to MVP mode (integer or decimal like `2.1`). Phase must already exist in ROADMAP.md. |
+
+| Flag | Description |
+|------|-------------|
+| `--force` | Override the status guard. Required when the target phase is `in_progress` or `completed` — converting an active phase to MVP mode invalidates existing plans/summaries. |
+
+**What it does:**
+1. **User-story prompts** — three sequential `AskUserQuestion` calls capture an `As a [role] / I want to [capability] / So that [outcome]` story. Validated by `gsd-sdk query user-story.validate` (canonical regex `/^As a .+, I want to .+, so that .+\.$/`); empty fields are re-prompted.
+2. **SPIDR splitting check** — if the assembled story is too large (>120 chars, compound capabilities, multi-actor, or vague), walks the user through the **S**pike / **P**aths / **I**nterfaces / **D**ata / **R**ules axes and offers `/gsd-add-phase` invocations to split.
+3. **ROADMAP mutation** — writes `**Mode:** mvp` and replaces `**Goal:**` with the assembled user story.
+4. **Delegate to `/gsd-plan-phase <N>`** — the planner auto-detects MVP via the roadmap mode field (no `--mvp` flag needed at delegation time).
+
+**Prerequisites:** `.planning/ROADMAP.md` exists; phase `N` is present and not `in_progress`/`completed` (unless `--force`).
+**Produces:** ROADMAP.md edits (`**Mode:** mvp` + new `**Goal:**`), then everything `/gsd-plan-phase` produces.
+
+```bash
+/gsd-mvp-phase 1                  # Convert Phase 1 to MVP mode interactively
+/gsd-mvp-phase 2 --force          # Override status guard (use with care)
+```
+
+**Verifying MVP mode is active for a phase:**
+
+```bash
+gsd-sdk query phase.mvp-mode 1
+# → {"active": true, "source": "roadmap", "roadmap_mode": "mvp", ...}
+```
+
+See [docs/CLI-TOOLS.md → MVP Commands](CLI-TOOLS.md#mvp-commands) for the underlying query verbs and [docs/USER-GUIDE.md → MVP Mode](USER-GUIDE.md#mvp-mode) for the end-to-end walkthrough.
 
 ---
 

--- a/docs/RELEASE-v1.50.0-canary.2.md
+++ b/docs/RELEASE-v1.50.0-canary.2.md
@@ -1,0 +1,114 @@
+# v1.50.0-canary.2 Release Notes
+
+Second canary cut for the **1.50.0** train. Published to npm under the `canary` dist-tag.
+
+```bash
+npx get-shit-done-cc@canary
+# or pin exact:
+npm install -g get-shit-done-cc@1.50.0-canary.2
+```
+
+> **Canary stream caveat.** Canary builds come from the long-lived `dev` integration branch and may carry rough edges that the `next` (RC) and `latest` (stable) channels never see. Use canary when you want to exercise in-flight features early and report findings; do NOT pin production projects to it. See [CANARY.md](CANARY.md) for the stream policy and rollback path.
+
+---
+
+## Headline: MVP umbrella stabilization + first user-facing docs
+
+`canary.1` shipped the [Vertical MVP planning track](RELEASE-v1.50.0-canary.1.md) (umbrella PRD [#2826](https://github.com/gsd-build/get-shit-done/issues/2826)) — five phases of new code spanning planner, executor, verifier, and discovery surfaces. `canary.2` is the *stabilization* cut: bug fix for a silent SDK parity gap that was breaking the most common MVP activation path, three centralized query verbs that collapse architectural duplication, and the first end-to-end user-facing docs for the feature.
+
+### What's new since canary.1
+
+#### Bug fix: SDK roadmap mode-extraction parity gap ([#3178](https://github.com/gsd-build/get-shit-done/pull/3178))
+
+The SDK port of `roadmap.get-phase` silently omitted the `mode` field that the CJS implementation already extracted (`get-shit-done/bin/lib/roadmap.cjs:120-123`). On the native dispatch path, `gsd-sdk query roadmap.get-phase 1 --pick mode` returned `null` even when ROADMAP.md had `**Mode:** mvp` set — causing `MVP_MODE` to silently fall through to the config/false branch in every consuming workflow.
+
+In other words: the canonical authoring path established by `/gsd-mvp-phase` (write `**Mode:** mvp` to ROADMAP) did not actually activate MVP mode through the SDK. The feature only worked when users passed `--mvp` on the CLI or set `workflow.mvp_mode` in config.
+
+Fix in `sdk/src/query/roadmap.ts`: `searchPhaseInContent` now extracts the `mode` field, restoring CJS parity. Covered by regression tests; consumers of the unchanged response shape are unaffected (additive field).
+
+#### Three centralized MVP query verbs ([#3178](https://github.com/gsd-build/get-shit-done/pull/3178))
+
+The architecture review against the MVP umbrella surfaced three duplications. New verbs collapse them into single canonical seams. Full reference: [docs/CLI-TOOLS.md → MVP Commands](CLI-TOOLS.md#mvp-commands).
+
+- **`gsd-sdk query phase.mvp-mode <N> [--cli-flag]`** — single canonical precedence resolver (CLI flag → ROADMAP `**Mode:** mvp` → `workflow.mvp_mode` config → false). Replaces 4–8 lines of nearly-identical bash that was duplicated across `plan-phase.md`, `execute-phase.md`, `verify-work.md`, and `progress.md`. Returns `{active, source, roadmap_mode, config_mvp_mode, cli_flag_present}` so callers can both decide *and* diagnose.
+- **`gsd-sdk query task.is-behavior-adding <plan-file> | --task-content <xml>`** — Behavior-Adding Task predicate (tdd="true" + `<behavior>` block + non-test source files in `<files>`). Replaces the prose-only specification in `references/execute-mvp-tdd.md`; the gsd-executor agent now invokes the verb instead of re-inlining the three checks at runtime.
+- **`gsd-sdk query user-story.validate "<text>"`** — owns the canonical User Story regex `/^As a .+, I want to .+, so that .+\.$/`. Consumed by gsd-verifier (phase-goal guard) and `/gsd-mvp-phase` (interactive-prompt validation) — single source of truth, so the validator users see during interactive prompting matches what the verifier applies later.
+
+#### CONTEXT.md gains seven MVP domain terms ([#3176](https://github.com/gsd-build/get-shit-done/pull/3176))
+
+`CONTEXT.md` previously had eleven SDK/dispatch domain modules and zero MVP terms despite the umbrella having shipped in canary.1. Now adds canonical definitions for: **MVP Mode**, **User Story**, **Walking Skeleton**, **Vertical Slice**, **Behavior-Adding Task**, **MVP+TDD Gate**, **SPIDR Splitting**.
+
+New file [`get-shit-done/references/mvp-concepts.md`](../get-shit-done/references/mvp-concepts.md) indexes the six MVP reference files (planner-mvp-mode, skeleton-template, user-story-template, spidr-splitting, execute-mvp-tdd, verify-mvp-mode) with file map + concept-to-file map + interaction notes (how `--mvp` and `--prd` compose on Phase 1).
+
+#### First user-facing MVP docs (this PR)
+
+The canary.1 release shipped the feature with no entries in `USER-GUIDE.md`, `COMMANDS.md`, or `CLI-TOOLS.md`. canary.2 closes that gap so users testing the canary can actually find their way around:
+
+- **[USER-GUIDE.md → MVP Mode](USER-GUIDE.md#mvp-mode)** — when to pick MVP, how the loop differs from standard mode (5-row diff table), worked walkthrough using the same webhook-validator example as the standard walkthrough, "how to confirm MVP mode is actually on" recipe, configuration knobs, links to all reference docs.
+- **[COMMANDS.md → /gsd-mvp-phase](COMMANDS.md#gsd-mvp-phase)** — full command entry: arguments table, flags table (`--force`), four-step behavior breakdown, prerequisites, what it produces, examples.
+- **[COMMANDS.md → /gsd-plan-phase](COMMANDS.md#gsd-plan-phase)** — `--mvp` flag row added to the existing flags table; example added to the examples block.
+- **[COMMANDS.md → /gsd-new-project](COMMANDS.md#gsd-new-project)** — Vertical MVP / Horizontal Layers mode prompt documented inline.
+- **[CLI-TOOLS.md → MVP Commands](CLI-TOOLS.md#mvp-commands)** — full reference for the three new query verbs (input forms, return shapes, per-field tables).
+
+---
+
+## How to test the headline features
+
+If you're trialing canary.2 and want to exercise the MVP path end-to-end, the recommended sequence:
+
+```bash
+# 1. Install canary
+npx get-shit-done-cc@canary
+
+# 2. Bootstrap a fresh project — pick "Vertical MVP" at the mode prompt
+/gsd-new-project
+
+# 3. Frame Phase 1 as a user story
+/gsd-mvp-phase 1
+
+# 4. Confirm MVP mode is actually active
+gsd-sdk query phase.mvp-mode 1
+# expect: {"active": true, "source": "roadmap", ...}
+
+# 5. Plan, execute, verify — the planner now sees MVP mode automatically
+/gsd-plan-phase 1
+/gsd-execute-phase 1
+/gsd-verify-work 1
+```
+
+Walkthrough with expected output and what gets created at each step: **[USER-GUIDE.md → MVP Mode → MVP walkthrough (the diff vs. standard)](USER-GUIDE.md#mvp-walkthrough-the-diff-vs-standard)**.
+
+---
+
+## Bonus: dev synced with main
+
+The merge that prepared this canary brought in **50 main-stream commits** that had accumulated since canary.1 — including the recent SDK runtime bridge work, graphify staleness improvements, hotfix release flow, and the prerelease-editions install guidance. See `git log v1.50.0-canary.1..v1.50.0-canary.2 --first-parent` for the full integration list.
+
+---
+
+## Install / upgrade
+
+```bash
+# Try the canary
+npx get-shit-done-cc@canary
+
+# Or pin exact
+npm install -g get-shit-done-cc@1.50.0-canary.2
+```
+
+The installer's defensive purge will rewrite stale config blocks left by older GSD versions on first run. No manual cleanup needed.
+
+## Reporting issues
+
+If something breaks on canary, file against [the issue tracker](https://github.com/gsd-build/get-shit-done/issues) with the `bug` template and mention `1.50.0-canary.2` so it gets routed back into the dev stream rather than the stable stream.
+
+For MVP-mode-specific issues, please include the output of `gsd-sdk query phase.mvp-mode <N>` for the affected phase — the `source` field tells maintainers which signal in the precedence chain decided, which speeds triage.
+
+## What ships next in this train
+
+Pending dev-stream items that should land before promotion to `next`:
+- Implement the documented `--force-mvp-gate` escape hatch in the executor's argument parser (referenced in the user-facing error message but parser support is canary-bake from canary.1).
+- Tighten the few remaining workflow variables in the MVP+TDD gate snippet (`${PLAN_ID}`, `${TASK_TDD}` wiring — also canary-bake from canary.1).
+- Ride a few canary cycles for real-user MVP/TDD/UAT feedback now that the docs surface exists.
+
+When the dev stream stabilizes, the train promotes to `main` as `v1.50.0-rc.1` (the `next` channel).

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -286,6 +286,169 @@ For the full command reference with all flags, see [`docs/COMMANDS.md`](COMMANDS
 
 ---
 
+## MVP Mode
+
+GSD ships two project disciplines side by side:
+
+- **Horizontal Layers** (the default; what the [End-to-End Walkthrough](#end-to-end-walkthrough) above demonstrates) — each phase ships a complete technical layer (data, API, UI). Best for infrastructure-heavy projects with well-understood domains.
+- **Vertical MVP** (this section) — each phase ships an end-to-end *user capability*: UI → API → DB for one user story per phase. Best for new products and rapid-iteration MVPs where you want a usable end-to-end slice as early as possible.
+
+You pick once at project init. Per-phase mode is stored in ROADMAP.md as `**Mode:** mvp`, so individual phases can opt in or out later via `/gsd-mvp-phase` and `/gsd-edit-phase`.
+
+### When to pick MVP mode
+
+- You're starting a new product and want a usable end-to-end slice in Phase 1.
+- The biggest project risk is "do users actually want this?" — not "can we build the platform?"
+- You can articulate the first user capability as a one-sentence story: *"As a [role], I want to [capability], so that [outcome]."*
+
+If you can't articulate a user story, that's a signal — pick Horizontal Layers and revisit MVP mode once the requirements clarify.
+
+### How the loop differs from the standard walkthrough
+
+Same four-step loop (`new-project → plan-phase → execute-phase → verify-work → ship`), three differences:
+
+| Step | Standard mode | MVP mode |
+|---|---|---|
+| **`new-project`** | Asks about the project, generates roadmap. | **Also** prompts: *"Vertical MVP or Horizontal Layers?"* Picking Vertical MVP writes `**Mode:** mvp` on every initial phase. |
+| **Before `plan-phase`** | Skip directly to plan. | Run `/gsd-mvp-phase <N>` first to capture the user story interactively. SPIDR splitting kicks in if the story is too large. |
+| **Phase 1 of new project under MVP** | Plan ordinary tasks. | Planner emits `SKELETON.md` — the "Walking Skeleton": thinnest end-to-end stack proving framework + DB + routing + UI + deployment all wire together. |
+| **`execute-phase`** | Standard execution. | When `MVP_MODE` and `TDD_MODE` are both on, the MVP+TDD Gate refuses to advance any *behavior-adding* task without a failing-test commit first. |
+| **`verify-work`** | Technical checks first. | UAT script asks *"can a real user complete the feature?"* before any technical correctness checks. Halts if the phase goal isn't a valid User Story. |
+| **`progress` / `stats` / `graphify`** | Same output for every phase. | MVP-mode phases get a "User-flow next up" panel; stats includes an `MVP phases: N` line; graphify renders MVP nodes in a distinct color with `(MVP)` label suffix. |
+
+### MVP walkthrough (the diff vs. standard)
+
+This continues the same webhook-validator example from the standard walkthrough — see those steps for the parts that don't change.
+
+#### 1. Pick MVP at init
+
+```
+/gsd-new-project
+```
+
+```
+> What are you building?
+  A webhook signature validator middleware for Express apps.
+
+[...]
+
+> Choose project mode:
+  > Vertical MVP — each phase delivers an end-to-end user capability (recommended for new products)
+    Horizontal Layers — build complete technical layers, assemble at the end
+
+[Roadmap generated with `**Mode:** mvp` on every initial phase.]
+```
+
+#### 2. Frame the phase as a user story
+
+```
+/gsd-mvp-phase 1
+```
+
+```
+> As a [user role]?
+  Backend developer
+
+> I want to [capability]?
+  validate incoming webhook signatures
+
+> So that [outcome]?
+  malicious requests are rejected before reaching my handlers
+
+[ROADMAP.md updated:
+   **Mode:** mvp
+   **Goal:** As a backend developer, I want to validate incoming webhook signatures, so that malicious requests are rejected before reaching my handlers.]
+```
+
+If your story is compound ("validate signatures **and** rate-limit") or too long, GSD walks you through SPIDR splitting and offers `/gsd-add-phase` invocations to break the work into multiple phases. See [`references/spidr-splitting.md`](../get-shit-done/references/spidr-splitting.md).
+
+The command then auto-delegates to `/gsd-plan-phase 1` — the planner sees `**Mode:** mvp` in the roadmap and plans accordingly.
+
+#### 3. Plan produces a Walking Skeleton on Phase 1
+
+Because this is Phase 1 of a new project under MVP mode, the planner emits `SKELETON.md` alongside the usual `01-PLAN.md`:
+
+```
+.planning/phases/01-validate-signatures/
+  SKELETON.md         # Walking skeleton: Express app + crypto + one route + one test + dev deploy
+  01-01-PLAN.md       # First slice of the user story
+```
+
+`SKELETON.md` captures the architectural decisions subsequent slices inherit (which framework, which DB, which deploy target). Phase 2 onward references it instead of re-deriving.
+
+#### 4. Execute with the MVP+TDD Gate
+
+If you have `workflow.tdd_mode: true` in your config (or pass `--tdd`), the MVP+TDD Gate activates during execution. Before running any *behavior-adding* task, the executor checks for a failing-test commit (`test(<phase>-<plan>): …`) on the branch. If absent, execution halts with a structured report. Pure doc-only / config-only / test-only tasks are exempt.
+
+Verify a task is gated by the predicate directly:
+
+```bash
+gsd-sdk query task.is-behavior-adding ./.planning/phases/01-validate-signatures/01-01-PLAN.md
+# → {"is_behavior_adding": true, "checks": {...}, "reason": null}
+```
+
+#### 5. Verify with user-flow-first UAT
+
+```
+/gsd-verify-work 1
+```
+
+The UAT script under MVP mode asks user-action steps **before** technical checks:
+
+```
+1. Open a fresh terminal in your example app's directory.
+2. Send a request with a valid HMAC signature header.
+3. Observe a 200 response.
+4. Send the same request with an invalid signature.
+5. Observe a 401 response.
+
+[Technical checks deferred — they run only after the user flow passes.]
+```
+
+If the phase's `**Goal:**` isn't in valid User Story format, verification halts with a pointer to re-run `/gsd-mvp-phase` to repair the goal.
+
+### How to confirm MVP mode is actually on
+
+The most common confusion: "I set `**Mode:** mvp` in ROADMAP.md but the planner ran in standard mode." The new query verb resolves this in one call:
+
+```bash
+gsd-sdk query phase.mvp-mode 1
+```
+
+```json
+{
+  "active": true,
+  "source": "roadmap",
+  "roadmap_mode": "mvp",
+  "config_mvp_mode": false,
+  "cli_flag_present": false
+}
+```
+
+- `active: true` means MVP mode applies to this phase.
+- `source` tells you *why* — `roadmap` (from ROADMAP.md), `cli_flag` (you passed `--mvp`), `config` (from `workflow.mvp_mode`), or `none` (not active).
+- If `active: false` and you expected `true`, check `roadmap_mode` (was the field actually parsed?) and `config_mvp_mode` (is the project default off?).
+
+### Configuration knobs
+
+| Config key | Default | Effect |
+|---|---|---|
+| `workflow.mvp_mode` | `false` | Project-wide default for MVP mode. Lowest precedence — overridden by ROADMAP `**Mode:** mvp` and by the `--mvp` CLI flag. |
+| `workflow.tdd_mode` | `false` | Enables the TDD gate. Combine with `MVP_MODE=true` to activate the MVP+TDD Gate during execution. |
+
+### Reference docs
+
+- [`references/planner-mvp-mode.md`](../get-shit-done/references/planner-mvp-mode.md) — vertical-slice planning rules.
+- [`references/skeleton-template.md`](../get-shit-done/references/skeleton-template.md) — Walking Skeleton template.
+- [`references/user-story-template.md`](../get-shit-done/references/user-story-template.md) — User Story format and slot definitions.
+- [`references/spidr-splitting.md`](../get-shit-done/references/spidr-splitting.md) — five-axis splitting discipline.
+- [`references/execute-mvp-tdd.md`](../get-shit-done/references/execute-mvp-tdd.md) — MVP+TDD Gate semantics.
+- [`references/verify-mvp-mode.md`](../get-shit-done/references/verify-mvp-mode.md) — UAT framing under MVP mode.
+- [`references/mvp-concepts.md`](../get-shit-done/references/mvp-concepts.md) — concept-to-file index for the six MVP references above.
+- [`docs/CLI-TOOLS.md → MVP Commands`](CLI-TOOLS.md#mvp-commands) — `phase.mvp-mode`, `task.is-behavior-adding`, `user-story.validate` query verb reference.
+
+---
+
 ## Workflow Diagrams
 
 ### Full Project Lifecycle


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #3179

The linked issue carries the `approved-enhancement` label.

---

## What this enhancement improves

User-facing documentation for the MVP umbrella feature (#2826) shipped in v1.50.0-canary.1 with no entries in `USER-GUIDE.md`, `COMMANDS.md`, or `CLI-TOOLS.md`. Plus first-time docs for the three new SDK query verbs from #3178. Plus a canary.2 release notes file mirroring canary.1's structure.

## Before / After

**Before:** `grep -ci -E "mvp|vertical slice|walking skeleton|mvp-phase" docs/USER-GUIDE.md docs/COMMANDS.md docs/FEATURES.md README.md` returns `0 0 0 0`. CHANGELOG entries are the only place users see MVP mentions, and CHANGELOGs aren't where users go to learn how to use a feature.

**After:**
- [USER-GUIDE.md → MVP Mode](docs/USER-GUIDE.md#mvp-mode) — focused walkthrough section with 5-row diff table vs standard mode, worked example, "how to confirm MVP is on" recipe, configuration knobs.
- [COMMANDS.md → /gsd-mvp-phase](docs/COMMANDS.md#gsd-mvp-phase) — full per-command entry matching the existing pattern (args/flags table, behavior breakdown, examples).
- COMMANDS.md → `/gsd-plan-phase` flags table — `--mvp` flag row added + new example.
- COMMANDS.md → `/gsd-new-project` — Vertical MVP / Horizontal Layers mode prompt documented.
- [CLI-TOOLS.md → MVP Commands](docs/CLI-TOOLS.md#mvp-commands) — full reference for `phase.mvp-mode`, `task.is-behavior-adding`, `user-story.validate` (input forms, return shapes, per-field tables).
- New [docs/RELEASE-v1.50.0-canary.2.md](docs/RELEASE-v1.50.0-canary.2.md) — release notes for canary.2 with cross-links into all four doc additions and a "how to test the headline features" copy-paste recipe.

## How it was implemented

- USER-GUIDE.md: diff-style "this works like the standard walkthrough, here are the 3 differences" instead of a parallel walkthrough — keeps in sync as the standard walkthrough evolves and avoids ~240 lines of duplicated content. Same webhook-validator scenario as the standard walkthrough so readers can compare side by side.
- COMMANDS.md: `/gsd-mvp-phase` placed directly after `/gsd-plan-phase` (commands that produce PLAN.md cluster together; matches the user mental model of "plan a phase as MVP"). `--mvp` flag added to the existing `/gsd-plan-phase` table rather than a new section, since it's a flag on an existing command.
- CLI-TOOLS.md: new "MVP Commands" section after Roadmap Commands. Three small focused verbs documented individually — input forms, return shapes, per-field tables, and the canonical-source rationale (each verb owns one cross-cutting concern).
- canary.2 release notes follow canary.1's structure exactly — Headline section → "What's new since canary.1" → "How to test the headline features" → "Bonus" → "Install / upgrade" → "Reporting issues" → "What ships next".

## Testing

### How I verified the enhancement works

Docs-only change. Verified by:
- Reading each new section against the canonical source files (CONTEXT.md domain terms, command frontmatter, query verb implementations, reference files).
- Verifying every cross-link anchor resolves (`#mvp-mode`, `#gsd-mvp-phase`, `#mvp-commands`, `#gsd-plan-phase`, `#gsd-new-project`).
- Confirming every example command and `gsd-sdk query` invocation matches the actual CLI surface.

### Platforms tested

- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

---

## Checklist

- [x] Issue linked above with `Closes #NNN`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass — N/A, docs-only change with no test impact
- [x] New or updated tests cover the enhanced behavior — N/A, docs-only
- [x] `.changeset/` fragment added (`canary-2-mvp-feature-docs.md`, type `Changed`)
- [x] Documentation updated if behavior or output changed — this PR *is* the docs update
- [x] No unnecessary dependencies added

## Breaking changes

None. Documentation addition only.

## Targeting `dev`

This PR targets `dev`, not `main`, as part of v1.50.0-canary.2 prep. `dev` is the canary publish stream per project release-stream policy (#2828). Stacks on top of #3176 (concept cleanup) and #3178 (three new query verbs + SDK roadmap mode-extraction fix). Recommended merge order: #3176 → #3178 → this PR → cut canary.2.

## Surfaced for follow-up (NOT in this PR)

- The README.md storyline doesn't mention MVP mode at all. Whether MVP belongs in the README "What is GSD?" elevator pitch or only in the deeper docs is a positioning call — flagging for a separate decision.
- `docs/FEATURES.md` (the feature catalog) doesn't have an MVP entry. Adding one would be a separate PR; the FEATURES catalog has its own structural conventions and shouldn't be edited piecemeal alongside command/walkthrough docs.
