### PR TITLE
fix(3297): apply project_code prefix to add-backlog phase directory

### DIFF
--- a/.changeset/3297-add-backlog-project-code-prefix.md
+++ b/.changeset/3297-add-backlog-project-code-prefix.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3297
+---
+**`/gsd-capture --backlog` now applies `project_code` prefix to the backlog phase directory** — projects with `project_code` set in `.planning/config.json` no longer accumulate a naming mismatch between active phases (e.g. `CK-01-foundation/`) and backlog items (e.g. `999.1-my-idea/`). `workflows/add-backlog.md` Step 4 now reads `project_code` via `gsd-sdk query config-get project_code` and prepends `${PREFIX:+${PREFIX}-}` to the `${NEXT}-${SLUG}` name, producing `CK-999.1-my-idea/` for projects with a prefix set. When `project_code` is empty or absent the path is unchanged (graceful fallback). (#3297)

--- a/.changeset/3297-add-backlog-project-code-prefix.md
+++ b/.changeset/3297-add-backlog-project-code-prefix.md
@@ -2,4 +2,10 @@
 type: Fixed
 pr: 3300
 ---
-**`/gsd-capture --backlog` now applies `project_code` prefix to the backlog phase directory** — projects with `project_code` set in `.planning/config.json` no longer accumulate a naming mismatch between active phases (e.g. `CK-01-foundation/`) and backlog items (e.g. `999.1-my-idea/`). `workflows/add-backlog.md` Step 4 now reads `project_code` via `gsd-sdk query config-get project_code` and prepends `${PREFIX:+${PREFIX}-}` to the `${NEXT}-${SLUG}` name, producing `CK-999.1-my-idea/` for projects with a prefix set. When `project_code` is empty or absent the path is unchanged (graceful fallback). (#3297)
+**`/gsd-capture --backlog` now applies `project_code` prefix to the backlog phase directory** —
+projects with `project_code` set in `.planning/config.json` no longer accumulate a naming mismatch
+between active phases (e.g. `CK-01-foundation/`) and backlog items (e.g. `999.1-my-idea/`).
+`workflows/add-backlog.md` Step 4 now reads `project_code` via `gsd-sdk query config-get project_code`
+and prepends `${PREFIX:+${PREFIX}-}` to the `${NEXT}-${SLUG}` name, producing `CK-999.1-my-idea/`
+for projects with a prefix set. When `project_code` is empty or absent the path is unchanged
+(graceful fallback). (#3297)

--- a/.changeset/3297-add-backlog-project-code-prefix.md
+++ b/.changeset/3297-add-backlog-project-code-prefix.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 3297
+pr: 3300
 ---
 **`/gsd-capture --backlog` now applies `project_code` prefix to the backlog phase directory** — projects with `project_code` set in `.planning/config.json` no longer accumulate a naming mismatch between active phases (e.g. `CK-01-foundation/`) and backlog items (e.g. `999.1-my-idea/`). `workflows/add-backlog.md` Step 4 now reads `project_code` via `gsd-sdk query config-get project_code` and prepends `${PREFIX:+${PREFIX}-}` to the `${NEXT}-${SLUG}` name, producing `CK-999.1-my-idea/` for projects with a prefix set. When `project_code` is empty or absent the path is unchanged (graceful fallback). (#3297)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased](https://github.com/gsd-build/get-shit-done/compare/v1.41.0...HEAD)
 
+### Enhancement
+
+- **Shared `scanPhasePlans()` helper extracted to `bin/lib/plan-scan.cjs` (k014)** — four divergent copies of the plan-scan algorithm in `state.cjs`, `roadmap.cjs`, `init.cjs`, and `phase.cjs` are now replaced by a single canonical implementation. Each copy had subtle differences (regex shapes, flat vs nested coverage, pre-bounce exclusion patterns) that caused plan-count drift between the four callers. The helper covers both the flat layout (`*-PLAN.md`, `PLAN.md`) and the nested layout (`plans/PLAN-NN-slug.md`) introduced in #3139, and returns `{ planCount, summaryCount, completed, hasNestedPlans, planFiles, summaryFiles }`. (#3262)
+
 ### Fixed
 
-- **`/gsd-capture --backlog` now applies `project_code` prefix to the backlog phase directory** —
-  projects with `project_code` set in `.planning/config.json` no longer accumulate a naming mismatch
-  between active phases (e.g. `CK-01-foundation/`) and backlog items (e.g. `999.1-my-idea/`).
-  Step 4 of `workflows/add-backlog.md` now reads `project_code` via `gsd-sdk query config-get project_code`
-  and prepends `${PREFIX:+${PREFIX}-}` before the `${NEXT}-${SLUG}` name, matching the
-  `phase.add`/`phase.insert` convention. When `project_code` is empty/absent the path is unchanged
-  (graceful fallback). (#3297)
 - **`/gsd-discuss-phase` and `/gsd-plan-phase` first-touch creation now apply `project_code` prefix consistently with `phase.add`/`phase.insert`** — projects with `project_code` set in `.planning/config.json` no longer accumulate a two-headed naming convention (`01-foundation/` mixed with `XR-02.1-spike/`). `init.phase-op` and `init.plan-phase` now expose `expected_phase_dir` (with prefix) in their JSON bundle; workflow fallback mkdir calls use this value instead of constructing the path from `padded_phase`+`phase_slug`. `phase.scaffold phase-dir` (CJS and SDK) also fixed. (#3287)
 - **`buildStateFrontmatter` now counts nested `plans/<N>-PLAN-<NN>-<slug>.md` files** — repos using the nested layout (post-#3139) no longer get `progress.*` counters silently overwritten downward on every state mutation. Sibling fix to #3115/#3139/#3191. (#3261)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **`/gsd-capture --backlog` now applies `project_code` prefix to the backlog phase directory** — projects with `project_code` set in `.planning/config.json` no longer accumulate a naming mismatch between active phases (e.g. `CK-01-foundation/`) and backlog items (e.g. `999.1-my-idea/`). Step 4 of `workflows/add-backlog.md` now reads `project_code` via `gsd-sdk query config-get project_code` and prepends `${PREFIX:+${PREFIX}-}` before the `${NEXT}-${SLUG}` name, matching the `phase.add`/`phase.insert` convention. When `project_code` is empty/absent the path is unchanged (graceful fallback). (#3297)
 - **`/gsd-discuss-phase` and `/gsd-plan-phase` first-touch creation now apply `project_code` prefix consistently with `phase.add`/`phase.insert`** — projects with `project_code` set in `.planning/config.json` no longer accumulate a two-headed naming convention (`01-foundation/` mixed with `XR-02.1-spike/`). `init.phase-op` and `init.plan-phase` now expose `expected_phase_dir` (with prefix) in their JSON bundle; workflow fallback mkdir calls use this value instead of constructing the path from `padded_phase`+`phase_slug`. `phase.scaffold phase-dir` (CJS and SDK) also fixed. (#3287)
 - **`buildStateFrontmatter` now counts nested `plans/<N>-PLAN-<NN>-<slug>.md` files** — repos using the nested layout (post-#3139) no longer get `progress.*` counters silently overwritten downward on every state mutation. Sibling fix to #3115/#3139/#3191. (#3261)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
-- **`/gsd-capture --backlog` now applies `project_code` prefix to the backlog phase directory** — projects with `project_code` set in `.planning/config.json` no longer accumulate a naming mismatch between active phases (e.g. `CK-01-foundation/`) and backlog items (e.g. `999.1-my-idea/`). Step 4 of `workflows/add-backlog.md` now reads `project_code` via `gsd-sdk query config-get project_code` and prepends `${PREFIX:+${PREFIX}-}` before the `${NEXT}-${SLUG}` name, matching the `phase.add`/`phase.insert` convention. When `project_code` is empty/absent the path is unchanged (graceful fallback). (#3297)
+- **`/gsd-capture --backlog` now applies `project_code` prefix to the backlog phase directory** —
+  projects with `project_code` set in `.planning/config.json` no longer accumulate a naming mismatch
+  between active phases (e.g. `CK-01-foundation/`) and backlog items (e.g. `999.1-my-idea/`).
+  Step 4 of `workflows/add-backlog.md` now reads `project_code` via `gsd-sdk query config-get project_code`
+  and prepends `${PREFIX:+${PREFIX}-}` before the `${NEXT}-${SLUG}` name, matching the
+  `phase.add`/`phase.insert` convention. When `project_code` is empty/absent the path is unchanged
+  (graceful fallback). (#3297)
 - **`/gsd-discuss-phase` and `/gsd-plan-phase` first-touch creation now apply `project_code` prefix consistently with `phase.add`/`phase.insert`** — projects with `project_code` set in `.planning/config.json` no longer accumulate a two-headed naming convention (`01-foundation/` mixed with `XR-02.1-spike/`). `init.phase-op` and `init.plan-phase` now expose `expected_phase_dir` (with prefix) in their JSON bundle; workflow fallback mkdir calls use this value instead of constructing the path from `padded_phase`+`phase_slug`. `phase.scaffold phase-dir` (CJS and SDK) also fixed. (#3287)
 - **`buildStateFrontmatter` now counts nested `plans/<N>-PLAN-<NN>-<slug>.md` files** — repos using the nested layout (post-#3139) no longer get `progress.*` counters silently overwritten downward on every state mutation. Sibling fix to #3115/#3139/#3191. (#3261)
 

--- a/get-shit-done/workflows/add-backlog.md
+++ b/get-shit-done/workflows/add-backlog.md
@@ -49,16 +49,23 @@ Plans:
 
 ## Step 4: Create the phase directory
 
+Read the project_code prefix first so the directory name matches the convention
+used by `phase.add` / `phase.insert` (e.g. `CK-999.1-my-idea`). When
+`project_code` is empty or absent the prefix expands to nothing, preserving
+current behavior for projects that do not set one (k301: graceful root fallback).
+
 ```bash
 SLUG=$(gsd-sdk query generate-slug "$ARGUMENTS" --raw)
-mkdir -p ".planning/phases/${NEXT}-${SLUG}"
-touch ".planning/phases/${NEXT}-${SLUG}/.gitkeep"
+PREFIX=$(gsd-sdk query config-get project_code --raw 2>/dev/null || echo "")
+DIR="${PREFIX:+${PREFIX}-}${NEXT}-${SLUG}"
+mkdir -p ".planning/phases/${DIR}"
+touch ".planning/phases/${DIR}/.gitkeep"
 ```
 
 ## Step 5: Commit
 
 ```bash
-gsd-sdk query commit "docs: add backlog item ${NEXT} — ${ARGUMENTS}" --files .planning/ROADMAP.md ".planning/phases/${NEXT}-${SLUG}/.gitkeep"
+gsd-sdk query commit "docs: add backlog item ${NEXT} — ${ARGUMENTS}" --files .planning/ROADMAP.md ".planning/phases/${DIR}/.gitkeep"
 ```
 
 ## Step 6: Report
@@ -67,7 +74,7 @@ gsd-sdk query commit "docs: add backlog item ${NEXT} — ${ARGUMENTS}" --files .
 ## 📋 Backlog Item Added
 
 Phase {NEXT}: {description}
-Directory: .planning/phases/{NEXT}-{slug}/
+Directory: .planning/phases/{DIR}/
 
 This item lives in the backlog parking lot.
 Use /gsd-discuss-phase {NEXT} to explore it further.

--- a/tests/bug-3297-add-backlog-project-code-prefix.test.cjs
+++ b/tests/bug-3297-add-backlog-project-code-prefix.test.cjs
@@ -1,0 +1,122 @@
+// allow-test-rule: source-text-is-the-product — workflow .md files ARE what
+// the runtime loads; asserting their behavioural content tests the deployed
+// skill surface contract, not implementation internals.
+
+'use strict';
+
+// Regression tests for bug #3297.
+//
+// get-shit-done/workflows/add-backlog.md Step 4 constructs the phase directory
+// as `.planning/phases/${NEXT}-${SLUG}` — without the project_code prefix from
+// .planning/config.json.
+//
+// For projects with project_code "CK" the result is `.planning/phases/999.1-foo`
+// instead of `.planning/phases/CK-999.1-foo`, breaking directory-name parity
+// with phase.add / phase.insert which both apply the prefix.
+//
+// Fix (Option 1 from issue): read project_code via
+//   `gsd-sdk query config-get project_code --raw`
+// and prepend `${PREFIX:+${PREFIX}-}` to the directory name.
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..');
+const WORKFLOW = path.join(ROOT, 'get-shit-done', 'workflows', 'add-backlog.md');
+
+describe('#3297: add-backlog.md must apply project_code prefix to phase directory', () => {
+  let src;
+  test('workflow file is readable', () => {
+    try {
+      src = fs.readFileSync(WORKFLOW, 'utf8');
+    } catch (err) {
+      assert.fail(`Could not read ${WORKFLOW}: ${err.message}`);
+    }
+  });
+
+  test('reads project_code from config via gsd-sdk query config-get', () => {
+    if (!src) src = fs.readFileSync(WORKFLOW, 'utf8');
+    assert.ok(
+      src.includes('config-get') && src.includes('project_code'),
+      'add-backlog.md must fetch project_code via "gsd-sdk query config-get project_code" ' +
+        '(or equivalent) before constructing the phase directory path',
+    );
+  });
+
+  test('applies project_code prefix using ${PREFIX:+${PREFIX}-} or equivalent guard', () => {
+    if (!src) src = fs.readFileSync(WORKFLOW, 'utf8');
+    // Accept any of the canonical shell prefix patterns used elsewhere in the codebase:
+    //   ${PREFIX:+${PREFIX}-}   — POSIX conditional expansion (preferred)
+    //   ${PREFIX}-${NEXT}       — bare concatenation when PREFIX may be empty is wrong;
+    //                             only accept if there is also a guard like [ -n "$PREFIX" ]
+    const hasPosixExpansion = src.includes('${PREFIX:+${PREFIX}-}') ||
+      src.includes('${PREFIX:+$PREFIX-}');
+    const hasGuardedConcat =
+      (src.includes('[ -n') || src.includes('[[ -n')) &&
+      src.includes('PREFIX') &&
+      src.includes('${NEXT}');
+    assert.ok(
+      hasPosixExpansion || hasGuardedConcat,
+      'add-backlog.md must guard the project_code prefix so that an empty ' +
+        'project_code produces no prefix (use ${PREFIX:+${PREFIX}-} or an ' +
+        'explicit -n guard before concatenation)',
+    );
+  });
+
+  test('phase directory name uses PREFIX before NEXT in mkdir', () => {
+    if (!src) src = fs.readFileSync(WORKFLOW, 'utf8');
+    // The mkdir command must reference PREFIX (or DIR) before NEXT in the path.
+    // Accept: ${PREFIX:+${PREFIX}-}${NEXT}  OR  ${DIR}  (a variable holding the full name)
+    const mkdirLine = src.split('\n').find((l) => l.includes('mkdir') && l.includes('phases'));
+    assert.ok(
+      mkdirLine,
+      'add-backlog.md must have a mkdir line that creates the phase directory under .planning/phases/',
+    );
+    const prefixBeforeNext =
+      /\$\{PREFIX[^}]*\}[^$]*\$\{NEXT\}/.test(mkdirLine) ||
+      /\$PREFIX[^$]*\$NEXT/.test(mkdirLine) ||
+      mkdirLine.includes('${DIR}') ||
+      mkdirLine.includes('$DIR');
+    assert.ok(
+      prefixBeforeNext,
+      `mkdir line must include PREFIX (or DIR) before NEXT in the path.\nGot: ${mkdirLine}`,
+    );
+  });
+
+  test('commit step references the prefixed directory variable', () => {
+    if (!src) src = fs.readFileSync(WORKFLOW, 'utf8');
+    const commitLine = src.split('\n').find((l) => l.includes('query commit') && l.includes('phases'));
+    assert.ok(
+      commitLine,
+      'add-backlog.md must have a gsd-sdk query commit line that references the phase directory',
+    );
+    const usesPrefixOrDir =
+      commitLine.includes('${DIR}') ||
+      commitLine.includes('$DIR') ||
+      (commitLine.includes('PREFIX') && commitLine.includes('NEXT'));
+    assert.ok(
+      usesPrefixOrDir,
+      `commit step must reference the prefixed directory (DIR or PREFIX+NEXT).\nGot: ${commitLine}`,
+    );
+  });
+
+  test('Step 6 report uses prefixed directory name', () => {
+    if (!src) src = fs.readFileSync(WORKFLOW, 'utf8');
+    // The report section should show the directory with prefix
+    const reportIdx = src.indexOf('## Step 6') !== -1 ? src.indexOf('## Step 6') : src.indexOf('## 📋');
+    assert.ok(reportIdx !== -1, 'Step 6 / report section not found in add-backlog.md');
+    const reportSection = src.slice(reportIdx);
+    const usesPrefixOrDir =
+      reportSection.includes('${DIR}') ||
+      reportSection.includes('$DIR') ||
+      reportSection.includes('PREFIX') ||
+      reportSection.includes('{prefix}') ||
+      reportSection.includes('{dir}');
+    assert.ok(
+      usesPrefixOrDir,
+      'Step 6 report section must reference the prefixed directory name (${DIR}, $DIR, or {dir})',
+    );
+  });
+});

--- a/tests/bug-3297-add-backlog-project-code-prefix.test.cjs
+++ b/tests/bug-3297-add-backlog-project-code-prefix.test.cjs
@@ -111,12 +111,13 @@ describe('#3297: add-backlog.md must apply project_code prefix to phase director
     const usesPrefixOrDir =
       reportSection.includes('${DIR}') ||
       reportSection.includes('$DIR') ||
+      reportSection.includes('{DIR}') ||
       reportSection.includes('PREFIX') ||
       reportSection.includes('{prefix}') ||
       reportSection.includes('{dir}');
     assert.ok(
       usesPrefixOrDir,
-      'Step 6 report section must reference the prefixed directory name (${DIR}, $DIR, or {dir})',
+      'Step 6 report section must reference the prefixed directory name (${DIR}, $DIR, {DIR}, or {dir})',
     );
   });
 });


### PR DESCRIPTION
## Fix PR

### Summary

- `get-shit-done/workflows/add-backlog.md` Step 4 constructed the backlog phase directory as `.planning/phases/${NEXT}-${SLUG}` — without the `project_code` prefix from `.planning/config.json`.
- Projects with `project_code: "CK"` got `.planning/phases/999.1-foo` instead of `.planning/phases/CK-999.1-foo`, breaking directory-name parity with `phase.add`/`phase.insert`.
- Fix reads `project_code` via `gsd-sdk query config-get project_code --raw` and applies `${PREFIX:+${PREFIX}-}` guard (POSIX conditional expansion), identical to the pattern in `phase-lifecycle.ts:128`. Empty/absent `project_code` produces no prefix (graceful fallback).

### Changes

- `get-shit-done/workflows/add-backlog.md` — Step 4 now reads PREFIX and builds `DIR="${PREFIX:+${PREFIX}-}${NEXT}-${SLUG}"`. All downstream references (mkdir, touch, commit, Step 6 report) use `${DIR}`.
- `tests/bug-3297-add-backlog-project-code-prefix.test.cjs` — 6 regression tests (RED → GREEN).
- `CHANGELOG.md` — entry under `[Unreleased] > Fixed`.
- `.changeset/3297-add-backlog-project-code-prefix.md` — changeset.

### Test plan

- [ ] `node --test tests/bug-3297-add-backlog-project-code-prefix.test.cjs` — 6/6 pass
- [ ] `node --test tests/bug-3135-capture-backlog-workflow.test.cjs` — 82/82 pass (no regression)
- [ ] CI green

### Checklist

- [x] CHANGELOG.md updated
- [x] Changeset added
- [x] Tests added (TDD red → green commits visible in git log)
- [x] `project_code` empty/absent → graceful fallback (no prefix, same as before)

Fixes #3297

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Backlog directory creation now consistently applies the configured project-code prefix (and omits it when unset) to match active phase directories.

* **Tests**
  * Added a regression test verifying prefix application and omission for backlog directories.

* **Documentation**
  * Updated workflow and changelog entries to reflect the prefixed backlog directory naming and reporting.

* **Enhancement**
  * Noted extraction of a shared plan-scan helper to unify plan counting across commands.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3300)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->