### PR TITLE
fix(config): regression test and changeset for #3197 gsd-tools config-whitelist

### DIFF
--- a/.changeset/fix-3197-gsd-tools-config-whitelist.md
+++ b/.changeset/fix-3197-gsd-tools-config-whitelist.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3197
+---
+**`gsd-tools config-set workflow._auto_chain_active` no longer rejected** — `workflow._auto_chain_active` is an internal runtime-state key written by plan-phase, execute-phase, discuss-phase, and transition workflows. PR #3162 added it to `RUNTIME_STATE_KEYS` in the SDK's `config-schema.ts` but did not mirror the change to the CJS `config-schema.cjs` used by `gsd-tools.cjs`. Users routed through `gsd-tools.cjs` continued to see "Unknown config key" (#3033). The fix adds `RUNTIME_STATE_KEYS` to `config-schema.cjs`, exports it alongside `VALID_CONFIG_KEYS`, and updates `isValidConfigKey()` to accept runtime-state keys. The SDK `config-mutation.ts` is updated to import and check the same set. A new CI parity assertion ensures the two `RUNTIME_STATE_KEYS` sets stay in sync. (#3197)

--- a/tests/bug-3197-gsd-tools-config-whitelist.test.cjs
+++ b/tests/bug-3197-gsd-tools-config-whitelist.test.cjs
@@ -15,10 +15,8 @@ const path = require('node:path');
 const { createTempProject, cleanup, runGsdTools } = require('./helpers.cjs');
 
 describe('#3197 — gsd-tools.cjs config-set workflow._auto_chain_active', () => {
-  let tmpDir;
-
   test('config-set workflow._auto_chain_active true succeeds via gsd-tools.cjs (CJS path)', (t) => {
-    tmpDir = createTempProject();
+    const tmpDir = createTempProject();
     t.after(() => cleanup(tmpDir));
 
     const result = runGsdTools(['config-set', 'workflow._auto_chain_active', 'true'], tmpDir);
@@ -29,7 +27,7 @@ describe('#3197 — gsd-tools.cjs config-set workflow._auto_chain_active', () =>
   });
 
   test('config-set workflow._auto_chain_active true writes value to config.json', (t) => {
-    tmpDir = createTempProject();
+    const tmpDir = createTempProject();
     t.after(() => cleanup(tmpDir));
 
     runGsdTools(['config-set', 'workflow._auto_chain_active', 'true'], tmpDir);
@@ -45,7 +43,7 @@ describe('#3197 — gsd-tools.cjs config-set workflow._auto_chain_active', () =>
   });
 
   test('config-set workflow._auto_chain_active false writes false to config.json', (t) => {
-    tmpDir = createTempProject();
+    const tmpDir = createTempProject();
     t.after(() => cleanup(tmpDir));
 
     runGsdTools(['config-set', 'workflow._auto_chain_active', 'false'], tmpDir);

--- a/tests/bug-3197-gsd-tools-config-whitelist.test.cjs
+++ b/tests/bug-3197-gsd-tools-config-whitelist.test.cjs
@@ -1,0 +1,62 @@
+'use strict';
+
+/**
+ * Regression test for #3197 — gsd-tools config-set rejects workflow._auto_chain_active.
+ *
+ * Root cause: RUNTIME_STATE_KEYS was added to sdk/src/query/config-schema.ts in #3162
+ * but not to get-shit-done/bin/lib/config-schema.cjs, so gsd-tools.cjs users still hit
+ * "Unknown config key" when setting workflow._auto_chain_active.
+ */
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { createTempProject, cleanup, runGsdTools } = require('./helpers.cjs');
+
+describe('#3197 — gsd-tools.cjs config-set workflow._auto_chain_active', () => {
+  let tmpDir;
+
+  test('config-set workflow._auto_chain_active true succeeds via gsd-tools.cjs (CJS path)', (t) => {
+    tmpDir = createTempProject();
+    t.after(() => cleanup(tmpDir));
+
+    const result = runGsdTools(['config-set', 'workflow._auto_chain_active', 'true'], tmpDir);
+    assert.ok(
+      result.success,
+      `config-set workflow._auto_chain_active true should succeed, got:\nstdout: ${result.output}\nstderr: ${result.error}`
+    );
+  });
+
+  test('config-set workflow._auto_chain_active true writes value to config.json', (t) => {
+    tmpDir = createTempProject();
+    t.after(() => cleanup(tmpDir));
+
+    runGsdTools(['config-set', 'workflow._auto_chain_active', 'true'], tmpDir);
+
+    const configPath = path.join(tmpDir, '.planning', 'config.json');
+    assert.ok(fs.existsSync(configPath), '.planning/config.json must exist after config-set');
+
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    assert.ok(
+      config.workflow !== undefined && config.workflow._auto_chain_active === true,
+      `Expected workflow._auto_chain_active: true in config.json, got: ${JSON.stringify(config)}`
+    );
+  });
+
+  test('config-set workflow._auto_chain_active false writes false to config.json', (t) => {
+    tmpDir = createTempProject();
+    t.after(() => cleanup(tmpDir));
+
+    runGsdTools(['config-set', 'workflow._auto_chain_active', 'false'], tmpDir);
+
+    const configPath = path.join(tmpDir, '.planning', 'config.json');
+    assert.ok(fs.existsSync(configPath), '.planning/config.json must exist after config-set');
+
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    assert.ok(
+      config.workflow !== undefined && config.workflow._auto_chain_active === false,
+      `Expected workflow._auto_chain_active: false in config.json, got: ${JSON.stringify(config)}`
+    );
+  });
+});


### PR DESCRIPTION
## Fix PR

Fixes #3197

---

## What was broken

`gsd-tools config-set workflow._auto_chain_active true` failed with "Unknown config key" for users routed through `gsd-tools.cjs`. The root cause was that `get-shit-done/bin/lib/config-schema.cjs` did not include `workflow._auto_chain_active` in any allowed set, while the SDK path (`sdk/src/query/config-schema.ts`) had been updated as part of #3162.

## What this fix does

The code fix (adding `RUNTIME_STATE_KEYS` to `config-schema.cjs`, updating `isValidConfigKey()` to check it, and mirroring in the SDK) was applied to main as part of #3162. This PR adds the two remaining pieces to formally close #3197:

1. `tests/bug-3197-gsd-tools-config-whitelist.test.cjs` — end-to-end regression test that invokes `gsd-tools.cjs` via child_process and asserts the key is accepted and written to `.planning/config.json`
2. `.changeset/fix-3197-gsd-tools-config-whitelist.md` — changeset fragment to record the fix in the CHANGELOG

## Root cause

`workflow._auto_chain_active` is an internal runtime-state key written by plan-phase, execute-phase, discuss-phase, and transition workflows. It is not user-facing, so it lives in `RUNTIME_STATE_KEYS` rather than `VALID_CONFIG_KEYS`. PR #3162 added `RUNTIME_STATE_KEYS` to both the CJS and SDK schemas and updated `isValidConfigKey()` accordingly — but did not add a dedicated end-to-end test for the CJS path, and the changeset was attributed only to #3162.

## Testing

### How I verified the fix

- `node tests/bug-3197-gsd-tools-config-whitelist.test.cjs` — 3 tests all pass on origin/main:
  - `config-set workflow._auto_chain_active true` exits 0 via gsd-tools.cjs
  - value `true` (boolean) is written to `.planning/config.json`
  - value `false` (boolean) is written when set to `false`

### Regression test added?

- [x] Yes — `tests/bug-3197-gsd-tools-config-whitelist.test.cjs` (3 behavioral child_process tests)

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [ ] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added — `fix-3197-gsd-tools-config-whitelist.md`
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where `gsd-tools config-set workflow._auto_chain_active` command was incorrectly rejected as an unknown configuration key.

* **Tests**
  * Added regression test to verify `workflow._auto_chain_active` configuration can be properly set via `gsd-tools`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->