### PR TITLE
fix(artifacts): register RETROSPECTIVE.md as canonical planning artifact

### DIFF
--- a/.changeset/3198-retrospective-canonical.md
+++ b/.changeset/3198-retrospective-canonical.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 3198
+pr: 3200
 ---
 `gsd-health` no longer raises W019 for `RETROSPECTIVE.md` — the file is now registered in `CANONICAL_EXACT` in `artifacts.cjs`, matching its established status as a living artifact produced by `/gsd-complete-milestone`.

--- a/.changeset/3198-retrospective-canonical.md
+++ b/.changeset/3198-retrospective-canonical.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3198
+---
+`gsd-health` no longer raises W019 for `RETROSPECTIVE.md` — the file is now registered in `CANONICAL_EXACT` in `artifacts.cjs`, matching its established status as a living artifact produced by `/gsd-complete-milestone`.

--- a/get-shit-done/bin/lib/artifacts.cjs
+++ b/get-shit-done/bin/lib/artifacts.cjs
@@ -22,6 +22,7 @@ const CANONICAL_EXACT = new Set([
   'THREADS.md',
   'config.json',
   'CLAUDE.md',
+  'RETROSPECTIVE.md',
 ]);
 
 // Pattern-match canonical file names (regex tests on the basename)

--- a/get-shit-done/templates/README.md
+++ b/get-shit-done/templates/README.md
@@ -22,6 +22,7 @@ These files live directly at `.planning/` — not inside phase subdirectories.
 | `THREADS.md` | *(inline)* | `/gsd-thread` | Persistent discussion threads |
 | `config.json` | `config.json` | `/gsd-new-project`, `/gsd-health --repair` | Project-specific GSD configuration |
 | `CLAUDE.md` | `claude-md.md` | `/gsd-profile` | Auto-assembled Claude Code context file |
+| `RETROSPECTIVE.md` | *(inline)* | `/gsd-complete-milestone` | Living milestone retrospective updated at each milestone close |
 
 ### Version-stamped artifacts (pattern: `vX.Y-*.md`)
 

--- a/tests/enh-2448-artifact-registry.test.cjs
+++ b/tests/enh-2448-artifact-registry.test.cjs
@@ -47,6 +47,10 @@ describe('artifacts.cjs — isCanonicalPlanningFile', () => {
     assert.ok(isCanonicalPlanningFile('v2.3.1-MILESTONE-AUDIT.md'));
   });
 
+  test('returns true for RETROSPECTIVE.md (produced by /gsd-complete-milestone)', () => {
+    assert.strictEqual(isCanonicalPlanningFile('RETROSPECTIVE.md'), true);
+  });
+
   test('returns false for clearly non-canonical names', () => {
     assert.strictEqual(isCanonicalPlanningFile('MY-NOTES.md'), false);
     assert.strictEqual(isCanonicalPlanningFile('scratch.md'), false);


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

Fixes #3198

---

## What was broken

`gsd-health` raised W019 ("Unrecognized .planning/ file: RETROSPECTIVE.md") after any `/gsd-complete-milestone` run, even though that workflow itself creates and manages `RETROSPECTIVE.md`.

## What this fix does

Adds `'RETROSPECTIVE.md'` to `CANONICAL_EXACT` in `get-shit-done/bin/lib/artifacts.cjs` so `isCanonicalPlanningFile('RETROSPECTIVE.md')` returns `true` and W019 is never emitted for this file.

## Root cause

`RETROSPECTIVE.md` was established as a living canonical artifact in PR #644 but was never added to the W019 registry introduced in PR #2488. Clean omission at registry creation time.

## Testing

### How I verified the fix

```
node -e "const { isCanonicalPlanningFile } = require('./get-shit-done/bin/lib/artifacts.cjs'); console.log(isCanonicalPlanningFile('RETROSPECTIVE.md'));"
# true
```

All 11 tests in `tests/enh-2448-artifact-registry.test.cjs` pass, including the new regression test.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved linting warnings for the milestone retrospective by registering it as a canonical planning artifact.

* **Documentation**
  * Updated the canonical planning artifact registry to include the milestone retrospective template.

* **Tests**
  * Added test coverage to verify the retrospective is recognized as a canonical planning artifact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->