### PR TITLE
fix(3265): prefer YAML frontmatter for state-snapshot canonical fields

### DIFF
--- a/.changeset/sharp-badgers-squeak.md
+++ b/.changeset/sharp-badgers-squeak.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3275
+---
+state-snapshot no longer returns wrong status and other fields when STATE.md body contains a Markdown table cell with bold field syntax (e.g. **Status:** in a task history row) — YAML frontmatter values now take precedence over body extraction for all canonical scalar fields.

--- a/get-shit-done/bin/lib/state.cjs
+++ b/get-shit-done/bin/lib/state.cjs
@@ -648,17 +648,30 @@ function cmdStateSnapshot(cwd, raw) {
 
   const content = fs.readFileSync(statePath, 'utf-8');
 
-  // Extract basic fields
-  const currentPhase = stateExtractField(content, 'Current Phase');
-  const currentPhaseName = stateExtractField(content, 'Current Phase Name');
-  const totalPhasesRaw = stateExtractField(content, 'Total Phases');
-  const currentPlan = stateExtractField(content, 'Current Plan');
-  const totalPlansRaw = stateExtractField(content, 'Total Plans in Phase');
-  const status = stateExtractField(content, 'Status');
-  const progressRaw = stateExtractField(content, 'Progress');
-  const lastActivity = stateExtractField(content, 'Last Activity');
-  const lastActivityDesc = stateExtractField(content, 'Last Activity Description');
-  const pausedAt = stateExtractField(content, 'Paused At');
+  // Bug #3265: prefer YAML frontmatter for canonical scalar fields so that a
+  // body table cell containing **Status:** Y cannot shadow the authoritative
+  // frontmatter value.  Mirrors the fix in sdk/src/query/state.ts.
+  const fm = extractFrontmatter(content);
+  const body = stripFrontmatter(content);
+
+  // Helper: return frontmatter string value when present and non-empty,
+  // otherwise return null so the caller falls back to body extraction.
+  const fmStr = (key) => {
+    const v = fm[key];
+    return (typeof v === 'string' && v.trim()) ? v.trim() : null;
+  };
+
+  // Extract basic fields — frontmatter keys take precedence over body
+  const currentPhase = fmStr('current_phase') ?? stateExtractField(body, 'Current Phase');
+  const currentPhaseName = fmStr('current_phase_name') ?? stateExtractField(body, 'Current Phase Name');
+  const totalPhasesRaw = fmStr('total_phases') ?? stateExtractField(body, 'Total Phases');
+  const currentPlan = fmStr('current_plan') ?? stateExtractField(body, 'Current Plan');
+  const totalPlansRaw = fmStr('total_plans_in_phase') ?? stateExtractField(body, 'Total Plans in Phase');
+  const status = fmStr('status') ?? stateExtractField(body, 'Status');
+  const progressRaw = fmStr('progress') ?? stateExtractField(body, 'Progress');
+  const lastActivity = fmStr('last_activity') ?? stateExtractField(body, 'Last Activity');
+  const lastActivityDesc = fmStr('last_activity_desc') ?? stateExtractField(body, 'Last Activity Description');
+  const pausedAt = fmStr('paused_at') ?? stateExtractField(body, 'Paused At');
 
   // Parse numeric fields
   const totalPhases = totalPhasesRaw ? parseInt(totalPhasesRaw, 10) : null;
@@ -667,7 +680,7 @@ function cmdStateSnapshot(cwd, raw) {
 
   // Extract decisions table
   const decisions = [];
-  const decisionsMatch = content.match(/##\s*Decisions Made[\s\S]*?\n\|[^\n]+\n\|[-|\s]+\n([\s\S]*?)(?=\n##|\n$|$)/i);
+  const decisionsMatch = body.match(/##\s*Decisions Made[\s\S]*?\n\|[^\n]+\n\|[-|\s]+\n([\s\S]*?)(?=\n##|\n$|$)/i);
   if (decisionsMatch) {
     const tableBody = decisionsMatch[1];
     const rows = tableBody.trim().split('\n').filter(r => r.includes('|'));
@@ -685,7 +698,7 @@ function cmdStateSnapshot(cwd, raw) {
 
   // Extract blockers list
   const blockers = [];
-  const blockersMatch = content.match(/##\s*Blockers\s*\n([\s\S]*?)(?=\n##|$)/i);
+  const blockersMatch = body.match(/##\s*Blockers\s*\n([\s\S]*?)(?=\n##|$)/i);
   if (blockersMatch) {
     const blockersSection = blockersMatch[1];
     const items = blockersSection.match(/^-\s+(.+)$/gm) || [];
@@ -701,7 +714,7 @@ function cmdStateSnapshot(cwd, raw) {
     resume_file: null,
   };
 
-  const sessionMatch = content.match(/##\s*Session\s*\n([\s\S]*?)(?=\n##|$)/i);
+  const sessionMatch = body.match(/##\s*Session\s*\n([\s\S]*?)(?=\n##|$)/i);
   if (sessionMatch) {
     const sessionSection = sessionMatch[1];
     const lastDateMatch = sessionSection.match(/\*\*Last Date:\*\*\s*(.+)/i)

--- a/get-shit-done/bin/lib/state.cjs
+++ b/get-shit-done/bin/lib/state.cjs
@@ -654,24 +654,30 @@ function cmdStateSnapshot(cwd, raw) {
   const fm = extractFrontmatter(content);
   const body = stripFrontmatter(content);
 
-  // Helper: return frontmatter string value when present and non-empty,
-  // otherwise return null so the caller falls back to body extraction.
-  const fmStr = (key) => {
+  // Helper: return frontmatter scalar value when present and non-empty.
+  // Accepts strings, numbers, and booleans — coercing non-string primitives to
+  // their string representation so callers always receive string | null.
+  // Returns null for missing, null/undefined, or empty-after-trim values so
+  // the caller falls back to body extraction.
+  const fmScalar = (key) => {
     const v = fm[key];
-    return (typeof v === 'string' && v.trim()) ? v.trim() : null;
+    if (v === null || v === undefined) return null;
+    if (typeof v === 'string') return v.trim() || null;
+    if (typeof v === 'number' || typeof v === 'boolean') return String(v);
+    return null;
   };
 
   // Extract basic fields — frontmatter keys take precedence over body
-  const currentPhase = fmStr('current_phase') ?? stateExtractField(body, 'Current Phase');
-  const currentPhaseName = fmStr('current_phase_name') ?? stateExtractField(body, 'Current Phase Name');
-  const totalPhasesRaw = fmStr('total_phases') ?? stateExtractField(body, 'Total Phases');
-  const currentPlan = fmStr('current_plan') ?? stateExtractField(body, 'Current Plan');
-  const totalPlansRaw = fmStr('total_plans_in_phase') ?? stateExtractField(body, 'Total Plans in Phase');
-  const status = fmStr('status') ?? stateExtractField(body, 'Status');
-  const progressRaw = fmStr('progress') ?? stateExtractField(body, 'Progress');
-  const lastActivity = fmStr('last_activity') ?? stateExtractField(body, 'Last Activity');
-  const lastActivityDesc = fmStr('last_activity_desc') ?? stateExtractField(body, 'Last Activity Description');
-  const pausedAt = fmStr('paused_at') ?? stateExtractField(body, 'Paused At');
+  const currentPhase = fmScalar('current_phase') ?? stateExtractField(body, 'Current Phase');
+  const currentPhaseName = fmScalar('current_phase_name') ?? stateExtractField(body, 'Current Phase Name');
+  const totalPhasesRaw = fmScalar('total_phases') ?? stateExtractField(body, 'Total Phases');
+  const currentPlan = fmScalar('current_plan') ?? stateExtractField(body, 'Current Plan');
+  const totalPlansRaw = fmScalar('total_plans_in_phase') ?? stateExtractField(body, 'Total Plans in Phase');
+  const status = fmScalar('status') ?? stateExtractField(body, 'Status');
+  const progressRaw = fmScalar('progress') ?? stateExtractField(body, 'Progress');
+  const lastActivity = fmScalar('last_activity') ?? stateExtractField(body, 'Last Activity');
+  const lastActivityDesc = fmScalar('last_activity_desc') ?? stateExtractField(body, 'Last Activity Description');
+  const pausedAt = fmScalar('paused_at') ?? stateExtractField(body, 'Paused At');
 
   // Parse numeric fields
   const totalPhases = totalPhasesRaw ? parseInt(totalPhasesRaw, 10) : null;

--- a/sdk/src/query/state.test.ts
+++ b/sdk/src/query/state.test.ts
@@ -346,6 +346,126 @@ describe('stateSnapshot', () => {
   });
 });
 
+// ─── Regression: #3265 — frontmatter wins over bold-body cell ─────────────
+
+describe('stateSnapshot — bug #3265 frontmatter precedence', () => {
+  it('returns frontmatter status, not **Status:** value embedded in a body table cell', async () => {
+    // Reproduce the collision: frontmatter says "executing", but the body
+    // contains a Markdown table cell with "**Status:** to ✅ COMPLETE ..."
+    // which stateExtractField (bold pattern) would match before the YAML line.
+    const stateContent = [
+      '---',
+      'gsd_state_version: 1.0',
+      'status: executing',
+      'current_plan: 19.5-05',
+      '---',
+      '',
+      '# Project State',
+      '',
+      '## Recent Quick Tasks',
+      '',
+      '| Date | Task | Notes |',
+      '|------|------|-------|',
+      '| 2026-05-01 | Reopened Plan 19.5-05. **Status:** to ✅ COMPLETE | done |',
+      '',
+      '**Current Phase:** 19',
+      '**Current Plan:** archived-lane',
+      '',
+    ].join('\n');
+
+    const localDir = await mkdtemp(join(tmpdir(), 'gsd-3265-'));
+    await mkdir(join(localDir, '.planning'), { recursive: true });
+    await writeFile(join(localDir, '.planning', 'STATE.md'), stateContent);
+
+    const result = await stateSnapshot([], localDir);
+    const data = result.data as Record<string, unknown>;
+
+    // Frontmatter status must win
+    expect(data.status).toBe('executing');
+
+    await rm(localDir, { recursive: true, force: true });
+  });
+
+  it('returns frontmatter current_plan, not bold body value when both present', async () => {
+    const stateContent = [
+      '---',
+      'gsd_state_version: 1.0',
+      'status: executing',
+      'current_plan: 19.5-05',
+      '---',
+      '',
+      '# Project State',
+      '',
+      '**Current Phase:** 19',
+      '**Current Plan:** archived-lane',
+      '',
+    ].join('\n');
+
+    const localDir = await mkdtemp(join(tmpdir(), 'gsd-3265b-'));
+    await mkdir(join(localDir, '.planning'), { recursive: true });
+    await writeFile(join(localDir, '.planning', 'STATE.md'), stateContent);
+
+    const result = await stateSnapshot([], localDir);
+    const data = result.data as Record<string, unknown>;
+
+    // Frontmatter current_plan must win over body bold value
+    expect(data.current_plan).toBe('19.5-05');
+
+    await rm(localDir, { recursive: true, force: true });
+  });
+
+  it('falls back to body extraction when no frontmatter block is present', async () => {
+    const stateContent = [
+      '# Project State',
+      '',
+      '**Current Phase:** 07',
+      '**Status:** paused',
+      '',
+    ].join('\n');
+
+    const localDir = await mkdtemp(join(tmpdir(), 'gsd-3265c-'));
+    await mkdir(join(localDir, '.planning'), { recursive: true });
+    await writeFile(join(localDir, '.planning', 'STATE.md'), stateContent);
+
+    const result = await stateSnapshot([], localDir);
+    const data = result.data as Record<string, unknown>;
+
+    // No frontmatter — body extraction must still work
+    expect(data.status).toBe('paused');
+    expect(data.current_phase).toBe('07');
+
+    await rm(localDir, { recursive: true, force: true });
+  });
+
+  it('falls back to body extractor for a field absent from frontmatter', async () => {
+    // Frontmatter has status but no current_plan — snapshot must body-extract current_plan
+    const stateContent = [
+      '---',
+      'gsd_state_version: 1.0',
+      'status: planning',
+      '---',
+      '',
+      '# Project State',
+      '',
+      '**Current Plan:** 05-03',
+      '',
+    ].join('\n');
+
+    const localDir = await mkdtemp(join(tmpdir(), 'gsd-3265d-'));
+    await mkdir(join(localDir, '.planning'), { recursive: true });
+    await writeFile(join(localDir, '.planning', 'STATE.md'), stateContent);
+
+    const result = await stateSnapshot([], localDir);
+    const data = result.data as Record<string, unknown>;
+
+    expect(data.status).toBe('planning');
+    // current_plan absent from frontmatter — must come from body
+    expect(data.current_plan).toBe('05-03');
+
+    await rm(localDir, { recursive: true, force: true });
+  });
+});
+
 // ─── Regression: --ws propagation (#2618 gap 1) ────────────────────────────
 
 describe('stateJson with --ws workstream', () => {

--- a/sdk/src/query/state.test.ts
+++ b/sdk/src/query/state.test.ts
@@ -499,3 +499,90 @@ Status: planning
     expect(data.status).toBe('planning');
   });
 });
+
+// ─── Regression: #3275 CR — fmScalar handles numeric/boolean YAML scalars ───
+
+describe('stateSnapshot — CR #3275 fmScalar non-string scalar coercion', () => {
+  it('treats numeric current_phase as string "19", not missing', async () => {
+    // A real YAML parser (e.g. js-yaml) would parse `current_phase: 19` as
+    // the number 19, not the string "19".  fmScalar must coerce it so the
+    // frontmatter value wins over the body's bold field.
+    const stateContent = [
+      '---',
+      'gsd_state_version: 1.0',
+      'current_phase: 19',
+      '---',
+      '',
+      '# Project State',
+      '',
+      '**Current Phase:** 03',
+      '**Status:** executing',
+      '',
+    ].join('\n');
+
+    const localDir = await mkdtemp(join(tmpdir(), 'gsd-3275a-'));
+    await mkdir(join(localDir, '.planning'), { recursive: true });
+    await writeFile(join(localDir, '.planning', 'STATE.md'), stateContent);
+
+    const result = await stateSnapshot([], localDir);
+    const data = result.data as Record<string, unknown>;
+
+    // Frontmatter wins: current_phase must be "19", not "03" (from body)
+    expect(data.current_phase).toBe('19');
+
+    await rm(localDir, { recursive: true, force: true });
+  });
+
+  it('treats numeric total_phases in frontmatter as string, not missing', async () => {
+    const stateContent = [
+      '---',
+      'gsd_state_version: 1.0',
+      'total_phases: 7',
+      '---',
+      '',
+      '# Project State',
+      '',
+      '**Total Phases:** 3',
+      '**Status:** executing',
+      '',
+    ].join('\n');
+
+    const localDir = await mkdtemp(join(tmpdir(), 'gsd-3275b-'));
+    await mkdir(join(localDir, '.planning'), { recursive: true });
+    await writeFile(join(localDir, '.planning', 'STATE.md'), stateContent);
+
+    const result = await stateSnapshot([], localDir);
+    const data = result.data as Record<string, unknown>;
+
+    // total_phases is parsed as int downstream: frontmatter 7 must win over body 3
+    expect(data.total_phases).toBe(7);
+
+    await rm(localDir, { recursive: true, force: true });
+  });
+
+  it('treats numeric total_plans_in_phase in frontmatter as string, not missing', async () => {
+    const stateContent = [
+      '---',
+      'gsd_state_version: 1.0',
+      'total_plans_in_phase: 5',
+      '---',
+      '',
+      '# Project State',
+      '',
+      '**Total Plans in Phase:** 2',
+      '**Status:** executing',
+      '',
+    ].join('\n');
+
+    const localDir = await mkdtemp(join(tmpdir(), 'gsd-3275c-'));
+    await mkdir(join(localDir, '.planning'), { recursive: true });
+    await writeFile(join(localDir, '.planning', 'STATE.md'), stateContent);
+
+    const result = await stateSnapshot([], localDir);
+    const data = result.data as Record<string, unknown>;
+
+    expect(data.total_plans_in_phase).toBe(5);
+
+    await rm(localDir, { recursive: true, force: true });
+  });
+});

--- a/sdk/src/query/state.ts
+++ b/sdk/src/query/state.ts
@@ -337,17 +337,32 @@ export const stateSnapshot: QueryHandler = async (_args, projectDir, workstream)
     return { data: { error: 'STATE.md not found' } };
   }
 
-  // Extract basic fields
-  const currentPhase = stateExtractField(content, 'Current Phase');
-  const currentPhaseName = stateExtractField(content, 'Current Phase Name');
-  const totalPhasesRaw = stateExtractField(content, 'Total Phases');
-  const currentPlan = stateExtractField(content, 'Current Plan');
-  const totalPlansRaw = stateExtractField(content, 'Total Plans in Phase');
-  const status = stateExtractField(content, 'Status');
-  const progressRaw = stateExtractField(content, 'Progress');
-  const lastActivity = stateExtractField(content, 'Last Activity');
-  const lastActivityDesc = stateExtractField(content, 'Last Activity Description');
-  const pausedAt = stateExtractField(content, 'Paused At');
+  // Bug #3265: prefer YAML frontmatter for canonical scalar fields so that a
+  // body table cell containing **Status:** Y cannot shadow the authoritative
+  // frontmatter value.  Matches the precedent set by buildStateFrontmatter
+  // (see state.ts:92 Bug #2613 comment).
+  const fm = extractFrontmatter(content);
+  const body = stripFrontmatter(content);
+
+  // Helper: return frontmatter string value when present and non-empty,
+  // otherwise fall back to body extractor (covers STATE.md files that have
+  // no frontmatter at all, or frontmatter that lacks the specific key).
+  const fmStr = (key: string): string | null => {
+    const v = fm[key];
+    return (typeof v === 'string' && v.trim()) ? v.trim() : null;
+  };
+
+  // Extract basic fields — frontmatter keys take precedence over body
+  const currentPhase = fmStr('current_phase') ?? stateExtractField(body, 'Current Phase');
+  const currentPhaseName = fmStr('current_phase_name') ?? stateExtractField(body, 'Current Phase Name');
+  const totalPhasesRaw = fmStr('total_phases') ?? stateExtractField(body, 'Total Phases');
+  const currentPlan = fmStr('current_plan') ?? stateExtractField(body, 'Current Plan');
+  const totalPlansRaw = fmStr('total_plans_in_phase') ?? stateExtractField(body, 'Total Plans in Phase');
+  const status = fmStr('status') ?? stateExtractField(body, 'Status');
+  const progressRaw = fmStr('progress') ?? stateExtractField(body, 'Progress');
+  const lastActivity = fmStr('last_activity') ?? stateExtractField(body, 'Last Activity');
+  const lastActivityDesc = fmStr('last_activity_desc') ?? stateExtractField(body, 'Last Activity Description');
+  const pausedAt = fmStr('paused_at') ?? stateExtractField(body, 'Paused At');
 
   // Parse numeric fields
   const totalPhases = totalPhasesRaw ? parseInt(totalPhasesRaw, 10) : null;
@@ -361,7 +376,7 @@ export const stateSnapshot: QueryHandler = async (_args, projectDir, workstream)
 
   // Extract decisions table
   const decisions: Array<{ phase: string; summary: string; rationale: string }> = [];
-  const decisionsMatch = content.match(/##\s*Decisions Made[\s\S]*?\n\|[^\n]+\n\|[-|\s]+\n([\s\S]*?)(?=\n##|\n$|$)/i);
+  const decisionsMatch = body.match(/##\s*Decisions Made[\s\S]*?\n\|[^\n]+\n\|[-|\s]+\n([\s\S]*?)(?=\n##|\n$|$)/i);
   if (decisionsMatch) {
     const tableBody = decisionsMatch[1];
     const rows = tableBody.trim().split('\n').filter(r => r.includes('|'));
@@ -379,7 +394,7 @@ export const stateSnapshot: QueryHandler = async (_args, projectDir, workstream)
 
   // Extract blockers list
   const blockers: string[] = [];
-  const blockersMatch = content.match(/##\s*Blockers\s*\n([\s\S]*?)(?=\n##|$)/i);
+  const blockersMatch = body.match(/##\s*Blockers\s*\n([\s\S]*?)(?=\n##|$)/i);
   if (blockersMatch) {
     const blockersSection = blockersMatch[1];
     const items = blockersSection.match(/^-\s+(.+)$/gm) || [];
@@ -395,7 +410,7 @@ export const stateSnapshot: QueryHandler = async (_args, projectDir, workstream)
     resume_file: null,
   };
 
-  const sessionMatch = content.match(/##\s*Session\s*\n([\s\S]*?)(?=\n##|$)/i);
+  const sessionMatch = body.match(/##\s*Session\s*\n([\s\S]*?)(?=\n##|$)/i);
   if (sessionMatch) {
     const sessionSection = sessionMatch[1];
     const lastDateMatch = sessionSection.match(/\*\*Last Date:\*\*\s*(.+)/i)

--- a/sdk/src/query/state.ts
+++ b/sdk/src/query/state.ts
@@ -344,25 +344,31 @@ export const stateSnapshot: QueryHandler = async (_args, projectDir, workstream)
   const fm = extractFrontmatter(content);
   const body = stripFrontmatter(content);
 
-  // Helper: return frontmatter string value when present and non-empty,
-  // otherwise fall back to body extractor (covers STATE.md files that have
+  // Helper: return frontmatter scalar value when present and non-empty.
+  // Accepts strings, numbers, and booleans — coercing non-string primitives to
+  // their string representation so callers always receive string | null.
+  // Returns null for missing, null/undefined, or empty-after-trim values so
+  // the caller falls back to body extractor (covers STATE.md files that have
   // no frontmatter at all, or frontmatter that lacks the specific key).
-  const fmStr = (key: string): string | null => {
+  const fmScalar = (key: string): string | null => {
     const v = fm[key];
-    return (typeof v === 'string' && v.trim()) ? v.trim() : null;
+    if (v === null || v === undefined) return null;
+    if (typeof v === 'string') return v.trim() || null;
+    if (typeof v === 'number' || typeof v === 'boolean') return String(v);
+    return null;
   };
 
   // Extract basic fields — frontmatter keys take precedence over body
-  const currentPhase = fmStr('current_phase') ?? stateExtractField(body, 'Current Phase');
-  const currentPhaseName = fmStr('current_phase_name') ?? stateExtractField(body, 'Current Phase Name');
-  const totalPhasesRaw = fmStr('total_phases') ?? stateExtractField(body, 'Total Phases');
-  const currentPlan = fmStr('current_plan') ?? stateExtractField(body, 'Current Plan');
-  const totalPlansRaw = fmStr('total_plans_in_phase') ?? stateExtractField(body, 'Total Plans in Phase');
-  const status = fmStr('status') ?? stateExtractField(body, 'Status');
-  const progressRaw = fmStr('progress') ?? stateExtractField(body, 'Progress');
-  const lastActivity = fmStr('last_activity') ?? stateExtractField(body, 'Last Activity');
-  const lastActivityDesc = fmStr('last_activity_desc') ?? stateExtractField(body, 'Last Activity Description');
-  const pausedAt = fmStr('paused_at') ?? stateExtractField(body, 'Paused At');
+  const currentPhase = fmScalar('current_phase') ?? stateExtractField(body, 'Current Phase');
+  const currentPhaseName = fmScalar('current_phase_name') ?? stateExtractField(body, 'Current Phase Name');
+  const totalPhasesRaw = fmScalar('total_phases') ?? stateExtractField(body, 'Total Phases');
+  const currentPlan = fmScalar('current_plan') ?? stateExtractField(body, 'Current Plan');
+  const totalPlansRaw = fmScalar('total_plans_in_phase') ?? stateExtractField(body, 'Total Plans in Phase');
+  const status = fmScalar('status') ?? stateExtractField(body, 'Status');
+  const progressRaw = fmScalar('progress') ?? stateExtractField(body, 'Progress');
+  const lastActivity = fmScalar('last_activity') ?? stateExtractField(body, 'Last Activity');
+  const lastActivityDesc = fmScalar('last_activity_desc') ?? stateExtractField(body, 'Last Activity Description');
+  const pausedAt = fmScalar('paused_at') ?? stateExtractField(body, 'Paused At');
 
   // Parse numeric fields
   const totalPhases = totalPhasesRaw ? parseInt(totalPhasesRaw, 10) : null;

--- a/tests/bug-3275-fmstr-non-string-scalars.test.cjs
+++ b/tests/bug-3275-fmstr-non-string-scalars.test.cjs
@@ -1,0 +1,146 @@
+/**
+ * GSD Tools Tests — Bug #3275 (CR finding)
+ *
+ * Regression guard: `state-snapshot` must prefer YAML frontmatter scalar
+ * values even when those scalars are numeric (e.g. current_phase: 19) or
+ * boolean — not just when they are strings.
+ *
+ * Prior to the fix, `fmStr` checked `typeof v === 'string'`, so a numeric
+ * frontmatter value like `current_phase: 19` was treated as missing and the
+ * snapshot fell back to body extraction, which could return a stale or
+ * incorrect value.
+ */
+
+const { test, describe, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
+
+describe('state-snapshot: fmStr accepts non-string YAML scalars (#3275 CR)', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('numeric current_phase in frontmatter wins over body extraction', () => {
+    // YAML parses bare integers as numbers, not strings.
+    // fmStr must not drop the frontmatter value when it is a number.
+    const stateMd = [
+      '---',
+      'gsd_state_version: 1.0',
+      'current_phase: 19',
+      '---',
+      '',
+      '# Project State',
+      '',
+      '**Current Phase:** 03',
+      '**Status:** executing',
+      '',
+    ].join('\n');
+
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), stateMd);
+
+    const result = runGsdTools('state-snapshot', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    // Frontmatter numeric value must win over bold-body value
+    assert.strictEqual(output.current_phase, '19', 'numeric frontmatter current_phase must be used');
+  });
+
+  test('numeric total_phases in frontmatter wins over body extraction', () => {
+    const stateMd = [
+      '---',
+      'gsd_state_version: 1.0',
+      'total_phases: 7',
+      '---',
+      '',
+      '# Project State',
+      '',
+      '**Total Phases:** 3',
+      '**Status:** executing',
+      '',
+    ].join('\n');
+
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), stateMd);
+
+    const result = runGsdTools('state-snapshot', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    // Frontmatter says 7, body says 3 — frontmatter must win
+    assert.strictEqual(output.total_phases, 7, 'numeric frontmatter total_phases must be used');
+  });
+
+  test('numeric total_plans_in_phase in frontmatter wins over body extraction', () => {
+    const stateMd = [
+      '---',
+      'gsd_state_version: 1.0',
+      'total_plans_in_phase: 5',
+      '---',
+      '',
+      '# Project State',
+      '',
+      '**Total Plans in Phase:** 2',
+      '**Status:** executing',
+      '',
+    ].join('\n');
+
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), stateMd);
+
+    const result = runGsdTools('state-snapshot', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.total_plans_in_phase, 5, 'numeric frontmatter total_plans_in_phase must be used');
+  });
+
+  test('string current_phase in frontmatter still works (no regression)', () => {
+    const stateMd = [
+      '---',
+      'gsd_state_version: 1.0',
+      "current_phase: '19'",
+      '---',
+      '',
+      '# Project State',
+      '',
+      '**Current Phase:** 03',
+      '**Status:** executing',
+      '',
+    ].join('\n');
+
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), stateMd);
+
+    const result = runGsdTools('state-snapshot', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.current_phase, '19', 'string frontmatter current_phase still works');
+  });
+
+  test('no-frontmatter file still extracts from body (no regression)', () => {
+    const stateMd = [
+      '# Project State',
+      '',
+      '**Current Phase:** 05',
+      '**Total Phases:** 8',
+      '**Status:** paused',
+      '',
+    ].join('\n');
+
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), stateMd);
+
+    const result = runGsdTools('state-snapshot', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.current_phase, '05', 'body extraction still works without frontmatter');
+    assert.strictEqual(output.total_phases, 8, 'numeric body total_phases still extracted');
+  });
+});

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -191,6 +191,98 @@ describe('state-snapshot command', () => {
   });
 });
 
+// ─── Regression: #3265 — frontmatter wins over bold-body cell ─────────────
+
+describe('state-snapshot — bug #3265 frontmatter precedence', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('returns frontmatter status, not **Status:** value embedded in a body table cell', () => {
+    // Reproduce the collision: frontmatter says "executing", but the body
+    // contains a Markdown table cell with "**Status:** to ✅ COMPLETE ..."
+    // which stateExtractField (bold pattern) would match before the YAML line.
+    const stateContent = [
+      '---',
+      'gsd_state_version: 1.0',
+      'status: executing',
+      'current_plan: 19.5-05',
+      '---',
+      '',
+      '# Project State',
+      '',
+      '## Recent Quick Tasks',
+      '',
+      '| Date | Task | Notes |',
+      '|------|------|-------|',
+      '| 2026-05-01 | Reopened Plan 19.5-05. **Status:** to ✅ COMPLETE | done |',
+      '',
+      '**Current Phase:** 19',
+      '**Current Plan:** archived-lane',
+      '',
+    ].join('\n');
+
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), stateContent);
+
+    const result = runGsdTools('state-snapshot', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    // Frontmatter status must win over the table cell's **Status:** match
+    assert.strictEqual(output.status, 'executing', 'frontmatter status beats body table cell');
+  });
+
+  test('returns frontmatter current_plan, not bold body value when both present', () => {
+    const stateContent = [
+      '---',
+      'gsd_state_version: 1.0',
+      'status: executing',
+      'current_plan: 19.5-05',
+      '---',
+      '',
+      '# Project State',
+      '',
+      '**Current Phase:** 19',
+      '**Current Plan:** archived-lane',
+      '',
+    ].join('\n');
+
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), stateContent);
+
+    const result = runGsdTools('state-snapshot', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.current_plan, '19.5-05', 'frontmatter current_plan beats body bold value');
+  });
+
+  test('falls back to body extraction when no frontmatter block is present', () => {
+    const stateContent = [
+      '# Project State',
+      '',
+      '**Current Phase:** 07',
+      '**Status:** paused',
+      '',
+    ].join('\n');
+
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), stateContent);
+
+    const result = runGsdTools('state-snapshot', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    // No frontmatter — body extraction must still work
+    assert.strictEqual(output.status, 'paused', 'body extraction works without frontmatter');
+    assert.strictEqual(output.current_phase, '07', 'body extraction works without frontmatter');
+  });
+});
+
 describe('state mutation commands', () => {
   let tmpDir;
 


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #3265

---

## What was broken

`state-snapshot` (and the CJS `cmdStateSnapshot` twin) passed the entire STATE.md blob — frontmatter + body — to `stateExtractField`. That function's bold pattern (`\*\*Field:\*\*`) has no line anchor, so a body Markdown table cell such as `**Status:** to ✅ COMPLETE` shadowed the authoritative YAML frontmatter `status:` value.

## What this fix does

Both `stateSnapshot` (TypeScript, `sdk/src/query/state.ts`) and `cmdStateSnapshot` (CJS, `get-shit-done/bin/lib/state.cjs`) now:
1. Parse `extractFrontmatter(content)` before any body extraction.
2. Strip frontmatter with `stripFrontmatter(content)` to produce a clean `body` string passed to `stateExtractField`.
3. For each canonical scalar field (`status`, `current_phase`, `current_plan`, `last_activity`, `paused_at`, etc.) use the non-empty frontmatter value when present, falling back to body extraction when the field is absent or no frontmatter block exists.

Body-only fields (decisions table, blockers list, session block) continue to use body extraction only.

## Root cause

`stateExtractField`'s bold-anywhere regex (`**Field:**` with `i` flag, no `^` anchor, no `m` flag) can match anywhere in the file, including inside table cells. The same precedent for frontmatter-first lookup was already established by `buildStateFrontmatter` (Bug #2613 fix), but `stateSnapshot` was not updated alongside it.

## Testing

### How I verified the fix

Regression tests added in both test suites confirm the fix.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

Tests added:
- `sdk/src/query/state.test.ts` — 4 vitest cases (frontmatter status beats table cell **Status:** match; frontmatter current_plan beats body bold; no-frontmatter body fallback; per-field frontmatter absence fallback)
- `tests/state.test.cjs` — 3 node:test cases (same core scenarios, CJS parity)

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * state-snapshot now prioritizes YAML frontmatter for scalar fields (status, progress, current_plan, phases, etc.) and falls back to body extraction when frontmatter keys are missing, preventing markdown table/body collisions.

* **Tests**
  * Added regression tests covering frontmatter precedence and proper handling of non-string YAML scalars (e.g., numeric values).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->