### PR TITLE
feat(3310): wire remaining ERROR_REASON typed codes into gsd-tools

### DIFF
--- a/.changeset/sunny-dogs-frolic.md
+++ b/.changeset/sunny-dogs-frolic.md
@@ -1,5 +1,5 @@
 ---
 type: Changed
-pr: 3310
+pr: 3311
 ---
 **`gsd-tools --json-errors` covers every error path** — every "Unknown <subsystem> subcommand" and missing-required-arg error now emits a typed `ERROR_REASON` code (`sdk_unknown_command` or `usage`) instead of the fallback `unknown`. Tests can now lock these paths via `JSON.parse(stderr).reason` without grepping the human message (#3310, builds on #3255).

--- a/.changeset/sunny-dogs-frolic.md
+++ b/.changeset/sunny-dogs-frolic.md
@@ -1,0 +1,5 @@
+---
+type: Changed
+pr: 3310
+---
+**`gsd-tools --json-errors` covers every error path** — every "Unknown <subsystem> subcommand" and missing-required-arg error now emits a typed `ERROR_REASON` code (`sdk_unknown_command` or `usage`) instead of the fallback `unknown`. Tests can now lock these paths via `JSON.parse(stderr).reason` without grepping the human message (#3310, builds on #3255).

--- a/get-shit-done/bin/gsd-tools.cjs
+++ b/get-shit-done/bin/gsd-tools.cjs
@@ -244,24 +244,42 @@ function parseMultiwordArg(args, flag) {
 async function main() {
   let args = process.argv.slice(2);
 
+  // --json-errors / GSD_JSON_ERRORS=1: when active, error() emits structured
+  // JSON ({ ok: false, reason: <ERROR_REASON code>, message }) to stderr
+  // instead of "Error: <text>". Lets test suites assert on typed reason codes
+  // per CONTRIBUTING.md "Prohibited: Raw Text Matching" (#2974).
+  //
+  // Detect early — before any flag parsing that can fire error() — so even
+  // --cwd and workstream-resolution failures emit structured stderr (#3310).
+  // The argv splice must happen here too, otherwise the dispatcher below sees
+  // "--json-errors" as an unknown command. Default off — human operators keep
+  // their plain-text diagnostic.
+  const jsonErrorsIdx = args.indexOf('--json-errors');
+  if (jsonErrorsIdx !== -1) {
+    core.setJsonErrorMode(true);
+    args.splice(jsonErrorsIdx, 1);
+  } else if (process.env.GSD_JSON_ERRORS === '1') {
+    core.setJsonErrorMode(true);
+  }
+
   // Optional cwd override for sandboxed subagents running outside project root.
   let cwd = process.cwd();
   const cwdEqArg = args.find(arg => arg.startsWith('--cwd='));
   const cwdIdx = args.indexOf('--cwd');
   if (cwdEqArg) {
     const value = cwdEqArg.slice('--cwd='.length).trim();
-    if (!value) error('Missing value for --cwd');
+    if (!value) error('Missing value for --cwd', ERROR_REASON.USAGE);
     args.splice(args.indexOf(cwdEqArg), 1);
     cwd = path.resolve(value);
   } else if (cwdIdx !== -1) {
     const value = args[cwdIdx + 1];
-    if (!value || value.startsWith('--')) error('Missing value for --cwd');
+    if (!value || value.startsWith('--')) error('Missing value for --cwd', ERROR_REASON.USAGE);
     args.splice(cwdIdx, 2);
     cwd = path.resolve(value);
   }
 
   if (!fs.existsSync(cwd) || !fs.statSync(cwd).isDirectory()) {
-    error(`Invalid --cwd: ${cwd}`);
+    error(`Invalid --cwd: ${cwd}`, ERROR_REASON.USAGE);
   }
 
   // Resolve worktree root: in a linked worktree, .planning/ lives in the main worktree.
@@ -293,20 +311,6 @@ async function main() {
   const rawIndex = args.indexOf('--raw');
   const raw = rawIndex !== -1;
   if (rawIndex !== -1) args.splice(rawIndex, 1);
-
-  // --json-errors: when present, error() emits structured JSON to stderr
-  // ({ ok: false, reason: <ERROR_REASON code>, message }) instead of plain
-  // "Error: <text>". Lets test suites assert on typed reason codes per the
-  // CONTRIBUTING.md "Prohibited: Raw Text Matching on Test Outputs" rule
-  // (#2974). Default off — human operators see the original plain-text
-  // diagnostic.
-  const jsonErrorsIdx = args.indexOf('--json-errors');
-  if (jsonErrorsIdx !== -1) {
-    core.setJsonErrorMode(true);
-    args.splice(jsonErrorsIdx, 1);
-  } else if (process.env.GSD_JSON_ERRORS === '1') {
-    core.setJsonErrorMode(true);
-  }
 
   // --pick <name>: extract a single field from JSON output (replaces jq dependency).
   // Supports dot-notation (e.g., --pick workflow.research) and bracket notation
@@ -579,7 +583,7 @@ async function runCommand(command, args, cwd, raw, defaultValue, originalCommand
           wave: wave || '1',
         }, raw);
       } else {
-        error('Unknown template subcommand. Available: select, fill');
+        error('Unknown template subcommand. Available: select, fill', ERROR_REASON.SDK_UNKNOWN_COMMAND);
       }
       break;
     }
@@ -597,7 +601,7 @@ async function runCommand(command, args, cwd, raw, defaultValue, originalCommand
       } else if (subcommand === 'validate') {
         frontmatter.cmdFrontmatterValidate(cwd, file, parseNamedArgs(args, ['schema']).schema, raw);
       } else {
-        error('Unknown frontmatter subcommand. Available: get, set, merge, validate');
+        error('Unknown frontmatter subcommand. Available: get, set, merge, validate', ERROR_REASON.SDK_UNKNOWN_COMMAND);
       }
       break;
     }
@@ -706,7 +710,7 @@ async function runCommand(command, args, cwd, raw, defaultValue, originalCommand
       if (subcommand === 'mark-complete') {
         milestone.cmdRequirementsMarkComplete(cwd, args.slice(2), raw);
       } else {
-        error('Unknown requirements subcommand. Available: mark-complete');
+        error('Unknown requirements subcommand. Available: mark-complete', ERROR_REASON.SDK_UNKNOWN_COMMAND);
       }
       break;
     }
@@ -736,7 +740,7 @@ async function runCommand(command, args, cwd, raw, defaultValue, originalCommand
         const archivePhases = args.includes('--archive-phases');
         milestone.cmdMilestoneComplete(cwd, args[2], { name: milestoneName, archivePhases }, raw);
       } else {
-        error('Unknown milestone subcommand. Available: complete');
+        error('Unknown milestone subcommand. Available: complete', ERROR_REASON.SDK_UNKNOWN_COMMAND);
       }
       break;
     }
