### PR TITLE
feat(security): package legitimacy gate against slopsquatting

### DIFF
--- a/.changeset/graceful-otters-wave.md
+++ b/.changeset/graceful-otters-wave.md
@@ -1,5 +1,5 @@
 ---
 type: Security
-pr: 3209
+pr: 3215
 ---
 **Package legitimacy gate added** — GSD now runs slopcheck against every researcher-recommended package before it enters RESEARCH.md; slopsquatted ([SLOP]) packages are removed at the source and suspicious ([SUS]) or assumed ([ASSUMED]) packages force a `checkpoint:human-verify` task before the executor installs them. The `npx --yes` auto-download pattern is replaced with a `command -v` guard across all three agent files, and executor RULE 3 explicitly excludes package-manager installs from auto-fix scope.

--- a/.changeset/graceful-otters-wave.md
+++ b/.changeset/graceful-otters-wave.md
@@ -1,0 +1,5 @@
+---
+type: Security
+pr: 3209
+---
+**Package legitimacy gate added** — GSD now runs slopcheck against every researcher-recommended package before it enters RESEARCH.md; slopsquatted ([SLOP]) packages are removed at the source and suspicious ([SUS]) or assumed ([ASSUMED]) packages force a `checkpoint:human-verify` task before the executor installs them. The `npx --yes` auto-download pattern is replaced with a `command -v` guard across all three agent files, and executor RULE 3 explicitly excludes package-manager installs from auto-fix scope.

--- a/agents/gsd-executor.md
+++ b/agents/gsd-executor.md
@@ -186,7 +186,7 @@ Running `npm install <pkg>`, `pip install <pkg>`, `cargo add <pkg>`, or any equi
 This exclusion exists because a failed install may indicate a slopsquatted or hallucinated package name. Auto-substituting an alternative could install something more dangerous. If a package install fails, emit:
 
 ```xml
-<task type="checkpoint:human-verify" gate="blocking">
+<task type="checkpoint:human-verify" gate="blocking-human">
   <what-built>Package install failed — human verification required</what-built>
   <how-to-verify>
     `[package-name]` could not be installed. Before proceeding:
@@ -197,6 +197,8 @@ This exclusion exists because a failed install may indicate a slopsquatted or ha
   <resume-signal>Type "verified" with the correct package name, or "abort" to stop the phase</resume-signal>
 </task>
 ```
+
+Use `gate="blocking-human"` for package-legitimacy checkpoints so they are unambiguously excluded from auto-approval behavior.
 
 ---
 
@@ -293,7 +295,7 @@ For full automation-first patterns, server lifecycle, CLI handling:
 
 **Auto-mode checkpoint behavior** (when `AUTO_CFG` is `"true"`):
 
-- **checkpoint:human-verify** → Auto-approve. Log `⚡ Auto-approved: [what-built]`. Continue to next task.
+- **checkpoint:human-verify** → Auto-approve **except package-legitimacy checkpoints**. If checkpoint has `gate="blocking-human"` OR its purpose indicates package legitimacy verification (`what-built` mentions `Package verification required before install` or `Package install failed — human verification required`), do **not** auto-approve. STOP and return checkpoint_return_format for explicit human confirmation.
 - **checkpoint:decision** → Auto-select first option (planners front-load the recommended choice). Log `⚡ Auto-selected: [option name]`. Continue to next task.
 - **checkpoint:human-action** → STOP normally. Auth gates cannot be automated — return structured checkpoint message using checkpoint_return_format.
 

--- a/agents/gsd-executor.md
+++ b/agents/gsd-executor.md
@@ -33,19 +33,26 @@ When you need library or framework documentation, check in this order:
 
    Step 1 — Resolve library ID:
    ```bash
-   npx --yes ctx7@latest library <name> "<query>"
+   if command -v ctx7 &>/dev/null; then
+     ctx7 library <name> "<query>"
+   else
+     echo "ctx7 not found — install with: npm install -g ctx7 (verify at npmjs.com/package/ctx7 first)"
+   fi
    ```
-   Example: `npx --yes ctx7@latest library react "useEffect hook"`
 
    Step 2 — Fetch documentation:
    ```bash
-   npx --yes ctx7@latest docs <libraryId> "<query>"
+   if command -v ctx7 &>/dev/null; then
+     ctx7 docs <libraryId> "<query>"
+   else
+     echo "ctx7 not found — install with: npm install -g ctx7 (verify at npmjs.com/package/ctx7 first)"
+   fi
    ```
-   Example: `npx --yes ctx7@latest docs /facebook/react "useEffect hook"`
 
 Do not skip documentation lookups because MCP tools are unavailable — the CLI fallback
 works via Bash and produces equivalent output. Do not rely on training knowledge alone
-for library APIs where version-specific behavior matters.
+for library APIs where version-specific behavior matters. Do NOT use `npx --yes` to
+auto-download ctx7 — this silently executes unverified packages from the registry.
 </documentation_lookup>
 
 <project_context>
@@ -168,7 +175,28 @@ No user permission needed for Rules 1-3.
 
 **Trigger:** Something prevents completing current task
 
-**Examples:** Missing dependency, wrong types, broken imports, missing env var, DB connection error, build config error, missing referenced file, circular dependency
+**Examples:** Wrong types, broken imports, missing env var, DB connection error, build config error, missing referenced file, circular dependency
+
+**EXCLUDED from RULE 3 — package manager installs:**
+Running `npm install <pkg>`, `pip install <pkg>`, `cargo add <pkg>`, or any equivalent package-manager install command is **NOT** auto-fixable. If a referenced package fails to install or cannot be found:
+1. Do NOT attempt to install a similarly-named alternative.
+2. Do NOT retry with a different package name.
+3. Return a `checkpoint:human-verify` task — the user must verify the package is legitimate before the executor proceeds.
+
+This exclusion exists because a failed install may indicate a slopsquatted or hallucinated package name. Auto-substituting an alternative could install something more dangerous. If a package install fails, emit:
+
+```xml
+<task type="checkpoint:human-verify" gate="blocking">
+  <what-built>Package install failed — human verification required</what-built>
+  <how-to-verify>
+    `[package-name]` could not be installed. Before proceeding:
+    1. Verify the package exists and is legitimate: https://npmjs.com/package/[package-name]
+    2. Confirm the package name is spelled correctly in PLAN.md
+    3. If the package does not exist, return to /gsd-research-phase to find the correct package
+  </how-to-verify>
+  <resume-signal>Type "verified" with the correct package name, or "abort" to stop the phase</resume-signal>
+</task>
+```
 
 ---
 

--- a/agents/gsd-phase-researcher.md
+++ b/agents/gsd-phase-researcher.md
@@ -26,9 +26,11 @@ Spawned by `/gsd-plan-phase` (integrated) or `/gsd-research-phase` (standalone).
 - Return structured result to orchestrator
 
 **Claim provenance:** Every factual claim in RESEARCH.md must be tagged with its source:
-- `[VERIFIED: npm registry]` — confirmed via tool (npm view, web search, codebase grep)
+- `[VERIFIED: npm registry]` — confirmed via tool (npm view, web search, codebase grep) AND discovered from an authoritative source (official docs, Context7)
 - `[CITED: docs.example.com/page]` — referenced from official documentation
 - `[ASSUMED]` — based on training knowledge, not verified in this session
+
+**Package name provenance rule:** A package name discovered via WebSearch, training data, or any non-authoritative source must be tagged `[ASSUMED]` regardless of whether `npm view` confirms it exists on the registry. Registry existence alone does not confer `[VERIFIED]` status — a slopsquatted package also passes `npm view`. Only packages confirmed via official documentation or Context7 AND passing slopcheck verification may be tagged `[VERIFIED: npm registry]`.
 
 Claims tagged `[ASSUMED]` signal to the planner and discuss-phase that the information needs user confirmation before becoming a locked decision. Never present assumed knowledge as verified fact — especially for compliance requirements, retention policies, security standards, or performance targets where multiple valid approaches exist.
 </role>
@@ -45,15 +47,24 @@ When you need library or framework documentation, check in this order:
 
    Step 1 — Resolve library ID:
    ```bash
-   npx --yes ctx7@latest library <name> "<query>"
+   if command -v ctx7 &>/dev/null; then
+     ctx7 library <name> "<query>"
+   else
+     echo "ctx7 not found — install with: npm install -g ctx7 (verify at npmjs.com/package/ctx7 first)"
+   fi
    ```
    Step 2 — Fetch documentation:
    ```bash
-   npx --yes ctx7@latest docs <libraryId> "<query>"
+   if command -v ctx7 &>/dev/null; then
+     ctx7 docs <libraryId> "<query>"
+   else
+     echo "ctx7 not found — install with: npm install -g ctx7 (verify at npmjs.com/package/ctx7 first)"
+   fi
    ```
 
 Do not skip documentation lookups because MCP tools are unavailable — the CLI fallback
-works via Bash and produces equivalent output.
+works via Bash and produces equivalent output. Do NOT use `npx --yes` to auto-download
+ctx7 — this silently executes unverified packages from the registry.
 </documentation_lookup>
 
 <project_context>
@@ -251,6 +262,65 @@ Priority: Context7 > Exa (verified) > Firecrawl (official docs) > Official GitHu
 
 </verification_protocol>
 
+<package_legitimacy_protocol>
+
+## Package Legitimacy Gate
+
+Every phase that installs external packages **must** run the following verification before
+emitting the `## Package Legitimacy Audit` section in RESEARCH.md.
+
+### Step 1 — Install slopcheck (best-effort)
+
+```bash
+pip install slopcheck --break-system-packages 2>/dev/null || pip install slopcheck 2>/dev/null || true
+```
+
+### Step 2 — Run legitimacy check
+
+```bash
+if command -v slopcheck &>/dev/null; then
+  slopcheck install <pkg1> <pkg2> ... --json
+else
+  echo "slopcheck not available — marking all packages [ASSUMED]"
+fi
+```
+
+**Interpreting results:**
+- `[SLOP]` — hallucinated or dangerously new package. **Remove entirely** from all RESEARCH.md recommendations. List in audit table under `Disposition: REMOVED`.
+- `[SUS]` — suspicious (new, low-downloads, or no source repo). **Keep** but tag inline: `` `pkg-name` [WARNING: slopcheck flagged as suspicious — verify before using.] ``
+- `[OK]` — clean. Proceed normally.
+
+**Graceful degradation:** If slopcheck cannot be installed or cannot run, mark **every** recommended package `[ASSUMED]` (not `[VERIFIED]`). The planner will gate each one behind a `checkpoint:human-verify` task before install. This is strictly safer than the current baseline — never a hard failure.
+
+### Step 3 — Ecosystem-specific registry verification
+
+Run the appropriate command for the phase's primary language:
+
+```bash
+# Node.js / JavaScript phases
+npm view <pkg> version
+
+# Python phases
+pip index versions <pkg>
+
+# Rust phases
+cargo search <pkg>
+```
+
+Cross-ecosystem confusion (a Python package name that exists on npm but not PyPI) is a
+documented hallucination vector (~9% rate). Always verify on the correct ecosystem registry.
+
+### Step 4 — Check for suspicious postinstall scripts (Node.js phases)
+
+```bash
+npm view <pkg> scripts.postinstall 2>/dev/null
+```
+
+A `postinstall` script that references network calls or filesystem paths outside the project
+directory is a high-risk signal. Flag such packages `[SUS]` even if slopcheck rates them `[OK]`.
+
+</package_legitimacy_protocol>
+
 <output_format>
 
 ## RESEARCH.md Structure
