### PR TITLE
fix(docs): replace deleted /gsd-new-workspace with /gsd-workspace --new in FEATURES.md

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -2796,7 +2796,7 @@ Users who run a memory / knowledge-base MCP server (for example, ExoCortex-style
 **Document:** [`docs/issue-driven-orchestration.md`](issue-driven-orchestration.md)
 
 **Covered workflow:**
-1. Create an isolated workspace per issue (`/gsd-new-workspace`)
+1. Create an isolated workspace per issue (`/gsd-workspace --new`)
 2. Run the manager dashboard to get oriented (`/gsd-manager`)
 3. Execute autonomously (`/gsd-autonomous`)
 4. Verify and review (`/gsd-verify-work`, `/gsd-review`)


### PR DESCRIPTION
## Fix

**Type:** Bug fix (confirmed bug — see #3220)

**Root cause:** The v1.41.0 doc update (`c0be296`) added Feature 129 (Issue-Driven Orchestration Guide) to `docs/FEATURES.md` with a workflow step referencing `/gsd-new-workspace` — a command deleted in v1.40.0. The stale-ref test at `tests/bug-3042-3044-research-flag-and-stale-refs.test.cjs:253` catches this and has been failing on `main` since the merge.

**Change:** One-line replacement — `/gsd-new-workspace` → `/gsd-workspace --new` in Feature 129's workflow step list.

**Testing:** `npm test` — the stale-ref assertion now passes; no other test touched.

Fixes #3220

---

**Checklist**
- [x] Linked issue has `confirmed-bug` label
- [x] CHANGELOG.md updated (no — single-line docs correction, `no-changelog` label applied)
- [x] Tests pass locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Issue-Driven Orchestration Guide with the latest workspace creation command syntax to ensure developers have accurate guidance for creating isolated workspaces per issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->