### PR TITLE
fix(3264): document cross-wave-deviation cleanup tail in execute-phase step 5.5

### DIFF
--- a/.changeset/tidy-finches-caper.md
+++ b/.changeset/tidy-finches-caper.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3273
+---
+Orchestrators now have a documented cleanup-tail snippet to run when wave merges deviate from the templated path (e.g., cross-wave dependency merges with custom messages) — residual worktree-agent-* directories can be removed without manual forensics.

--- a/get-shit-done/workflows/execute-phase.md
+++ b/get-shit-done/workflows/execute-phase.md
@@ -694,6 +694,10 @@ increases monotonically across waves. `{status}` is `complete` (success),
 
 5.5. **Worktree cleanup (when `isolation="worktree"` was used):**
 
+   **Standard wave contract:** Each wave's worktrees merge to main via the templated path below before the next wave's worktrees fork. The cleanup loop runs once per wave at the end of the wave lifecycle. Worktrees created in wave N must be fully removed before wave N+1 forks new ones.
+
+   **Cross-wave dependency deviation (supported execution mode):** When the orchestrator legitimately deviates from the standard wave model — for example, a phase with cross-wave plan dependencies that requires custom inter-worktree base-update merges (e.g., `merge: bring 09-01 + 09-02 into 09-03 base`) — the cleanup loop below is NOT automatically re-entered for those custom merges. The deviation path produces correct final history but bypasses this loop, leaving `worktree-agent-*` directories in place. Use the **cleanup-tail snippet** below to remove any residual worktrees after such a deviation.
+
    When executor agents ran in worktree isolation, their commits land on temporary branches in separate working trees. After the wave completes, merge these changes back and clean up:
 
    ```bash
@@ -828,7 +832,42 @@ increases monotonically across waves. `{status}` is `complete` (success),
    done < <(git worktree list --porcelain | grep "^worktree " | grep "\.claude/worktrees/agent-" | sed 's/^worktree //')
    ```
 
+   **Cleanup-tail snippet (use after any wave whose merges did not flow through the templated path above):**
+
+   If the orchestrator deviated from the standard wave merge path (e.g., custom inter-worktree base-update merges with `merge: bring …` style messages), run this snippet after the custom merges are complete. It discovers and removes any residual `worktree-agent-*` worktrees. Safe to run when no residuals exist — it is a no-op in that case.
+
+   ```bash
+   # Cleanup-tail: remove residual agent worktrees after a cross-wave-dependency deviation.
+   # Inclusion-based filter (#2774): match ONLY agent-spawned worktrees under
+   # `.claude/worktrees/agent-`. Do NOT use exclusion filters (grep -v "$(pwd)$") —
+   # they destroy the parent workspace's .git in multi-workspace or cross-drive setups.
+   # Read line-by-line so worktree paths containing whitespace are preserved (#2774).
+   while IFS= read -r WT; do
+     [ -z "$WT" ] && continue
+     WT_BRANCH=$(git -C "$WT" rev-parse --abbrev-ref HEAD 2>/dev/null)
+     [ -z "$WT_BRANCH" ] || [ "$WT_BRANCH" = "HEAD" ] && continue
+     echo "Cleaning up residual worktree: $WT (branch: $WT_BRANCH)"
+     git worktree unlock "$WT" 2>/dev/null || true
+     if ! git worktree remove "$WT" --force; then
+       WT_NAME=$(basename "$WT")
+       if [ -f ".git/worktrees/${WT_NAME}/locked" ]; then
+         echo "⚠ Worktree $WT is locked — unlock failed; manual cleanup required:"
+         echo "    git worktree unlock \"$WT\" && git worktree remove \"$WT\" --force && git branch -D \"$WT_BRANCH\""
+       else
+         echo "⚠ Residual worktree at $WT — remove failed; manual cleanup required"
+       fi
+     else
+       git branch -D "$WT_BRANCH" 2>/dev/null || true
+     fi
+   done < <(git worktree list --porcelain | grep "^worktree " | grep "\.claude/worktrees/agent-" | sed 's/^worktree //')
+   git worktree prune
+   ```
+
+   **When to skip step 5.5:**
+
    **If no plan in this wave used worktree isolation** (project-level `USE_WORKTREES=false` OR every plan in the wave had `USE_WORKTREES_FOR_PLAN=false` — i.e. `WAVE_WORKTREE_PLANS` from step 2.5 is empty): all agents ran on the main working tree — skip this step entirely.