@@ -788,7 +792,7 @@ async function runCommand(command, args, cwd, raw, defaultValue, originalCommand
         const options = parseNamedArgs(args, ['file']);
         uat.cmdRenderCheckpoint(cwd, options, raw);
       } else {
-        error('Unknown uat subcommand. Available: render-checkpoint');
+        error('Unknown uat subcommand. Available: render-checkpoint', ERROR_REASON.SDK_UNKNOWN_COMMAND);
       }
       break;
     }
@@ -806,7 +810,7 @@ async function runCommand(command, args, cwd, raw, defaultValue, originalCommand
       } else if (subcommand === 'match-phase') {
         commands.cmdTodoMatchPhase(cwd, args[2], raw);
       } else {
-        error('Unknown todo subcommand. Available: complete, match-phase');
+        error('Unknown todo subcommand. Available: complete, match-phase', ERROR_REASON.SDK_UNKNOWN_COMMAND);
       }
       break;
     }
@@ -882,7 +886,7 @@ async function runCommand(command, args, cwd, raw, defaultValue, originalCommand
       const sessionsPath = pathIdx !== -1 ? args[pathIdx + 1] : null;
       const projectArg = args[1];
       if (!projectArg || projectArg.startsWith('--')) {
-        error('Usage: gsd-tools extract-messages <project> [--session <id>] [--limit N] [--path <dir>]\nRun scan-sessions first to see available projects.');
+        error('Usage: gsd-tools extract-messages <project> [--session <id>] [--limit N] [--path <dir>]\nRun scan-sessions first to see available projects.', ERROR_REASON.USAGE);
       }
       await profilePipeline.cmdExtractMessages(projectArg, { sessionId, limit }, raw, sessionsPath);
       break;
@@ -906,7 +910,7 @@ async function runCommand(command, args, cwd, raw, defaultValue, originalCommand
     case 'write-profile': {
       const inputIdx = args.indexOf('--input');
       const inputPath = inputIdx !== -1 ? args[inputIdx + 1] : null;
-      if (!inputPath) error('--input <analysis-json-path> is required');
+      if (!inputPath) error('--input <analysis-json-path> is required', ERROR_REASON.USAGE);
       const outputIdx = args.indexOf('--output');
       const outputPath = outputIdx !== -1 ? args[outputIdx + 1] : null;
       profileOutput.cmdWriteProfile(cwd, { input: inputPath, output: outputPath }, raw);
@@ -972,7 +976,7 @@ async function runCommand(command, args, cwd, raw, defaultValue, originalCommand
       } else if (subcommand === 'progress') {
         workstream.cmdWorkstreamProgress(cwd, raw);
       } else {
-        error('Unknown workstream subcommand. Available: create, list, status, complete, set, get, progress');
+        error('Unknown workstream subcommand. Available: create, list, status, complete, set, get, progress', ERROR_REASON.SDK_UNKNOWN_COMMAND);
       }
       break;
     }
@@ -984,7 +988,7 @@ async function runCommand(command, args, cwd, raw, defaultValue, originalCommand
       const subcommand = args[1];
       if (subcommand === 'query') {
         const term = args[2];
-        if (!term) error('Usage: gsd-tools intel query <term>');
+        if (!term) error('Usage: gsd-tools intel query <term>', ERROR_REASON.USAGE);
         const planningDir = path.join(cwd, '.planning');
         core.output(intel.intelQuery(term, planningDir), raw);
       } else if (subcommand === 'status') {
@@ -1006,14 +1010,14 @@ async function runCommand(command, args, cwd, raw, defaultValue, originalCommand
         core.output(intel.intelSnapshot(planningDir), raw);
       } else if (subcommand === 'patch-meta') {
         const filePath = args[2];
-        if (!filePath) error('Usage: gsd-tools intel patch-meta <file-path>');
+        if (!filePath) error('Usage: gsd-tools intel patch-meta <file-path>', ERROR_REASON.USAGE);
         core.output(intel.intelPatchMeta(path.resolve(cwd, filePath)), raw);
       } else if (subcommand === 'validate') {
         const planningDir = path.join(cwd, '.planning');
         core.output(intel.intelValidate(planningDir), raw);
       } else if (subcommand === 'extract-exports') {
         const filePath = args[2];
-        if (!filePath) error('Usage: gsd-tools intel extract-exports <file-path>');
+        if (!filePath) error('Usage: gsd-tools intel extract-exports <file-path>', ERROR_REASON.USAGE);
         core.output(intel.intelExtractExports(path.resolve(cwd, filePath)), raw);
       } else if (subcommand === 'update') {
         const planningDir = path.join(cwd, '.planning');
@@ -1031,7 +1035,7 @@ async function runCommand(command, args, cwd, raw, defaultValue, originalCommand
       const subcommand = args[1];
       if (subcommand === 'query') {
         const term = args[2];
-        if (!term) error('Usage: gsd-tools graphify query <term>');
+        if (!term) error('Usage: gsd-tools graphify query <term>', ERROR_REASON.USAGE);
         const budgetIdx = args.indexOf('--budget');
         const budget = budgetIdx !== -1 ? parseInt(args[budgetIdx + 1], 10) : null;
         core.output(graphify.graphifyQuery(cwd, term, { budget }), raw);
@@ -1046,7 +1050,7 @@ async function runCommand(command, args, cwd, raw, defaultValue, originalCommand
           core.output(graphify.graphifyBuild(cwd), raw);
         }
       } else {
-        error('Unknown graphify subcommand. Available: build, query, status, diff');
+        error('Unknown graphify subcommand. Available: build, query, status, diff', ERROR_REASON.SDK_UNKNOWN_COMMAND);
       }
       break;
     }
@@ -1067,21 +1071,21 @@ async function runCommand(command, args, cwd, raw, defaultValue, originalCommand
       } else if (subcommand === 'query') {
         const tagIdx = args.indexOf('--tag');
         const tag = tagIdx !== -1 ? args[tagIdx + 1] : null;
-        if (!tag) error('Usage: gsd-tools learnings query --tag <tag>');
+        if (!tag) error('Usage: gsd-tools learnings query --tag <tag>', ERROR_REASON.USAGE);
         learnings.cmdLearningsQuery(tag, raw);
       } else if (subcommand === 'copy') {
         learnings.cmdLearningsCopy(cwd, raw);
       } else if (subcommand === 'prune') {
         const olderIdx = args.indexOf('--older-than');
         const olderThan = olderIdx !== -1 ? args[olderIdx + 1] : null;
-        if (!olderThan) error('Usage: gsd-tools learnings prune --older-than <duration>');
+        if (!olderThan) error('Usage: gsd-tools learnings prune --older-than <duration>', ERROR_REASON.USAGE);
         learnings.cmdLearningsPrune(olderThan, raw);
       } else if (subcommand === 'delete') {
         const id = args[2];
-        if (!id) error('Usage: gsd-tools learnings delete <id>');
+        if (!id) error('Usage: gsd-tools learnings delete <id>', ERROR_REASON.USAGE);
         learnings.cmdLearningsDelete(id, raw);
       } else {
-        error('Unknown learnings subcommand. Available: list, query, copy, prune, delete');
+        error('Unknown learnings subcommand. Available: list, query, copy, prune, delete', ERROR_REASON.SDK_UNKNOWN_COMMAND);
       }
       break;
     }
@@ -1101,11 +1105,11 @@ async function runCommand(command, args, cwd, raw, defaultValue, originalCommand
       const configDirIdx = args.indexOf('--config-dir');
       const configDir = configDirIdx !== -1 ? args[configDirIdx + 1] : null;
       if (!configDir) {
-        error('Usage: gsd-tools detect-custom-files --config-dir <path>');
+        error('Usage: gsd-tools detect-custom-files --config-dir <path>', ERROR_REASON.USAGE);
       }
       const resolvedConfigDir = path.resolve(configDir);
       if (!fs.existsSync(resolvedConfigDir)) {
-        error(`Config directory not found: ${resolvedConfigDir}`);
+        error(`Config directory not found: ${resolvedConfigDir}`, ERROR_REASON.USAGE);
       }
 
       const manifestPath = path.join(resolvedConfigDir, 'gsd-file-manifest.json');

--- a/tests/feat-3310-followup-typed-codes.test.cjs
+++ b/tests/feat-3310-followup-typed-codes.test.cjs
@@ -1,0 +1,225 @@
+/**
+ * Follow-up tests for #3310: every remaining `error()` call at a subcommand
+ * boundary or usage check in `gsd-tools.cjs` carries a typed `ERROR_REASON`.
+ *
+ * #3304 wired four representative paths (unknown top-level command, unknown
+ * intel subcommand, missing --pick value, --version flag). The rest fell
+ * through to `ERROR_REASON.UNKNOWN`. This file locks the post-#3310 contract:
+ *
+ *   - Every "Unknown <subsystem> subcommand" emits reason: "sdk_unknown_command".
+ *   - Every "Usage: ..." / missing-required-arg path emits reason: "usage".
+ *
+ * All assertions parse stderr via JSON.parse — never `.includes()` — per the
+ * #2974 / CONTRIBUTING.md "Prohibited: Raw Text Matching" rule.
+ */
+
+'use strict';
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
+
+// Run gsd-tools with GSD_JSON_ERRORS=1 (env-var activation, exercises the
+// path #3304 added alongside the --json-errors flag) and parse the
+// structured stderr. Returns the parsed object; throws if stderr is not JSON.
+function runJsonErrors(args, tmpDir, env = {}) {
+  const result = runGsdTools(args, tmpDir, { ...env, GSD_JSON_ERRORS: '1' });
+  assert.strictEqual(result.success, false,
+    `Expected failure with GSD_JSON_ERRORS=1 for args: ${args.join(' ')}\n` +
+    `stdout: ${result.output}\nstderr: ${result.error}`);
+  let parsed;
+  try {
+    parsed = JSON.parse(result.error);
+  } catch (e) {
+    throw new Error(
+      `GSD_JSON_ERRORS=1 must emit valid JSON on stderr.\n` +
+      `Args: ${args.join(' ')}\nstderr: ${result.error}\nparse error: ${e.message}`
+    );
+  }
+  return parsed;
+}
+
+// Assert the typed-IR contract: object shape + reason. Keeps the per-test
+// boilerplate minimal so each error-path test reads as a single fact.
+function assertTypedError(parsed, expectedReason, label) {
+  assert.strictEqual(parsed.ok, false,
+    `${label}: error object must have ok: false`);
+  assert.strictEqual(parsed.reason, expectedReason,
+    `${label}: reason must be "${expectedReason}", got: ${parsed.reason}`);
+  assert.ok(typeof parsed.message === 'string' && parsed.message.length > 0,
+    `${label}: message must be a non-empty string`);
+}
+
+describe('feat #3310: typed ERROR_REASON codes on remaining error paths', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  // ── Unknown <subsystem> subcommand → SDK_UNKNOWN_COMMAND ────────────────
+  // Each of these used to fall through to reason: "unknown" before #3310.
+
+  test('unknown template subcommand → sdk_unknown_command', () => {
+    const parsed = runJsonErrors(['template', 'bogus-subcommand-xyzzy'], tmpDir);
+    assertTypedError(parsed, 'sdk_unknown_command', 'template');
+  });
+
+  test('unknown frontmatter subcommand → sdk_unknown_command', () => {
+    // frontmatter expects subcommand at args[1] and file at args[2]; pass a
+    // bogus subcommand with a placeholder file so we definitely reach the
+    // unknown-subcommand branch, not an earlier validation.
+    const parsed = runJsonErrors(
+      ['frontmatter', 'bogus-subcommand-xyzzy', 'placeholder.md'],
+      tmpDir
+    );
+    assertTypedError(parsed, 'sdk_unknown_command', 'frontmatter');
+  });
+
+  test('unknown requirements subcommand → sdk_unknown_command', () => {
+    const parsed = runJsonErrors(['requirements', 'bogus-subcommand-xyzzy'], tmpDir);
+    assertTypedError(parsed, 'sdk_unknown_command', 'requirements');
+  });
+
+  test('unknown milestone subcommand → sdk_unknown_command', () => {
+    const parsed = runJsonErrors(['milestone', 'bogus-subcommand-xyzzy'], tmpDir);
+    assertTypedError(parsed, 'sdk_unknown_command', 'milestone');
+  });
+
+  test('unknown uat subcommand → sdk_unknown_command', () => {
+    const parsed = runJsonErrors(['uat', 'bogus-subcommand-xyzzy'], tmpDir);
+    assertTypedError(parsed, 'sdk_unknown_command', 'uat');
+  });
+
+  test('unknown todo subcommand → sdk_unknown_command', () => {
+    const parsed = runJsonErrors(['todo', 'bogus-subcommand-xyzzy'], tmpDir);
+    assertTypedError(parsed, 'sdk_unknown_command', 'todo');
+  });
+
+  test('unknown workstream subcommand → sdk_unknown_command', () => {
+    const parsed = runJsonErrors(['workstream', 'bogus-subcommand-xyzzy'], tmpDir);
+    assertTypedError(parsed, 'sdk_unknown_command', 'workstream');
+  });
+
+  test('unknown graphify subcommand → sdk_unknown_command', () => {
+    const parsed = runJsonErrors(['graphify', 'bogus-subcommand-xyzzy'], tmpDir);
+    assertTypedError(parsed, 'sdk_unknown_command', 'graphify');
+  });
+
+  test('unknown learnings subcommand → sdk_unknown_command', () => {
+    const parsed = runJsonErrors(['learnings', 'bogus-subcommand-xyzzy'], tmpDir);
+    assertTypedError(parsed, 'sdk_unknown_command', 'learnings');
+  });
+
+  // ── Missing required positional/flag values → USAGE ─────────────────────
+  // These previously emitted reason: "unknown" because the second argument
+  // to error() was absent.
+
+  test('missing --cwd value → usage', () => {
+    // The --cwd flag is consumed before the command dispatcher; passing it
+    // bare with no following value triggers the usage error at L253/L258.
+    const parsed = runJsonErrors(['--cwd'], tmpDir);
+    assertTypedError(parsed, 'usage', '--cwd missing value');
+  });
+
+  test('invalid --cwd directory → usage', () => {
+    // --cwd <nonexistent-path> hits the existsSync / isDirectory check at L264.
+    const parsed = runJsonErrors(
+      ['--cwd', '/this/path/should/not/exist/anywhere/xyzzy', 'state', 'load'],
+      tmpDir
+    );
+    assertTypedError(parsed, 'usage', 'invalid --cwd directory');
+  });
+
+  test('intel query missing term → usage', () => {
+    const parsed = runJsonErrors(['intel', 'query'], tmpDir);
+    assertTypedError(parsed, 'usage', 'intel query missing term');
+  });
+
+  test('intel patch-meta missing file path → usage', () => {
+    const parsed = runJsonErrors(['intel', 'patch-meta'], tmpDir);
+    assertTypedError(parsed, 'usage', 'intel patch-meta missing file');
+  });
+
+  test('intel extract-exports missing file path → usage', () => {
+    const parsed = runJsonErrors(['intel', 'extract-exports'], tmpDir);
+    assertTypedError(parsed, 'usage', 'intel extract-exports missing file');
+  });
+
+  test('graphify query missing term → usage', () => {
+    const parsed = runJsonErrors(['graphify', 'query'], tmpDir);
+    assertTypedError(parsed, 'usage', 'graphify query missing term');
+  });
+
+  test('learnings query missing --tag → usage', () => {
+    const parsed = runJsonErrors(['learnings', 'query'], tmpDir);
+    assertTypedError(parsed, 'usage', 'learnings query missing --tag');
+  });
+
+  test('learnings prune missing --older-than → usage', () => {
+    const parsed = runJsonErrors(['learnings', 'prune'], tmpDir);
+    assertTypedError(parsed, 'usage', 'learnings prune missing --older-than');
+  });
+
+  test('learnings delete missing id → usage', () => {
+    const parsed = runJsonErrors(['learnings', 'delete'], tmpDir);
+    assertTypedError(parsed, 'usage', 'learnings delete missing id');
+  });
+
+  test('extract-messages missing project arg → usage', () => {
+    // L877 — args[1] is undefined or starts with '--'.
+    const parsed = runJsonErrors(['extract-messages'], tmpDir);
+    assertTypedError(parsed, 'usage', 'extract-messages missing project');
+  });
+
+  test('write-profile missing --input → usage', () => {
+    const parsed = runJsonErrors(['write-profile'], tmpDir);
+    assertTypedError(parsed, 'usage', 'write-profile missing --input');
+  });
+
+  test('detect-custom-files missing --config-dir → usage', () => {
+    const parsed = runJsonErrors(['detect-custom-files'], tmpDir);
+    assertTypedError(parsed, 'usage', 'detect-custom-files missing --config-dir');
+  });
+
+  test('detect-custom-files invalid --config-dir → usage', () => {
+    const parsed = runJsonErrors(
+      ['detect-custom-files', '--config-dir', '/nonexistent/path/xyzzy'],
+      tmpDir
+    );
+    assertTypedError(parsed, 'usage', 'detect-custom-files invalid --config-dir');
+  });
+
+  // ── Shape regression guard: every newly-typed path emits the canonical
+  //    {ok, reason, message} object — no leakage of reason: "unknown". ────
+
+  test('every remaining typed path emits the canonical {ok, reason, message} shape', () => {
+    const probes = [
+      ['template', 'bogus'],
+      ['frontmatter', 'bogus', 'placeholder.md'],
+      ['requirements', 'bogus'],
+      ['milestone', 'bogus'],
+      ['uat', 'bogus'],
+      ['todo', 'bogus'],
+      ['workstream', 'bogus'],
+      ['graphify', 'bogus'],
+      ['learnings', 'bogus'],
+      ['intel', 'query'],
+      ['extract-messages'],
+      ['write-profile'],
+      ['detect-custom-files'],
+    ];
+    for (const args of probes) {
+      const parsed = runJsonErrors(args, tmpDir);
+      const keys = Object.keys(parsed).sort();
+      assert.deepStrictEqual(keys, ['message', 'ok', 'reason'],
+        `args ${args.join(' ')}: keys must be exactly {ok,reason,message}, got ${keys.join(',')}`);
+      assert.notStrictEqual(parsed.reason, 'unknown',
+        `args ${args.join(' ')}: reason must be a typed code, not the fallback "unknown"`);
+    }
+  });
+});


### PR DESCRIPTION
## Enhancement PR

---

## Linked Issue

Closes #3310

> Stacked on top of #3304 (base = `fix/3255-add-json-errors-mode-gsd-tools`).
> When #3304 merges to main, GitHub auto-retargets this PR to main.

---

## What this enhancement improves

#3304 wired `ERROR_REASON` codes into 4 representative error paths. The remaining `error()` calls at subcommand boundaries fell through to `ERROR_REASON.UNKNOWN`, which forced any test wanting to lock those paths back into substring matching on the human message — exactly the anti-pattern CONTRIBUTING.md `Prohibited: Raw Text Matching` calls out. This PR completes the contract by wiring typed codes into every remaining `Unknown <subsystem> subcommand` and missing-required-arg path.

## Before / After

**Before** (`reason: "unknown"` for every untyped path):

```bash
$ GSD_JSON_ERRORS=1 gsd-tools intel bogus 2>&1
{"ok":false,"reason":"unknown","message":"Unknown intel subcommand. ..."}

$ GSD_JSON_ERRORS=1 gsd-tools template bogus 2>&1
{"ok":false,"reason":"unknown","message":"Unknown template subcommand. ..."}
```

(Wait — `intel` actually was typed in #3304. The other 9 subsystems were not.)

**After** (each path emits a typed code; `unknown` no longer leaks through these paths):

```bash
$ GSD_JSON_ERRORS=1 gsd-tools template bogus 2>&1
{"ok":false,"reason":"sdk_unknown_command","message":"Unknown template subcommand. ..."}

$ GSD_JSON_ERRORS=1 gsd-tools learnings query 2>&1
{"ok":false,"reason":"usage","message":"Usage: gsd-tools learnings query --tag <tag>"}

$ GSD_JSON_ERRORS=1 gsd-tools --cwd 2>&1
{"ok":false,"reason":"usage","message":"Missing value for --cwd"}
```

Tests now write:

```javascript
const err = JSON.parse(result.error);
assert.strictEqual(err.reason, 'sdk_unknown_command');
```

with no string-matching on prose.

## How it was implemented

- **`get-shit-done/bin/gsd-tools.cjs`** — passed `ERROR_REASON.SDK_UNKNOWN_COMMAND` to the 9 remaining `Unknown <subsystem> subcommand` calls (template, frontmatter, requirements, milestone, uat, todo, workstream, graphify, learnings) and `ERROR_REASON.USAGE` to the remaining missing-required-arg / `Usage:` paths (--cwd, intel `query`/`patch-meta`/`extract-exports`, graphify `query`, learnings `query`/`prune`/`delete`, `extract-messages`, `write-profile`, `detect-custom-files`).
- **JSON-mode activation moved up.** Without this move, `--cwd` validation errors fire before #3304's activation block and emit plain text even when `GSD_JSON_ERRORS=1` is set. Detection now runs at the very top of `main()`, before any flag parsing that can fire `error()`. The argv splice for the flag stays inline with the activation.
- **`tests/feat-3310-followup-typed-codes.test.cjs`** (new) — 23 tests, one per error path covered, all asserting via `JSON.parse(stderr).reason` (never `.includes()`). The final test is a closure regression guard: it probes every newly-typed path and asserts the canonical `{ok, reason, message}` shape and that `reason !== 'unknown'`. If a future PR adds a new subcommand with an untyped error, this test fails with a precise diff.
- **`.changeset/sunny-dogs-frolic.md`** — type `Changed`, references #3310. Will be re-numbered to the merged PR number per the repo convention.

No new enum values. No new dependencies. Default plain-text output unchanged when `--json-errors` is off.

## Testing

### How I verified the enhancement works

- All 23 tests in `feat-3310-followup-typed-codes.test.cjs` pass green.
- All 10 pre-existing tests in `feat-3255-json-errors-mode.test.cjs` still pass — no regression on #3304's contract.
- `npm test` overall: 8,575 tests / 8,570 pass / 2 fail. Confirmed both failures are pre-existing on the unmodified `fix/3255-add-json-errors-mode-gsd-tools` branch (Homebrew Cellar vs symlink path mismatch in `bug-3017-codex-hook-absolute-node` and `codex-config` — environment-specific, not introduced by this PR).
- `npm run lint:tests` — `447 test files checked, 0 violations`. New test file uses only `JSON.parse` on stderr, never raw-text matching.
- `node scripts/changeset/lint.cjs` — `ok_fragment_present`.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

> One incidental change beyond the literal line list in #3310: the `--json-errors` / `GSD_JSON_ERRORS=1` activation was moved from after `--cwd` parsing to the top of `main()`. This was required for the `--cwd` typed-code paths in #3310's scope to actually emit JSON; without it, those `USAGE` codes fire correctly but in plain-text mode, which defeats the purpose. Documented inline at the activation site.

---

## Checklist

- [x] Issue linked above with `Closes #3310`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [x] All existing tests pass (`npm test`) — pre-existing #3017 codex failures unaffected
- [x] New or updated tests cover the enhanced behavior (`feat-3310-followup-typed-codes.test.cjs`, 23 tests)
- [x] `.changeset/sunny-dogs-frolic.md` added (type: Changed, pr: 3310 placeholder)
- [x] Documentation updated — `docs/json-errors.md` taxonomy from #3304 still accurate; no new codes introduced
- [x] No unnecessary dependencies added

## Breaking changes

None. The default plain-text stderr output is byte-for-byte unchanged. Consumers of `--json-errors` that previously saw `reason: "unknown"` for these paths now see a more specific code; this is strictly more information. Any test asserting `reason === "unknown"` against these paths was asserting the absence of the typed-IR work this enhancement completes — and there are no such tests in the suite (verified: zero hits for `reason === 'unknown'` in `tests/`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI error responses now include specific typed reason codes when `--json-errors` is enabled: `sdk_unknown_command` for unknown subcommands and `usage` for missing arguments, replacing generic messages and enabling more reliable programmatic error parsing.

* **Tests**
  * Added comprehensive test suite validating typed error codes across multiple command paths and error scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3311)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->