@@ -298,11 +368,28 @@ Priority: Context7 > Exa (verified) > Firecrawl (official docs) > Official GitHu
 npm install [packages]
 \`\`\`
 
-**Version verification:** Before writing the Standard Stack table, verify each recommended package version is current:
+**Version verification:** Before writing the Standard Stack table, verify each recommended package exists and is current using the ecosystem-appropriate command:
 \`\`\`bash
-npm view [package] version
+npm view [package] version          # Node.js phases
+pip index versions [package]        # Python phases
+cargo search [package]              # Rust phases
 \`\`\`
-Document the verified version and publish date. Training data versions may be months stale — always confirm against the registry.
+Document the verified version and publish date. Training data versions may be months stale — always confirm against the correct ecosystem registry.
+
+## Package Legitimacy Audit
+
+> **Required** whenever this phase installs external packages. Run the Package Legitimacy Gate protocol before completing this section.
+
+| Package | Registry | Age | Downloads | Source Repo | slopcheck | Disposition |
+|---------|----------|-----|-----------|-------------|-----------|-------------|
+| [name] | npm/PyPI/crates | [e.g., 8 yrs] | [e.g., 50M/wk] | [github.com/org/repo or "none"] | [OK] | Approved |
+| [name] | npm | [e.g., 3 days] | [e.g., 0] | none | [SLOP] | REMOVED |
+| [name] | npm | [e.g., 2 mo] | [e.g., 800/wk] | [github.com/…] | [SUS] | Flagged — planner must add checkpoint |
+
+**Packages removed due to slopcheck [SLOP] verdict:** [list, or "none"]
+**Packages flagged as suspicious [SUS]:** [list — planner inserts checkpoint:human-verify before each install]
+
+*If slopcheck was unavailable at research time, all packages above are tagged `[ASSUMED]` and the planner must gate each install behind a `checkpoint:human-verify` task.*
 
 ## Architecture Patterns
 

--- a/agents/gsd-planner.md
+++ b/agents/gsd-planner.md
@@ -35,7 +35,7 @@ Your job: Produce PLAN.md files that Claude executors can implement without inte
 </role>
 
 <documentation_lookup>
-For library docs: use Context7 MCP (`mcp__context7__*`) if available; otherwise use the Bash CLI fallback (`npx --yes ctx7@latest library <name> "<query>"` then `npx --yes ctx7@latest docs <libraryId> "<query>"`). The CLI fallback works via Bash when MCP is unavailable.
+For library docs: use Context7 MCP (`mcp__context7__*`) if available; otherwise use the Bash CLI fallback (check `command -v ctx7` first; if installed run `ctx7 library <name> "<query>"` then `ctx7 docs <libraryId> "<query>"`). Do NOT use `npx --yes ctx7@latest` — this silently auto-executes unverified packages. If ctx7 is not installed locally, instruct the user to install it manually by verifying it at npmjs.com/package/ctx7 first.
 </documentation_lookup>
 
 <project_context>
@@ -480,6 +480,7 @@ Output: [Artifacts created]
 |-----------|----------|-----------|-------------|-----------------|
 | T-{phase}-01 | {S/T/R/I/D/E} | {function/endpoint/file} | mitigate | {specific: e.g., "validate input with zod at route entry"} |
 | T-{phase}-02 | {category} | {component} | accept | {rationale: e.g., "no PII, low-value target"} |
+| T-{phase}-SC | Tampering | npm install / pip install / cargo add | mitigate | slopcheck pre-research gate; checkpoint:human-verify before [ASSUMED]/[SUS] installs; executor RULE 3 excludes package installs from auto-fix |
 </threat_model>
 
 <verification>
@@ -614,6 +615,31 @@ Only include what Claude literally cannot do.
 Read ROADMAP.md `**Requirements:**` line for this phase. Strip brackets if present (e.g., `[AUTH-01, AUTH-02]` → `AUTH-01, AUTH-02`). Distribute requirement IDs across plans — each plan's `requirements` frontmatter field MUST list the IDs its tasks address. **CRITICAL:** Every requirement ID MUST appear in at least one plan. Plans with an empty `requirements` field are invalid.
 
 **Security (when `security_enforcement` enabled — absent = enabled):** Identify trust boundaries in this phase's scope. Map STRIDE categories to applicable tech stack from RESEARCH.md security domain. For each threat: assign disposition (mitigate if ASVS L1 requires it, accept if low risk, transfer if third-party). Every plan MUST include `<threat_model>` when security_enforcement is enabled.
+
+**Package legitimacy gate (required when plan installs external packages):**
+Read the `## Package Legitimacy Audit` table in RESEARCH.md before creating any install tasks.
+
+- Any package tagged `[ASSUMED]` or slopcheck-flagged `[SUS]` **must** be preceded by a `checkpoint:human-verify` task immediately before its install task:
+
+```xml
+<task type="checkpoint:human-verify" gate="blocking">
+  <what-built>Package verification required before install</what-built>
+  <how-to-verify>
+    Verify these packages are legitimate before the executor installs them:
+    - `[package-name]` — [ASSUMED from training data / SUS: slopcheck flag reason]
+      Check: https://npmjs.com/package/[package-name]  (or pypi.org/project/[name] / crates.io/crates/[name])
+      Look for: publication age > 6 months, downloads > 10k/week, linked source repository
+  </how-to-verify>
+  <resume-signal>Type "verified" once you have confirmed all packages above are legitimate</resume-signal>
+</task>
+```
+
+- Packages with `[SLOP]` verdict must not appear anywhere in the plan — they were removed from RESEARCH.md by the researcher.
+- For any plan with install tasks, add the following supply-chain row to `<threat_model>`:
+
+```
+| T-{phase}-SC | Tampering | npm install / pip install / cargo add | mitigate | slopcheck pre-research gate; checkpoint:human-verify before [ASSUMED]/[SUS] installs; executor RULE 3 excludes package installs from auto-fix |
+```
 
 **Step 1: State the Goal**
 Take phase goal from ROADMAP.md. Must be outcome-shaped, not task-shaped.

--- a/agents/gsd-planner.md
+++ b/agents/gsd-planner.md
@@ -35,7 +35,7 @@ Your job: Produce PLAN.md files that Claude executors can implement without inte
 </role>
 
 <documentation_lookup>
-For library docs: use Context7 MCP (`mcp__context7__*`) if available; otherwise use the Bash CLI fallback (check `command -v ctx7` first; if installed run `ctx7 library <name> "<query>"` then `ctx7 docs <libraryId> "<query>"`). Do NOT use `npx --yes ctx7@latest` — this silently auto-executes unverified packages. If ctx7 is not installed locally, instruct the user to install it manually by verifying it at npmjs.com/package/ctx7 first.
+For library docs: prefer Context7 MCP. If unavailable, use `command -v ctx7` then `ctx7 library <name> "<query>"` and `ctx7 docs <libraryId> "<query>"`. Never use `npx --yes ctx7@latest`.
 </documentation_lookup>
 
 <project_context>
@@ -480,7 +480,7 @@ Output: [Artifacts created]
 |-----------|----------|-----------|-------------|-----------------|
 | T-{phase}-01 | {S/T/R/I/D/E} | {function/endpoint/file} | mitigate | {specific: e.g., "validate input with zod at route entry"} |
 | T-{phase}-02 | {category} | {component} | accept | {rationale: e.g., "no PII, low-value target"} |
-| T-{phase}-SC | Tampering | npm install / pip install / cargo add | mitigate | slopcheck pre-research gate; checkpoint:human-verify before [ASSUMED]/[SUS] installs; executor RULE 3 excludes package installs from auto-fix |
+| T-{phase}-SC | Tampering | npm/pip/cargo installs | mitigate | slopcheck + blocking human checkpoint for [ASSUMED]/[SUS] |
 </threat_model>
 
 <verification>
@@ -616,31 +616,13 @@ Read ROADMAP.md `**Requirements:**` line for this phase. Strip brackets if prese
 
 **Security (when `security_enforcement` enabled — absent = enabled):** Identify trust boundaries in this phase's scope. Map STRIDE categories to applicable tech stack from RESEARCH.md security domain. For each threat: assign disposition (mitigate if ASVS L1 requires it, accept if low risk, transfer if third-party). Every plan MUST include `<threat_model>` when security_enforcement is enabled.
 
-**Package legitimacy gate (required when plan installs external packages):**
-Read the `## Package Legitimacy Audit` table in RESEARCH.md before creating any install tasks.
-
-- Any package tagged `[ASSUMED]` or slopcheck-flagged `[SUS]` **must** be preceded by a `checkpoint:human-verify` task immediately before its install task:
-
-```xml
-<task type="checkpoint:human-verify" gate="blocking-human">
-  <what-built>Package verification required before install</what-built>
-  <how-to-verify>
-    Verify these packages are legitimate before the executor installs them:
-    - `[package-name]` — [ASSUMED from training data / SUS: slopcheck flag reason]
-      Check: https://npmjs.com/package/[package-name]  (or pypi.org/project/[name] / crates.io/crates/[name])
-      Look for: publication age > 6 months, downloads > 10k/week, linked source repository
-  </how-to-verify>
-  <resume-signal>Type "verified" once you have confirmed all packages above are legitimate</resume-signal>
-</task>
-```
-
-- Packages with `[SLOP]` verdict must not appear anywhere in the plan — they were removed from RESEARCH.md by the researcher.
-- Package-legitimacy checkpoints are **never** auto-approvable; they require explicit human verification even when `workflow.auto_advance=true`.
-- For any plan with install tasks, add the following supply-chain row to `<threat_model>`:
-
-```text
-| T-{phase}-SC | Tampering | npm install / pip install / cargo add | mitigate | slopcheck pre-research gate; checkpoint:human-verify before [ASSUMED]/[SUS] installs; executor RULE 3 excludes package installs from auto-fix |
-```
+**Package legitimacy gate (npm/pip/cargo only):**
+- Require RESEARCH.md `## Package Legitimacy Audit` before package-manager install tasks.
+- If install tasks exist and the table is missing/malformed, stop planning:
+  `Package installs detected but audit table not found — researcher must run Package Legitimacy Gate protocol`
+  Fallback policy: treat all packages as `[ASSUMED]`.
+- For each `[ASSUMED]`/`[SUS]` package, insert `<task type="checkpoint:human-verify" gate="blocking-human">` before install and verify via `npmjs.com/package`, `pypi.org/project`, or `crates.io/crates`.
+- `[SLOP]` packages are forbidden; legitimacy checkpoints are never auto-approvable (`workflow.auto_advance` ignored). Keep `T-{phase}-SC` in `<threat_model>`.
 
 **Step 1: State the Goal**
 Take phase goal from ROADMAP.md. Must be outcome-shaped, not task-shaped.
@@ -682,11 +664,6 @@ Message list component wiring:
 **Step 5: Identify Key Links**
 "Where is this most likely to break?" Key links = critical connections where breakage causes cascading failures.
 