+
+   **If the orchestrator merged via custom messages (cross-wave-dependency deviation):** the templated cleanup loop above was not triggered for those merges. Run the cleanup-tail snippet above instead. After the snippet completes, proceed to step 5.6.
 
    **If at least one plan used worktrees but others did not:** still run this cleanup — it iterates over actual `git worktree list` output and only merges back the worktrees that were created, leaving sequential plans' commits on the main tree untouched.
 

--- a/tests/execute-phase-step-5-5-deviation-doc.test.cjs
+++ b/tests/execute-phase-step-5-5-deviation-doc.test.cjs
@@ -1,0 +1,140 @@
+// allow-test-rule: source-text-is-the-product
+// The workflow .md file is the installed AI contract — its text IS what the orchestrator
+// executes at runtime. Testing structural content of step 5.5 guards against accidental
+// deletion of the cross-wave-deviation cleanup documentation (#3264).
+
+/**
+ * Regression tests for #3264: cross-wave-dependency deviation cleanup documentation
+ *
+ * Guards that step 5.5 of execute-phase.md documents both skip conditions and
+ * contains a self-contained cleanup-tail snippet for the deviation path.
+ */
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const WORKFLOW_PATH = path.join(
+  __dirname,
+  '..',
+  'get-shit-done',
+  'workflows',
+  'execute-phase.md',
+);
+
+/**
+ * Locate the step 5.5 block in the workflow file.
+ * Returns the substring from "5.5." up to (but not including) "5.6.".
+ * Throws if the block cannot be found.
+ */
+function extractStep55Block(content) {
+  const start = content.indexOf('\n5.5.');
+  assert.ok(start !== -1, 'execute-phase.md must contain a step 5.5 block');
+
+  const end = content.indexOf('\n5.6.', start + 1);
+  assert.ok(end !== -1, 'execute-phase.md must contain a step 5.6 block after 5.5');
+
+  return content.slice(start, end);
+}
+
+describe('execute-phase step 5.5: cross-wave-deviation cleanup documentation (#3264)', () => {
+  const content = fs.readFileSync(WORKFLOW_PATH, 'utf-8');
+
+  test('workflow file exists', () => {
+    assert.ok(fs.existsSync(WORKFLOW_PATH), 'workflows/execute-phase.md should exist');
+  });
+
+  test('step 5.5 block exists and is bounded', () => {
+    // extractStep55Block throws on failure — this test validates the helper itself
+    const block = extractStep55Block(content);
+    assert.ok(block.length > 0, 'step 5.5 block must be non-empty');
+  });
+
+  test('step 5.5 documents the standard wave contract', () => {
+    const block = extractStep55Block(content);
+    assert.ok(
+      block.includes('Standard wave contract'),
+      'step 5.5 must name the standard wave contract explicitly',
+    );
+  });
+
+  test('step 5.5 names cross-wave dependency deviation as a supported execution mode', () => {
+    const block = extractStep55Block(content);
+    assert.ok(
+      block.includes('Cross-wave dependency deviation'),
+      'step 5.5 must name the cross-wave dependency deviation as a supported mode',
+    );
+  });
+
+  test('cleanup-tail snippet contains git worktree prune', () => {
+    const block = extractStep55Block(content);
+    assert.ok(
+      block.includes('git worktree prune'),
+      'step 5.5 cleanup-tail snippet must include git worktree prune',
+    );
+  });
+
+  test('cleanup-tail snippet contains git worktree remove --force', () => {
+    const block = extractStep55Block(content);
+    assert.ok(
+      block.includes('git worktree remove') && block.includes('--force'),
+      'step 5.5 cleanup-tail snippet must include git worktree remove --force',
+    );
+  });
+
+  test('cleanup-tail snippet contains git worktree unlock', () => {
+    const block = extractStep55Block(content);
+    assert.ok(
+      block.includes('git worktree unlock'),
+      'step 5.5 cleanup-tail snippet must include git worktree unlock',
+    );
+  });
+
+  test('cleanup-tail snippet contains git branch -D', () => {
+    const block = extractStep55Block(content);
+    assert.ok(
+      block.includes('git branch -D'),
+      'step 5.5 cleanup-tail snippet must include git branch -D',
+    );
+  });
+
+  test('skip conditions enumerate empty-WAVE_WORKTREE_PLANS case', () => {
+    const block = extractStep55Block(content);
+    assert.ok(
+      block.includes('WAVE_WORKTREE_PLANS'),
+      'step 5.5 must document the empty-WAVE_WORKTREE_PLANS skip condition',
+    );
+  });
+
+  test('skip conditions enumerate custom-merge-deviation case', () => {
+    const block = extractStep55Block(content);
+    // The deviation skip condition must reference the cleanup-tail as the alternative
+    assert.ok(
+      block.includes('cleanup-tail'),
+      'step 5.5 must document the custom-merge-deviation skip condition with a pointer to the cleanup-tail',
+    );
+  });
+
+  test('cleanup-tail uses inclusion-based filter for agent namespace', () => {
+    const block = extractStep55Block(content);
+    // Must use .claude/worktrees/agent- inclusion filter, not exclusion (per #2774 precedent)
+    assert.ok(
+      block.includes('.claude/worktrees/agent-'),
+      'cleanup-tail must use inclusion-based filter matching .claude/worktrees/agent- namespace',
+    );
+  });
+
+  test('cleanup-tail reads git worktree list --porcelain line-by-line', () => {
+    const block = extractStep55Block(content);
+    assert.ok(
+      block.includes('git worktree list --porcelain'),
+      'cleanup-tail must parse git worktree list --porcelain output',
+    );
+    // Line-by-line reading requires IFS= read -r pattern
+    assert.ok(
+      block.includes('IFS= read -r'),
+      'cleanup-tail must read line-by-line to preserve paths with whitespace',
+    );
+  });
+});


