### PR TITLE
fix(sdk): anchor extractFrontmatter at file start (#3240)

### DIFF
--- a/.changeset/gentle-goats-fly.md
+++ b/.changeset/gentle-goats-fly.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3247
+---
+**`gsd-sdk query phase-plan-index` now reads frontmatter from the file's leading block** — plans with embedded YAML examples or markdown horizontal rules no longer silently mis-parse to wave=1, autonomous=true.

--- a/sdk/src/plan-parser.test.ts
+++ b/sdk/src/plan-parser.test.ts
@@ -217,6 +217,57 @@ describe('extractFrontmatter', () => {
     const result = extractFrontmatter('');
     expect(result).toEqual({});
   });
+
+  it('returns the LEADING block when body contains markdown horizontal rules', () => {
+    // Regression: LAST-block semantics picked up body separators as frontmatter (#3240)
+    const content = [
+      '---',
+      'wave: 3',
+      'autonomous: false',
+      'phase: 05-hardening',
+      '---',
+      '',
+      '## Section One',
+      '',
+      '---',
+      '',
+      '## Section Two',
+      '',
+      '---',
+      '',
+      'body text',
+    ].join('\n');
+    const result = extractFrontmatter(content);
+    expect(result.wave).toBe(3);
+    expect(result.autonomous).toBe(false);
+    expect(result.phase).toBe('05-hardening');
+  });
+
+  it('returns the LEADING block when body contains embedded YAML in fenced code block', () => {
+    // Regression: LAST-block semantics matched YAML inside ```yaml fences (#3240)
+    const content = [
+      '---',
+      'wave: 2',
+      'autonomous: true',
+      'phase: 04-polish',
+      '---',
+      '',
+      '## Example',
+      '',
+      '```yaml',
+      '---',
+      'name: example',
+      'value: 99',
+      '---',
+      '```',
+      '',
+      'More body text.',
+    ].join('\n');
+    const result = extractFrontmatter(content);
+    expect(result.wave).toBe(2);
+    expect(result.autonomous).toBe(true);
+    expect(result.phase).toBe('04-polish');
+  });
 });
 
 describe('parsePlan — frontmatter', () => {

--- a/sdk/src/plan-parser.ts
+++ b/sdk/src/plan-parser.ts
@@ -25,13 +25,17 @@ import type {
  * Uses a stack-based parser that handles nested objects, inline arrays,
  * multi-line arrays, and boolean/numeric coercion. Ported from the CJS
  * reference implementation with the same edge-case coverage.
+ *
+ * Anchored at the start of the file — only the leading `---...---` block is
+ * considered canonical frontmatter. Body `---` separators and embedded YAML
+ * inside fenced code blocks are never picked up.
  */
 export function extractFrontmatter(content: string): Record<string, unknown> {
   const frontmatter: Record<string, unknown> = {};
 
-  // Find ALL frontmatter blocks — if multiple exist (corruption), use the last one
-  const allBlocks = [...content.matchAll(/(?:^|\n)\s*---\r?\n([\s\S]+?)\r?\n---/g)];
-  const match = allBlocks.length > 0 ? allBlocks[allBlocks.length - 1] : null;
+  // Anchored at file start — only the leading ---...--- block is canonical frontmatter.
+  // Body `---` separators and embedded YAML inside fenced code blocks are not matched.
+  const match = content.match(/^---\r?\n([\s\S]+?)\r?\n---/);
   if (!match) return frontmatter;
 
   const yaml = match[1];

--- a/sdk/src/query/frontmatter.test.ts
+++ b/sdk/src/query/frontmatter.test.ts
@@ -66,10 +66,62 @@ describe('extractFrontmatter', () => {
     expect(result).toEqual({ items: ['one', 'two'] });
   });
 
-  it('uses the LAST block when multiple stacked blocks exist', () => {
+  it('uses the LEADING block when multiple stacked blocks exist', () => {
+    // extractFrontmatter is anchored at file start — leading block wins (#3240 fix)
     const content = '---\nold: data\n---\n---\nnew: data\n---\nbody';
     const result = extractFrontmatter(content);
-    expect(result).toEqual({ new: 'data' });
+    expect(result).toEqual({ old: 'data' });
+  });
+
+  it('returns the LEADING block when body contains markdown horizontal rules', () => {
+    // Regression: LAST-block semantics picked up body separators as frontmatter (#3240)
+    const content = [
+      '---',
+      'wave: 3',
+      'autonomous: false',
+      'phase: 05-hardening',
+      '---',
+      '',
+      '## Section One',
+      '',
+      '---',
+      '',
+      '## Section Two',
+      '',
+      '---',
+      '',
+      'body text',
+    ].join('\n');
+    const result = extractFrontmatter(content);
+    expect(result.wave).toBe('3');
+    expect(result.autonomous).toBe('false');
+    expect(result.phase).toBe('05-hardening');
+  });
+
+  it('returns the LEADING block when body contains embedded YAML in fenced code block', () => {
+    // Regression: LAST-block semantics matched YAML inside ```yaml fences (#3240)
+    const content = [
+      '---',
+      'wave: 2',
+      'autonomous: true',
+      'phase: 04-polish',
+      '---',
+      '',
+      '## Example',
+      '',
+      '```yaml',
+      '---',
+      'name: example',
+      'value: 99',
+      '---',
+      '```',
+      '',
+      'More body text.',
+    ].join('\n');
+    const result = extractFrontmatter(content);
+    expect(result.wave).toBe('2');
+    expect(result.autonomous).toBe('true');
+    expect(result.phase).toBe('04-polish');
   });
 
   it('handles empty-object-to-array conversion', () => {

--- a/sdk/src/query/frontmatter.ts
+++ b/sdk/src/query/frontmatter.ts
@@ -174,20 +174,18 @@ export function extractFrontmatterLeading(content: string): Record<string, unkno
  * - Nested objects via indentation
  * - Inline arrays: key: [a, b, c]
  * - Dash arrays with auto-conversion from empty objects
- * - Multiple stacked blocks (uses the LAST match)
  * - CRLF line endings
  * - Quoted value stripping
+ *
+ * Anchored at the start of the file — only the leading `---...---` block is
+ * considered canonical frontmatter. Body `---` separators and embedded YAML
+ * examples inside fenced code blocks are never picked up.
  *
  * @param content - File content potentially containing frontmatter
  * @returns Parsed frontmatter as a record, or empty object if none found
  */
 export function extractFrontmatter(content: string): Record<string, unknown> {
-  // Find ALL frontmatter blocks. Use the LAST one (corruption recovery).
-  const allBlocks = [...content.matchAll(/(?:^|\n)\s*---\r?\n([\s\S]+?)\r?\n---/g)];
-  const match = allBlocks.length > 0 ? allBlocks[allBlocks.length - 1] : null;
-  if (!match) return {};
-
-  return parseFrontmatterYamlLines(match[1]);
+  return extractFrontmatterLeading(content);
 }
 
 // ─── stripFrontmatter ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Fix PR

Fixes #3240

---

## What was broken

`extractFrontmatter` in `sdk/src/query/frontmatter.ts` and `sdk/src/plan-parser.ts` used a global regex (`/g` flag) that found **all** `---...---` blocks then picked the **last** one. When a plan body contained markdown horizontal rules (`---`) or embedded YAML examples inside fenced code blocks, the parser silently picked a body block instead of the file's leading frontmatter, causing downstream consumers to default to `wave=1, autonomous=true` and dispatch plans in the wrong order.

## What this fix does

Both `extractFrontmatter` implementations are now anchored at `^` (file start) without the `/g` flag — only the leading `---...---` block is treated as canonical frontmatter. In `frontmatter.ts`, `extractFrontmatter` now delegates directly to the already-correct `extractFrontmatterLeading` helper. In `plan-parser.ts`, the regex is updated to match only from position 0.

## Root cause

The global non-anchored regex `/(?:^|\n)\s*---\r?\n([\s\S]+?)\r?\n---/g` matched any `---` delimiter in the file body. Collecting all matches and taking the last index (`allBlocks[allBlocks.length - 1]`) meant any trailing `--- ... ---` pair — a markdown HR, a YAML example in a code block — could override the real frontmatter. Frontmatter is by definition the *leading* block; anchoring at `^` makes this invariant explicit.

## Testing

### How I verified the fix

Two regression tests added to each affected file:

1. **Markdown horizontal rules**: a plan with valid leading frontmatter followed by `\n---\n` section separators — asserts `extractFrontmatter` returns the leading block's `wave`, `autonomous`, `phase`.
2. **Fenced code block YAML**: a plan with leading frontmatter and an embedded `---\nname: example\nvalue: 99\n---` inside a ` ```yaml ` fence — asserts the leading block wins.

Both tests were confirmed RED before the fix and GREEN after.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where embedded YAML examples or markdown horizontal rules in file content caused incorrect parsing of configuration values.

* **Tests**
  * Added regression test cases to ensure frontmatter parsing consistently handles files with embedded YAML and markdown separators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->