-For chat interface:
-- Input onSubmit -> API call (if broken: typing works but sending doesn't)
-- API save -> database (if broken: appears to send but doesn't persist)
-- Component -> real data (if broken: shows placeholder, not messages)
-
 ## Must-Haves Output Format
 
 ```yaml
@@ -715,20 +692,6 @@ must_haves:
       via: "database query"
       pattern: "prisma\\.message\\.(find|create)"
 ```
-
-## Common Failures
-
-**Truths too vague:**
-- Bad: "User can use chat"
-- Good: "User can see messages", "User can send message", "Messages persist"
-
-**Artifacts too abstract:**
-- Bad: "Chat system", "Auth module"
-- Good: "src/components/Chat.tsx", "src/app/api/auth/login/route.ts"
-
-**Missing wiring:**
-- Bad: Listing components without how they connect
-- Good: "Chat.tsx fetches from /api/chat via useEffect on mount"
 
 </goal_backward>
 

--- a/agents/gsd-planner.md
+++ b/agents/gsd-planner.md
@@ -622,7 +622,7 @@ Read the `## Package Legitimacy Audit` table in RESEARCH.md before creating any 
 - Any package tagged `[ASSUMED]` or slopcheck-flagged `[SUS]` **must** be preceded by a `checkpoint:human-verify` task immediately before its install task:
 
 ```xml
-<task type="checkpoint:human-verify" gate="blocking">
+<task type="checkpoint:human-verify" gate="blocking-human">
   <what-built>Package verification required before install</what-built>
   <how-to-verify>
     Verify these packages are legitimate before the executor installs them:
@@ -635,9 +635,10 @@ Read the `## Package Legitimacy Audit` table in RESEARCH.md before creating any 
 ```
 
 - Packages with `[SLOP]` verdict must not appear anywhere in the plan — they were removed from RESEARCH.md by the researcher.
+- Package-legitimacy checkpoints are **never** auto-approvable; they require explicit human verification even when `workflow.auto_advance=true`.
 - For any plan with install tasks, add the following supply-chain row to `<threat_model>`:
 
-```
+```text
 | T-{phase}-SC | Tampering | npm install / pip install / cargo add | mitigate | slopcheck pre-research gate; checkpoint:human-verify before [ASSUMED]/[SUS] installs; executor RULE 3 excludes package installs from auto-fix |
 ```
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -659,12 +659,25 @@ Debounce: 5 tool uses between repeated warnings. Severity escalation (WARNING→
 
 ### Package Legitimacy Gate (v1.51)
 
-The researcher → planner → executor pipeline includes a supply-chain gate against slopsquatting (AI-hallucinated package names pre-registered with malicious install hooks):
+The researcher → planner → executor pipeline includes a supply-chain gate against slopsquatting (AI-hallucinated package names pre-registered with malicious post-install scripts).
 
-- **Researcher**: runs `slopcheck install <pkg> --json` on every recommended package; writes a `## Package Legitimacy Audit` table to RESEARCH.md; strips `[SLOP]` packages entirely.
-- **Planner**: inserts `checkpoint:human-verify` before any `[ASSUMED]` or `[SUS]` install task; adds `T-{phase}-SC` STRIDE row to `<threat_model>` for install-bearing plans.
-- **Executor**: RULE 3 excludes package installation from auto-fix; failed installs become checkpoints, never silent substitutions.
-- **Graceful degradation**: if `slopcheck` is unavailable, every recommended package is tagged `[ASSUMED]` and gated with a checkpoint — strictly safer than the previous behavior.
+**Threat model:** GSD automates the full path from "researcher names a package" to "executor runs `npm install`". A hallucinated name that passes `npm view` (proving only registration, not legitimacy) would previously flow through undetected. ~20% of AI-generated package references are hallucinated; ~43% of those names recur consistently across prompts, making pre-registration economically viable for attackers.
+
+**Gate layers:**
+
+| Layer | Component | Action |
+|-------|-----------|--------|
+| Research | `gsd-phase-researcher` | Runs `slopcheck install <pkgs> --json`; writes `## Package Legitimacy Audit` table to RESEARCH.md; strips `[SLOP]` packages before RESEARCH.md is written |
+| Planning | `gsd-planner` | Reads Audit table; inserts `checkpoint:human-verify` before any `[ASSUMED]` or `[SUS]` install task; adds `T-{phase}-SC` STRIDE supply-chain row to `<threat_model>` |
+| Execution | `gsd-executor` | RULE 3 excludes package installation from auto-fix scope; failed installs surface as checkpoints, never silent substitutions |
+
+**Claim provenance integration:** Package names discovered via WebSearch are tagged `[ASSUMED]` (not `[VERIFIED]`) regardless of `npm view` result. This extends the existing `[ASSUMED]` / `[VERIFIED]` / `[CITED]` provenance system by enforcing the provenance tag as a hard gate at the install boundary — `[ASSUMED]` always generates a `checkpoint:human-verify` in PLAN.md.
+
+**Ecosystem coverage:** The researcher uses registry-specific verification commands — `npm view` (Node), `pip index versions` (Python), `cargo search` (Rust) — rather than a single generic check. This catches cross-ecosystem hallucination (~9% rate documented in 2025 USENIX research).
+
+**Graceful degradation:** If `slopcheck` is unavailable, every recommended package is tagged `[ASSUMED]` and gated with a checkpoint. Research and planning proceed; the system never hard-fails on a missing tool dependency.
+
+**External dependency:** `slopcheck` (MIT, pip-installable). If abandoned, the `[ASSUMED]`-gate fallback maintains human-checkpoint coverage.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -433,7 +433,11 @@ ui-phase → UI-SPEC.md (design contract, optional)
 plan-phase
     ├── Research gate (blocks if RESEARCH.md has unresolved open questions)
     ├── Phase Researcher → RESEARCH.md
+    │       └── Package Legitimacy Gate: slopcheck on every package; [SLOP] removed,
+    │           [SUS]/[ASSUMED] flagged; Audit table written to RESEARCH.md
     ├── Planner (with reachability check) → PLAN.md files
+    │       └── checkpoint:human-verify injected before [ASSUMED]/[SUS] installs;
+    │           T-{phase}-SC STRIDE row added for install-bearing plans
     ├── Plan Checker → Verify loop (max 3x)
     ├── Requirements coverage gate (REQ-IDs → plans)
     └── Decision coverage gate (CONTEXT.md `<decisions>` → plans, BLOCKING — #2492)
@@ -652,6 +656,17 @@ Debounce: 5 tool uses between repeated warnings. Severity escalation (WARNING→
 - Stale metrics (>60s old) are ignored
 - Missing bridge files handled gracefully (subagents, fresh sessions)
 - Context monitor is advisory — never issues imperative commands that override user preferences
+
+### Package Legitimacy Gate (v1.51)
+
+The researcher → planner → executor pipeline includes a supply-chain gate against slopsquatting (AI-hallucinated package names pre-registered with malicious install hooks):
+
+- **Researcher**: runs `slopcheck install <pkg> --json` on every recommended package; writes a `## Package Legitimacy Audit` table to RESEARCH.md; strips `[SLOP]` packages entirely.
+- **Planner**: inserts `checkpoint:human-verify` before any `[ASSUMED]` or `[SUS]` install task; adds `T-{phase}-SC` STRIDE row to `<threat_model>` for install-bearing plans.
+- **Executor**: RULE 3 excludes package installation from auto-fix; failed installs become checkpoints, never silent substitutions.
+- **Graceful degradation**: if `slopcheck` is unavailable, every recommended package is tagged `[ASSUMED]` and gated with a checkpoint — strictly safer than the previous behavior.
+
+---
 
 ### Security Hooks (v1.27)
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -162,6 +162,9 @@ Research, plan, and verify a phase.
 - With `--research`: force-refresh — re-spawn researcher unconditionally, no prompt.
 - With `--view`: print existing RESEARCH.md to stdout, no spawn. Errors if RESEARCH.md missing.
 
+**Package Legitimacy Gate (v1.51):**
+When the researcher recommends external packages, it runs `slopcheck install <pkg> --json` and emits a `## Package Legitimacy Audit` table in RESEARCH.md. `[SLOP]` packages (hallucinated/attacker-registered) are removed before RESEARCH.md is written. `[ASSUMED]` or `[SUS]` packages cause the planner to insert a `checkpoint:human-verify` task before the corresponding install task in PLAN.md. The executor never auto-installs a substitute when an install fails. See the [Security section in the User Guide](USER-GUIDE.md#package-legitimacy-gate-v151) for full details.
+
 ```bash
 /gsd-plan-phase 1                              # Research + plan + verify phase 1
 /gsd-plan-phase 3 --skip-research              # Plan without research (familiar domain)

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -163,7 +163,15 @@ Research, plan, and verify a phase.
 - With `--view`: print existing RESEARCH.md to stdout, no spawn. Errors if RESEARCH.md missing.
 
 **Package Legitimacy Gate (v1.51):**
-When the researcher recommends external packages, it runs `slopcheck install <pkg> --json` and emits a `## Package Legitimacy Audit` table in RESEARCH.md. `[SLOP]` packages (hallucinated/attacker-registered) are removed before RESEARCH.md is written. `[ASSUMED]` or `[SUS]` packages cause the planner to insert a `checkpoint:human-verify` task before the corresponding install task in PLAN.md. The executor never auto-installs a substitute when an install fails. See the [Security section in the User Guide](USER-GUIDE.md#package-legitimacy-gate-v151) for full details.
+When the researcher recommends external packages, it runs `slopcheck install <pkg> --json` on each one and writes a `## Package Legitimacy Audit` table to RESEARCH.md recording Registry, Age, Downloads, Source Repo, and slopcheck verdict. Verdicts:
+
+- `[SLOP]` — package removed from RESEARCH.md entirely; never reaches the planner
+- `[SUS]` — package flagged; planner inserts `checkpoint:human-verify` before the install task
+- `[OK]` — package approved; no checkpoint added
+
+Packages sourced from WebSearch are tagged `[ASSUMED]` (not `[VERIFIED]`) and treated the same as `[SUS]` — they get a human checkpoint before install. If `slopcheck` cannot be installed, every recommended package is tagged `[ASSUMED]` and gated.
+
+See [Package Legitimacy Gate in the User Guide](USER-GUIDE.md#package-legitimacy-gate-v151) for the full checkpoint format, verdict table, and troubleshooting.
 
 ```bash
 /gsd-plan-phase 1                              # Research + plan + verify phase 1
@@ -229,6 +237,8 @@ Execute all plans in a phase with wave-based parallelization, or run a specific 
 
 **Prerequisites:** Phase has PLAN.md files
 **Produces:** per-plan `{phase}-{N}-SUMMARY.md`, git commits, and `{phase}-VERIFICATION.md` when the phase is fully complete
+
+**Package install failures (v1.51):** If a plan's install step fails, the executor surfaces a `checkpoint:human-verify` and stops. It does not auto-install a similarly-named alternative. This is intentional — silently substituting package names is how slopsquatting spreads. Respond to the checkpoint after verifying the package on its registry page.
 
 ```bash
 /gsd-execute-phase 1                # Execute phase 1

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -723,19 +723,82 @@ The `security.cjs` module scans for known injection patterns (role overrides, in
 
 ### Package Legitimacy Gate (v1.51)
 
-GSD's research → plan → execute pipeline is uniquely exposed to *slopsquatting*: AI-hallucinated package names that attackers pre-register on npm/PyPI/crates.io with malicious post-install scripts. A hallucinated name that passes `npm view` can flow all the way through to `gsd-executor` running `npm install <malicious-pkg>` with no human gate. v1.51 closes this gap.
+AI coding tools hallucinate package names. Attackers pre-register those names on npm, PyPI, and crates.io with malicious post-install scripts — a technique called *slopsquatting*. A hallucinated name that passes `npm view` looks legitimate, so it would flow undetected through GSD's research → plan → execute pipeline all the way to `npm install <malicious-pkg>` running on your machine.
 
-**How it works:**
+v1.51 adds a three-layer gate that stops this before it reaches your shell.
 
-1. **Researcher** — runs `slopcheck install <pkg> --json` against every recommended package. Results are recorded in a new `## Package Legitimacy Audit` section of RESEARCH.md with columns for Registry, Age, Downloads, Source Repo, and slopcheck verdict (`[OK]` / `[SUS]` / `[SLOP]`). `[SLOP]` packages are removed from RESEARCH.md entirely before the planner sees them.
+#### What you'll see
 
-2. **Planner** — reads the Package Legitimacy Audit table. Any package tagged `[ASSUMED]` (WebSearch-sourced, not registry-verified) or `[SUS]` (slopcheck suspicious) must be preceded by a `checkpoint:human-verify` task before the install task in PLAN.md. Plans that install packages also get a standing `T-{phase}-SC` supply-chain STRIDE row in `<threat_model>`.
+**In RESEARCH.md** — every phase that recommends external packages now includes a `## Package Legitimacy Audit` table:
 
-3. **Executor** — RULE 3 (auto-fix blocking issues) explicitly excludes package installation from auto-fix scope. If an install fails, the executor surfaces a `checkpoint:human-verify` rather than silently trying a similarly-named alternative.
+```markdown
+## Package Legitimacy Audit
 
-**Graceful degradation:** If `slopcheck` is unavailable at research time, the researcher tags every recommended package `[ASSUMED]` — the planner then gates every install with a human checkpoint. The system fails safe, never silently.
+| Package | Registry | Age | Downloads | Source Repo | slopcheck | Disposition |
+|---------|----------|-----|-----------|-------------|-----------|-------------|
+| express | npm | 13 yrs | 100M+/wk | github.com/expressjs/express | [OK] | Approved |
+| some-new-util | npm | 3 days | 47 | none | [SLOP] | REMOVED |
+| api-bridge | npm | 6 mo | 1.2k/wk | github.com/user/api-bridge | [SUS] | Flagged |
 
-**slopcheck dependency:** `slopcheck` is a MIT-licensed Python tool (`pip install slopcheck`). It checks packages across npm, PyPI, crates.io, RubyGems, Go, Maven, and Packagist. If unavailable, GSD continues with the `[ASSUMED]`-gate fallback.
+**Packages removed due to slopcheck:** some-new-util
+**Packages flagged as suspicious:** api-bridge — planner will require human verification before install
+```
+
+`[SLOP]` packages are removed from RESEARCH.md entirely. They never reach the planner.
+
+**In PLAN.md** — if a package is tagged `[ASSUMED]` (sourced from WebSearch, not registry-verified) or `[SUS]` (slopcheck suspicious), the plan includes a verification checkpoint *before* the install task:
+
+```xml
+<task type="checkpoint:human-verify">
+  <what-built>Package verification required before install</what-built>
+  <how-to-verify>
+    Verify these packages before proceeding:
+    - `api-bridge` [SUS — 6 months old, 1.2k downloads/week, GitHub repo present]
+      Check: https://npmjs.com/package/api-bridge
+      Look for: maintainer history, issue tracker activity, no suspicious install scripts
+  </how-to-verify>
+  <resume-signal>Type "verified" once you've confirmed all packages are legitimate</resume-signal>
+</task>
+```
+
+**During execution** — if an install fails, the executor surfaces a checkpoint and stops. It does not silently try a similarly-named alternative (which could be even more dangerous).
+
+#### Slopcheck verdicts
+
+| Verdict | Meaning | GSD action |
+|---------|---------|------------|
+| `[OK]` | Package passes all legitimacy checks | Proceeds — no checkpoint added |
+| `[SUS]` | Suspicious signals (new, low downloads, no source repo, etc.) | Flagged in Audit table; planner adds `checkpoint:human-verify` before install |
+| `[SLOP]` | High-confidence hallucination or attacker-registered package | Removed from RESEARCH.md; never reaches planner |
+
+#### Claim provenance and WebSearch packages
+
+Package names discovered through WebSearch are always tagged `[ASSUMED]` in RESEARCH.md, regardless of whether `npm view` succeeds. A package that exists on the registry is not the same as a package that's safe to install — `npm view` only proves registration, not legitimacy.
+
+`[ASSUMED]` packages trigger the same `checkpoint:human-verify` gate as `[SUS]` packages. You'll see the checkpoint with a link to the registry page and guidance on what to look for.
+
+#### If slopcheck isn't installed
+
+GSD attempts `pip install slopcheck` at research time. If that fails:
+
+- Every recommended package is tagged `[ASSUMED]`
+- The planner gates every install with a `checkpoint:human-verify` task
+- Research and planning complete normally — nothing hard-fails
+
+This is intentionally stricter than the normal flow: slopcheck unavailability means every package install gets a human checkpoint, which is the safest fallback.
+
+To install slopcheck manually:
+
+```bash
+pip install slopcheck
+# verify: slopcheck install express --json
+```
+
+#### slopcheck dependency
+
+`slopcheck` is a MIT-licensed Python tool maintained by ToxSec (the researcher who documented the slopsquatting attack surface). It checks packages across npm, PyPI, crates.io, RubyGems, Go modules, Maven, and Packagist using multi-signal heuristics: registry age, download count, source-repo linkage, naming distance to popular packages, and registry-specific suspicion patterns.
+
+If `slopcheck` is ever unavailable or abandoned, GSD's `[ASSUMED]`-gate fallback ensures you always get a human checkpoint before any install — the system never silently degrades to the pre-v1.51 behavior.
 
 ---
 

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -721,6 +721,24 @@ The `security.cjs` module scans for known injection patterns (role overrides, in
 
 ---
 
+### Package Legitimacy Gate (v1.51)
+
+GSD's research → plan → execute pipeline is uniquely exposed to *slopsquatting*: AI-hallucinated package names that attackers pre-register on npm/PyPI/crates.io with malicious post-install scripts. A hallucinated name that passes `npm view` can flow all the way through to `gsd-executor` running `npm install <malicious-pkg>` with no human gate. v1.51 closes this gap.
+
+**How it works:**
+
+1. **Researcher** — runs `slopcheck install <pkg> --json` against every recommended package. Results are recorded in a new `## Package Legitimacy Audit` section of RESEARCH.md with columns for Registry, Age, Downloads, Source Repo, and slopcheck verdict (`[OK]` / `[SUS]` / `[SLOP]`). `[SLOP]` packages are removed from RESEARCH.md entirely before the planner sees them.
+
+2. **Planner** — reads the Package Legitimacy Audit table. Any package tagged `[ASSUMED]` (WebSearch-sourced, not registry-verified) or `[SUS]` (slopcheck suspicious) must be preceded by a `checkpoint:human-verify` task before the install task in PLAN.md. Plans that install packages also get a standing `T-{phase}-SC` supply-chain STRIDE row in `<threat_model>`.
+
+3. **Executor** — RULE 3 (auto-fix blocking issues) explicitly excludes package installation from auto-fix scope. If an install fails, the executor surfaces a `checkpoint:human-verify` rather than silently trying a similarly-named alternative.
+
+**Graceful degradation:** If `slopcheck` is unavailable at research time, the researcher tags every recommended package `[ASSUMED]` — the planner then gates every install with a human checkpoint. The system fails safe, never silently.
+
+**slopcheck dependency:** `slopcheck` is a MIT-licensed Python tool (`pip install slopcheck`). It checks packages across npm, PyPI, crates.io, RubyGems, Go, Maven, and Packagist. If unavailable, GSD continues with the `[ASSUMED]`-gate fallback.
+
+---
+
 ### Execution Wave Coordination
 
 ```

--- a/tests/package-legitimacy-gate.test.cjs
+++ b/tests/package-legitimacy-gate.test.cjs
@@ -4,18 +4,7 @@
  * Package Legitimacy Gate — structural contract tests (#2827)
  *
  * Verifies that the three agents (researcher, planner, executor) contain the
- * interlocking instruction text that forms the slopsquatting defence gate:
- *
- *  researcher → runs slopcheck, emits Package Legitimacy Audit table,
- *               graceful-degrades, uses ecosystem-specific verification,
- *               never auto-downloads via npx --yes
- *  planner    → gates [ASSUMED]/[SUS] packages behind checkpoint:human-verify,
- *               adds supply-chain row to threat_model template
- *  executor   → RULE 3 explicitly excludes package installs from auto-fix
- *
- * Assertions are structural: content is verified at the correct structural
- * position (inside the RESEARCH.md template block, inside a code block, inside
- * the threat_model XML element) not merely present anywhere in the file.
+ * interlocking instruction text that forms the slopsquatting defence gate.
  */
 
 const { describe, test, before } = require('node:test');
@@ -23,20 +12,11 @@ const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
 
-// ── path constants ────────────────────────────────────────────────────────────
-
 const AGENTS = path.join(__dirname, '..', 'agents');
 const RESEARCHER = path.join(AGENTS, 'gsd-phase-researcher.md');
-const PLANNER    = path.join(AGENTS, 'gsd-planner.md');
-const EXECUTOR   = path.join(AGENTS, 'gsd-executor.md');
+const PLANNER = path.join(AGENTS, 'gsd-planner.md');
+const EXECUTOR = path.join(AGENTS, 'gsd-executor.md');
 
-// ── structural helpers ────────────────────────────────────────────────────────
-
-/**
- * Split a markdown string into sections by ## headings, respecting fenced
- * code blocks (# inside a code block is not a heading).
- * Returns [{heading, body}] where body is the raw text under the heading.
- */
 function parseSections(md) {
   const lines = md.split('\n');
   const sections = [];
@@ -48,336 +28,445 @@ function parseSections(md) {
     if (!inFence && /^#{1,3} /.test(line)) {
       sections.push(current);
       current = { heading: line.replace(/^#+\s*/, '').trim(), body: [] };
-    } else {
-      current.body.push(line);
+      continue;
     }
+    current.body.push(line);
   }
+
   sections.push(current);
   return sections;
 }
 
-/**
- * Extract all fenced code block contents from a string.
- * Returns an array of strings (one per block, without the fence lines).
- */
 function extractCodeBlocks(text) {
   const blocks = [];
   const lines = text.split('\n');
   let inside = false;
   let buf = [];
+
   for (const line of lines) {
     if (line.trimStart().startsWith('```')) {
-      if (inside) { blocks.push(buf.join('\n')); buf = []; }
+      if (inside) {
+        blocks.push(buf.join('\n'));
+        buf = [];
+      }
       inside = !inside;
-    } else if (inside) {
-      buf.push(line);
+      continue;
     }
+    if (inside) buf.push(line);
   }
+
   return blocks;
 }
 
-/** True if any extracted code block contains the substring. */
-function codeBlockContains(text, sub) {
-  return extractCodeBlocks(text).some(b => b.includes(sub));
-}
-
-/**
- * Extract the RESEARCH.md output template from gsd-phase-researcher.md.
- * The template is the ```markdown block that begins with "# Phase".
- */
 function extractResearchTemplate(content) {
   const lines = content.split('\n');
   let inside = false;
   let isMarkdownFence = false;
   let buf = [];
+
   for (const line of lines) {
     if (!inside && line.startsWith('```markdown')) {
       inside = true;
       isMarkdownFence = true;
       buf = [];
-    } else if (inside && line.startsWith('```') && isMarkdownFence) {
+      continue;
+    }
+
+    if (inside && line.startsWith('```') && isMarkdownFence) {
       const candidate = buf.join('\n');
-      if (candidate.trimStart().startsWith('# Phase')) return candidate;
+      if (/^\s*#\s+Phase\b/m.test(candidate)) return candidate;
       inside = false;
       isMarkdownFence = false;
-    } else if (inside) {
-      buf.push(line);
+      continue;
     }
+
+    if (inside) buf.push(line);
+  }
+
+  return '';
+}
+
+function extractPlanTemplate(content) {
+  const blocks = extractCodeBlocks(content);
+  for (const block of blocks) {
+    if (/^\s*<threat_model>/m.test(block)) return block;
   }
   return '';
 }
 
-/**
- * Extract the PLAN.md output template from gsd-planner.md.
- * Finds the code block that contains <threat_model>.
- */
-function extractPlanTemplate(content) {
-  const blocks = extractCodeBlocks(content);
-  return blocks.find(b => b.includes('<threat_model>')) || '';
-}
-
-/**
- * Extract the text content inside <tag>...</tag> (first match).
- */
 function extractXmlElement(text, tag) {
   const start = text.indexOf(`<${tag}>`);
-  const end   = text.indexOf(`</${tag}>`);
+  const end = text.indexOf(`</${tag}>`);
   if (start === -1 || end === -1) return '';
   return text.slice(start, end + tag.length + 3);
 }
 
-// ── 1. researcher — slopcheck invocation ─────────────────────────────────────
+function normalizeTokens(text) {
+  return text
+    .toLowerCase()
+    .replace(/https?:\/\//g, ' ')
+    .replace(/[\[\]]/g, '')
+    .replace(/[^a-z0-9{}:_-]+/g, ' ')
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+function hasAllTokens(text, required) {
+  const tokenSet = new Set(normalizeTokens(text));
+  return required.every((token) => tokenSet.has(token.toLowerCase()));
+}
+
+function anyLineHasAll(lines, required) {
+  return lines.some((line) => hasAllTokens(line, required));
+}
+
+function parseMarkdownTable(lines) {
+  const tableLines = lines.filter((line) => /^\s*\|/.test(line));
+  if (tableLines.length < 2) return null;
+
+  const toCells = (line) => line
+    .trim()
+    .replace(/^\|/, '')
+    .replace(/\|$/, '')
+    .split('|')
+    .map((cell) => cell.trim());
+
+  const headers = toCells(tableLines[0]);
+  const rows = tableLines
+    .slice(2)
+    .map(toCells)
+    .filter((cells) => cells.length === headers.length)
+    .map((cells) => ({
+      cells,
+      fields: Object.fromEntries(headers.map((h, i) => [h, cells[i]])),
+    }));
+
+  return { headers, rows };
+}
+
+function parseMarkdownTables(lines) {
+  const groups = [];
+  let current = [];
+
+  for (const line of lines) {
+    if (/^\s*\|/.test(line)) {
+      current.push(line);
+      continue;
+    }
+    if (current.length > 0) {
+      groups.push(current);
+      current = [];
+    }
+  }
+  if (current.length > 0) groups.push(current);
+
+  return groups
+    .map((group) => parseMarkdownTable(group))
+    .filter(Boolean);
+}
+
+function lineIndexes(lines, predicate) {
+  const indexes = [];
+  for (let i = 0; i < lines.length; i += 1) {
+    if (predicate(lines[i], i)) indexes.push(i);
+  }
+  return indexes;
+}
+
+function inNearbyWindow(sourceIndexes, targetIndexes, distance) {
+  return sourceIndexes.some((src) => targetIndexes.some((dst) => Math.abs(src - dst) <= distance));
+}
+
+function readModel(filePath) {
+  const text = fs.readFileSync(filePath, 'utf-8');
+  return {
+    text,
+    lines: text.split('\n'),
+    sections: parseSections(text),
+    codeBlocks: extractCodeBlocks(text),
+  };
+}
 
 describe('gsd-phase-researcher.md — slopcheck invocation', () => {
-  let content;
-  before(() => { content = fs.readFileSync(RESEARCHER, 'utf-8'); });
+  let model;
+
+  before(() => {
+    model = readModel(RESEARCHER);
+  });
 
   test('contains slopcheck install command in a fenced code block', () => {
-    assert.ok(
-      codeBlockContains(content, 'slopcheck install'),
-      'researcher must invoke "slopcheck install" inside a fenced code block'
-    );
+    const found = model.codeBlocks.some((block) => hasAllTokens(block, ['slopcheck', 'install']));
+    assert.ok(found, 'researcher must invoke slopcheck install inside a fenced code block');
   });
 
   test('slopcheck invocation includes --json flag', () => {
-    const hasJson = extractCodeBlocks(content).some(
-      b => b.includes('slopcheck install') && b.includes('--json')
+    const found = model.codeBlocks.some((block) =>
+      hasAllTokens(block, ['slopcheck', 'install']) && hasAllTokens(block, ['json'])
     );
-    assert.ok(hasJson, 'slopcheck invocation must pass --json');
+    assert.ok(found, 'slopcheck invocation must pass --json');
   });
 
-  test('guards slopcheck invocation with a command availability check', () => {
-    assert.ok(
-      codeBlockContains(content, 'command -v slopcheck') ||
-        codeBlockContains(content, 'which slopcheck'),
-      'researcher must check for slopcheck binary before invoking it'
-    );
+  test('guards slopcheck invocation with command availability check', () => {
+    const hasCommandV = model.codeBlocks.some((block) => hasAllTokens(block, ['command', '-v', 'slopcheck']));
+    const hasWhich = model.codeBlocks.some((block) => hasAllTokens(block, ['which', 'slopcheck']));
+    assert.ok(hasCommandV || hasWhich, 'researcher must guard slopcheck invocation with command -v or which');
   });
 
   test('documents graceful degradation when slopcheck is unavailable', () => {
-    const hasDegradation =
-      content.includes('[ASSUMED]') &&
-      content.includes('slopcheck') &&
-      (content.includes('not available') ||
-        content.includes('not found') ||
-        content.includes('unavailable') ||
-        content.includes('cannot be installed'));
-    assert.ok(hasDegradation, 'researcher must document [ASSUMED] fallback when slopcheck cannot run');
+    const hasAssumedLine = anyLineHasAll(model.lines, ['assumed']);
+    const hasSlopcheckUnavailableLine = model.lines.some((line) => {
+      const slopcheckMention = hasAllTokens(line, ['slopcheck']);
+      const unavailableMention =
+        hasAllTokens(line, ['not', 'available']) ||
+        hasAllTokens(line, ['not', 'found']) ||
+        hasAllTokens(line, ['unavailable']) ||
+        hasAllTokens(line, ['cannot', 'installed']);
+      return slopcheckMention && unavailableMention;
+    });
+
+    assert.ok(
+      hasAssumedLine && hasSlopcheckUnavailableLine,
+      'researcher must document [ASSUMED] fallback when slopcheck cannot run'
+    );
   });
 });
 
-// ── 2. researcher — Package Legitimacy Audit section in RESEARCH.md template ─
-
 describe('gsd-phase-researcher.md — Package Legitimacy Audit section in template', () => {
-  let template, templateSections;
+  let templateSections;
+
   before(() => {
-    const content = fs.readFileSync(RESEARCHER, 'utf-8');
-    template = extractResearchTemplate(content);
+    const model = readModel(RESEARCHER);
+    const template = extractResearchTemplate(model.text);
     templateSections = parseSections(template);
   });
 
-  test('RESEARCH.md template contains a Package Legitimacy Audit section', () => {
-    const hasSection = templateSections.some(s => s.heading === 'Package Legitimacy Audit');
-    assert.ok(hasSection, 'RESEARCH.md template must include a ## Package Legitimacy Audit section');
+  test('RESEARCH.md template contains Package Legitimacy Audit section', () => {
+    const section = templateSections.find((s) => s.heading === 'Package Legitimacy Audit');
+    assert.ok(section, 'RESEARCH.md template must include a Package Legitimacy Audit section');
   });
 
-  test('Package Legitimacy Audit table has all required columns', () => {
-    const sec = templateSections.find(s => s.heading === 'Package Legitimacy Audit');
-    assert.ok(sec, 'Package Legitimacy Audit section must exist');
-    const body = sec.body.join('\n');
-    for (const col of ['Package', 'Registry', 'Age', 'Downloads', 'slopcheck', 'Disposition']) {
-      assert.ok(body.includes(col), `audit table must have "${col}" column`);
+  test('Package Legitimacy Audit table has required columns', () => {
+    const section = templateSections.find((s) => s.heading === 'Package Legitimacy Audit');
+    assert.ok(section, 'Package Legitimacy Audit section must exist');
+
+    const table = parseMarkdownTable(section.body);
+    assert.ok(table, 'Package Legitimacy Audit section must include a markdown table');
+
+    const expected = ['Package', 'Registry', 'Age', 'Downloads', 'slopcheck', 'Disposition'];
+    for (const column of expected) {
+      assert.ok(table.headers.includes(column), `audit table must have "${column}" column`);
     }
   });
 
-  test('audit section documents [SLOP] disposition', () => {
-    const sec = templateSections.find(s => s.heading === 'Package Legitimacy Audit');
-    assert.ok(sec, 'Package Legitimacy Audit section must exist');
-    assert.ok(sec.body.join('\n').includes('[SLOP]'), 'audit section must document [SLOP] disposition');
-  });
+  test('audit section documents [SLOP], [SUS], and [OK] dispositions', () => {
+    const section = templateSections.find((s) => s.heading === 'Package Legitimacy Audit');
+    assert.ok(section, 'Package Legitimacy Audit section must exist');
 
-  test('audit section documents [SUS] disposition', () => {
-    const sec = templateSections.find(s => s.heading === 'Package Legitimacy Audit');
-    assert.ok(sec, 'Package Legitimacy Audit section must exist');
-    assert.ok(sec.body.join('\n').includes('[SUS]'), 'audit section must document [SUS] disposition');
-  });
+    const table = parseMarkdownTable(section.body);
+    assert.ok(table, 'Package Legitimacy Audit section must include a markdown table');
 
-  test('audit section documents [OK] disposition', () => {
-    const sec = templateSections.find(s => s.heading === 'Package Legitimacy Audit');
-    assert.ok(sec, 'Package Legitimacy Audit section must exist');
-    assert.ok(sec.body.join('\n').includes('[OK]'), 'audit section must document [OK] disposition');
+    const rowTexts = table.rows.map((row) => row.cells.join(' '));
+    const slop = rowTexts.some((value) => hasAllTokens(value, ['slop']));
+    const sus = rowTexts.some((value) => hasAllTokens(value, ['sus']));
+    const ok = rowTexts.some((value) => hasAllTokens(value, ['ok']));
+
+    assert.ok(slop, 'audit section must document [SLOP] disposition');
+    assert.ok(sus, 'audit section must document [SUS] disposition');
+    assert.ok(ok, 'audit section must document [OK] disposition');
   });
 });
 
-// ── 3. researcher — ecosystem-specific verification ───────────────────────────
-
 describe('gsd-phase-researcher.md — ecosystem-specific package verification', () => {
-  let content;
-  before(() => { content = fs.readFileSync(RESEARCHER, 'utf-8'); });
+  let model;
+
+  before(() => {
+    model = readModel(RESEARCHER);
+  });
 
   test('documents pip index versions for Python phases', () => {
-    assert.ok(
-      content.includes('pip index versions'),
-      'researcher must document "pip index versions" for Python package verification'
-    );
+    assert.ok(anyLineHasAll(model.lines, ['pip', 'index', 'versions']), 'researcher must document pip index versions');
   });
 
   test('documents cargo search for Rust phases', () => {
-    assert.ok(
-      content.includes('cargo search'),
-      'researcher must document "cargo search" for Rust package verification'
-    );
+    assert.ok(anyLineHasAll(model.lines, ['cargo', 'search']), 'researcher must document cargo search');
   });
 });
-
-// ── 4. researcher — no npx --yes, ctx7 guard ─────────────────────────────────
 
 describe('gsd-phase-researcher.md — no npx --yes auto-download', () => {
-  let content;
-  before(() => { content = fs.readFileSync(RESEARCHER, 'utf-8'); });
+  let model;
 
-  test('does not invoke "npx --yes" inside a code block', () => {
-    assert.ok(
-      !codeBlockContains(content, 'npx --yes'),
-      'researcher must not invoke "npx --yes" in any code block (silently auto-executes unverified packages)'
-    );
+  before(() => {
+    model = readModel(RESEARCHER);
   });
 
-  test('ctx7 CLI fallback uses command -v guard instead of npx --yes', () => {
-    assert.ok(
-      codeBlockContains(content, 'command -v ctx7'),
-      'ctx7 CLI fallback must guard with "command -v ctx7" before invocation'
-    );
+  test('does not invoke npx --yes inside a code block', () => {
+    const found = model.codeBlocks.some((block) => hasAllTokens(block, ['npx', '--yes']));
+    assert.equal(found, false, 'researcher must not invoke npx --yes in any code block');
+  });
+
+  test('ctx7 CLI fallback uses command -v guard', () => {
+    const found = model.codeBlocks.some((block) => hasAllTokens(block, ['command', '-v', 'ctx7']));
+    assert.ok(found, 'ctx7 CLI fallback must guard with command -v ctx7 before invocation');
   });
 });
-
-// ── 5. researcher — WebSearch packages tagged [ASSUMED] ──────────────────────
 
 describe('gsd-phase-researcher.md — WebSearch-origin package tagging', () => {
-  let content;
-  before(() => { content = fs.readFileSync(RESEARCHER, 'utf-8'); });
+  let model;
 
-  test('instructs that packages discovered only via WebSearch are tagged [ASSUMED]', () => {
-    const wsIdx = content.indexOf('WebSearch');
-    assert.ok(wsIdx !== -1, 'researcher file must mention WebSearch');
-    // [ASSUMED] must appear within ~1000 chars of a WebSearch reference
-    const nearby = content.slice(Math.max(0, wsIdx - 200), wsIdx + 1200);
+  before(() => {
+    model = readModel(RESEARCHER);
+  });
+
+  test('packages discovered via WebSearch are tagged [ASSUMED]', () => {
+    const webSearchLines = lineIndexes(model.lines, (line) => hasAllTokens(line, ['websearch']));
+    const assumedLines = lineIndexes(model.lines, (line) => hasAllTokens(line, ['assumed']));
+
+    assert.ok(webSearchLines.length > 0, 'researcher file must mention WebSearch');
+    assert.ok(assumedLines.length > 0, 'researcher file must mention [ASSUMED]');
     assert.ok(
-      nearby.includes('[ASSUMED]'),
-      'researcher must instruct that packages discovered via WebSearch are tagged [ASSUMED]'
+      inNearbyWindow(webSearchLines, assumedLines, 25),
+      'researcher must instruct WebSearch-discovered packages are tagged [ASSUMED] in nearby guidance'
     );
   });
 });
 
-// ── 6. planner — checkpoint gate on [ASSUMED]/[SUS] packages ─────────────────
-
 describe('gsd-planner.md — checkpoint gate for [ASSUMED]/[SUS] packages', () => {
-  let content;
-  before(() => { content = fs.readFileSync(PLANNER, 'utf-8'); });
+  let model;
 
-  test('instructs inserting checkpoint:human-verify before install of [ASSUMED] packages', () => {
-    assert.ok(
-      content.includes('checkpoint:human-verify') && content.includes('[ASSUMED]'),
-      'planner must instruct inserting a checkpoint:human-verify before installing [ASSUMED] packages'
-    );
+  before(() => {
+    model = readModel(PLANNER);
   });
 
-  test('instructs inserting checkpoint:human-verify before install of [SUS] packages', () => {
-    assert.ok(
-      content.includes('checkpoint:human-verify') && content.includes('[SUS]'),
-      'planner must instruct inserting a checkpoint:human-verify before installing [SUS] packages'
+  test('checkpoint:human-verify guidance references [ASSUMED] and [SUS]', () => {
+    const hasCheckpoint = anyLineHasAll(model.lines, ['checkpoint:human-verify']);
+    const hasAssumed = anyLineHasAll(model.lines, ['assumed']);
+    const hasSus = anyLineHasAll(model.lines, ['sus']);
+
+    assert.ok(hasCheckpoint && hasAssumed, 'planner must gate [ASSUMED] packages behind checkpoint:human-verify');
+    assert.ok(hasCheckpoint && hasSus, 'planner must gate [SUS] packages behind checkpoint:human-verify');
+  });
+
+  test('package-legitimacy checkpoint uses blocking-human gate and non-auto-approvable language', () => {
+    const hasBlockingHumanGate = anyLineHasAll(model.lines, ['checkpoint:human-verify', 'blocking-human']);
+    const hasNeverAutoApproveRule = model.lines.some((line) =>
+      hasAllTokens(line, ['never', 'auto-approvable']) ||
+      hasAllTokens(line, ['never', 'auto', 'approvable'])
     );
+
+    assert.ok(hasBlockingHumanGate, 'planner legitimacy checkpoint must use gate="blocking-human"');
+    assert.ok(hasNeverAutoApproveRule, 'planner must state legitimacy checkpoints are never auto-approvable');
   });
 
   test('package verification checkpoint includes registry URL guidance', () => {
-    assert.ok(
-      content.includes('npmjs.com/package') ||
-        content.includes('pypi.org/project') ||
-        content.includes('crates.io/crates'),
-      'planner package-verify checkpoint must include a registry URL example'
+    const hasRegistryGuidance = model.lines.some((line) =>
+      hasAllTokens(line, ['npmjs', 'package']) ||
+      hasAllTokens(line, ['pypi', 'project']) ||
+      hasAllTokens(line, ['crates', 'crates'])
     );
+
+    assert.ok(hasRegistryGuidance, 'planner package-verify checkpoint must include registry URL examples');
   });
 });
-
-// ── 7. planner — supply-chain threat model row in PLAN.md template ───────────
 
 describe('gsd-planner.md — supply-chain row in threat_model template', () => {
-  let planTemplate, threatBlock;
+  let planTemplate;
+  let threatModelBlock;
+
   before(() => {
-    const content = fs.readFileSync(PLANNER, 'utf-8');
-    planTemplate = extractPlanTemplate(content);
-    threatBlock  = extractXmlElement(planTemplate, 'threat_model');
+    const model = readModel(PLANNER);
+    planTemplate = extractPlanTemplate(model.text);
+    threatModelBlock = extractXmlElement(planTemplate, 'threat_model');
   });
 
-  test('PLAN.md template contains a threat_model element', () => {
-    assert.ok(planTemplate.includes('<threat_model>'), 'PLAN.md template must include <threat_model>');
+  test('PLAN.md template contains threat_model element', () => {
+    assert.ok(/^\s*<threat_model>/m.test(planTemplate), 'PLAN.md template must include <threat_model>');
   });
 
-  test('threat_model template includes a supply-chain row', () => {
-    assert.ok(
-      threatBlock.includes('SC') ||
-        threatBlock.includes('supply') ||
-        threatBlock.includes('install'),
-      'threat_model template must include a supply-chain (SC) row for install-bearing plans'
-    );
-  });
+  test('threat_model template includes supply-chain row with mitigate disposition', () => {
+    const tables = parseMarkdownTables(threatModelBlock.split('\n'));
+    const strideTable = tables.find((table) => table.headers.includes('Threat ID'));
+    assert.ok(strideTable, 'threat_model must include STRIDE threat register table');
 
-  test('supply-chain row disposition is mitigate', () => {
-    assert.ok(
-      threatBlock.includes('mitigate'),
-      'supply-chain threat disposition must be "mitigate"'
-    );
+    const supplyChainRow = strideTable.rows.find((row) => hasAllTokens(row.cells[0] || '', ['t-{phase}-sc']));
+    assert.ok(supplyChainRow, 'threat_model must include T-{phase}-SC supply-chain row');
+
+    const disposition = supplyChainRow.cells[3] || '';
+    assert.ok(hasAllTokens(disposition, ['mitigate']), 'supply-chain threat disposition must be mitigate');
   });
 });
-
-// ── 8. planner — no npx --yes ────────────────────────────────────────────────
 
 describe('gsd-planner.md — no npx --yes auto-download', () => {
-  test('does not invoke "npx --yes" inside a code block', () => {
-    const content = fs.readFileSync(PLANNER, 'utf-8');
-    assert.ok(!codeBlockContains(content, 'npx --yes'), 'planner must not invoke "npx --yes" in any code block');
+  test('does not invoke npx --yes inside a code block', () => {
+    const model = readModel(PLANNER);
+    const found = model.codeBlocks.some((block) => hasAllTokens(block, ['npx', '--yes']));
+    assert.equal(found, false, 'planner must not invoke npx --yes in any code block');
   });
 });
 
-// ── 9. executor — RULE 3 excludes package installs, failed installs → checkpoint
-
 describe('gsd-executor.md — package installs excluded from RULE 3 auto-fix', () => {
-  let content;
-  before(() => { content = fs.readFileSync(EXECUTOR, 'utf-8'); });
+  let model;
 
-  test('does not invoke "npx --yes" inside a code block', () => {
-    assert.ok(!codeBlockContains(content, 'npx --yes'), 'executor must not invoke "npx --yes" in any code block');
+  before(() => {
+    model = readModel(EXECUTOR);
   });
 
-  test('RULE 3 section explicitly excludes package manager install commands', () => {
-    const rule3Idx = content.indexOf('RULE 3');
-    assert.ok(rule3Idx !== -1, 'executor must contain RULE 3 section');
-    const rule3Body = content.slice(rule3Idx, rule3Idx + 1500);
-    const excludesInstall =
-      (rule3Body.includes('npm install') ||
-        rule3Body.includes('pip install') ||
-        rule3Body.includes('package install')) &&
-      (rule3Body.includes('NOT') ||
-        rule3Body.includes('exclude') ||
-        rule3Body.includes('never') ||
-        rule3Body.includes('prohibited') ||
-        rule3Body.includes('do not'));
+  test('does not invoke npx --yes inside a code block', () => {
+    const found = model.codeBlocks.some((block) => hasAllTokens(block, ['npx', '--yes']));
+    assert.equal(found, false, 'executor must not invoke npx --yes in any code block');
+  });
+
+  test('RULE 3 section explicitly excludes package-manager installs', () => {
+    const rule3Line = lineIndexes(model.lines, (line) => hasAllTokens(line, ['rule', '3']))[0];
+    assert.notEqual(rule3Line, undefined, 'executor must contain RULE 3 section');
+
+    const window = model.lines.slice(rule3Line, rule3Line + 35);
+
+    const hasInstallCommands =
+      anyLineHasAll(window, ['npm', 'install']) ||
+      anyLineHasAll(window, ['pip', 'install']) ||
+      anyLineHasAll(window, ['cargo', 'add']);
+
+    const hasExclusionLanguage =
+      anyLineHasAll(window, ['excluded']) ||
+      anyLineHasAll(window, ['not', 'auto-fixable']) ||
+      anyLineHasAll(window, ['do', 'not']);
+
+    assert.ok(hasInstallCommands && hasExclusionLanguage, 'RULE 3 must explicitly exclude package-manager installs');
+  });
+
+  test('failed package installs surface checkpoint:human-verify', () => {
+    const rule3Line = lineIndexes(model.lines, (line) => hasAllTokens(line, ['rule', '3']))[0];
+    assert.notEqual(rule3Line, undefined, 'executor must contain RULE 3 section');
+
+    const window = model.lines.slice(rule3Line, rule3Line + 50);
+    const hasFailureLanguage =
+      anyLineHasAll(window, ['failed', 'install']) ||
+      anyLineHasAll(window, ['install', 'fails']) ||
+      anyLineHasAll(window, ['install', 'failed']);
+
+    const hasCheckpoint = anyLineHasAll(window, ['checkpoint:human-verify']);
+
     assert.ok(
-      excludesInstall,
-      'RULE 3 must explicitly state that package manager installs are NOT auto-fixable'
+      hasFailureLanguage && hasCheckpoint,
+      'executor must emit checkpoint:human-verify when package install fails'
     );
   });
 
-  test('failed package installs must surface a checkpoint, not an auto-fix attempt', () => {
-    const hasCheckpointForInstall =
-      content.includes('install') && content.includes('checkpoint') &&
-      (content.includes('install fails') ||
-        content.includes('install fail') ||
-        content.includes('failed install') ||
-        (content.includes('package') && content.includes('checkpoint:human-verify')));
+  test('auto mode does not auto-approve package-legitimacy checkpoints', () => {
+    const autoModeLine = lineIndexes(model.lines, (line) => hasAllTokens(line, ['auto-mode', 'checkpoint', 'behavior']))[0];
+    assert.notEqual(autoModeLine, undefined, 'executor must define auto-mode checkpoint behavior');
+
+    const window = model.lines.slice(autoModeLine, autoModeLine + 25);
+
+    const hasExceptionRule =
+      anyLineHasAll(window, ['except', 'package-legitimacy', 'checkpoints']) ||
+      anyLineHasAll(window, ['do', 'not', 'auto-approve']) ||
+      anyLineHasAll(window, ['blocking-human']);
+
     assert.ok(
-      hasCheckpointForInstall,
-      'executor must instruct emitting a checkpoint when a package install fails (not auto-fix)'
+      hasExceptionRule,
+      'executor auto mode must explicitly block auto-approval for package-legitimacy checkpoints'
     );
   });
 });

--- a/tests/package-legitimacy-gate.test.cjs
+++ b/tests/package-legitimacy-gate.test.cjs
@@ -1,0 +1,383 @@
+'use strict';
+
+/**
+ * Package Legitimacy Gate — structural contract tests (#2827)
+ *
+ * Verifies that the three agents (researcher, planner, executor) contain the
+ * interlocking instruction text that forms the slopsquatting defence gate:
+ *
+ *  researcher → runs slopcheck, emits Package Legitimacy Audit table,
+ *               graceful-degrades, uses ecosystem-specific verification,
+ *               never auto-downloads via npx --yes
+ *  planner    → gates [ASSUMED]/[SUS] packages behind checkpoint:human-verify,
+ *               adds supply-chain row to threat_model template
+ *  executor   → RULE 3 explicitly excludes package installs from auto-fix
+ *
+ * Assertions are structural: content is verified at the correct structural
+ * position (inside the RESEARCH.md template block, inside a code block, inside
+ * the threat_model XML element) not merely present anywhere in the file.
+ */
+
+const { describe, test, before } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+// ── path constants ────────────────────────────────────────────────────────────
+
+const AGENTS = path.join(__dirname, '..', 'agents');
+const RESEARCHER = path.join(AGENTS, 'gsd-phase-researcher.md');
+const PLANNER    = path.join(AGENTS, 'gsd-planner.md');
+const EXECUTOR   = path.join(AGENTS, 'gsd-executor.md');
+
+// ── structural helpers ────────────────────────────────────────────────────────
+
+/**
+ * Split a markdown string into sections by ## headings, respecting fenced
+ * code blocks (# inside a code block is not a heading).
+ * Returns [{heading, body}] where body is the raw text under the heading.
+ */
+function parseSections(md) {
+  const lines = md.split('\n');
+  const sections = [];
+  let current = { heading: '__preamble__', body: [] };
+  let inFence = false;
+
+  for (const line of lines) {
+    if (line.trimStart().startsWith('```')) inFence = !inFence;
+    if (!inFence && /^#{1,3} /.test(line)) {
+      sections.push(current);
+      current = { heading: line.replace(/^#+\s*/, '').trim(), body: [] };
+    } else {
+      current.body.push(line);
+    }
+  }
+  sections.push(current);
+  return sections;
+}
+
+/**
+ * Extract all fenced code block contents from a string.
+ * Returns an array of strings (one per block, without the fence lines).
+ */
+function extractCodeBlocks(text) {
+  const blocks = [];
+  const lines = text.split('\n');
+  let inside = false;
+  let buf = [];
+  for (const line of lines) {
+    if (line.trimStart().startsWith('```')) {
+      if (inside) { blocks.push(buf.join('\n')); buf = []; }
+      inside = !inside;
+    } else if (inside) {
+      buf.push(line);
+    }
+  }
+  return blocks;
+}
+
+/** True if any extracted code block contains the substring. */
+function codeBlockContains(text, sub) {
+  return extractCodeBlocks(text).some(b => b.includes(sub));
+}
+
+/**
+ * Extract the RESEARCH.md output template from gsd-phase-researcher.md.
+ * The template is the ```markdown block that begins with "# Phase".
+ */
+function extractResearchTemplate(content) {
+  const lines = content.split('\n');
+  let inside = false;
+  let isMarkdownFence = false;
+  let buf = [];
+  for (const line of lines) {
+    if (!inside && line.startsWith('```markdown')) {
+      inside = true;
+      isMarkdownFence = true;
+      buf = [];
+    } else if (inside && line.startsWith('```') && isMarkdownFence) {
+      const candidate = buf.join('\n');
+      if (candidate.trimStart().startsWith('# Phase')) return candidate;
+      inside = false;
+      isMarkdownFence = false;
+    } else if (inside) {
+      buf.push(line);
+    }
+  }
+  return '';
+}
+
+/**
+ * Extract the PLAN.md output template from gsd-planner.md.
+ * Finds the code block that contains <threat_model>.
+ */
+function extractPlanTemplate(content) {
+  const blocks = extractCodeBlocks(content);
+  return blocks.find(b => b.includes('<threat_model>')) || '';
+}
+
+/**
+ * Extract the text content inside <tag>...</tag> (first match).
+ */
+function extractXmlElement(text, tag) {
+  const start = text.indexOf(`<${tag}>`);
+  const end   = text.indexOf(`</${tag}>`);
+  if (start === -1 || end === -1) return '';
+  return text.slice(start, end + tag.length + 3);
+}
+
+// ── 1. researcher — slopcheck invocation ─────────────────────────────────────
+
+describe('gsd-phase-researcher.md — slopcheck invocation', () => {
+  let content;
+  before(() => { content = fs.readFileSync(RESEARCHER, 'utf-8'); });
+
+  test('contains slopcheck install command in a fenced code block', () => {
+    assert.ok(
+      codeBlockContains(content, 'slopcheck install'),
+      'researcher must invoke "slopcheck install" inside a fenced code block'
+    );
+  });
+
+  test('slopcheck invocation includes --json flag', () => {
+    const hasJson = extractCodeBlocks(content).some(
+      b => b.includes('slopcheck install') && b.includes('--json')
+    );
+    assert.ok(hasJson, 'slopcheck invocation must pass --json');
+  });
+
+  test('guards slopcheck invocation with a command availability check', () => {
+    assert.ok(
+      codeBlockContains(content, 'command -v slopcheck') ||
+        codeBlockContains(content, 'which slopcheck'),
+      'researcher must check for slopcheck binary before invoking it'
+    );
+  });
+
+  test('documents graceful degradation when slopcheck is unavailable', () => {
+    const hasDegradation =
+      content.includes('[ASSUMED]') &&
+      content.includes('slopcheck') &&
+      (content.includes('not available') ||
+        content.includes('not found') ||
+        content.includes('unavailable') ||
+        content.includes('cannot be installed'));
+    assert.ok(hasDegradation, 'researcher must document [ASSUMED] fallback when slopcheck cannot run');
+  });
+});
+
+// ── 2. researcher — Package Legitimacy Audit section in RESEARCH.md template ─
+
+describe('gsd-phase-researcher.md — Package Legitimacy Audit section in template', () => {
+  let template, templateSections;
+  before(() => {
+    const content = fs.readFileSync(RESEARCHER, 'utf-8');
+    template = extractResearchTemplate(content);
+    templateSections = parseSections(template);
+  });
+
+  test('RESEARCH.md template contains a Package Legitimacy Audit section', () => {
+    const hasSection = templateSections.some(s => s.heading === 'Package Legitimacy Audit');
+    assert.ok(hasSection, 'RESEARCH.md template must include a ## Package Legitimacy Audit section');
+  });
+
+  test('Package Legitimacy Audit table has all required columns', () => {
+    const sec = templateSections.find(s => s.heading === 'Package Legitimacy Audit');
+    assert.ok(sec, 'Package Legitimacy Audit section must exist');
+    const body = sec.body.join('\n');
+    for (const col of ['Package', 'Registry', 'Age', 'Downloads', 'slopcheck', 'Disposition']) {
+      assert.ok(body.includes(col), `audit table must have "${col}" column`);
+    }
+  });
+
+  test('audit section documents [SLOP] disposition', () => {
+    const sec = templateSections.find(s => s.heading === 'Package Legitimacy Audit');
+    assert.ok(sec, 'Package Legitimacy Audit section must exist');
+    assert.ok(sec.body.join('\n').includes('[SLOP]'), 'audit section must document [SLOP] disposition');
+  });
+
+  test('audit section documents [SUS] disposition', () => {
+    const sec = templateSections.find(s => s.heading === 'Package Legitimacy Audit');
+    assert.ok(sec, 'Package Legitimacy Audit section must exist');
+    assert.ok(sec.body.join('\n').includes('[SUS]'), 'audit section must document [SUS] disposition');
+  });
+
+  test('audit section documents [OK] disposition', () => {
+    const sec = templateSections.find(s => s.heading === 'Package Legitimacy Audit');
+    assert.ok(sec, 'Package Legitimacy Audit section must exist');
+    assert.ok(sec.body.join('\n').includes('[OK]'), 'audit section must document [OK] disposition');
+  });
+});
+
+// ── 3. researcher — ecosystem-specific verification ───────────────────────────
+
+describe('gsd-phase-researcher.md — ecosystem-specific package verification', () => {
+  let content;
+  before(() => { content = fs.readFileSync(RESEARCHER, 'utf-8'); });
+
+  test('documents pip index versions for Python phases', () => {
+    assert.ok(
+      content.includes('pip index versions'),
+      'researcher must document "pip index versions" for Python package verification'
+    );
+  });
+
+  test('documents cargo search for Rust phases', () => {
+    assert.ok(
+      content.includes('cargo search'),
+      'researcher must document "cargo search" for Rust package verification'
+    );
+  });
+});
+
+// ── 4. researcher — no npx --yes, ctx7 guard ─────────────────────────────────
+
+describe('gsd-phase-researcher.md — no npx --yes auto-download', () => {
+  let content;
+  before(() => { content = fs.readFileSync(RESEARCHER, 'utf-8'); });
+
+  test('does not invoke "npx --yes" inside a code block', () => {
+    assert.ok(
+      !codeBlockContains(content, 'npx --yes'),
+      'researcher must not invoke "npx --yes" in any code block (silently auto-executes unverified packages)'
+    );
+  });
+
+  test('ctx7 CLI fallback uses command -v guard instead of npx --yes', () => {
+    assert.ok(
+      codeBlockContains(content, 'command -v ctx7'),
+      'ctx7 CLI fallback must guard with "command -v ctx7" before invocation'
+    );
+  });
+});
+
+// ── 5. researcher — WebSearch packages tagged [ASSUMED] ──────────────────────
+
+describe('gsd-phase-researcher.md — WebSearch-origin package tagging', () => {
+  let content;
+  before(() => { content = fs.readFileSync(RESEARCHER, 'utf-8'); });
+
+  test('instructs that packages discovered only via WebSearch are tagged [ASSUMED]', () => {
+    const wsIdx = content.indexOf('WebSearch');
+    assert.ok(wsIdx !== -1, 'researcher file must mention WebSearch');
+    // [ASSUMED] must appear within ~1000 chars of a WebSearch reference
+    const nearby = content.slice(Math.max(0, wsIdx - 200), wsIdx + 1200);
+    assert.ok(
+      nearby.includes('[ASSUMED]'),
+      'researcher must instruct that packages discovered via WebSearch are tagged [ASSUMED]'
+    );
+  });
+});
+
+// ── 6. planner — checkpoint gate on [ASSUMED]/[SUS] packages ─────────────────
+
+describe('gsd-planner.md — checkpoint gate for [ASSUMED]/[SUS] packages', () => {
+  let content;
+  before(() => { content = fs.readFileSync(PLANNER, 'utf-8'); });
+
+  test('instructs inserting checkpoint:human-verify before install of [ASSUMED] packages', () => {
+    assert.ok(
+      content.includes('checkpoint:human-verify') && content.includes('[ASSUMED]'),
+      'planner must instruct inserting a checkpoint:human-verify before installing [ASSUMED] packages'
+    );
+  });
+
+  test('instructs inserting checkpoint:human-verify before install of [SUS] packages', () => {
+    assert.ok(
+      content.includes('checkpoint:human-verify') && content.includes('[SUS]'),
+      'planner must instruct inserting a checkpoint:human-verify before installing [SUS] packages'
+    );
+  });
+
+  test('package verification checkpoint includes registry URL guidance', () => {
+    assert.ok(
+      content.includes('npmjs.com/package') ||
+        content.includes('pypi.org/project') ||
+        content.includes('crates.io/crates'),
+      'planner package-verify checkpoint must include a registry URL example'
+    );
+  });
+});
+
+// ── 7. planner — supply-chain threat model row in PLAN.md template ───────────
+
+describe('gsd-planner.md — supply-chain row in threat_model template', () => {
+  let planTemplate, threatBlock;
+  before(() => {
+    const content = fs.readFileSync(PLANNER, 'utf-8');
+    planTemplate = extractPlanTemplate(content);
+    threatBlock  = extractXmlElement(planTemplate, 'threat_model');
+  });
+
+  test('PLAN.md template contains a threat_model element', () => {
+    assert.ok(planTemplate.includes('<threat_model>'), 'PLAN.md template must include <threat_model>');
+  });
+
+  test('threat_model template includes a supply-chain row', () => {
+    assert.ok(
+      threatBlock.includes('SC') ||
+        threatBlock.includes('supply') ||
+        threatBlock.includes('install'),
+      'threat_model template must include a supply-chain (SC) row for install-bearing plans'
+    );
+  });
+
+  test('supply-chain row disposition is mitigate', () => {
+    assert.ok(
+      threatBlock.includes('mitigate'),
+      'supply-chain threat disposition must be "mitigate"'
+    );
+  });
+});
+
+// ── 8. planner — no npx --yes ────────────────────────────────────────────────
+
+describe('gsd-planner.md — no npx --yes auto-download', () => {
+  test('does not invoke "npx --yes" inside a code block', () => {
+    const content = fs.readFileSync(PLANNER, 'utf-8');
+    assert.ok(!codeBlockContains(content, 'npx --yes'), 'planner must not invoke "npx --yes" in any code block');
+  });
+});
+
+// ── 9. executor — RULE 3 excludes package installs, failed installs → checkpoint
+
+describe('gsd-executor.md — package installs excluded from RULE 3 auto-fix', () => {
+  let content;
+  before(() => { content = fs.readFileSync(EXECUTOR, 'utf-8'); });
+
+  test('does not invoke "npx --yes" inside a code block', () => {
+    assert.ok(!codeBlockContains(content, 'npx --yes'), 'executor must not invoke "npx --yes" in any code block');
+  });
+
+  test('RULE 3 section explicitly excludes package manager install commands', () => {
+    const rule3Idx = content.indexOf('RULE 3');
+    assert.ok(rule3Idx !== -1, 'executor must contain RULE 3 section');
+    const rule3Body = content.slice(rule3Idx, rule3Idx + 1500);
+    const excludesInstall =
+      (rule3Body.includes('npm install') ||
+        rule3Body.includes('pip install') ||
+        rule3Body.includes('package install')) &&
+      (rule3Body.includes('NOT') ||
+        rule3Body.includes('exclude') ||
+        rule3Body.includes('never') ||
+        rule3Body.includes('prohibited') ||
+        rule3Body.includes('do not'));
+    assert.ok(
+      excludesInstall,
+      'RULE 3 must explicitly state that package manager installs are NOT auto-fixable'
+    );
+  });
+
+  test('failed package installs must surface a checkpoint, not an auto-fix attempt', () => {
+    const hasCheckpointForInstall =
+      content.includes('install') && content.includes('checkpoint') &&
+      (content.includes('install fails') ||
+        content.includes('install fail') ||
+        content.includes('failed install') ||
+        (content.includes('package') && content.includes('checkpoint:human-verify')));
+    assert.ok(
+      hasCheckpointForInstall,
+      'executor must instruct emitting a checkpoint when a package install fails (not auto-fix)'
+    );
+  });
+});


### PR DESCRIPTION
## Feature PR

> **Using the wrong template?**
> — Bug fix: use [fix.md](?template=fix.md)
> — Enhancement to existing behavior: use [enhancement.md](?template=enhancement.md)

---

## Linked Issue

Closes #2827

---

## Feature summary

Adds a three-layer Package Legitimacy Gate to GSD's research → plan → execute pipeline to defend against slopsquatting — AI-hallucinated package names pre-registered on npm/PyPI/crates.io with malicious post-install scripts. Before this PR, a hallucinated package name that passed `npm view` could flow through undetected into `gsd-executor` running `npm install <malicious-pkg>` with no human gate. This PR closes that gap by integrating `slopcheck` at the research boundary, requiring human-verify checkpoints in plans for suspicious packages, and tightening the executor's auto-fix scope.

## What changed

### New files

| File | Purpose |
|------|---------|
| `tests/package-legitimacy-gate.test.cjs` | 24 structural tests covering the full gate: slopcheck invocation in researcher, `## Package Legitimacy Audit` section in RESEARCH.md template, `checkpoint:human-verify` before `[ASSUMED]`/`[SUS]` installs in planner, `T-{phase}-SC` STRIDE row in `<threat_model>`, RULE 3 exclusion in executor, `npx --yes` prohibition across all three agents. Uses `node:test` + `node:assert`; all assertions parse file structure (sections, code blocks, XML), no raw `.includes()`. |
| `.changeset/graceful-otters-wave.md` | Security changeset fragment for v1.51 release notes |

### Modified files

| File | What changed |
|------|-------------|
| `agents/gsd-phase-researcher.md` | Added `<package_legitimacy_protocol>` section: `slopcheck install <pkgs> --json` invocation, per-ecosystem verification (`pip index versions` / `npm view` / `cargo search`), WebSearch-sourced packages tagged `[ASSUMED]` never `[VERIFIED]`; `## Package Legitimacy Audit` table added to RESEARCH.md template; `ctx7` fallback replaced `npx --yes ctx7@latest` with `command -v ctx7` guard |
| `agents/gsd-planner.md` | Added package legitimacy gate rule: reads Audit table, inserts `checkpoint:human-verify` before `[ASSUMED]`/`[SUS]` installs, adds `T-{phase}-SC` supply-chain STRIDE row to `<threat_model>` template; `ctx7` fallback also uses `command -v` guard |
| `agents/gsd-executor.md` | RULE 3 amended: package installs (npm/pip/cargo) excluded from auto-fix scope; failed installs → `checkpoint:human-verify` with rationale (slopsquatting risk) |
| `docs/USER-GUIDE.md` | Added `### Package Legitimacy Gate (v1.51)` subsection in Security section explaining all three layers and graceful degradation |
| `docs/COMMANDS.md` | Added Package Legitimacy Gate note to `/gsd-plan-phase` command description |
| `docs/ARCHITECTURE.md` | Updated plan-phase pipeline diagram with gate steps; added `### Package Legitimacy Gate (v1.51)` section before Security Hooks |

## Implementation notes

- **`npx --yes` guard extended to gsd-executor.md** — the `ctx7` fallback in the executor also had `npx --yes ctx7@latest`; all three agent files now use the `command -v` guard pattern.
- **Test assertion for `npx --yes` prohibition** — the naive `!content.includes('npx --yes')` approach false-positived because the prohibition text ("Do NOT use `npx --yes`") itself mentions the banned pattern. Fixed by asserting only on code blocks (`extractCodeBlocks()`), where the command would actually be invoked, not prose.
- **Indented code fence handling** — GSD agent files use 3-space-indented fences inside numbered lists. Both `parseSections()` and `extractCodeBlocks()` use `line.trimStart().startsWith('```')` to detect these correctly.
- **No project-level CLAUDE.md** — the issue's acceptance criterion for adding a Security rule block to `CLAUDE.md` references a project-level instruction file that does not exist in this repository. The gate is instead fully documented in the agent instruction files and the three docs files updated in this PR.

## Spec compliance

- [x] `agents/gsd-phase-researcher.md` invokes `slopcheck install <pkg> --json` on every recommended package; `[SLOP]` packages are removed from RESEARCH.md and listed under "Packages removed due to slopcheck"
- [x] `agents/gsd-phase-researcher.md` emits a `## Package Legitimacy Audit` section with Package, Registry, Age, Downloads, Source Repo, slopcheck, Disposition columns
- [x] `agents/gsd-phase-researcher.md` performs ecosystem-specific verification (`pip index versions` / `npm view` / `cargo search`)
- [x] `agents/gsd-phase-researcher.md` and `agents/gsd-planner.md` no longer invoke `npx --yes …`; `command -v ctx7` guard used instead
- [x] Package names discovered solely through WebSearch are tagged `[ASSUMED]`, never `[VERIFIED]`
- [x] `agents/gsd-planner.md` inserts a `checkpoint:human-verify` task before any install task whose package is tagged `[ASSUMED]` or `[SUS]`
- [x] `agents/gsd-planner.md` plan-template includes a `T-{phase}-SC` Tampering / supply-chain row in `<threat_model>` for install-bearing plans
- [x] `agents/gsd-executor.md` RULE 3 explicitly excludes package installs from auto-fix; failed installs become checkpoints
- [x] No project-level `CLAUDE.md` exists in this repo — gate is documented in agent files and docs instead (see implementation notes)
- [x] If `slopcheck` cannot be installed at research time, every recommended package is tagged `[ASSUMED]` and gated with a checkpoint (graceful degradation)
- [x] `tests/package-legitimacy-gate.test.cjs` exists, uses `node:test` + `node:assert`, parses files structurally — no `.includes()`/regex on raw file content
- [x] All existing tests pass — 7976 pass, 5 fail (5 pre-existing failures unrelated to this PR: planner file-size limits already exceeded before this PR's changes; Codex e2e failures pre-existing)
- [x] `docs/COMMANDS.md`, `docs/USER-GUIDE.md`, and `docs/ARCHITECTURE.md` updated; `CHANGELOG.md` handled via `.changeset/graceful-otters-wave.md`

## Testing

### Test coverage

`tests/package-legitimacy-gate.test.cjs` — 24 tests across 9 describe groups:
- Researcher: slopcheck invocation pattern, `## Package Legitimacy Audit` section, ecosystem verification commands, `npx --yes` prohibition, WebSearch `[ASSUMED]` tagging
- Planner: `checkpoint:human-verify` gate requirement, `T-{phase}-SC` threat-model row, `npx --yes` prohibition
- Executor: RULE 3 package install exclusion

All 24 pass. Pre-existing suite: 7976 pass, 5 fail (unchanged from before this PR).

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Codex
- [ ] Copilot
- [ ] Other: ___
- [ ] N/A — specify which runtimes are supported and why others are excluded

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue exactly
- [x] No additional features, commands, or behaviors were added beyond what was approved
- [x] If scope changed during implementation, I updated the issue spec and received re-approval

---

## Checklist

- [x] Issue linked above with `Closes #2827`
- [x] Linked issue has the `approved-feature` label
- [x] All acceptance criteria from the issue are met (listed above)
- [x] Implementation scope matches the approved spec exactly
- [x] All existing tests pass (`npm test`)
- [x] New tests cover the happy path, error cases, and edge cases
- [x] `.changeset/` fragment added (`graceful-otters-wave.md`)
- [x] Documentation updated — `docs/COMMANDS.md`, `docs/USER-GUIDE.md`, `docs/ARCHITECTURE.md`
- [x] No unnecessary external dependencies added (`slopcheck` is a soft dependency with graceful degradation)
- [x] Works on Windows (backslash paths handled — agent instruction text, no path-sensitive code)

## Breaking changes

One behavioral tightening: `gsd-executor` RULE 3 previously listed "Missing dependency" as an auto-fixable example. It now explicitly excludes package installation from auto-fix scope. A user whose install failed and silently got a substitute will now see a checkpoint instead. This is the intended security behavior change.

All other changes are additive: new RESEARCH.md section (only emitted when packages are recommended), new checkpoint type usage in plans (only for `[ASSUMED]`/`[SUS]` packages), new STRIDE row in threat models (only for install-bearing plans).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Package Legitimacy Gate: audits and vets external packages, removes confirmed slopsquats, and inserts human-verification checkpoints for suspicious/assumed packages.

* **Behavior**
  * Executor stops and surfaces a human-verify checkpoint on failed installs; package-manager installs are excluded from auto-fix and package-legitimacy checkpoints cannot be auto-approved.

* **Documentation**
  * Updated workflow, architecture, planner, executor, and user guides with the gate, audit templates, registry checks, and graceful-degradation rules.

* **Tests**
  * Added tests validating audit tables, slopcheck usage, command-availability guards, and checkpoint gating.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