### PR DESCRIPTION
## Fix PR

Fixes #3264

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

Step 5.5 of `execute-phase.md` documented only the empty-`WAVE_WORKTREE_PLANS` skip condition. When the orchestrator legitimately deviated from the standard wave merge path (e.g., for cross-wave plan dependencies requiring custom `merge: bring …` messages), there was no documented re-entry path for worktree cleanup. Residual `worktree-agent-*` directories survived milestone close, milestone tag, and milestone-archive commit — detectable only via `/gsd-forensics`.

## What this fix does

Adds to step 5.5: (1) an explicit statement of the standard wave contract, (2) a named cross-wave-dependency deviation as a supported execution mode with a caveat that the loop is not auto-re-entered, and (3) a self-contained cleanup-tail snippet the orchestrator can run after any wave whose merges did not flow through the templated path, (4) an updated skip-condition list that enumerates both the empty-`WAVE_WORKTREE_PLANS` case and the new custom-merge-deviation case with a pointer to the cleanup-tail.

## Root cause

The cleanup loop ran only once per wave at a fixed point in the templated wave lifecycle. When the orchestrator deviated for cross-wave dependencies, that fixed point was bypassed with no documented escape hatch.

## Testing

### How I verified the fix

Structural regression test `tests/execute-phase-step-5-5-deviation-doc.test.cjs` — locates the step 5.5 block, then asserts each required element (cleanup-tail commands, both skip conditions, contract statement). All 12 new tests pass. All 67 execute-phase + worktree tests pass. `npm run lint:tests` clean.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically remove residual worktree-agent directories when wave merges deviate from the standard path, avoiding manual cleanup.

* **Documentation**
  * Clarified the standard wave contract and added guidance for custom cross-wave dependency deviations, including a cleanup-tail snippet to handle deviations.

* **Tests**
  * Added a regression test to verify the documentation and presence of the deviation/cleanup-tail guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->