### PR TITLE
chore: revert redundant CHANGELOG.md row from #3308 (use .changeset/ fragment)

### DIFF
--- a/.changeset/tidy-tigers-dance.md
+++ b/.changeset/tidy-tigers-dance.md
@@ -1,0 +1,5 @@
+---
+type: Removed
+pr: 3313
+---
+**Redundant `CHANGELOG.md` row left behind by #3308 has been deleted** — the canonical `.changeset/3262-extract-scan-phase-plans.md` fragment remains the single source of truth for the `scanPhasePlans` extraction (k014, #3262). Per [CONTRIBUTING.md](CONTRIBUTING.md) ("Do not edit `CHANGELOG.md` directly"), the release workflow folds `.changeset/*.md` fragments into the changelog at release time; the hand-written row would have produced a duplicated entry on the next release. (#3313)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased](https://github.com/gsd-build/get-shit-done/compare/v1.41.0...HEAD)
 
-### Enhancement
-
-- **Shared `scanPhasePlans()` helper extracted to `bin/lib/plan-scan.cjs` (k014)** — four divergent copies of the plan-scan algorithm in `state.cjs`, `roadmap.cjs`, `init.cjs`, and `phase.cjs` are now replaced by a single canonical implementation. Each copy had subtle differences (regex shapes, flat vs nested coverage, pre-bounce exclusion patterns) that caused plan-count drift between the four callers. The helper covers both the flat layout (`*-PLAN.md`, `PLAN.md`) and the nested layout (`plans/PLAN-NN-slug.md`) introduced in #3139, and returns `{ planCount, summaryCount, completed, hasNestedPlans, planFiles, summaryFiles }`. (#3262)
-
 ### Fixed
 
 - **`/gsd-discuss-phase` and `/gsd-plan-phase` first-touch creation now apply `project_code` prefix consistently with `phase.add`/`phase.insert`** — projects with `project_code` set in `.planning/config.json` no longer accumulate a two-headed naming convention (`01-foundation/` mixed with `XR-02.1-spike/`). `init.phase-op` and `init.plan-phase` now expose `expected_phase_dir` (with prefix) in their JSON bundle; workflow fallback mkdir calls use this value instead of constructing the path from `padded_phase`+`phase_slug`. `phase.scaffold phase-dir` (CJS and SDK) also fixed. (#3287)


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

This is technically a chore (no chore PR template exists in this repo), so the Fix template is used as the closest match — the change removes a CONTRIBUTING.md violation that landed in #3308.

---

## Linked Issue

Closes #3262

> Note: #3262 is already closed (by PR #3308). This PR is a follow-up cleanup that removes a redundant `CHANGELOG.md` row #3308 left behind. The `Closes` keyword is required by `.github/workflows/require-issue-link.yml` (regex `(closes|fixes|resolves)\s+#[0-9]+`); on an already-closed issue it's a no-op for issue state, so it's safe to use here. Semantically this is `Refs #3262`.

---

## What was broken

PR #3308 added a 4-line `### Enhancement` block to `CHANGELOG.md` for the `scanPhasePlans` helper extraction (#3262), in addition to dropping the canonical `.changeset/3262-extract-scan-phase-plans.md` fragment. That violates `CONTRIBUTING.md` line 110 ("Do not edit CHANGELOG.md directly. ... every PR with user-facing changes drops a fragment file in .changeset/").

The release workflow (`scripts/changeset/cli.cjs render`) folds `.changeset/*.md` fragments into `CHANGELOG.md` at release time and deletes consumed fragments. A hand-written row plus an unconsumed fragment means the next release run will produce a duplicate entry under `### Enhancement`.

## What this fix does

Removes only the 4 lines added by #3308 (the `### Enhancement` heading, blank line, single bullet about `scanPhasePlans`, and trailing blank line). The fragment `.changeset/3262-extract-scan-phase-plans.md` on `main` is the single source of truth for this changelog entry and is unchanged.

## Root cause

Out-of-band CHANGELOG edit during the #3308 merge — the contributor flow allows fragments-only, but a manual row was committed alongside the fragment.

## Testing

### How I verified the fix

- `git diff origin/main` against the head of this branch shows exactly `CHANGELOG.md | 4 ----` plus a single new `.changeset/` fragment, nothing else.
- `.changeset/3262-extract-scan-phase-plans.md` is unchanged on `main` (still present, untouched).
- The cleanup itself is a `Removed` changeset fragment in this PR.

### Regression test added?

- [ ] Yes — added a test that would have caught this bug
- [x] No — explain why: this is a one-off documentation cleanup. The CONTRIBUTING.md rule is the policy; enforcing it via a CI check that blocks direct `CHANGELOG.md` edits is a separate concern that should be filed as its own issue if desired.

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Closes #NNN` — **PR will be auto-closed if missing**
- [ ] Linked issue has the `confirmed-bug` label (#3262 was an enhancement, not a bug — and it's already closed; this PR only cleans up an unintended side effect of the merge)
- [x] Fix is scoped — only the 4-line CHANGELOG block + a single `.changeset/` Removed fragment
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added (`--type Removed`, follow-up commit so the fragment carries the real PR number)
- [x] No unnecessary dependencies added

## Breaking changes

None. `CHANGELOG.md` is documentation; removing a duplicated row has no behavioral impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated changelog to reflect release status.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3313)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->