### PR TITLE
ci(3314): add schedule fallback to dismiss-unauthorized-pr-approvals

### DIFF
--- a/.github/workflows/dismiss-unauthorized-pr-approvals.yml
+++ b/.github/workflows/dismiss-unauthorized-pr-approvals.yml
@@ -3,20 +3,29 @@ name: Dismiss Unauthorized PR Approvals
 on:
   pull_request_review:
     types: [submitted]
+  schedule:
+    # Fallback poll: pull_request_review runs whose triggering_actor is an
+    # outside collaborator are held in `action_required` until a maintainer
+    # approves them — so the event-driven path never fires for the very
+    # reviewers we want to dismiss. The schedule path runs as
+    # github-actions[bot] and bypasses that gate.
+    - cron: '*/15 * * * *'
+  workflow_dispatch:
 
 permissions:
   contents: read
   pull-requests: write
 
 concurrency:
-  group: dismiss-unauthorized-pr-approvals-${{ github.event.pull_request.number }}
+  # Per-PR group for review events; single shared group for schedule/dispatch
+  # so polls serialize instead of stomping each other.
+  group: dismiss-unauthorized-pr-approvals-${{ github.event.pull_request.number || 'scheduled' }}
   cancel-in-progress: false
 
 jobs:
   dismiss-unauthorized-approval:
-    if: github.event.review.state == 'approved' && github.event.pull_request.state == 'open'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
 
     steps:
       - name: Dismiss blocked/non-collaborator approvals
@@ -25,6 +34,7 @@ jobs:
           script: |
             const owner = context.repo.owner;
             const repo = context.repo.repo;
+            const eventName = context.eventName;
 
             // Any login here is always blocked, even if they are a collaborator.
             const blockedReviewers = new Set(['ari4ka']);
@@ -36,19 +46,28 @@ jobs:
               return (v || '').trim().toLowerCase();
             }
 
+            const roleCache = new Map();
             async function resolveRole(login) {
+              const key = norm(login);
+              if (roleCache.has(key)) return roleCache.get(key);
+              let role;
               try {
                 const resp = await github.rest.repos.getCollaboratorPermissionLevel({
                   owner,
                   repo,
                   username: login,
                 });
-                return norm(resp.data.role_name) || 'unknown';
+                role = norm(resp.data.role_name) || 'unknown';
               } catch (error) {
-                if (error.status === 404) return 'none'; // not a collaborator
-                core.warning(`Could not resolve reviewer role for ${login}: ${error.message}`);
-                return 'unknown';
+                if (error.status === 404) {
+                  role = 'none'; // confirmed non-collaborator
+                } else {
+                  core.warning(`Could not resolve reviewer role for ${login}: ${error.message}`);
+                  role = 'unknown';
+                }
               }
+              roleCache.set(key, role);
+              return role;
             }
 
             function shouldDismissReviewer(login, roleName) {
@@ -93,19 +112,62 @@ jobs:
               }
             }
 
-            const review = context.payload.review;
-            const reviewer = review.user.login;
-            const roleName = await resolveRole(reviewer);
-            const verdict = shouldDismissReviewer(reviewer, roleName);
+            async function processApproval({ pull_number, review_id, reviewer }) {
+              const roleName = await resolveRole(reviewer);
+              const verdict = shouldDismissReviewer(reviewer, roleName);
+              if (!verdict.dismiss) {
+                core.info(`Approval from ${reviewer} on PR #${pull_number} kept (role: ${roleName}).`);
+                return;
+              }
+              await dismissReview(pull_number, review_id, reviewer, verdict.message);
+            }
 
-            if (!verdict.dismiss) {
-              core.info(`Approval from ${reviewer} kept (role: ${roleName}).`);
+            if (eventName === 'pull_request_review') {
+              const review = context.payload.review;
+              const pull = context.payload.pull_request;
+              if (norm(review.state) !== 'approved') {
+                core.info(`Skipping non-approval review (state=${review.state}).`);
+                return;
+              }
+              if (pull.state !== 'open') {
+                core.info(`Skipping review on non-open PR #${pull.number}.`);
+                return;
+              }
+              await processApproval({
+                pull_number: pull.number,
+                review_id: review.id,
+                reviewer: review.user.login,
+              });
               return;
             }
 
-            await dismissReview(
-              context.payload.pull_request.number,
-              review.id,
-              reviewer,
-              verdict.message
-            );
+            // schedule or workflow_dispatch — scan all open PRs.
+            core.info(`Scanning open PRs for unauthorized approvals (event=${eventName})...`);
+            const pulls = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+            });
+            core.info(`Found ${pulls.length} open PR(s).`);
+
+            let approvalsScanned = 0;
+            for (const pull of pulls) {
+              const reviews = await github.paginate(github.rest.pulls.listReviews, {
+                owner,
+                repo,
+                pull_number: pull.number,
+                per_page: 100,
+              });
+              for (const review of reviews) {
+                // Already-dismissed reviews have state DISMISSED, so we won't reprocess them.
+                if (review.state !== 'APPROVED') continue;
+                approvalsScanned += 1;
+                await processApproval({
+                  pull_number: pull.number,
+                  review_id: review.id,
+                  reviewer: review.user.login,
+                });
+              }
+            }
+            core.info(`Scan complete: ${approvalsScanned} approval(s) evaluated across ${pulls.length} open PR(s).`);


