### PR TITLE
fix(executor): detect subagent stalls and STATE drift on resume (#3212)

### DIFF
--- a/.changeset/sharp-wasps-chatter.md
+++ b/.changeset/sharp-wasps-chatter.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3212
+---
+**Executor stall + STATE drift detection** — adds atomic close-out invariant doc, opt-in plan-consistency-check (STATE.md vs disk vs git log) used by resume-project to detect partial-execution drift, and dispatch.commit-since surveillance probe complementing subagent_timeout. All changes additive.

--- a/agents/gsd-executor.md
+++ b/agents/gsd-executor.md
@@ -135,6 +135,22 @@ For each task:
 
 </execution_flow>
 
+<atomic_closeout_invariant>
+**Invariant:** Per-task production commits, the SUMMARY.md, the STATE.md update, and the ROADMAP.md update are a single observational unit. If any one is missing for a plan, the plan is in a *drift* state and the next workflow that touches it MUST reconcile, not redo.
+
+**Sequence (do not reorder):**
+
+1. `<execute_tasks>` — per-task production commits land first.
+2. `<self_check>` — verify those commits exist before writing SUMMARY.
+3. `<summary_creation>` — write SUMMARY.md.
+4. `<state_updates>` — call `gsd-sdk query state.advance-plan`, `state.update-progress`, `roadmap.update-plan-progress`.
+5. `<final_commit>` — single commit covering SUMMARY + STATE + ROADMAP. Returning to the orchestrator before this commit lands is, by definition, a partial close-out.
+
+**Full contract, drift table, and reconciliation guidance:** see `docs/ATOMIC-CLOSEOUT-INVARIANT.md`.
+
+**Stall posture:** if you cannot complete steps 3–5 within your task budget, *do not* return success. Return a checkpoint via `checkpoint_return_format` with the per-task commit hashes already landed so the resume path can reconcile cleanly.
+</atomic_closeout_invariant>
+
 <deviation_rules>
 **While executing, you WILL discover work not in the plan.** Apply these rules automatically. Track all deviations for Summary.
 

--- a/docs/ATOMIC-CLOSEOUT-INVARIANT.md
+++ b/docs/ATOMIC-CLOSEOUT-INVARIANT.md
@@ -1,0 +1,161 @@
+# Plan Atomic Close-Out Invariant
+
+> **Status:** Documented and partially enforced as of v1.50.0 (issue
+> [#3212](https://github.com/gsd-build/get-shit-done/issues/3212)).
+> Documentation is the contract; runtime enforcement is split across
+> `agents/gsd-executor.md` (producer side) and the new `plan.consistency-check`
+> SDK handler (consumer side).
+
+When the GSD executor finishes a plan, **four artifacts must exist together**.
+This document names them, defines what "together" means, and tells you what
+to do if you find them out of sync.
+
+---
+
+## The four artifacts
+
+For every plan `{phase}-{plan}` that the executor reports as complete:
+
+| # | Artifact | Where it lives | What it proves |
+|---|---|---|---|
+| 1 | **Per-task production commits** | `git log --grep="({phase}-{plan})"` | The code changes the plan asked for actually landed |
+| 2 | **`{phase}-{plan}-SUMMARY.md`** | `.planning/phases/XX-name/` | The agent finished the plan, recorded deviations, and self-checked |
+| 3 | **`STATE.md` advanced** | `.planning/STATE.md` | The cursor (`Current Plan`, progress bar) reflects the plan as done |
+| 4 | **`ROADMAP.md` updated** | `.planning/ROADMAP.md` | Cross-phase progress table reflects the plan as done |
+
+The atomic close-out **commit** that lands artifacts 2–4 is a single `git commit`
+created by the executor's `<final_commit>` step (`agents/gsd-executor.md` lines
+659–666). It is intentionally separate from the per-task production commits so
+that resume tooling can distinguish "code landed" from "plan reported done."
+
+---
+
+## What "atomic" means here
+
+"Atomic" in this context is **observational**, not transactional. We cannot
+make four file writes and a git commit physically atomic. Instead, the
+contract is:
+
+> **If artifact 1 (production commits) exists for a plan, then artifacts 2, 3,
+> and 4 must also exist before any other GSD workflow treats that plan as
+> done.**
+
+The framework cannot prevent a partial-write at runtime (network glitch,
+agent stall, kill -9). What it **does** do — newly, post-#3212 — is detect
+the partial state on the next entry into a workflow and refuse to advance.
+
+---
+
+## Possible inconsistent states
+
+| State | Production commits? | SUMMARY.md? | STATE advanced? | ROADMAP updated? | Meaning |
+|---|---|---|---|---|---|
+| **Consistent: not started** | no | no | no | no | Plan has not been executed; safe to dispatch |
+| **Consistent: complete** | yes | yes | yes | yes | Plan finished cleanly; safe to advance |
+| **Drift A: stalled mid-execute** | yes | no | no | no | Agent committed code, then stopped before SUMMARY. **Resume requires reconciliation** — do NOT redo. |
+| **Drift B: SUMMARY without state** | yes | yes | no | no | SUMMARY landed but STATE/ROADMAP did not. Cursor still points here. **Re-run only the state-update step.** |
+| **Drift C: state without SUMMARY** | yes | no | yes | yes | STATE moved on but SUMMARY is missing. **Reconstruct SUMMARY from git log; do NOT redo code.** |
+| **Drift D: phantom done** | no | yes | yes | yes | SUMMARY/state say done but no code commits exist. **Investigate — likely a manually-edited STATE.md.** |
+
+The new `plan.consistency-check` SDK handler returns one of these state names
+(or `consistent`/`unknown`) so workflows can branch on the result.
+
+---
+
+## Producer-side responsibilities (`agents/gsd-executor.md`)
+
+The executor agent's prose in `<execution_flow>` already orders the four
+steps correctly. Post-#3212, that file also carries an explicit
+`<atomic_closeout_invariant>` callout pointing here, so future edits do not
+silently reorder the sequence.
+
+The executor MUST:
+
+1. Land all per-task production commits **first** (loop in `<execute_tasks>`).
+2. Run `<self_check>` — verify code commits exist before writing SUMMARY.
+3. Write **and commit** SUMMARY.md (`<summary_creation>` → per-task commit
+   protocol; in worktree mode, commit happens inside the agent's own commit;
+   in single-tree mode, SUMMARY.md is committed in `<final_commit>`).
+4. Update STATE.md and ROADMAP.md via SDK handlers (`<state_updates>`).
+5. Land the final commit covering SUMMARY + STATE + ROADMAP
+   (`<final_commit>`). This single commit is what makes the close-out
+   observable from outside.
+
+If the executor returns to the orchestrator before step 5, the plan is in a
+**drift** state by definition.
+
+---
+
+## Consumer-side responsibilities (resume / dispatch)
+
+Any workflow that decides "is this plan done?" or "should I dispatch this
+plan?" must consult `plan.consistency-check` first.
+
+```bash
+# Inspect a single plan
+gsd-sdk query plan.consistency-check --phase 4 --plan 03
+
+# Returns:
+# {
+#   "phase": "4",
+#   "plan": "03",
+#   "state": "drift_a_stalled_midexecute",
+#   "production_commits": 2,
+#   "summary_exists": false,
+#   "state_advanced": false,
+#   "roadmap_updated": false,
+#   "advice": "Reconcile manually — do NOT redo code."
+# }
+```
+
+The `commands/gsd/resume-work.md` flow (via `resume-project.md`'s
+`check_incomplete_work` step) calls this handler for any phase whose
+directory exists. Drift states surface as a blocker prompt rather than
+silently re-dispatching.
+
+---
+
+## What changes in v1.50.0 (from #3212)
+
+1. **This document exists** — the invariant has a single canonical home.
+2. **`agents/gsd-executor.md` has an `<atomic_closeout_invariant>` block**
+   pointing here.
+3. **`plan.consistency-check` SDK handler** computes the table above for any
+   `{phase, plan}` pair without modifying disk.
+4. **`commands/gsd/resume-work.md` is wired** to call the handler before
+   re-dispatching incomplete plans (the existing "PLAN without SUMMARY"
+   branch is preserved as a fallback when the handler is unavailable).
+5. **Optional dispatch surveillance probe** — `dispatch.commit-since` SDK
+   handler. Orchestrators that want stall detection can poll
+   `gsd-sdk query dispatch.commit-since --since $T0 [--plan $plan_id]` on a
+   wall-clock cadence; `count == 0` means no new commits landed since $T0.
+   The probe is read-only, requires no config keys, and is **complementary
+   to** (not a replacement for) the existing `workflow.subagent_timeout`
+   wall-clock kill switch. Existing workflows that do not call this probe
+   continue to work exactly as before.
+
+---
+
+## Backward compatibility
+
+All five additions are **purely additive**:
+
+- No existing config key changes default value.
+- No existing agent prompt is rewritten — only an invariant callout is added.
+- No existing `gsd-sdk query` command changes its return shape.
+- The new `plan.consistency-check` handler only **reads** disk and git log.
+- Surveillance is opt-in and defaults to off.
+
+A project that ignores all of this continues to work exactly as before.
+
+---
+
+## Related issues
+
+- **#3212** — Executor Subagent Stall and STATE Invariant Breakdown
+  (this issue: defines the three problems and the additive fix).
+- **#1472** — `workflow.subagent_timeout` config key
+  (the wall-clock kill switch that surveillance complements).
+- **#2833** — STATE.md phase-lifecycle frontmatter
+  (the read-side that visualizes plan progress; consistency-check protects
+  the data this surfaces).

--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -657,6 +657,15 @@ increases monotonically across waves. `{status}` is `complete` (success),
    [checkpoint] phase {PHASE_NUMBER} wave {N}/{M} plan {plan_id} checkpoint ({P}/{Q} plans done)
    ```
 
+   **Stall surveillance probe (#3212, optional):** for runtimes that can poll during
+   the await, an orchestrator can call `gsd-sdk query dispatch.commit-since --since $T0 --plan {plan_id}`
+   on a wall-clock cadence (e.g. every 60s) where $T0 is the Unix epoch captured immediately
+   before the `Agent()` dispatch. `count == 0` for an extended period (suggested: 5 minutes
+   for execution-heavy plans, 2 minutes for short plans) is a stall signal — surface it as a
+   warning and offer the user a continue/abort choice. The probe is read-only, returns
+   immediately, and is **complementary to** (not a replacement for) `workflow.subagent_timeout`.
+   Workflows that do not implement polling continue to work exactly as before — this is opt-in.
+
    **Completion signal fallback (Copilot and runtimes where Agent() may not return):**
 
    If a spawned agent does not return a completion signal but appears to have finished

--- a/get-shit-done/workflows/resume-project.md
+++ b/get-shit-done/workflows/resume-project.md
@@ -69,11 +69,28 @@ cat .planning/HANDOFF.json 2>/dev/null || true
 # Check for continue-here files (mid-plan resumption)
 ls .planning/phases/*/.continue-here*.md 2>/dev/null || true
 
-# Check for plans without summaries (incomplete execution)
+# Check for plans without summaries (incomplete execution).
+# Post-#3212: when SUMMARY is missing we also ask the SDK whether the
+# plan is in a *drift* state (production commits already landed). The
+# SDK call is best-effort — if it fails or is unavailable, fall through
+# to the existing filesystem-only signal.
 for plan in .planning/phases/*/*-PLAN.md; do
   [ -e "$plan" ] || continue
   summary="${plan/PLAN/SUMMARY}"
-  [ ! -f "$summary" ] && echo "Incomplete: $plan"
+  if [ ! -f "$summary" ]; then
+    echo "Incomplete: $plan"
+    # Extract phase + plan ids from the filename, e.g. "04-03-PLAN.md" -> phase=04 plan=03.
+    base="$(basename "$plan")"
+    phase_id="${base%%-*}"
+    rest="${base#$phase_id-}"
+    plan_id="${rest%%-*}"
+    if [ -n "$phase_id" ] && [ -n "$plan_id" ]; then
+      pcc="$(gsd-sdk query plan.consistency-check --phase "$phase_id" --plan "$plan_id" 2>/dev/null || true)"
+      if [ -n "$pcc" ]; then
+        echo "Consistency: $pcc"
+      fi
+    fi
+  fi
 done 2>/dev/null || true
 
 # Check for interrupted agents (use has_interrupted_agent and interrupted_agent_id from init)
@@ -103,6 +120,7 @@ fi
 
 - Execution was started but not completed
 - Flag: "Found incomplete plan execution"
+- **Drift detection (#3212):** if the `Consistency:` line above (from `gsd-sdk query plan.consistency-check`) reports a `drift_*` state, the plan is in a partial close-out — see `docs/ATOMIC-CLOSEOUT-INVARIANT.md`. Surface the `advice` field to the user verbatim and **do NOT redispatch the executor** until the user confirms reconciliation. If the consistency-check output is missing (older SDK or call failure), fall through to the existing filesystem-only behavior.
 
 **If interrupted agent found:**
 

--- a/sdk/src/query/command-static-catalog-domain.ts
+++ b/sdk/src/query/command-static-catalog-domain.ts
@@ -16,6 +16,8 @@ import { uatRenderCheckpoint, auditUat } from './uat.js';
 import { intelStatus, intelDiff, intelSnapshot, intelValidate, intelQuery, intelExtractExports, intelPatchMeta, intelUpdate } from './intel.js';
 import { writeProfile, generateClaudeProfile, generateDevPreferences, generateClaudeMd } from './profile-output.js';
 import { phaseMvpMode, taskIsBehaviorAdding, userStoryValidate } from './mvp.js';
+import { planConsistencyCheck } from './plan-consistency-check.js';
+import { dispatchCommitSince } from './dispatch-surveillance.js';
 
 export const DOMAIN_STATIC_CATALOG: ReadonlyArray<readonly [string, QueryHandler]> = [
   ['agent-skills', agentSkills],
@@ -111,4 +113,10 @@ export const DOMAIN_STATIC_CATALOG: ReadonlyArray<readonly [string, QueryHandler
   ['task is-behavior-adding', taskIsBehaviorAdding],
   ['user-story.validate', userStoryValidate],
   ['user-story validate', userStoryValidate],
+  // ── Plan close-out invariant (#3212) — read-only diagnostic ──
+  ['plan.consistency-check', planConsistencyCheck],
+  ['plan consistency-check', planConsistencyCheck],
+  // ── Stall surveillance (#3212) — read-only commit progress probe ──
+  ['dispatch.commit-since', dispatchCommitSince],
+  ['dispatch commit-since', dispatchCommitSince],
 ] as const;

--- a/sdk/src/query/dispatch-surveillance.test.ts
+++ b/sdk/src/query/dispatch-surveillance.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Vitest unit tests for `dispatch.commit-since` (issue #3212, Stage C).
+ *
+ * Each test arranges a tmp git project with controlled commit timestamps
+ * and asserts the surveillance probe correctly detects "did anything land
+ * since T?" The handler is a best-effort read-only probe — its contract
+ * with callers is: never throw on git failures, always return the result
+ * shape, treat "no git" the same as "no commits."
+ */
+
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { dispatchCommitSince, type DispatchCommitSinceResult } from './dispatch-surveillance.js';
+
+interface GitFixture { dir: string }
+
+function mkGitRepo(): GitFixture {
+  const dir = mkdtempSync(join(tmpdir(), 'gsd-surv-'));
+  execFileSync('git', ['init', '-q'], { cwd: dir });
+  execFileSync('git', ['config', 'user.email', 'test@test.com'], { cwd: dir });
+  execFileSync('git', ['config', 'user.name', 'Test'], { cwd: dir });
+  execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd: dir });
+  return { dir };
+}
+
+function commit(dir: string, subject: string, timestampUnix?: number): void {
+  const env: Record<string, string> = { ...process.env } as Record<string, string>;
+  if (timestampUnix !== undefined) {
+    const iso = new Date(timestampUnix * 1000).toISOString();
+    env.GIT_AUTHOR_DATE = iso;
+    env.GIT_COMMITTER_DATE = iso;
+  }
+  execFileSync('git', ['commit', '--allow-empty', '-m', subject], { cwd: dir, env });
+}
+
+function nowUnix(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+describe('dispatchCommitSince — argv validation', () => {
+  test('throws when --since is missing', async () => {
+    await expect(dispatchCommitSince([], '/tmp')).rejects.toThrow(/--since/);
+  });
+
+  test('throws when --since has no value', async () => {
+    await expect(dispatchCommitSince(['--since'], '/tmp')).rejects.toThrow();
+  });
+
+  test('throws when --since is not numeric', async () => {
+    await expect(dispatchCommitSince(['--since', 'yesterday'], '/tmp')).rejects.toThrow(/non-negative/);
+  });
+
+  test('throws when --since is negative', async () => {
+    await expect(dispatchCommitSince(['--since', '-1'], '/tmp')).rejects.toThrow();
+  });
+
+  test('throws when --plan has no value', async () => {
+    await expect(dispatchCommitSince(['--since', '0', '--plan'], '/tmp')).rejects.toThrow(/--plan/);
+  });
+});
+
+describe('dispatchCommitSince — best-effort failure handling', () => {
+  test('returns count=0 in non-git directory (no throw)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gsd-surv-nogit-'));
+    try {
+      const out = await dispatchCommitSince(['--since', '0'], dir);
+      const data = out.data as DispatchCommitSinceResult;
+      expect(data.count).toBe(0);
+      expect(data.latest_hash).toBeNull();
+      expect(data.latest_timestamp_unix).toBeNull();
+      expect(data.since_unix).toBe(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('echoes since_unix and plan_filter regardless of git state', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'gsd-surv-nogit-'));
+    try {
+      const out = await dispatchCommitSince(['--since', '1234567890', '--plan', '4-03'], dir);
+      const data = out.data as DispatchCommitSinceResult;
+      expect(data.since_unix).toBe(1234567890);
+      expect(data.plan_filter).toBe('4-03');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('dispatchCommitSince — git probe correctness', () => {
+  let fix: GitFixture;
+  beforeEach(() => { fix = mkGitRepo(); });
+  afterEach(() => { rmSync(fix.dir, { recursive: true, force: true }); });
+
+  test('counts only commits after --since', async () => {
+    // Three commits at known timestamps, all in the past.
+    commit(fix.dir, 'old commit', 1_700_000_000);
+    commit(fix.dir, 'middle commit', 1_700_500_000);
+    commit(fix.dir, 'recent commit', 1_701_000_000);
+
+    // since=1_700_400_000 should exclude the first, include the latter two
+    const out = await dispatchCommitSince(['--since', '1700400000'], fix.dir);
+    const data = out.data as DispatchCommitSinceResult;
+    expect(data.count).toBe(2);
+    expect(data.latest_subject).toBe('recent commit');
+    expect(data.latest_timestamp_unix).toBe(1_701_000_000);
+  });
+
+  test('count=0 when nothing newer than since', async () => {
+    commit(fix.dir, 'old commit', 1_700_000_000);
+    const future = nowUnix() + 86_400;  // 1 day in the future
+    const out = await dispatchCommitSince(['--since', String(future)], fix.dir);
+    const data = out.data as DispatchCommitSinceResult;
+    expect(data.count).toBe(0);
+    expect(data.latest_hash).toBeNull();
+  });
+
+  test('--plan filter narrows count to subject-matching commits', async () => {
+    commit(fix.dir, 'feat(4-03): A', 1_700_000_000);
+    commit(fix.dir, 'feat(4-04): unrelated', 1_700_500_000);
+    commit(fix.dir, 'feat(4-03): B', 1_701_000_000);
+
+    const out = await dispatchCommitSince(['--since', '0', '--plan', '4-03'], fix.dir);
+    const data = out.data as DispatchCommitSinceResult;
+    expect(data.count).toBe(2);
+    expect(data.plan_filter).toBe('4-03');
+  });
+
+  test('latest_hash is a non-empty short hash when any commit matches', async () => {
+    commit(fix.dir, 'a commit', 1_700_000_000);
+    const out = await dispatchCommitSince(['--since', '0'], fix.dir);
+    const data = out.data as DispatchCommitSinceResult;
+    expect(data.latest_hash).toBeTruthy();
+    expect(typeof data.latest_hash).toBe('string');
+    expect((data.latest_hash as string).length).toBeGreaterThan(0);
+  });
+});
+
+describe('dispatchCommitSince — read-only contract', () => {
+  let fix: GitFixture;
+  beforeEach(() => { fix = mkGitRepo(); });
+  afterEach(() => { rmSync(fix.dir, { recursive: true, force: true }); });
+
+  test('does not create any files', async () => {
+    commit(fix.dir, 'one', 1_700_000_000);
+    const fs = await import('node:fs');
+    const before = fs.readdirSync(fix.dir).sort().join(',');
+    await dispatchCommitSince(['--since', '0'], fix.dir);
+    const after = fs.readdirSync(fix.dir).sort().join(',');
+    expect(after).toBe(before);
+  });
+
+  test('does not advance HEAD', async () => {
+    commit(fix.dir, 'one', 1_700_000_000);
+    const before = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: fix.dir, encoding: 'utf8' }).trim();
+    await dispatchCommitSince(['--since', '0'], fix.dir);
+    const after = execFileSync('git', ['rev-parse', 'HEAD'], { cwd: fix.dir, encoding: 'utf8' }).trim();
+    expect(after).toBe(before);
+  });
+});

--- a/sdk/src/query/dispatch-surveillance.ts
+++ b/sdk/src/query/dispatch-surveillance.ts
@@ -1,0 +1,182 @@
+/**
+ * `dispatch.commit-since` query handler — read-only progress probe used by
+ * orchestrators to detect stalls during subagent dispatch.
+ *
+ * Background (issue #3212): the `/gsd-execute-phase` orchestrator awaits
+ * `Agent()` returns synchronously and has no progress-during-dispatch
+ * monitor. The hard `workflow.subagent_timeout` is a wall-clock kill switch
+ * that fires AFTER the timeout window — it does not detect *stalls within
+ * the window*. Surveillance complements timeout: it answers "have any new
+ * commits landed since timestamp T?" so workflows can poll on a cadence
+ * and surface a warning before reaching the hard timeout.
+ *
+ * The handler is deliberately **stateless and additive**:
+ * - No config key reads (orchestrators pass the threshold inline as argv).
+ * - No file writes.
+ * - No git mutations — only `git log` reads.
+ * - Returns `{ count: 0, ... }` on any failure mode (no git repo,
+ *   timestamp parse error, git not on PATH) so polling loops never raise.
+ *
+ * @example
+ * ```bash
+ * # In an orchestrator polling loop:
+ * SINCE=$(date +%s)
+ * # ... dispatch agent ...
+ * # ... after wait interval ...
+ * gsd-sdk query dispatch.commit-since --since $SINCE
+ * # → { count: 2, latest_hash: "abc1234", latest_timestamp_unix: 1714942839, ... }
+ * ```
+ */
+
+import { execFileSync } from 'node:child_process';
+import { GSDError, ErrorClassification } from '../errors.js';
+import type { QueryHandler } from './utils.js';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface DispatchCommitSinceResult {
+  /** Count of commits with `committer date >= since` on any ref. */
+  count: number;
+  /** Short hash of the most recent commit, or null if none. */
+  latest_hash: string | null;
+  /** Subject of the most recent commit, or null. */
+  latest_subject: string | null;
+  /** Committer Unix epoch of the most recent commit, or null. */
+  latest_timestamp_unix: number | null;
+  /** Echoed `--since` value (Unix epoch seconds). */
+  since_unix: number;
+  /** Optional plan id filter that was applied. */
+  plan_filter: string | null;
+}
+
+// ─── argv parsing ───────────────────────────────────────────────────────────
+
+interface ParsedArgs {
+  sinceUnix: number;
+  planFilter: string | null;
+}
+
+function parseFlagArgs(args: string[]): ParsedArgs {
+  const sinceIdx = args.indexOf('--since');
+  if (sinceIdx === -1) {
+    throw new GSDError(
+      'dispatch.commit-since requires --since <unix-epoch-seconds>',
+      ErrorClassification.Validation,
+    );
+  }
+  const raw = args[sinceIdx + 1];
+  if (!raw || raw.startsWith('--')) {
+    throw new GSDError(
+      'dispatch.commit-since: --since requires a numeric value',
+      ErrorClassification.Validation,
+    );
+  }
+  const sinceUnix = Number(raw);
+  if (!Number.isFinite(sinceUnix) || sinceUnix < 0) {
+    throw new GSDError(
+      `dispatch.commit-since: --since must be a non-negative Unix epoch (got ${raw})`,
+      ErrorClassification.Validation,
+    );
+  }
+  // Optional `--plan <id>` filter — when set, only commits whose subject
+  // contains `(<id>)` are counted. Useful for "did THIS plan stall?"
+  // queries during a multi-plan wave.
+  const planIdx = args.indexOf('--plan');
+  let planFilter: string | null = null;
+  if (planIdx !== -1) {
+    const v = args[planIdx + 1];
+    if (!v || v.startsWith('--')) {
+      throw new GSDError(
+        'dispatch.commit-since: --plan requires a value',
+        ErrorClassification.Validation,
+      );
+    }
+    planFilter = v;
+  }
+  return { sinceUnix, planFilter };
+}
+
+// ─── handler ────────────────────────────────────────────────────────────────
+
+/**
+ * Best-effort git probe. Returns empty/null on any failure so callers can
+ * treat "no commits" and "no git" identically.
+ */
+function probeGit(cwd: string, sinceUnix: number, planFilter: string | null): {
+  commits: string[]; latestSubject: string | null; latestUnix: number | null
+} {
+  // Format: `<short-hash> <unix-timestamp> <subject>` per commit. Using `%ct`
+  // (committer date) so it matches what wall-clock-based stall detection
+  // expects. Author date is intentionally NOT used (it can be far in the
+  // past for cherry-picked / rebased commits).
+  const args = [
+    'log', '--all',
+    `--max-age=${sinceUnix}`,  // Unix epoch lower-bound; --since=@N is unreliable across git versions on Windows
+    '--pretty=format:%h %ct %s',
+  ];
+  if (planFilter) {
+    args.push('-F', `--grep=(${planFilter})`);
+  }
+  let stdout: string;
+  try {
+    stdout = execFileSync('git', args, {
+      cwd,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 5000,
+    });
+  } catch {
+    return { commits: [], latestSubject: null, latestUnix: null };
+  }
+  const lines = stdout.split('\n').map(l => l.trim()).filter(l => l.length > 0);
+  if (lines.length === 0) {
+    return { commits: [], latestSubject: null, latestUnix: null };
+  }
+  // git log returns newest-first; the first line is the latest commit.
+  const latest = lines[0];
+  const firstSpace = latest.indexOf(' ');
+  const secondSpace = firstSpace === -1 ? -1 : latest.indexOf(' ', firstSpace + 1);
+  let latestSubject: string | null = null;
+  let latestUnix: number | null = null;
+  if (firstSpace !== -1 && secondSpace !== -1) {
+    const tsStr = latest.slice(firstSpace + 1, secondSpace);
+    const n = Number(tsStr);
+    latestUnix = Number.isFinite(n) ? n : null;
+    latestSubject = latest.slice(secondSpace + 1);
+  }
+  return { commits: lines, latestSubject, latestUnix };
+}
+
+/**
+ * Query handler implementing `dispatch.commit-since`.
+ *
+ * @param args argv tail. Must contain `--since <unix-epoch-seconds>`. May
+ *             contain `--plan <id>` to filter to commits matching a single
+ *             plan's subject scope.
+ * @param projectDir Project root resolved by the dispatcher. The git probe
+ *                   runs in this directory.
+ * @returns `{ data: DispatchCommitSinceResult }` — never throws for git
+ *          failures; only throws `GSDError(Validation)` for malformed argv.
+ */
+export const dispatchCommitSince: QueryHandler<DispatchCommitSinceResult> = async (args, projectDir) => {
+  const { sinceUnix, planFilter } = parseFlagArgs(args);
+
+  const probe = probeGit(projectDir, sinceUnix, planFilter);
+  const latest = probe.commits[0] ?? null;
+  let latest_hash: string | null = null;
+  if (latest) {
+    const sp = latest.indexOf(' ');
+    if (sp > 0) latest_hash = latest.slice(0, sp);
+  }
+
+  return {
+    data: {
+      count: probe.commits.length,
+      latest_hash,
+      latest_subject: probe.latestSubject,
+      latest_timestamp_unix: probe.latestUnix,
+      since_unix: sinceUnix,
+      plan_filter: planFilter,
+    },
+  };
+};

--- a/sdk/src/query/helpers.test.ts
+++ b/sdk/src/query/helpers.test.ts
@@ -91,6 +91,10 @@ describe('comparePhaseNum', () => {
     expect(comparePhaseNum('12-foo', '12.1-bar')).toBeLessThan(0);
   });
 
+  it('compares multi-digit decimal segments numerically', () => {
+    expect(comparePhaseNum('12.2-feature', '12.10-feature')).toBeLessThan(0);
+  });
+
   it('returns 0 for equal phases', () => {
     expect(comparePhaseNum('01-name', '01-other')).toBe(0);
   });

--- a/sdk/src/query/plan-consistency-check.test.ts
+++ b/sdk/src/query/plan-consistency-check.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Vitest unit tests for `plan.consistency-check`.
+ *
+ * Each test arranges a tmp project directory with a controlled mix of the
+ * four close-out artifacts (production commits, SUMMARY.md, STATE.md cursor,
+ * ROADMAP.md row) and asserts that the handler classifies the state
+ * correctly. Tests cover all six rows of the docs table plus the argv-
+ * validation surface.
+ *
+ * Closes #3212 (Stage B — handler registration + classification correctness).
+ */
+
+import { describe, expect, test, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { planConsistencyCheck, type PlanConsistencyResult } from './plan-consistency-check.js';
+
+interface ProjectFixture {
+  dir: string;
+  phaseDir: string;
+}
+
+function mkProject(): ProjectFixture {
+  const dir = mkdtempSync(join(tmpdir(), 'gsd-pcc-'));
+  const phaseDir = join(dir, '.planning', 'phases', '04-feature');
+  mkdirSync(phaseDir, { recursive: true });
+  // Initialize git so the handler's git-log probe can run without raising.
+  execFileSync('git', ['init', '-q'], { cwd: dir });
+  execFileSync('git', ['config', 'user.email', 'test@test.com'], { cwd: dir });
+  execFileSync('git', ['config', 'user.name', 'Test'], { cwd: dir });
+  execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd: dir });
+  // Initial empty commit so HEAD exists.
+  execFileSync('git', ['commit', '--allow-empty', '-m', 'init'], { cwd: dir });
+  return { dir, phaseDir };
+}
+
+function landProductionCommit(dir: string, phase: string, plan: string, taskName: string): void {
+  // Match the executor's commit-message convention: `feat({phase}-{plan}): …`
+  execFileSync(
+    'git',
+    ['commit', '--allow-empty', '-m', `feat(${phase}-${plan}): ${taskName}`],
+    { cwd: dir },
+  );
+}
+
+function writeSummary(phaseDir: string, phase: string, plan: string): void {
+  writeFileSync(
+    join(phaseDir, `${phase}-${plan}-SUMMARY.md`),
+    `# Phase ${phase} Plan ${plan} Summary\n\n(synthetic)\n`,
+  );
+}
+
+function writeStateAdvanced(dir: string, currentPhase: string, currentPlan: string): void {
+  const planningDir = join(dir, '.planning');
+  writeFileSync(
+    join(planningDir, 'STATE.md'),
+    [
+      '# State',
+      '',
+      '## Current Position',
+      '',
+      `**Current Phase:** ${currentPhase}`,
+      `**Current Plan:** ${currentPlan}`,
+      '**Status:** executing',
+      '',
+    ].join('\n'),
+  );
+}
+
+function writeRoadmapPlanComplete(dir: string, phase: string, plan: string): void {
+  const planningDir = join(dir, '.planning');
+  writeFileSync(
+    join(planningDir, 'ROADMAP.md'),
+    [
+      '# Roadmap',
+      '',
+      `- ${phase}-${plan} ✓ complete`,
+      '',
+    ].join('\n'),
+  );
+}
+
+describe('planConsistencyCheck — argv validation', () => {
+  let fix: ProjectFixture;
+  beforeEach(() => { fix = mkProject(); });
+  afterEach(() => { rmSync(fix.dir, { recursive: true, force: true }); });
+
+  test('throws when --phase is missing', async () => {
+    await expect(planConsistencyCheck(['--plan', '03'], fix.dir)).rejects.toThrow(/--phase/);
+  });
+
+  test('throws when --plan is missing', async () => {
+    await expect(planConsistencyCheck(['--phase', '4'], fix.dir)).rejects.toThrow(/--plan/);
+  });
+
+  test('throws when --phase has no value', async () => {
+    await expect(planConsistencyCheck(['--phase', '--plan', '03'], fix.dir)).rejects.toThrow();
+  });
+});
+
+describe('planConsistencyCheck — classification matrix', () => {
+  let fix: ProjectFixture;
+  beforeEach(() => { fix = mkProject(); });
+  afterEach(() => { rmSync(fix.dir, { recursive: true, force: true }); });
+
+  test('consistent_not_started: no commits, no SUMMARY, STATE on earlier plan, no roadmap row', async () => {
+    writeStateAdvanced(fix.dir, '04', '01');
+    const out = await planConsistencyCheck(['--phase', '4', '--plan', '03'], fix.dir);
+    const data = out.data as PlanConsistencyResult;
+    expect(data.state).toBe('consistent_not_started');
+    expect(data.production_commits).toBe(0);
+    expect(data.summary_exists).toBe(false);
+    expect(data.state_advanced).toBe(false);
+    expect(data.roadmap_updated).toBe(false);
+  });
+
+  test('drift_a_stalled_midexecute: commits landed but SUMMARY missing and STATE not advanced', async () => {
+    landProductionCommit(fix.dir, '4', '03', 'first task');
+    landProductionCommit(fix.dir, '4', '03', 'second task');
+    writeStateAdvanced(fix.dir, '04', '03');  // STATE still pointing at this plan
+    const out = await planConsistencyCheck(['--phase', '4', '--plan', '03'], fix.dir);
+    const data = out.data as PlanConsistencyResult;
+    expect(data.state).toBe('drift_a_stalled_midexecute');
+    expect(data.production_commits).toBe(2);
+    expect(data.summary_exists).toBe(false);
+    expect(data.state_advanced).toBe(false);
+    expect(data.advice).toMatch(/do NOT redo/i);
+  });
+
+  test('drift_b_summary_without_state: commits + SUMMARY exist but STATE/ROADMAP not advanced', async () => {
+    landProductionCommit(fix.dir, '4', '03', 'first');
+    writeSummary(fix.phaseDir, '04', '03');
+    writeStateAdvanced(fix.dir, '04', '03');
+    const out = await planConsistencyCheck(['--phase', '4', '--plan', '03'], fix.dir);
+    const data = out.data as PlanConsistencyResult;
+    expect(data.state).toBe('drift_b_summary_without_state');
+    expect(data.summary_exists).toBe(true);
+    expect(data.state_advanced).toBe(false);
+  });
+
+  test('drift_c_state_without_summary: commits + STATE advanced + ROADMAP marked, no SUMMARY', async () => {
+    landProductionCommit(fix.dir, '4', '03', 'first');
+    writeStateAdvanced(fix.dir, '04', '04');  // moved past plan 03
+    writeRoadmapPlanComplete(fix.dir, '04', '03');
+    const out = await planConsistencyCheck(['--phase', '4', '--plan', '03'], fix.dir);
+    const data = out.data as PlanConsistencyResult;
+    expect(data.state).toBe('drift_c_state_without_summary');
+    expect(data.summary_exists).toBe(false);
+    expect(data.state_advanced).toBe(true);
+    expect(data.roadmap_updated).toBe(true);
+  });
+
+  test('drift_d_phantom_done: SUMMARY/state/roadmap claim done but no production commits', async () => {
+    writeSummary(fix.phaseDir, '04', '03');
+    writeStateAdvanced(fix.dir, '04', '04');
+    writeRoadmapPlanComplete(fix.dir, '04', '03');
+    const out = await planConsistencyCheck(['--phase', '4', '--plan', '03'], fix.dir);
+    const data = out.data as PlanConsistencyResult;
+    expect(data.state).toBe('drift_d_phantom_done');
+    expect(data.production_commits).toBe(0);
+    expect(data.summary_exists).toBe(true);
+    expect(data.state_advanced).toBe(true);
+    expect(data.roadmap_updated).toBe(true);
+  });
+
+  test('consistent_complete: all four artifacts present and STATE moved past', async () => {
+    landProductionCommit(fix.dir, '4', '03', 'first');
+    landProductionCommit(fix.dir, '4', '03', 'second');
+    writeSummary(fix.phaseDir, '04', '03');
+    writeStateAdvanced(fix.dir, '04', '04');
+    writeRoadmapPlanComplete(fix.dir, '04', '03');
+    const out = await planConsistencyCheck(['--phase', '4', '--plan', '03'], fix.dir);
+    const data = out.data as PlanConsistencyResult;
+    expect(data.state).toBe('consistent_complete');
+    expect(data.production_commits).toBe(2);
+    expect(data.summary_exists).toBe(true);
+    expect(data.state_advanced).toBe(true);
+    expect(data.roadmap_updated).toBe(true);
+  });
+});
+
+describe('planConsistencyCheck — read-only contract', () => {
+  let fix: ProjectFixture;
+  beforeEach(() => { fix = mkProject(); });
+  afterEach(() => { rmSync(fix.dir, { recursive: true, force: true }); });
+
+  test('does not create STATE.md when absent', async () => {
+    // Sanity: STATE.md not written by the project setup
+    await planConsistencyCheck(['--phase', '4', '--plan', '03'], fix.dir);
+    // After the call, STATE.md must STILL not exist — handler is read-only
+    const fs = await import('node:fs');
+    expect(fs.existsSync(join(fix.dir, '.planning', 'STATE.md'))).toBe(false);
+    expect(fs.existsSync(join(fix.dir, '.planning', 'ROADMAP.md'))).toBe(false);
+  });
+
+  test('returns advice string for every state', async () => {
+    const out = await planConsistencyCheck(['--phase', '4', '--plan', '03'], fix.dir);
+    const data = out.data as PlanConsistencyResult;
+    expect(typeof data.advice).toBe('string');
+    expect(data.advice.length).toBeGreaterThan(0);
+  });
+});

