### PR TITLE
docs(CONTEXT.md): codify release-notes formatting standard for AI agents (#3277)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -261,3 +261,48 @@ After stripping prose @-refs, some command `<process>` blocks retained bolded "*
 `WORKSTREAM.NAME.POLICY.cjs-module=get-shit-done/bin/lib/workstream-name-policy.cjs owns toWorkstreamSlug + active-name/path-segment validation`
 `WORKSTREAM.POINTER.SEAM.sdk-module=sdk/src/query/active-workstream-store.ts owns read/write self-heal for .planning/active-workstream`
 `CONFIG.SEAM.loadConfig-context=loadConfig(cwd,{workstream}) replaces env-mutation fallback; no temporary process.env GSD_WORKSTREAM rewrites`
+
+---
+
+## Release Notes Standard (2026-05-09, machine-oriented)
+
+`RELEASE-NOTES.SCOPE=GitHub Releases body for tags vX.Y.Z, vX.Y.Z-rcN; not CHANGELOG.md (changeset workflow owns that)`
+`RELEASE-NOTES.DEFAULT-STATE=auto-generated body is "What's Changed" PR list + Full Changelog link; treat as draft, not final`
+`RELEASE-NOTES.GATE.hotfix=manual edit required; auto-generated body for vX.Y.{Z>0} is "Full Changelog only" and must be replaced with structured body`
+`RELEASE-NOTES.GATE.rc=manual edit recommended; auto-generated PR list is acceptable for early RCs but final RC before vX.Y.0 should match standard`
+`RELEASE-NOTES.GATE.minor=auto-generated body acceptable when PR titles are clean; promote to structured body when >20 PRs or contains feature+refactor+fix mix`
+
+`RELEASE-NOTES.STANDARD.taxonomy=Keep-a-Changelog 1.1.0: Added | Changed | Deprecated | Removed | Fixed | Security | Documentation`
+`RELEASE-NOTES.STANDARD.heading-level=## for category, ### for subgroup (area), - for bullet`
+`RELEASE-NOTES.STANDARD.bullet-shape=**Bold user-visible change** — explanation of what was broken or what's new, leading with symptom not implementation. Trailing (#NNN) PR ref.`
+`RELEASE-NOTES.STANDARD.subgroups=phase-planning-state | workstream | query-dispatch-cli | code-review | install | capture | docs | architecture | security`
+`RELEASE-NOTES.STANDARD.footer.hotfix=Install/upgrade: \`npx get-shit-done-cc@latest\``
+`RELEASE-NOTES.STANDARD.footer.rc=Install for testing: \`npx get-shit-done-cc@next\` (per branch->dist-tag policy)`
+`RELEASE-NOTES.STANDARD.footer.canary=Install: \`npx get-shit-done-cc@canary\``
+`RELEASE-NOTES.STANDARD.footer.full-changelog=**Full Changelog**: https://github.com/gsd-build/get-shit-done/compare/<prev>...<this>`
+`RELEASE-NOTES.STANDARD.intro=optional one-paragraph framing for RC/feature releases; omit for pure-fix hotfixes`
+
+`RELEASE-NOTES.SOURCE.commits=git log <prev-tag>..<this-tag> --pretty=format:'%s%n%n%b' --no-merges`
+`RELEASE-NOTES.SOURCE.changesets=.changeset/*.md (frontmatter pr: + body bullets)`
+`RELEASE-NOTES.SOURCE.pr-bodies=gh pr view <NNN> --json title,body for fixes lacking a changeset`
+`RELEASE-NOTES.SOURCE.precedence=changeset body > commit body > PR body > commit subject (prefer authored content over auto-generated)`
+
+`RELEASE-NOTES.WORKFLOW.edit=gh release edit <tag> --notes-file <path>`
+`RELEASE-NOTES.WORKFLOW.view=gh release view <tag> --json body --jq .body`
+`RELEASE-NOTES.WORKFLOW.token=must use .envrc GITHUB_TOKEN per project CLAUDE.md; never ambient gh auth`
+`RELEASE-NOTES.WORKFLOW.idempotency=gh release edit overwrites body wholesale; safe to re-run after refining`
+
+`RELEASE-NOTES.ANTI-PATTERN=raw "What's Changed" PR list as final body for hotfix or feature release; "Full Changelog only" body for tagged release with >0 user-facing fixes`
+`RELEASE-NOTES.ANTI-PATTERN.implementation-first=do not lead bullet with file path or function name; lead with symptom/user-visible behavior`
+`RELEASE-NOTES.ANTI-PATTERN.risk-commentary=do not include "may break", "be careful", "test thoroughly" - per global CLAUDE.md no-risk-commentary rule`
+
+`RELEASE-NOTES.EXAMPLE.hotfix=v1.41.1 (https://github.com/gsd-build/get-shit-done/releases/tag/v1.41.1) - 14 fixes grouped by 6 subgroups`
+`RELEASE-NOTES.EXAMPLE.rc=v1.42.0-rc1 (https://github.com/gsd-build/get-shit-done/releases/tag/v1.42.0-rc1) - intro + Added/Changed/Fixed/Documentation taxonomy`
+`RELEASE-NOTES.EXAMPLE.minor-auto-acceptable=v1.41.0 - kept auto-generated body; many small fixes with clean conventional-commit titles`
+
+`RELEASE-NOTES.TEMPLATE.hotfix=## Fixed\n\n### <subgroup>\n- **<bold change>** — <explanation>. (#<PR>)\n\n---\n\nInstall/upgrade: \`npx get-shit-done-cc@latest\`\n\n**Full Changelog**: <compare-url>`
+`RELEASE-NOTES.TEMPLATE.rc=<one-paragraph intro>\n\n## Added\n### <subgroup>\n- **<change>** — <explanation>. (#<PR>)\n\n## Changed\n### Architecture\n- **<refactor>** — <user-visible benefit>. (#<PR>)\n\n## Fixed\n### <subgroup>\n- **<fix>** — <explanation>. (#<PR>)\n\n## Documentation\n- **<docs change>** — <reason>. (#<PR>)\n\n---\n\nThis is a release candidate. Install for testing:\n\`\`\`bash\nnpx get-shit-done-cc@next\n\`\`\`\n\n**Full Changelog**: <compare-url>`
+
+`RELEASE-NOTES.RELEASE-STREAM.dev-branch=canary dist-tag (only); install via @canary`
+`RELEASE-NOTES.RELEASE-STREAM.main-branch=next (RCs) + latest (stable); install via @next or @latest`
+`RELEASE-NOTES.RELEASE-STREAM.rule=streams do not mix; do not document @canary install in RC notes or @next in canary notes`


### PR DESCRIPTION
## Enhancement PR

## Linked Issue

Closes #3277

---

## What this enhancement improves

`CONTEXT.md` AI Ops Memory section. Today there is no codified contract for GitHub release notes formatting — every release-edit task re-derives the structure from prior releases (v1.38.4, v1.37.1, etc.). Hotfix releases (v1.41.1) and RC releases (v1.42.0-rc1) had ship'd with auto-generated bodies that did not match the structured format the repo's better releases use; both were just edited into shape manually. This PR records the resulting contract so the next agent does not have to re-derive it.

## Before / After

**Before:** No release-notes guidance in `CONTEXT.md`. Agents discover format by reading prior releases and grepping for examples.

**After:** New `RELEASE-NOTES.*` namespace under the existing AI Ops Memory section, mirroring the dot-namespaced backticked key=value pattern used by `WORKTREE.SEAM.*`, `PLANNING.PATH.*`, etc. An agent can grep `RELEASE-NOTES.STANDARD.bullet-shape` or `RELEASE-NOTES.TEMPLATE.hotfix` and lift the contract directly.

## How it was implemented

Single append to `CONTEXT.md` (45 lines). Covers:

- **Scope & gates** — `RELEASE-NOTES.GATE.{hotfix,rc,minor}` — when manual edit is required vs auto-generated body acceptable
- **Standard format** — Keep-a-Changelog 1.1.0 taxonomy, heading levels (`##` category, `###` subgroup), bullet shape (`**Bold** — explanation. (#NNN)`), canonical subgroup list (phase-planning-state | workstream | query-dispatch-cli | code-review | install | capture | docs | architecture | security)
- **Footers per stream** — `@latest` for hotfix, `@next` for RC, `@canary` for canary, aligned with the existing `project_release_streams` policy (`dev=canary`, `main=next/latest`)
- **Sources & precedence** — changeset body > commit body > PR body > commit subject (prefer authored content over auto-generated)
- **Workflow commands** — `gh release edit <tag> --notes-file <path>`, `gh release view <tag> --json body --jq .body`
- **Anti-patterns** — raw "What's Changed" PR list as final body, implementation-first bullets, risk commentary
- **Examples** — v1.41.1 (hotfix), v1.42.0-rc1 (RC), v1.41.0 (minor auto-acceptable)
- **Templates** — reproducible hotfix and RC structures with `\n` escapes

## Testing

### How I verified the enhancement works

The format being codified was just applied to two live releases:
- v1.41.1 — https://github.com/gsd-build/get-shit-done/releases/tag/v1.41.1
- v1.42.0-rc1 — https://github.com/gsd-build/get-shit-done/releases/tag/v1.42.0-rc1

Both bodies match the templates exactly, validating that the contract is reproducible.

### Platforms tested

- [x] N/A (not platform-specific — docs/AI-context only)

### Runtimes tested

- [x] N/A (not runtime-specific — docs/AI-context only)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

---

## Checklist

- [x] Issue linked above with `Closes #3277`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass (no test impact — single docs append, no code or workflow change)
- [x] New or updated tests cover the enhanced behavior — N/A (no behavior to test; docs-only)
- [x] `.changeset/` fragment added — **N/A, `no-changelog` label applied**: `CONTEXT.md` is internal AI ops memory, not user-facing. No CHANGELOG entry needed.
- [x] Documentation updated if behavior or output changed — this PR _is_ the documentation update
- [x] No unnecessary dependencies added

## Breaking changes

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal documentation formatting with whitespace adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->