### PR DESCRIPTION
<!-- CI/tooling change — the typed Fix/Enhancement/Feature templates do
     not apply per the carve-out in `.github/pull_request_template.md`:

       > If you believe your PR genuinely does not fit any of the above
       > categories (e.g., CI/tooling changes, dependency updates, or
       > doc-only fixes with no linked issue), delete this file and
       > describe your PR below. Add a note explaining why none of the
       > typed templates apply.

     This is a maintainer-only CI fix to a GitHub Actions workflow.
     No user-facing behaviour change. `no-changelog` label applied. -->

## Why this PR uses a custom body

This PR fixes a `.github/workflows/*.yml` file. The Fix template requires `confirmed-bug` on the linked issue and asks platform/runtime questions that are not meaningful for CI workflow files. The default PR template explicitly carves out CI/tooling changes — using a custom body here.

## Linked issue

Fixes #3314

The linked issue carries the `confirmed-bug` label (the workflow demonstrably did not fire on PR #3062's Ari4ka approval — see issue for the run ID and `action_required` evidence).

## What was broken

`dismiss-unauthorized-pr-approvals.yml` is supposed to auto-dismiss APPROVED reviews from blocked logins (e.g. `ari4ka`) and from non-collaborators. It uses the `pull_request_review` event.

GitHub holds workflow runs whose `triggering_actor` is an outside / first-time contributor in `action_required` until a maintainer manually approves the run. The blocked reviewer's own action is what gates the dismissal that would remove them, so the workflow never runs for the very reviewers it exists to dismiss. Run [`25594431700`](https://github.com/gsd-build/get-shit-done/actions/runs/25594431700) for the Ari4ka approval on PR #3062 has been sitting in `action_required` since 2026-05-09.

## What this fix does

Adds two extra triggers to the workflow:

```yaml
on:
  pull_request_review:
    types: [submitted]    # existing fast path (collaborator-triggered)
  schedule:
    - cron: '*/15 * * * *' # NEW — bypasses the action_required gate
  workflow_dispatch:       # NEW — manual run for verification/debugging
```

Scheduled runs execute as `github-actions[bot]` regardless of who submitted the underlying review, so they bypass the outside-actor gate.

The inline `actions/github-script` body now branches on `context.eventName`:

- `pull_request_review` — existing single-review path (immediate dismissal for collaborator-triggered events; no behaviour change).
- `schedule` / `workflow_dispatch` — paginates `pulls.list` (open) and `pulls.listReviews` per PR, applies the same role / blocklist check, dismisses any `APPROVED` review that fails it.

`resolveRole()` is now cached per-login so the schedule path doesn't repeatedly query the same reviewer's permission level once per PR. The concurrency group falls back to `'scheduled'` for non-PR events so concurrent polls serialize.

## Why not loosen Settings → Actions → General

Setting "Approval for outside collaborators" to "Require approval for first-time contributors only" would also make this workflow fire immediately, but it would weaken the safety gate for every workflow on the repo. The scheduled-fallback approach contains the change to the one workflow that needs it.

## Verification

- YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`) — `yaml: ok`
- After merge, `workflow_dispatch` from the Actions UI will scan all open PRs and report `Scan complete: N approval(s) evaluated across M open PR(s).` in the run logs. Any extant Ari4ka approval (e.g. on PR #3062) will be dismissed in the first run.
- Subsequent unauthorized approvals will be dismissed within 15 minutes by the scheduled poll. Collaborator-triggered approvals continue to be dismissed immediately by the existing event path.

No regression test added — this is a workflow file change with behaviour observable only by submitting a review against the live repo. Acceptance is observational (issue #3314 acceptance criteria).

## Checklist

- [x] Issue linked above with `Fixes #3314`
- [x] Linked issue carries `confirmed-bug`
- [x] No source-code changes — workflow file only, scoped to the bug
- [x] CI/tooling exemption invoked from default PR template (no typed template applies)
- [x] `no-changelog` label requested — no user-facing behaviour change
- [x] No new dependencies, no shell-string injection of untrusted input (script is `actions/github-script` JS context, not `run:` interpolation)

## Breaking changes

None. The existing event-driven path is unchanged in behaviour for collaborator-triggered reviews. The only addition is a poll that runs as `github-actions[bot]` and applies the same dismissal predicate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Approval validation now runs on a 15-minute schedule and supports manual triggers.

* **Improvements**
  * Enhanced error handling and resilience for permission verification.
  * Increased job timeout for improved stability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3315)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->