--- a/sdk/src/query/plan-consistency-check.test.ts
+++ b/sdk/src/query/plan-consistency-check.test.ts
@@ -179,6 +179,20 @@ describe('planConsistencyCheck — classification matrix', () => {
     expect(data.state_advanced).toBe(true);
     expect(data.roadmap_updated).toBe(true);
   });
+
+  test('consistent_complete: decimal phase 12.10 advances past 12.2', async () => {
+    const decimalPhaseDir = join(fix.dir, '.planning', 'phases', '12.2-inserted');
+    mkdirSync(decimalPhaseDir, { recursive: true });
+    landProductionCommit(fix.dir, '12.2', '03', 'decimal phase task');
+    writeSummary(decimalPhaseDir, '12.2', '03');
+    writeStateAdvanced(fix.dir, '12.10', '01');
+    writeRoadmapPlanComplete(fix.dir, '12.2', '03');
+
+    const out = await planConsistencyCheck(['--phase', '12.2', '--plan', '03'], fix.dir);
+    const data = out.data as PlanConsistencyResult;
+    expect(data.state).toBe('consistent_complete');
+    expect(data.state_advanced).toBe(true);
+  });
 });
 
 describe('planConsistencyCheck — read-only contract', () => {

--- a/sdk/src/query/plan-consistency-check.ts
+++ b/sdk/src/query/plan-consistency-check.ts
@@ -20,7 +20,7 @@ import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { GSDError, ErrorClassification } from '../errors.js';
-import { planningPaths, normalizePhaseName } from './helpers.js';
+import { planningPaths, normalizePhaseName, comparePhaseNum } from './helpers.js';
 import type { QueryHandler } from './utils.js';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -192,8 +192,9 @@ function stateAdvancedPastPlan(projectDir: string, phase: string, plan: string, 
   const askPhase = normalizePhaseName(phase);
   const curPlan = parseInt(String(currentPlanMatch[1]).trim().replace(/^0+/, '') || '0', 10);
   const askPlan = parseInt(plan.replace(/^0+/, '') || '0', 10);
-  if (curPhase > askPhase) return true;
-  if (curPhase === askPhase && Number.isFinite(curPlan) && Number.isFinite(askPlan) && curPlan > askPlan) return true;
+  const phaseComparison = comparePhaseNum(curPhase, askPhase);
+  if (phaseComparison > 0) return true;
+  if (phaseComparison === 0 && Number.isFinite(curPlan) && Number.isFinite(askPlan) && curPlan > askPlan) return true;
   // STATE.md may also encode completion via status === 'completed' for the
   // milestone — that signal is downstream of all individual plans being
   // done, so we treat it as "advanced past everything".

--- a/sdk/src/query/plan-consistency-check.ts
+++ b/sdk/src/query/plan-consistency-check.ts
@@ -1,0 +1,322 @@
+/**
+ * `plan.consistency-check` query handler — read-only diagnostic that compares
+ * a plan's expected close-out artifacts (production commits, SUMMARY.md,
+ * STATE.md cursor, ROADMAP.md row) and reports whether they are in sync.
+ *
+ * Exists to close GitHub issue #3212 (executor stall + STATE drift). The
+ * handler is purely additive: it never writes any file, never mutates STATE.md,
+ * and is safe to call from any workflow at any time. It is the canonical
+ * implementation of the "Possible inconsistent states" table in
+ * `docs/ATOMIC-CLOSEOUT-INVARIANT.md`.
+ *
+ * @example
+ * ```bash
+ * gsd-sdk query plan.consistency-check --phase 4 --plan 03
+ * # → { phase: "4", plan: "03", state: "consistent_complete", ... }
+ * ```
+ */
+
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { GSDError, ErrorClassification } from '../errors.js';
+import { planningPaths, normalizePhaseName } from './helpers.js';
+import type { QueryHandler } from './utils.js';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+/**
+ * Closed enum of all states the close-out invariant can be in for a single
+ * plan. Names mirror the rows in `docs/ATOMIC-CLOSEOUT-INVARIANT.md`.
+ */
+export type PlanConsistencyState =
+  | 'consistent_not_started'
+  | 'consistent_complete'
+  | 'drift_a_stalled_midexecute'
+  | 'drift_b_summary_without_state'
+  | 'drift_c_state_without_summary'
+  | 'drift_d_phantom_done'
+  | 'unknown';
+
+export interface PlanConsistencyResult {
+  phase: string;
+  plan: string;
+  state: PlanConsistencyState;
+  production_commits: number;
+  summary_exists: boolean;
+  state_advanced: boolean;
+  roadmap_updated: boolean;
+  advice: string;
+}
+
+// ─── argv parsing ───────────────────────────────────────────────────────────
+
+function parseFlagArgs(args: string[]): { phase: string; plan: string } {
+  const phaseIdx = args.indexOf('--phase');
+  const planIdx = args.indexOf('--plan');
+  if (phaseIdx === -1 || planIdx === -1) {
+    throw new GSDError(
+      'plan.consistency-check requires --phase <id> and --plan <id>',
+      ErrorClassification.Validation,
+    );
+  }
+  const phase = args[phaseIdx + 1];
+  const plan = args[planIdx + 1];
+  if (!phase || phase.startsWith('--') || !plan || plan.startsWith('--')) {
+    throw new GSDError(
+      'plan.consistency-check: --phase and --plan must each have a value',
+      ErrorClassification.Validation,
+    );
+  }
+  return { phase, plan };
+}
+
+// ─── disk inspection helpers (read-only) ────────────────────────────────────
+
+function findPhaseDir(phasesRoot: string, phase: string): string | null {
+  if (!existsSync(phasesRoot)) return null;
+  const normalized = normalizePhaseName(phase);
+  let entries: string[];
+  try {
+    entries = readdirSync(phasesRoot);
+  } catch {
+    return null;
+  }
+  // Phase dirs are typically `XX-name` where XX is the (zero-padded) phase id.
+  // Match either the normalized id at the start, or the raw input as a prefix
+  // (handles custom IDs like `PROJ-42-name`).
+  for (const entry of entries) {
+    if (entry.startsWith(`${normalized}-`)) return join(phasesRoot, entry);
+    if (entry.startsWith(`${phase}-`)) return join(phasesRoot, entry);
+    if (entry === normalized || entry === phase) return join(phasesRoot, entry);
+  }
+  return null;
+}
+
+function summaryExistsForPlan(phaseDir: string, phase: string, plan: string): boolean {
+  if (!existsSync(phaseDir)) return false;
+  let entries: string[];
+  try {
+    entries = readdirSync(phaseDir);
+  } catch {
+    return false;
+  }
+  // SUMMARY filename pattern: {phase}-{plan}-SUMMARY.md (with various
+  // zero-padding variants — be liberal in what we accept).
+  const candidates = new Set<string>([
+    `${phase}-${plan}-SUMMARY.md`,
+    `${normalizePhaseName(phase)}-${plan}-SUMMARY.md`,
+    `${phase}-${plan.padStart(2, '0')}-SUMMARY.md`,
+    `${normalizePhaseName(phase)}-${plan.padStart(2, '0')}-SUMMARY.md`,
+  ]);
+  for (const entry of entries) {
+    if (candidates.has(entry)) return true;
+    // Also accept a SUMMARY whose first two segments match phase + plan
+    // followed by `-SUMMARY.md`, regardless of intermediate naming
+    // conventions.
+    if (entry.endsWith('-SUMMARY.md')) {
+      const base = entry.slice(0, -'-SUMMARY.md'.length);
+      const segs = base.split('-');
+      if (segs.length >= 2 && (segs[0] === phase || segs[0] === normalizePhaseName(phase))) {
+        if (segs[1] === plan || segs[1] === plan.padStart(2, '0')) return true;
+      }
+    }
+  }
+  return false;
+}
+
+function escapeGrepFixed(needle: string): string {
+  // With -F (fixed-string), git treats the pattern literally. We still strip
+  // newlines defensively in case a caller passes a corrupt phase/plan id.
+  return needle.replace(/[\r\n]/g, '');
+}
+
+function countProductionCommits(projectDir: string, phase: string, plan: string): number {
+  // Look for commits whose subject contains `({phase}-{plan})` — the
+  // executor's commit-message convention from `agents/gsd-executor.md`
+  // <task_commit_protocol>. We use --grep with -F (fixed-string) so the
+  // parens in the pattern are not treated as regex metacharacters.
+  const variants = [
+    `(${phase}-${plan})`,
+    `(${normalizePhaseName(phase)}-${plan})`,
+    `(${phase}-${plan.padStart(2, '0')})`,
+    `(${normalizePhaseName(phase)}-${plan.padStart(2, '0')})`,
+  ];
+  // Dedupe (if normalization is a no-op all four collapse).
+  const unique = Array.from(new Set(variants));
+  const seen = new Set<string>();
+  for (const needle of unique) {
+    try {
+      const out = execFileSync(
+        'git',
+        ['log', '--all', '--oneline', `--grep=${escapeGrepFixed(needle)}`, '-F'],
+        { cwd: projectDir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 5000 },
+      );
+      for (const line of out.split('\n')) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        // Each git-log line starts with the short hash followed by a space.
+        // Dedupe by hash so commits whose subject matches multiple variants
+        // (when phase/plan normalize identically) only count once.
+        const hash = trimmed.split(/\s/, 1)[0];
+        if (hash) seen.add(hash);
+      }
+    } catch {
+      // git not available, not a repo, or other transient — treat as zero
+      // for this variant (the caller still gets a result so workflows do
+      // not hard-fail in non-git scratch dirs).
+      continue;
+    }
+  }
+  return seen.size;
+}
+
+function stateAdvancedPastPlan(projectDir: string, phase: string, plan: string, workstream?: string): boolean {
+  const statePath = planningPaths(projectDir, workstream).state;
+  if (!existsSync(statePath)) return false;
+  let content: string;
+  try {
+    content = readFileSync(statePath, 'utf8');
+  } catch {
+    return false;
+  }
+  // Look for "Current Plan:" body field. `state advanced past plan` means
+  // STATE.md's cursor is now on a plan with a higher numeric id within the
+  // same phase, OR the phase has been incremented entirely.
+  const currentPhaseMatch = content.match(/\*\*Current Phase:\*\*\s*([^\n\r]+)/i)
+    || content.match(/^Current Phase:\s*([^\n\r]+)/im);
+  const currentPlanMatch = content.match(/\*\*Current Plan:\*\*\s*([^\n\r]+)/i)
+    || content.match(/^Current Plan:\s*([^\n\r]+)/im);
+  if (!currentPhaseMatch || !currentPlanMatch) return false;
+  const curPhase = normalizePhaseName(currentPhaseMatch[1].trim());
+  const askPhase = normalizePhaseName(phase);
+  const curPlan = parseInt(String(currentPlanMatch[1]).trim().replace(/^0+/, '') || '0', 10);
+  const askPlan = parseInt(plan.replace(/^0+/, '') || '0', 10);
+  if (curPhase > askPhase) return true;
+  if (curPhase === askPhase && Number.isFinite(curPlan) && Number.isFinite(askPlan) && curPlan > askPlan) return true;
+  // STATE.md may also encode completion via status === 'completed' for the
+  // milestone — that signal is downstream of all individual plans being
+  // done, so we treat it as "advanced past everything".
+  if (/Status:\s*(completed|complete|done)/i.test(content)) return true;
+  return false;
+}
+
+function roadmapMentionsPlanComplete(projectDir: string, phase: string, plan: string, workstream?: string): boolean {
+  const roadmapPath = planningPaths(projectDir, workstream).roadmap;
+  if (!existsSync(roadmapPath)) return false;
+  let content: string;
+  try {
+    content = readFileSync(roadmapPath, 'utf8');
+  } catch {
+    return false;
+  }
+  // ROADMAP.md progress tables typically have rows like
+  //   | Phase 04 | 03/05 plans | … |
+  // We do NOT try to parse these tables — a generic check is "is there
+  // any row mentioning this phase whose progress numerator >= the plan id?"
+  // That is brittle, so as a deliberately-conservative proxy, we look for
+  // the {phase}-{plan} pair appearing in the same line as one of the
+  // completion markers. If we cannot prove completion, we report `false`
+  // and let the consumer decide.
+  const planNorm = plan.padStart(2, '0');
+  const phaseNorm = normalizePhaseName(phase);
+  const planRefs = [
+    `${phase}-${plan}`, `${phaseNorm}-${plan}`,
+    `${phase}-${planNorm}`, `${phaseNorm}-${planNorm}`,
+  ];
+  for (const line of content.split(/\r?\n/)) {
+    for (const ref of planRefs) {
+      if (line.includes(ref) && /[✓✔]|complete|done/i.test(line)) return true;
+    }
+  }
+  // Fallback: phase-level completion in the roadmap implies all its plans
+  // are complete.
+  const phaseCompleteRe = new RegExp(`Phase\\s+${phaseNorm}\\b[^\\n\\r]*\\b(complete|done)\\b`, 'i');
+  if (phaseCompleteRe.test(content)) return true;
+  return false;
+}
+
+// ─── classification ─────────────────────────────────────────────────────────
+
+function classify(
+  productionCommits: number,
+  summaryExists: boolean,
+  stateAdvanced: boolean,
+  roadmapUpdated: boolean,
+): { state: PlanConsistencyState; advice: string } {
+  // Truth table — order matters; matches the doc's "Possible inconsistent
+  // states" table 1:1.
+  if (productionCommits === 0 && !summaryExists && !stateAdvanced && !roadmapUpdated) {
+    return { state: 'consistent_not_started', advice: 'Plan has not been executed; safe to dispatch.' };
+  }
+  if (productionCommits > 0 && summaryExists && stateAdvanced && roadmapUpdated) {
+    return { state: 'consistent_complete', advice: 'Plan finished cleanly; safe to advance.' };
+  }
+  if (productionCommits > 0 && !summaryExists && !stateAdvanced && !roadmapUpdated) {
+    return {
+      state: 'drift_a_stalled_midexecute',
+      advice: 'Production commits landed but SUMMARY.md is missing. Reconcile manually — do NOT redo code.',
+    };
+  }
+  if (productionCommits > 0 && summaryExists && !stateAdvanced && !roadmapUpdated) {
+    return {
+      state: 'drift_b_summary_without_state',
+      advice: 'SUMMARY.md exists but STATE.md / ROADMAP.md not updated. Re-run only the state-update step.',
+    };
+  }
+  if (productionCommits > 0 && !summaryExists && stateAdvanced && roadmapUpdated) {
+    return {
+      state: 'drift_c_state_without_summary',
+      advice: 'STATE.md advanced but SUMMARY.md is missing. Reconstruct SUMMARY from git log; do NOT redo code.',
+    };
+  }
+  if (productionCommits === 0 && summaryExists && stateAdvanced && roadmapUpdated) {
+    return {
+      state: 'drift_d_phantom_done',
+      advice: 'SUMMARY/state say done but no production commits exist. Investigate — likely a manually-edited STATE.md.',
+    };
+  }
+  return {
+    state: 'unknown',
+    advice: 'Plan is in an unrecognized partial state. Inspect the four artifacts manually.',
+  };
+}
+
+// ─── handler ────────────────────────────────────────────────────────────────
+
+/**
+ * Query handler implementing `plan.consistency-check`.
+ *
+ * @param args argv tail after the dispatch tokens. Must contain
+ *             `--phase <id>` and `--plan <id>`.
+ * @param projectDir Project root resolved by the dispatcher.
+ * @param workstream Optional workstream name.
+ * @returns `{ data: PlanConsistencyResult }` — never throws for missing
+ *          artifacts; only throws `GSDError(Validation)` for missing argv.
+ */
+export const planConsistencyCheck: QueryHandler<PlanConsistencyResult> = async (args, projectDir, workstream) => {
+  const { phase, plan } = parseFlagArgs(args);
+
+  const paths = planningPaths(projectDir, workstream);
+  const phaseDir = findPhaseDir(paths.phases, phase);
+
+  const summary_exists = phaseDir ? summaryExistsForPlan(phaseDir, phase, plan) : false;
+  const production_commits = countProductionCommits(projectDir, phase, plan);
+  const state_advanced = stateAdvancedPastPlan(projectDir, phase, plan, workstream);
+  const roadmap_updated = roadmapMentionsPlanComplete(projectDir, phase, plan, workstream);
+
+  const { state, advice } = classify(production_commits, summary_exists, state_advanced, roadmap_updated);
+
+  return {
+    data: {
+      phase,
+      plan,
+      state,
+      production_commits,
+      summary_exists,
+      state_advanced,
+      roadmap_updated,
+      advice,
+    },
+  };
+};

--- a/tests/atomic-closeout-invariant.test.cjs
+++ b/tests/atomic-closeout-invariant.test.cjs
@@ -1,0 +1,106 @@
+// allow-test-rule: docs-presence-check
+//
+// Tests that the atomic close-out invariant is documented and that the
+// gsd-executor agent prompt carries the producer-side callout pointing to
+// the canonical doc. Closes #3212 (documentation gate — Stage A).
+//
+// These are structural file-presence + section-header checks. They do NOT
+// assert the prose content of the doc (which is allowed to evolve), only
+// that the contract surface exists and is wired between executor agent and
+// the canonical doc.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const DOC_PATH = path.join(REPO_ROOT, 'docs', 'ATOMIC-CLOSEOUT-INVARIANT.md');
+const EXECUTOR_PATH = path.join(REPO_ROOT, 'agents', 'gsd-executor.md');
+
+describe('atomic close-out invariant doc (#3212)', () => {
+  test('docs/ATOMIC-CLOSEOUT-INVARIANT.md exists', () => {
+    assert.ok(
+      fs.existsSync(DOC_PATH),
+      'docs/ATOMIC-CLOSEOUT-INVARIANT.md must exist as the canonical home for the invariant'
+    );
+  });
+
+  test('doc declares the four artifacts that must land together', () => {
+    const content = fs.readFileSync(DOC_PATH, 'utf8');
+    // Section heading present
+    assert.match(content, /##\s+The four artifacts/i,
+      'doc must have a "The four artifacts" section');
+    // All four artifact names present (structural anchors, not prose)
+    for (const anchor of ['Per-task production commits', 'SUMMARY.md', 'STATE.md', 'ROADMAP.md']) {
+      assert.ok(content.includes(anchor),
+        `doc must mention artifact: ${anchor}`);
+    }
+  });
+
+  test('doc enumerates drift states A-D', () => {
+    const content = fs.readFileSync(DOC_PATH, 'utf8');
+    for (const drift of ['Drift A', 'Drift B', 'Drift C', 'Drift D']) {
+      assert.ok(content.includes(drift),
+        `doc must enumerate ${drift} for the consistency-check handler to reference`);
+    }
+  });
+
+  test('doc references the plan.consistency-check handler by exact name', () => {
+    // The handler name is the API contract — Stage B will register it under
+    // this exact dispatch string.
+    const content = fs.readFileSync(DOC_PATH, 'utf8');
+    assert.ok(
+      content.includes('plan.consistency-check'),
+      'doc must reference plan.consistency-check (the SDK handler name) so the contract and code share a stable label'
+    );
+  });
+});
+
+describe('gsd-executor agent carries the invariant callout (#3212)', () => {
+  test('agents/gsd-executor.md contains <atomic_closeout_invariant> block', () => {
+    const content = fs.readFileSync(EXECUTOR_PATH, 'utf8');
+    assert.ok(
+      content.includes('<atomic_closeout_invariant>'),
+      'executor agent prompt must declare <atomic_closeout_invariant> so producer-side ordering cannot drift silently'
+    );
+    assert.ok(
+      content.includes('</atomic_closeout_invariant>'),
+      '<atomic_closeout_invariant> block must be closed'
+    );
+  });
+
+  test('callout points to canonical doc path', () => {
+    const content = fs.readFileSync(EXECUTOR_PATH, 'utf8');
+    assert.ok(
+      content.includes('docs/ATOMIC-CLOSEOUT-INVARIANT.md'),
+      'callout must point to the canonical doc so a reader has one place to find the full contract'
+    );
+  });
+
+  test('callout sits between </execution_flow> and <deviation_rules>', () => {
+    const content = fs.readFileSync(EXECUTOR_PATH, 'utf8');
+    const closeFlow = content.indexOf('</execution_flow>');
+    const callout = content.indexOf('<atomic_closeout_invariant>');
+    const deviation = content.indexOf('<deviation_rules>');
+    assert.ok(closeFlow !== -1, 'sanity: </execution_flow> exists');
+    assert.ok(callout !== -1, 'sanity: callout exists');
+    assert.ok(deviation !== -1, 'sanity: <deviation_rules> exists');
+    assert.ok(
+      closeFlow < callout && callout < deviation,
+      'callout must sit between </execution_flow> and <deviation_rules> so executor reads it before deviation rules are applied'
+    );
+  });
+
+  test('callout enumerates the five-step sequence', () => {
+    const content = fs.readFileSync(EXECUTOR_PATH, 'utf8');
+    // The five sequence anchors — these are the section names inside the
+    // executor prompt the callout binds to.
+    for (const anchor of ['<execute_tasks>', '<self_check>', '<summary_creation>', '<state_updates>', '<final_commit>']) {
+      assert.ok(
+        content.includes(anchor),
+        `callout must reference sequence anchor ${anchor} (it ties the invariant to the prose steps)`
+      );
+    }
+  });
+});

--- a/tests/atomic-closeout-invariant.test.cjs
+++ b/tests/atomic-closeout-invariant.test.cjs
@@ -1,13 +1,10 @@
-// allow-test-rule: docs-presence-check
 //
 // Tests that the atomic close-out invariant is documented and that the
 // gsd-executor agent prompt carries the producer-side callout pointing to
-// the canonical doc. Closes #3212 (documentation gate — Stage A).
+// the canonical doc. Closes #3212 (documentation gate, Stage A).
 //
-// These are structural file-presence + section-header checks. They do NOT
-// assert the prose content of the doc (which is allowed to evolve), only
-// that the contract surface exists and is wired between executor agent and
-// the canonical doc.
+// These checks parse markdown headings/tables and XML-like prompt blocks.
+// They assert on structural fields, not raw source-text presence.
 
 const { test, describe } = require('node:test');
 const assert = require('node:assert/strict');
@@ -18,6 +15,228 @@ const REPO_ROOT = path.join(__dirname, '..');
 const DOC_PATH = path.join(REPO_ROOT, 'docs', 'ATOMIC-CLOSEOUT-INVARIANT.md');
 const EXECUTOR_PATH = path.join(REPO_ROOT, 'agents', 'gsd-executor.md');
 
+function readLines(filePath) {
+  return fs.readFileSync(filePath, 'utf8').split(/\r?\n/);
+}
+
+function normalizeMarkdownText(value) {
+  return value
+    .replace(/`([^`]*)`/g, '$1')
+    .replace(/[*_]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function parseHeading(line, lineNumber) {
+  const heading = line.match(/^(#{1,6})\s+(.+?)\s*#*\s*$/);
+  if (!heading) return null;
+  return {
+    level: heading[1].length,
+    title: normalizeMarkdownText(heading[2]),
+    lineNumber,
+    endLine: null,
+    children: [],
+  };
+}
+
+function parseMarkdownDocument(filePath) {
+  const lines = readLines(filePath);
+  const root = { level: 0, title: '<root>', lineNumber: -1, endLine: lines.length, children: [] };
+  const headings = [];
+  const stack = [root];
+  let inFence = false;
+
+  for (let i = 0; i < lines.length; i += 1) {
+    if (lines[i].trim().slice(0, 3) === '```') {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+
+    const heading = parseHeading(lines[i], i);
+    if (!heading) continue;
+
+    while (stack[stack.length - 1].level >= heading.level) stack.pop();
+    stack[stack.length - 1].children.push(heading);
+    stack.push(heading);
+    headings.push(heading);
+  }
+
+  for (let i = 0; i < headings.length; i += 1) {
+    const current = headings[i];
+    const nextPeer = headings
+      .slice(i + 1)
+      .find(candidate => candidate.level <= current.level);
+    current.endLine = nextPeer ? nextPeer.lineNumber : lines.length;
+  }
+
+  return { lines, root, headings };
+}
+
+function findHeading(doc, title) {
+  const normalizedTitle = normalizeMarkdownText(title);
+  return doc.headings.find(heading => heading.title === normalizedTitle);
+}
+
+function splitTableRow(line) {
+  const trimmed = line.trim();
+  const body = trimmed.replace(/^\|/, '').replace(/\|$/, '');
+  return body.split('|').map(cell => normalizeMarkdownText(cell));
+}
+
+function isTableRow(line) {
+  const trimmed = line.trim();
+  return trimmed.length > 1 && trimmed[0] === '|' && trimmed[trimmed.length - 1] === '|';
+}
+
+function isSeparatorRow(cells) {
+  return cells.every(cell => /^:?-{3,}:?$/.test(cell.replace(/\s+/g, '')));
+}
+
+function parseTablesInSection(doc, section) {
+  const tables = [];
+  let lineNumber = section.lineNumber + 1;
+
+  while (lineNumber < section.endLine) {
+    if (!isTableRow(doc.lines[lineNumber])) {
+      lineNumber += 1;
+      continue;
+    }
+
+    const rawRows = [];
+    while (lineNumber < section.endLine && isTableRow(doc.lines[lineNumber])) {
+      rawRows.push(splitTableRow(doc.lines[lineNumber]));
+      lineNumber += 1;
+    }
+
+    if (rawRows.length >= 2 && isSeparatorRow(rawRows[1])) {
+      tables.push({ header: rawRows[0], rows: rawRows.slice(2) });
+    }
+  }
+
+  return tables;
+}
+
+function parseCodeFencesInSection(doc, section) {
+  const fences = [];
+  let current = null;
+
+  for (let lineNumber = section.lineNumber + 1; lineNumber < section.endLine; lineNumber += 1) {
+    const fence = doc.lines[lineNumber].trim().match(/^```(\S*)\s*$/);
+    if (!fence) {
+      if (current) current.lines.push(doc.lines[lineNumber]);
+      continue;
+    }
+
+    if (current) {
+      current.endLine = lineNumber;
+      fences.push(current);
+      current = null;
+    } else {
+      current = { info: fence[1], startLine: lineNumber, endLine: null, lines: [] };
+    }
+  }
+
+  return fences;
+}
+
+function shellCommandTokensFromFence(fence) {
+  return fence.lines
+    .map(line => line.trim())
+    .filter(line => line.length > 0 && line[0] !== '#')
+    .map(line => line.split(/\s+/));
+}
+
+function parseAttributes(source) {
+  const attrs = {};
+  if (!source) return attrs;
+  const attrRe = /([A-Za-z_][\w-]*)="([^"]*)"/g;
+  let match;
+  while ((match = attrRe.exec(source)) !== null) {
+    attrs[match[1]] = match[2];
+  }
+  return attrs;
+}
+
+function parsePromptBlocks(filePath) {
+  const lines = readLines(filePath);
+  const blocks = [];
+  const stack = [];
+  let inFence = false;
+
+  for (let lineNumber = 0; lineNumber < lines.length; lineNumber += 1) {
+    const trimmed = lines[lineNumber].trim();
+    if (trimmed.slice(0, 3) === '```') {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+
+    const opening = trimmed.match(/^<([A-Za-z_][\w-]*)(?:\s+([^>]*))?>$/);
+    if (opening) {
+      stack.push({
+        tag: opening[1],
+        attrs: parseAttributes(opening[2]),
+        startLine: lineNumber,
+        endLine: null,
+      });
+      continue;
+    }
+
+    const closing = trimmed.match(/^<\/([A-Za-z_][\w-]*)>$/);
+    if (!closing) continue;
+
+    const open = stack.pop();
+    if (open && open.tag === closing[1]) {
+      open.endLine = lineNumber;
+      blocks.push(open);
+    }
+  }
+
+  return { lines, blocks };
+}
+
+function findPromptBlock(prompt, tag, attrs = {}) {
+  return prompt.blocks.find(block => {
+    if (block.tag !== tag) return false;
+    return Object.entries(attrs).every(([key, value]) => block.attrs[key] === value);
+  });
+}
+
+function findPromptSection(prompt, name) {
+  return findPromptBlock(prompt, name) || findPromptBlock(prompt, 'step', { name });
+}
+
+function blockBodyLines(prompt, block) {
+  return prompt.lines.slice(block.startLine + 1, block.endLine);
+}
+
+function parseInlineCodeSpans(lines) {
+  const spans = [];
+  for (const line of lines) {
+    const spanRe = /`([^`]+)`/g;
+    let match;
+    while ((match = spanRe.exec(line)) !== null) {
+      spans.push(match[1]);
+    }
+  }
+  return spans;
+}
+
+function parseOrderedListFirstCodeSpans(lines) {
+  const items = [];
+  for (const line of lines) {
+    const ordered = line.match(/^\s*(\d+)\.\s+(.+)$/);
+    if (!ordered) continue;
+    const firstCodeSpan = parseInlineCodeSpans([ordered[2]])[0];
+    if (!firstCodeSpan) continue;
+    if (firstCodeSpan[0] !== '<') continue;
+    if (firstCodeSpan[firstCodeSpan.length - 1] !== '>') continue;
+    items.push({ number: Number(ordered[1]), code: firstCodeSpan });
+  }
+  return items;
+}
+
 describe('atomic close-out invariant doc (#3212)', () => {
   test('docs/ATOMIC-CLOSEOUT-INVARIANT.md exists', () => {
     assert.ok(
@@ -27,79 +246,120 @@ describe('atomic close-out invariant doc (#3212)', () => {
   });
 
   test('doc declares the four artifacts that must land together', () => {
-    const content = fs.readFileSync(DOC_PATH, 'utf8');
-    // Section heading present
-    assert.match(content, /##\s+The four artifacts/i,
-      'doc must have a "The four artifacts" section');
-    // All four artifact names present (structural anchors, not prose)
-    for (const anchor of ['Per-task production commits', 'SUMMARY.md', 'STATE.md', 'ROADMAP.md']) {
-      assert.ok(content.includes(anchor),
-        `doc must mention artifact: ${anchor}`);
-    }
+    const doc = parseMarkdownDocument(DOC_PATH);
+    const section = findHeading(doc, 'The four artifacts');
+    assert.ok(section, 'doc must have a "The four artifacts" heading');
+
+    const [table] = parseTablesInSection(doc, section);
+    assert.ok(table, 'artifact section must contain a markdown table');
+    assert.deepEqual(table.header, ['#', 'Artifact', 'Where it lives', 'What it proves']);
+    assert.deepEqual(
+      table.rows.map(row => row[1]),
+      [
+        'Per-task production commits',
+        '{phase}-{plan}-SUMMARY.md',
+        'STATE.md advanced',
+        'ROADMAP.md updated',
+      ],
+    );
   });
 
-  test('doc enumerates drift states A-D', () => {
-    const content = fs.readFileSync(DOC_PATH, 'utf8');
-    for (const drift of ['Drift A', 'Drift B', 'Drift C', 'Drift D']) {
-      assert.ok(content.includes(drift),
-        `doc must enumerate ${drift} for the consistency-check handler to reference`);
-    }
+  test('doc enumerates drift states A-D in the drift table', () => {
+    const doc = parseMarkdownDocument(DOC_PATH);
+    const section = findHeading(doc, 'Possible inconsistent states');
+    assert.ok(section, 'doc must have a "Possible inconsistent states" heading');
+
+    const [table] = parseTablesInSection(doc, section);
+    assert.ok(table, 'drift section must contain a markdown table');
+    assert.deepEqual(table.header, [
+      'State',
+      'Production commits?',
+      'SUMMARY.md?',
+      'STATE advanced?',
+      'ROADMAP updated?',
+      'Meaning',
+    ]);
+    assert.deepEqual(
+      table.rows.map(row => row[0]),
+      [
+        'Consistent: not started',
+        'Consistent: complete',
+        'Drift A: stalled mid-execute',
+        'Drift B: SUMMARY without state',
+        'Drift C: state without SUMMARY',
+        'Drift D: phantom done',
+      ],
+    );
   });
 
-  test('doc references the plan.consistency-check handler by exact name', () => {
-    // The handler name is the API contract — Stage B will register it under
-    // this exact dispatch string.
-    const content = fs.readFileSync(DOC_PATH, 'utf8');
-    assert.ok(
-      content.includes('plan.consistency-check'),
-      'doc must reference plan.consistency-check (the SDK handler name) so the contract and code share a stable label'
+  test('doc shows the plan.consistency-check handler in the consumer command block', () => {
+    const doc = parseMarkdownDocument(DOC_PATH);
+    const section = findHeading(doc, 'Consumer-side responsibilities (resume / dispatch)');
+    assert.ok(section, 'doc must have a consumer-side responsibilities heading');
+
+    const commands = parseCodeFencesInSection(doc, section)
+      .flatMap(shellCommandTokensFromFence)
+      .filter(tokens => tokens[0] === 'gsd-sdk' && tokens[1] === 'query');
+    const handlerCommand = commands.find(tokens => tokens[2] === 'plan.consistency-check');
+    assert.ok(handlerCommand, 'consumer code fence must demonstrate the SDK handler name workflows call');
+    assert.deepEqual(
+      handlerCommand.slice(0, 3),
+      ['gsd-sdk', 'query', 'plan.consistency-check'],
+      'consumer code fence must demonstrate the SDK handler name workflows call'
     );
   });
 });
 
 describe('gsd-executor agent carries the invariant callout (#3212)', () => {
-  test('agents/gsd-executor.md contains <atomic_closeout_invariant> block', () => {
-    const content = fs.readFileSync(EXECUTOR_PATH, 'utf8');
+  test('agents/gsd-executor.md contains a closed atomic_closeout_invariant block', () => {
+    const prompt = parsePromptBlocks(EXECUTOR_PATH);
     assert.ok(
-      content.includes('<atomic_closeout_invariant>'),
-      'executor agent prompt must declare <atomic_closeout_invariant> so producer-side ordering cannot drift silently'
-    );
-    assert.ok(
-      content.includes('</atomic_closeout_invariant>'),
-      '<atomic_closeout_invariant> block must be closed'
+      findPromptBlock(prompt, 'atomic_closeout_invariant'),
+      'executor agent prompt must declare a closed atomic_closeout_invariant block'
     );
   });
 
-  test('callout points to canonical doc path', () => {
-    const content = fs.readFileSync(EXECUTOR_PATH, 'utf8');
+  test('callout points to canonical doc path through an inline code token', () => {
+    const prompt = parsePromptBlocks(EXECUTOR_PATH);
+    const callout = findPromptBlock(prompt, 'atomic_closeout_invariant');
+    assert.ok(callout, 'sanity: callout block exists');
     assert.ok(
-      content.includes('docs/ATOMIC-CLOSEOUT-INVARIANT.md'),
-      'callout must point to the canonical doc so a reader has one place to find the full contract'
+      parseInlineCodeSpans(blockBodyLines(prompt, callout)).some(span => span === 'docs/ATOMIC-CLOSEOUT-INVARIANT.md'),
+      'callout must point to the canonical doc through a structured markdown code token'
     );
   });
 
-  test('callout sits between </execution_flow> and <deviation_rules>', () => {
-    const content = fs.readFileSync(EXECUTOR_PATH, 'utf8');
-    const closeFlow = content.indexOf('</execution_flow>');
-    const callout = content.indexOf('<atomic_closeout_invariant>');
-    const deviation = content.indexOf('<deviation_rules>');
-    assert.ok(closeFlow !== -1, 'sanity: </execution_flow> exists');
-    assert.ok(callout !== -1, 'sanity: callout exists');
-    assert.ok(deviation !== -1, 'sanity: <deviation_rules> exists');
+  test('callout sits between execution_flow and deviation_rules blocks', () => {
+    const prompt = parsePromptBlocks(EXECUTOR_PATH);
+    const executionFlow = findPromptBlock(prompt, 'execution_flow');
+    const callout = findPromptBlock(prompt, 'atomic_closeout_invariant');
+    const deviationRules = findPromptBlock(prompt, 'deviation_rules');
+    assert.ok(executionFlow, 'sanity: execution_flow block exists');
+    assert.ok(callout, 'sanity: callout block exists');
+    assert.ok(deviationRules, 'sanity: deviation_rules block exists');
     assert.ok(
-      closeFlow < callout && callout < deviation,
-      'callout must sit between </execution_flow> and <deviation_rules> so executor reads it before deviation rules are applied'
+      executionFlow.endLine < callout.startLine && callout.endLine < deviationRules.startLine,
+      'callout must sit between execution_flow and deviation_rules so executor reads it before deviation rules are applied'
     );
   });
 
-  test('callout enumerates the five-step sequence', () => {
-    const content = fs.readFileSync(EXECUTOR_PATH, 'utf8');
-    // The five sequence anchors — these are the section names inside the
-    // executor prompt the callout binds to.
-    for (const anchor of ['<execute_tasks>', '<self_check>', '<summary_creation>', '<state_updates>', '<final_commit>']) {
+  test('callout enumerates the five-step sequence as prompt section references', () => {
+    const prompt = parsePromptBlocks(EXECUTOR_PATH);
+    const callout = findPromptBlock(prompt, 'atomic_closeout_invariant');
+    assert.ok(callout, 'sanity: callout block exists');
+
+    const sequence = parseOrderedListFirstCodeSpans(blockBodyLines(prompt, callout));
+    assert.deepEqual(
+      sequence.map(item => item.code),
+      ['<execute_tasks>', '<self_check>', '<summary_creation>', '<state_updates>', '<final_commit>']
+    );
+    assert.deepEqual(sequence.map(item => item.number), [1, 2, 3, 4, 5]);
+
+    for (const item of sequence) {
+      const sectionName = item.code.slice(1, item.code.length - 1);
       assert.ok(
-        content.includes(anchor),
-        `callout must reference sequence anchor ${anchor} (it ties the invariant to the prose steps)`
+        findPromptSection(prompt, sectionName),
+        `callout sequence item ${item.code} must reference a structured prompt section`
       );
     }
   });

--- a/tests/dispatch-surveillance.test.cjs
+++ b/tests/dispatch-surveillance.test.cjs
@@ -1,0 +1,110 @@
+// allow-test-rule: integration-roundtrip
+//
+// Locks that `gsd-sdk query dispatch.commit-since` is dispatchable through
+// the same CLI surface that orchestrator workflows would call. Closes #3212
+// (Stage C — registration round-trip). Probe correctness lives in the SDK
+// Vitest suite at sdk/src/query/dispatch-surveillance.test.ts.
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { execFileSync } = require('child_process');
+const path = require('path');
+const { createTempGitProject, cleanup } = require('./helpers.cjs');
+
+const GSD_SDK_BIN = path.join(__dirname, '..', 'bin', 'gsd-sdk.js');
+
+function runSdk(args, cwd) {
+  try {
+    const result = execFileSync(process.execPath, [GSD_SDK_BIN, 'query', ...args], {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, GSD_QUERY_FALLBACK: 'off' },  // strict — must be native
+    });
+    return { success: true, output: result.trim() };
+  } catch (err) {
+    return {
+      success: false,
+      output: err.stdout?.toString().trim() || '',
+      error: err.stderr?.toString().trim() || err.message,
+      exitCode: err.status,
+    };
+  }
+}
+
+describe('dispatch.commit-since is registered (#3212)', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempGitProject();
+  });
+
+  afterEach(() => cleanup(tmpDir));
+
+  test('CLI dispatches dispatch.commit-since via dotted form', () => {
+    const result = runSdk(['dispatch.commit-since', '--since', '0'], tmpDir);
+    assert.ok(result.success, `dispatch failed: ${result.error}`);
+    const parsed = JSON.parse(result.output);
+    assert.ok('count' in parsed, 'result must include count');
+    assert.ok('latest_hash' in parsed, 'result must include latest_hash');
+    assert.ok('since_unix' in parsed, 'result must include since_unix');
+    assert.strictEqual(parsed.since_unix, 0);
+  });
+
+  test('CLI dispatches dispatch.commit-since via spaced form', () => {
+    const result = runSdk(['dispatch', 'commit-since', '--since', '0'], tmpDir);
+    assert.ok(result.success, `dispatch failed: ${result.error}`);
+    const parsed = JSON.parse(result.output);
+    assert.strictEqual(parsed.since_unix, 0);
+  });
+
+  test('result shape carries all six contract fields', () => {
+    const result = runSdk(['dispatch.commit-since', '--since', '0'], tmpDir);
+    assert.ok(result.success, result.error);
+    const parsed = JSON.parse(result.output);
+    for (const field of [
+      'count', 'latest_hash', 'latest_subject', 'latest_timestamp_unix',
+      'since_unix', 'plan_filter',
+    ]) {
+      assert.ok(field in parsed, `result must include field ${field}`);
+    }
+  });
+
+  test('plan_filter is echoed when provided', () => {
+    const result = runSdk(['dispatch.commit-since', '--since', '0', '--plan', '4-03'], tmpDir);
+    assert.ok(result.success, result.error);
+    const parsed = JSON.parse(result.output);
+    assert.strictEqual(parsed.plan_filter, '4-03');
+  });
+
+  test('count >= 1 in temp git project (which has the helper-init commit)', () => {
+    const result = runSdk(['dispatch.commit-since', '--since', '0'], tmpDir);
+    assert.ok(result.success, result.error);
+    const parsed = JSON.parse(result.output);
+    // createTempGitProject() always lands one initial commit, so any
+    // --since value low enough to include 'now' (e.g. 0) must see ≥ 1
+    // commit. This locks the round-trip end-to-end.
+    assert.ok(parsed.count >= 1,
+      `expected at least 1 commit since epoch 0 in tmp project, got count=${parsed.count}`);
+  });
+});
+
+describe('dispatch.commit-since argv validation (#3212)', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempGitProject();
+  });
+
+  afterEach(() => cleanup(tmpDir));
+
+  test('missing --since is rejected', () => {
+    const result = runSdk(['dispatch.commit-since'], tmpDir);
+    assert.ok(!result.success, 'missing --since must produce non-zero exit');
+  });
+
+  test('non-numeric --since is rejected', () => {
+    const result = runSdk(['dispatch.commit-since', '--since', 'yesterday'], tmpDir);
+    assert.ok(!result.success, 'non-numeric --since must produce non-zero exit');
+  });
+});

--- a/tests/plan-consistency-check.test.cjs
+++ b/tests/plan-consistency-check.test.cjs
@@ -1,0 +1,112 @@
+// allow-test-rule: integration-roundtrip
+//
+// Locks that `gsd-sdk query plan.consistency-check` is dispatchable through
+// the same CLI surface that the resume-work workflow calls. Closes #3212
+// (Stage B — registration round-trip; classification correctness lives in
+// the SDK Vitest suite at sdk/src/query/plan-consistency-check.test.ts).
+//
+// These tests do NOT re-test every classification branch — that would
+// duplicate the SDK suite. They confirm:
+//   1. The handler is registered (CLI can dispatch it).
+//   2. The CLI returns valid JSON shaped like PlanConsistencyResult.
+//   3. argv validation surfaces a non-zero exit / structured error.
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const { createTempGitProject, cleanup } = require('./helpers.cjs');
+
+const GSD_SDK_BIN = path.join(__dirname, '..', 'bin', 'gsd-sdk.js');
+
+function runSdk(args, cwd) {
+  try {
+    const result = execFileSync(process.execPath, [GSD_SDK_BIN, 'query', ...args], {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: { ...process.env, GSD_QUERY_FALLBACK: 'off' },  // strict — must be native
+    });
+    return { success: true, output: result.trim() };
+  } catch (err) {
+    return {
+      success: false,
+      output: err.stdout?.toString().trim() || '',
+      error: err.stderr?.toString().trim() || err.message,
+      exitCode: err.status,
+    };
+  }
+}
+
+describe('plan.consistency-check is registered (#3212)', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempGitProject();
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'phases', '04-feature'), { recursive: true });
+  });
+
+  afterEach(() => cleanup(tmpDir));
+
+  test('CLI dispatches plan.consistency-check via dotted form', () => {
+    const result = runSdk(['plan.consistency-check', '--phase', '4', '--plan', '03'], tmpDir);
+    assert.ok(result.success, `dispatch failed: ${result.error}`);
+    const parsed = JSON.parse(result.output);
+    assert.strictEqual(parsed.phase, '4', 'phase echoed');
+    assert.strictEqual(parsed.plan, '03', 'plan echoed');
+    assert.ok(typeof parsed.state === 'string', 'state is a string');
+    assert.ok(typeof parsed.advice === 'string', 'advice is a string');
+  });
+
+  test('CLI dispatches plan.consistency-check via spaced form', () => {
+    // The space-form alias is registered alongside the dotted form for
+    // workflows that expand `gsd-sdk query plan consistency-check`.
+    const result = runSdk(['plan', 'consistency-check', '--phase', '4', '--plan', '03'], tmpDir);
+    assert.ok(result.success, `dispatch failed: ${result.error}`);
+    const parsed = JSON.parse(result.output);
+    assert.strictEqual(parsed.phase, '4');
+  });
+
+  test('result shape carries all eight contract fields', () => {
+    const result = runSdk(['plan.consistency-check', '--phase', '4', '--plan', '03'], tmpDir);
+    assert.ok(result.success, result.error);
+    const parsed = JSON.parse(result.output);
+    for (const field of [
+      'phase', 'plan', 'state',
+      'production_commits', 'summary_exists', 'state_advanced', 'roadmap_updated',
+      'advice',
+    ]) {
+      assert.ok(field in parsed, `result must include field ${field}`);
+    }
+  });
+
+  test('fresh project reports consistent_not_started', () => {
+    const result = runSdk(['plan.consistency-check', '--phase', '99', '--plan', '99'], tmpDir);
+    assert.ok(result.success, result.error);
+    const parsed = JSON.parse(result.output);
+    assert.strictEqual(parsed.state, 'consistent_not_started');
+    assert.strictEqual(parsed.production_commits, 0);
+    assert.strictEqual(parsed.summary_exists, false);
+  });
+});
+
+describe('plan.consistency-check argv validation (#3212)', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempGitProject();
+  });
+
+  afterEach(() => cleanup(tmpDir));
+
+  test('missing --phase is rejected', () => {
+    const result = runSdk(['plan.consistency-check', '--plan', '03'], tmpDir);
+    assert.ok(!result.success, 'missing --phase must produce non-zero exit');
+  });
+
+  test('missing --plan is rejected', () => {
+    const result = runSdk(['plan.consistency-check', '--phase', '4'], tmpDir);
+    assert.ok(!result.success, 'missing --plan must produce non-zero exit');
+  });
+});


### PR DESCRIPTION
## Linked Issue

Fixes #3212

(Confirmed-bug label present on the issue.)

## What was broken

Executor subagents could land production commits, silently stall before the SUMMARY/STATE/ROADMAP close-out commit, and leave the framework with no detector for the stall and no safe-resume path. On resume, `check_incomplete_work` could neither distinguish "never started" from "started, committed code, stalled" nor refuse to re-dispatch over partial work.

## What this fix does

Three additive changes that close the gap without rewriting any dispatch or state core:

- **Stage A — Atomic close-out invariant (docs).** New `docs/ATOMIC-CLOSEOUT-INVARIANT.md` defines the canonical contract (production commits + `SUMMARY.md` + `STATE.md` + `ROADMAP.md` land atomically per plan) with a drift table A–D and reconciliation guidance. New `<atomic_closeout_invariant>` block in `agents/gsd-executor.md` locks the five-step sequence in the agent prompt.
- **Stage B — Safe-resume verification (Problem 1).** New `gsd-sdk query plan.consistency-check` handler (`sdk/src/query/plan-consistency-check.ts`) is read-only and classifies a plan into `consistent_*` / `drift_a..d` / `unknown` by comparing `STATE.md` against disk presence and `git log` commit presence. `get-shit-done/workflows/resume-project.md` `check_incomplete_work` step now invokes the handler before re-dispatching and surfaces drift guidance; the legacy "PLAN without SUMMARY" path is preserved as a fallback.
- **Stage C — Stall surveillance probe (Problem 2).** New `gsd-sdk query dispatch.commit-since` handler (`sdk/src/query/dispatch-surveillance.ts`) is read-only and returns the count of commits with committer-date ≥ `--since` (Unix epoch), optionally filtered by `--plan`. Stateless. No new config key. Orchestrators that can poll on a wall-clock cadence may invoke it during long `Agent()` awaits. `get-shit-done/workflows/execute-phase.md` Step 4 has an additive note documenting the probe.

The probe is **complementary** to the existing `workflow.subagent_timeout` (default 300000 ms) — it does not replace it. Both `tests/subagent-timeout.test.cjs` (13/13) and the timeout config key remain unchanged.

## Root cause

Three independent gaps compound:

1. `get-shit-done/workflows/execute-phase.md` Step 4 awaits `Agent()` synchronously with no commit-progress polling (line 1713: \"No polling — Agent blocks\").
2. `get-shit-done/workflows/resume-project.md` `<step name=\"check_incomplete_work\">` detects \"PLAN without SUMMARY\" via filesystem only — never cross-checks `git log` for production commits, so cannot tell partial-execution from never-started.
3. The four-artifact atomic close-out contract lived only as sequential prose in `agents/gsd-executor.md` with no canonical doc and no verifier.

## Testing

### How I verified the fix

Ran the new test files plus the adjacent suites the user explicitly flagged as must-not-break.

| Suite | Result |
|---|---|
| `tests/atomic-closeout-invariant.test.cjs` (new) | 8/8 pass |
| `tests/plan-consistency-check.test.cjs` (new) | 6/6 pass |
| `tests/dispatch-surveillance.test.cjs` (new) | 7/7 pass |
| `sdk/src/query/plan-consistency-check.test.ts` (new) | 11/11 pass |
| `sdk/src/query/dispatch-surveillance.test.ts` (new) | 13/13 pass |
| `tests/state.test.cjs` | 101/101 pass |
| `tests/subagent-timeout.test.cjs` | 13/13 pass |
| `tests/state-prune.test.cjs` | 8/8 pass |
| `sdk/src/query/command-static-catalog-domain.test.ts` | 11/11 pass |
| `sdk/src/query/registry-assembly.test.ts` | pass |

The pre-existing `tests/skill-manifest.test.cjs` failure (about unrelated skills like `screenshot`, `transcribe`, `vercel-deploy` not being declared in the manifest) was confirmed pre-existing on `main` via `git stash` — not introduced by this PR.

### Regression test added?

- [x] **Yes** — 21 new CJS tests + 24 new SDK Vitest tests covering all drift states, argv validation, read-only contracts, invariant structure, and surveillance edge cases.

### Platforms tested

- [ ] macOS
- [x] Windows (including backslash path handling — verified during test run on Windows 11; SDK uses `path.join`/`path.sep` everywhere)
- [ ] Linux
- [ ] N/A

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other
- [ ] N/A

(Workflow file edits are runtime-agnostic — both `agents/gsd-executor.md` and the `get-shit-done/workflows/*.md` files are vendored to all runtimes via the existing install pipeline; the new SDK handlers are CLI-level so all runtimes pick them up automatically.)

---

## Checklist

- [x] Issue linked above with `Fixes #3212`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (verified targeted suites; existing `skill-manifest` failure is pre-existing and unrelated)
- [x] `.changeset/` fragment added (`.changeset/sharp-wasps-chatter.md`, type `Fixed`, pr `3212`)
- [x] No unnecessary dependencies added

## Breaking changes

None. All changes are additive:

- Two new read-only `gsd-sdk query` handlers (`plan.consistency-check`, `dispatch.commit-since`) — neither shadows an existing alias or modifies existing handler signatures.
- `agents/gsd-executor.md` gains a new `<atomic_closeout_invariant>` block but its existing `<execution_flow>` and `<deviation_rules>` are untouched.
- `get-shit-done/workflows/resume-project.md` `check_incomplete_work` step calls the new handler but preserves its legacy filesystem-only path as a fallback when the handler returns `unknown`.
- `get-shit-done/workflows/execute-phase.md` adds a documentation note in Step 4 describing the optional probe; existing dispatch behavior is unchanged.
- `workflow.subagent_timeout` config key and its tests are untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in plan consistency verification to detect incomplete or drifted execution.
  * Optional stall-detection probe that monitors commit progress (dispatch.commit-since) during execution waits.

* **Documentation**
  * Added Atomic Close-Out Invariant guidance and updated executor/resume workflows with recovery advice.

* **Tests**
  * End-to-end and unit tests covering consistency checks and stall-detection behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3241)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
