### PR TITLE
fix(workflow): apply project_code prefix in plan-milestone-gaps + import (#3298)

### DIFF
--- a/.changeset/nimble-tigers-fly.md
+++ b/.changeset/nimble-tigers-fly.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3303
+---
+**`/gsd-plan-milestone-gaps` and `/gsd-import` now apply `project_code` prefix to phase directories** — projects with `project_code` set in `.planning/config.json` no longer accumulate mixed naming conventions when gap-closure phases or imported plans create new phase directories. Both workflows now query `gsd-sdk query init phase-op <N> --pick expected_phase_dir` and use that for the `mkdir`, matching the pattern PR #3292 established for `/gsd-discuss-phase` and `/gsd-plan-phase`. (#3298)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **`/gsd-plan-milestone-gaps` and `/gsd-import` now apply `project_code` prefix to phase directories** — projects with `project_code` set in `.planning/config.json` no longer accumulate mixed naming conventions when gap-closure phases or imported plans create new phase directories. Both workflows now query `gsd-sdk query init phase-op <N> --pick expected_phase_dir` and use that for the `mkdir`, matching the pattern PR #3292 established for `/gsd-discuss-phase` and `/gsd-plan-phase`. (#3298)
 - **`/gsd-discuss-phase` and `/gsd-plan-phase` first-touch creation now apply `project_code` prefix consistently with `phase.add`/`phase.insert`** — projects with `project_code` set in `.planning/config.json` no longer accumulate a two-headed naming convention (`01-foundation/` mixed with `XR-02.1-spike/`). `init.phase-op` and `init.plan-phase` now expose `expected_phase_dir` (with prefix) in their JSON bundle; workflow fallback mkdir calls use this value instead of constructing the path from `padded_phase`+`phase_slug`. `phase.scaffold phase-dir` (CJS and SDK) also fixed. (#3287)
 - **`buildStateFrontmatter` now counts nested `plans/<N>-PLAN-<NN>-<slug>.md` files** — repos using the nested layout (post-#3139) no longer get `progress.*` counters silently overwritten downward on every state mutation. Sibling fix to #3115/#3139/#3191. (#3261)
 

--- a/get-shit-done/workflows/import.md
+++ b/get-shit-done/workflows/import.md
@@ -173,14 +173,17 @@ Apply GSD naming convention for the output filename:
 - NEVER use `PLAN-01.md`, `plan-01.md`, or any other format
 - NN = phase number (zero-padded), MM = plan number within the phase (zero-padded)
 
-Determine the target directory:
+Determine the target directory by querying init for `expected_phase_dir` (which includes the `project_code` prefix from `.planning/config.json` when set):
+
+```bash
+expected_phase_dir=$(gsd-sdk query init phase-op {NN} --pick expected_phase_dir)
 ```
-.planning/phases/{NN}-{slug}/
-```
+
+`expected_phase_dir` resolves to `<CODE>-{NN}-{slug}/` for projects with a `project_code`, or `{NN}-{slug}/` otherwise — matching the shape produced by `phase.add` / `phase.insert` / `/gsd-discuss-phase` / `/gsd-plan-phase`.
 
 If the directory does not exist, create it:
 ```bash
-mkdir -p ".planning/phases/{NN}-{slug}/"
+mkdir -p "${expected_phase_dir}"
 ```
 
 Write the PLAN.md file to the target directory.

--- a/get-shit-done/workflows/plan-milestone-gaps.md
+++ b/get-shit-done/workflows/plan-milestone-gaps.md
@@ -139,9 +139,14 @@ grep -c "Pending" .planning/REQUIREMENTS.md
 
 ## 8. Create Phase Directories
 
+For each new phase N you added in step 6, query init for `expected_phase_dir` (which includes the `project_code` prefix from `.planning/config.json` when set) and use that for the `mkdir`:
+
 ```bash
-mkdir -p ".planning/phases/{NN}-{name}"
+expected_phase_dir=$(gsd-sdk query init phase-op {N} --pick expected_phase_dir)
+mkdir -p "${expected_phase_dir}"
 ```
+
+Repeat for every new phase (`{N}` through `{M}`). Do not construct `.planning/phases/{NN}-{name}` inline — that path skips the `project_code` prefix and yields mixed naming with `phase.add` / `phase.insert` / `/gsd-discuss-phase` / `/gsd-plan-phase`, all of which apply the prefix.
 
 ## 9. Commit Roadmap and Requirements Update
 

--- a/tests/bug-3298-workflow-mkdir-prefix.test.cjs
+++ b/tests/bug-3298-workflow-mkdir-prefix.test.cjs
@@ -1,0 +1,260 @@
+'use strict';
+
+/**
+ * Regression test for #3298 — phase-dir prefix drift in two specialised workflows.
+ *
+ * #3287 / PR #3292 unified the canonical phase-creation paths
+ * (`/gsd-discuss-phase`, `/gsd-plan-phase`, `phase scaffold`) so that the
+ * `project_code` prefix from `.planning/config.json` is applied uniformly via
+ * `expected_phase_dir` from the init bundle.
+ *
+ * Two specialised workflows were not in scope of #3292 and still construct
+ * directory paths from raw `{NN}-{slug}`:
+ *
+ *   1. `get-shit-done/workflows/plan-milestone-gaps.md` step
+ *      "## 8. Create Phase Directories" — creates many gap-closure phase dirs
+ *      from a milestone audit.
+ *   2. `get-shit-done/workflows/import.md` step `<step name="plan_convert">` —
+ *      creates a target phase directory when ingesting an external plan.
+ *
+ * Both must be brought in line with the #3292 contract: the mkdir command in
+ * each section must consume `expected_phase_dir` (which carries the prefix)
+ * rather than constructing the path inline from `{NN}-{slug}` / `{NN}-{name}`.
+ *
+ * These are structural assertions on the workflow markdown — workflows are
+ * agent guidance, not executable code, so the contract being verified is
+ * the *text* the agent sees. Per project convention (no raw substring grep
+ * over file content) the test extracts each fenced bash code block under
+ * the relevant section and asserts on the extracted block content.
+ */
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const WF_GAPS = path.join(ROOT, 'get-shit-done', 'workflows', 'plan-milestone-gaps.md');
+const WF_IMPORT = path.join(ROOT, 'get-shit-done', 'workflows', 'import.md');
+
+// ─── Markdown structural helpers ─────────────────────────────────────────────
+
+/**
+ * Slice a markdown document by `## ` headings.
+ *
+ * Returns a Map of heading-text → body lines (between this heading and the
+ * next `## ` heading or EOF). Heading text excludes the leading `## `.
+ */
+function sliceByH2(content) {
+  const lines = content.split(/\r?\n/);
+  const sections = new Map();
+  let currentTitle = null;
+  let currentLines = [];
+  for (const line of lines) {
+    const m = line.match(/^##\s+(.+?)\s*$/);
+    if (m && !line.startsWith('### ')) {
+      if (currentTitle !== null) sections.set(currentTitle, currentLines);
+      currentTitle = m[1].trim();
+      currentLines = [];
+    } else if (currentTitle !== null) {
+      currentLines.push(line);
+    }
+  }
+  if (currentTitle !== null) sections.set(currentTitle, currentLines);
+  return sections;
+}
+
+/**
+ * Slice a markdown document by `<step name="...">` tags.
+ *
+ * Returns a Map of step-name → body lines (between the opening tag and its
+ * matching `</step>`).
+ */
+function sliceByStepTag(content) {
+  const lines = content.split(/\r?\n/);
+  const sections = new Map();
+  let currentName = null;
+  let currentLines = [];
+  for (const line of lines) {
+    const open = line.match(/^<step\s+name="([^"]+)">\s*$/);
+    if (open) {
+      if (currentName !== null) sections.set(currentName, currentLines);
+      currentName = open[1];
+      currentLines = [];
+      continue;
+    }
+    if (line.match(/^<\/step>\s*$/) && currentName !== null) {
+      sections.set(currentName, currentLines);
+      currentName = null;
+      currentLines = [];
+      continue;
+    }
+    if (currentName !== null) currentLines.push(line);
+  }
+  if (currentName !== null) sections.set(currentName, currentLines);
+  return sections;
+}
+
+/**
+ * Extract the bodies of fenced code blocks from a list of lines, optionally
+ * filtering by info string (e.g. only `bash` blocks). Returns an array of
+ * { info, body } objects where body is the raw inner text.
+ */
+function extractFencedBlocks(lines, infoFilter = null) {
+  const blocks = [];
+  let inFence = false;
+  let info = null;
+  let buf = [];
+  for (const line of lines) {
+    const open = line.match(/^```([A-Za-z0-9_-]*)\s*$/);
+    if (!inFence && open) {
+      inFence = true;
+      info = open[1] || '';
+      buf = [];
+      continue;
+    }
+    if (inFence && /^```\s*$/.test(line)) {
+      if (infoFilter === null || info === infoFilter) {
+        blocks.push({ info, body: buf.join('\n') });
+      }
+      inFence = false;
+      info = null;
+      buf = [];
+      continue;
+    }
+    if (inFence) buf.push(line);
+  }
+  return blocks;
+}
+
+/**
+ * Find the bash code block(s) in a section that contain a `mkdir -p` of a
+ * phase directory. A "phase mkdir" is any mkdir whose target either
+ *   - hardcodes `.planning/phases/...`, or
+ *   - consumes `${expected_phase_dir}` (the canonical, prefix-aware path).
+ * Returns the bodies of those blocks.
+ */
+function findPhaseMkdirBlocks(sectionLines) {
+  return extractFencedBlocks(sectionLines, 'bash')
+    .map(b => b.body)
+    .filter(body =>
+      /\bmkdir\s+-p\s+["']?\.planning\/phases\//.test(body)
+      || /\bmkdir\s+-p\s+["']?\$\{?expected_phase_dir\}?/.test(body)
+    );
+}
+
+/**
+ * The prefix-aware contract: every `mkdir` of a phase directory in a section
+ * must either
+ *   (a) target `${expected_phase_dir}` from the init bundle, or
+ *   (b) be replaced by an SDK `phase add` / `phase insert` call (which reads
+ *       `project_code` internally).
+ *
+ * Returns { ok, reason } describing whether the section satisfies (a) or (b).
+ */
+function assertPrefixAwarePhaseCreation(sectionLines) {
+  const allBash = extractFencedBlocks(sectionLines, 'bash').map(b => b.body);
+  const phaseMkdirs = findPhaseMkdirBlocks(sectionLines);
+
+  // (b) — section uses `gsd-sdk query phase add` / `phase insert` to create
+  //       directories. If so, raw mkdirs are not required.
+  const usesSdkPhaseCreate = allBash.some(body =>
+    /gsd-sdk\s+query\s+phase\s+(add|insert)\b/.test(body)
+  );
+  if (usesSdkPhaseCreate && phaseMkdirs.length === 0) {
+    return { ok: true, reason: 'routes through gsd-sdk query phase add/insert' };
+  }
+
+  if (phaseMkdirs.length === 0) {
+    return {
+      ok: false,
+      reason: 'no phase-creation mechanism found (no mkdir, no phase add/insert)',
+    };
+  }
+
+  // (a) — every phase mkdir must target ${expected_phase_dir}, never
+  //       a raw `.planning/phases/{NN}-{slug}` literal.
+  for (const body of phaseMkdirs) {
+    const literalMkdir = body.match(
+      /\bmkdir\s+-p\s+["']?\.planning\/phases\/[^\s"']+/,
+    );
+    if (literalMkdir) {
+      return {
+        ok: false,
+        reason: [
+          'mkdir of .planning/phases/... must consume ${expected_phase_dir} instead;',
+          'offending command:',
+          literalMkdir[0],
+        ].join('\n'),
+      };
+    }
+    if (!/\$\{?expected_phase_dir\}?/.test(body)) {
+      return {
+        ok: false,
+        reason: [
+          'phase mkdir does not reference ${expected_phase_dir};',
+          'block:',
+          body,
+        ].join('\n'),
+      };
+    }
+  }
+  return { ok: true, reason: 'every phase mkdir uses ${expected_phase_dir}' };
+}
+
+// ─── Test A — plan-milestone-gaps.md step 8 ──────────────────────────────────
+
+describe('bug-3298 — plan-milestone-gaps.md step 8 applies project_code prefix', () => {
+  test('"## 8. Create Phase Directories" routes through expected_phase_dir or phase add', () => {
+    const content = fs.readFileSync(WF_GAPS, 'utf-8');
+    const sections = sliceByH2(content);
+
+    const stepTitle = '8. Create Phase Directories';
+    assert.ok(
+      sections.has(stepTitle),
+      `Expected H2 section "${stepTitle}" — found: ${JSON.stringify([...sections.keys()])}`,
+    );
+
+    const result = assertPrefixAwarePhaseCreation(sections.get(stepTitle));
+    assert.ok(
+      result.ok,
+      [
+        `plan-milestone-gaps.md step "${stepTitle}" must apply project_code prefix.`,
+        `Reason: ${result.reason}`,
+        '',
+        'Fix: route directory creation through `gsd-sdk query phase add` (which reads',
+        '     project_code) OR query `gsd-sdk query init phase-op <N>` and use the',
+        '     `expected_phase_dir` field for the mkdir. See PR #3292 for the pattern',
+        '     applied to /gsd-discuss-phase and /gsd-plan-phase.',
+      ].join('\n'),
+    );
+  });
+});
+
+// ─── Test B — import.md step plan_convert ────────────────────────────────────
+
+describe('bug-3298 — import.md plan_convert applies project_code prefix', () => {
+  test('<step name="plan_convert"> routes through expected_phase_dir or phase add', () => {
+    const content = fs.readFileSync(WF_IMPORT, 'utf-8');
+    const steps = sliceByStepTag(content);
+
+    const stepName = 'plan_convert';
+    assert.ok(
+      steps.has(stepName),
+      `Expected <step name="${stepName}"> — found: ${JSON.stringify([...steps.keys()])}`,
+    );
+
+    const result = assertPrefixAwarePhaseCreation(steps.get(stepName));
+    assert.ok(
+      result.ok,
+      [
+        `import.md step "${stepName}" must apply project_code prefix.`,
+        `Reason: ${result.reason}`,
+        '',
+        'Fix: query `gsd-sdk query init phase-op <N>` for the target phase and use',
+        '     the `expected_phase_dir` field for the mkdir. See PR #3292 for the',
+        '     pattern applied to /gsd-discuss-phase and /gsd-plan-phase.',
+      ].join('\n'),
+    );
+  });
+});


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #3298

> Linked issue has the `confirmed-bug` label.

---

## What was broken

Two specialised phase-creation workflows still constructed phase directory paths from raw `{NN}-{slug}` and bypassed the `project_code` prefix from `.planning/config.json`:

- `get-shit-done/workflows/plan-milestone-gaps.md` step 8 ("Create Phase Directories")
- `get-shit-done/workflows/import.md` step `<step name="plan_convert">`

Result: in projects with `project_code: "XR"` set, `/gsd-plan-milestone-gaps` and `/gsd-import` produced `06-fix-auth/` while `phase.add`, `/gsd-discuss-phase`, and `/gsd-plan-phase` produced `XR-06-fix-auth/` — a mixed naming convention.

## What this fix does

Both workflows now query `gsd-sdk query init phase-op <N> --pick expected_phase_dir` and `mkdir "${expected_phase_dir}"`, matching the pattern PR #3292 established for `/gsd-discuss-phase` and `/gsd-plan-phase`. `expected_phase_dir` resolves to `<CODE>-NN-slug/` when `project_code` is set, or `NN-slug/` otherwise — so the workflows are aligned with the canonical `phase.add` / `phase.insert` shape.

## Root cause

PR #3292 (#3287) unified the canonical paths but did not cover these two specialised workflows because they are not part of the standard discuss → plan → execute flow. Surfaced during a follow-up PRED.k015 audit.

## Testing

### How I verified the fix

`tests/bug-3298-workflow-mkdir-prefix.test.cjs` parses each workflow markdown structurally (by H2 heading and `<step>` tag), extracts fenced bash blocks within the relevant section, and asserts that any phase mkdir consumes `${expected_phase_dir}`. The test is RED before the fix and GREEN after.

```
$ node --test tests/bug-3298-workflow-mkdir-prefix.test.cjs
ℹ tests 2
ℹ pass 2
ℹ fail 0
```

Pre-fix (verified by stashing the workflow edits):

```
ℹ pass 0
ℹ fail 2
  Reason: mkdir of .planning/phases/... must consume ${expected_phase_dir} instead;
```

### Regression test added?

- [x] Yes — added a structural test on the workflow markdown that would have caught this bug
- [ ] No

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

> Workflow files are runtime-agnostic — the bash snippets are read by every runtime. macOS only because that's the local dev box; the change is text-only.

---

## Checklist

- [x] Issue linked above with `Fixes #3298` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`npm test`) — pre-existing codex-config failure on this machine (node runner path mismatch, unrelated, also fails on `origin/main` HEAD)
- [x] `.changeset/` fragment added (`.changeset/nimble-tigers-fly.md` + CHANGELOG.md)
- [x] No unnecessary dependencies added

## Breaking changes

None. `expected_phase_dir` falls back to `NN-slug/` (no prefix) when `project_code` is unset, matching the pre-fix shape for default projects.
