### PR TITLE
fix(3317): SDK detect-custom-files now scans skills/ (parity with CJS port)

### DIFF
--- a/.changeset/wise-rams-gather.md
+++ b/.changeset/wise-rams-gather.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 3317
+pr: 3318
 ---
 **`detect-custom-files` now scans `skills/`** — SDK port omitted `skills` from `GSD_MANAGED_DIRS`, so user-added skills under `<config-dir>/skills/<name>/` were never detected and got silently destroyed during `/gsd-update` (no entry written to `gsd-user-files-backup/`). One-line parity with `bin/gsd-tools.cjs`. (#3317)

--- a/.changeset/wise-rams-gather.md
+++ b/.changeset/wise-rams-gather.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3317
+---
+**`detect-custom-files` now scans `skills/`** — SDK port omitted `skills` from `GSD_MANAGED_DIRS`, so user-added skills under `<config-dir>/skills/<name>/` were never detected and got silently destroyed during `/gsd-update` (no entry written to `gsd-user-files-backup/`). One-line parity with `bin/gsd-tools.cjs`. (#3317)

--- a/sdk/src/query/detect-custom-files.test.ts
+++ b/sdk/src/query/detect-custom-files.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Regression test for #3317 — SDK detect-custom-files omits `skills/` from
+ * GSD_MANAGED_DIRS. Mirrors the CJS-side coverage in
+ * `tests/bug-2942-detect-custom-skills.test.cjs`.
+ *
+ * Without the fix, user-added skills under `<config-dir>/skills/<name>/`
+ * are not detected and get silently wiped on `/gsd-update`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { detectCustomFiles } from './detect-custom-files.js';
+
+function sha256(content: string): string {
+  return createHash('sha256').update(content).digest('hex');
+}
+
+async function writeManifest(configDir: string, files: Record<string, string>): Promise<void> {
+  const manifest = {
+    version: '1.41.1',
+    timestamp: new Date().toISOString(),
+    files: {} as Record<string, string>,
+  };
+  for (const [relPath, content] of Object.entries(files)) {
+    const fullPath = join(configDir, relPath);
+    await mkdir(join(fullPath, '..'), { recursive: true });
+    await writeFile(fullPath, content);
+    manifest.files[relPath] = sha256(content);
+  }
+  await writeFile(
+    join(configDir, 'gsd-file-manifest.json'),
+    JSON.stringify(manifest, null, 2),
+  );
+}
+
+async function writeCustomFile(configDir: string, relPath: string, content: string): Promise<void> {
+  const fullPath = join(configDir, relPath);
+  await mkdir(join(fullPath, '..'), { recursive: true });
+  await writeFile(fullPath, content);
+}
+
+interface DetectResult {
+  custom_files: string[];
+  custom_count: number;
+  manifest_found: boolean;
+}
+
+describe('detectCustomFiles — skills/ parity with CJS port (#3317)', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'gsd-3317-skills-'));
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('detects custom skill at skills/<name>/SKILL.md', async () => {
+    await writeManifest(tmpDir, {
+      'skills/gsd-planner/SKILL.md': '# GSD Planner Skill\n',
+    });
+    await writeCustomFile(tmpDir, 'skills/test-custom/SKILL.md', '# My Custom Skill\n');
+
+    const { data } = await detectCustomFiles(['--config-dir', tmpDir], tmpDir);
+    const result = data as DetectResult;
+
+    expect(Array.isArray(result.custom_files)).toBe(true);
+    expect(result.custom_files).toContain('skills/test-custom/SKILL.md');
+    expect(result.custom_count).toBeGreaterThanOrEqual(1);
+  });
+
+  it('does not flag GSD-owned skill listed in manifest', async () => {
+    await writeManifest(tmpDir, {
+      'skills/gsd-planner/SKILL.md': '# GSD Planner Skill\n',
+    });
+
+    const { data } = await detectCustomFiles(['--config-dir', tmpDir], tmpDir);
+    const result = data as DetectResult;
+
+    expect(result.custom_files).not.toContain('skills/gsd-planner/SKILL.md');
+  });
+
+  it('still detects custom files in get-shit-done/workflows/ (regression guard)', async () => {
+    await writeManifest(tmpDir, {
+      'get-shit-done/workflows/plan-phase.md': '# Plan Phase\n',
+      'skills/gsd-planner/SKILL.md': '# GSD Planner Skill\n',
+    });
+    await writeCustomFile(tmpDir, 'get-shit-done/workflows/custom-workflow.md', '# Custom\n');
+
+    const { data } = await detectCustomFiles(['--config-dir', tmpDir], tmpDir);
+    const result = data as DetectResult;
+
+    expect(result.custom_files).toContain('get-shit-done/workflows/custom-workflow.md');
+  });
+
+  it('custom_count matches custom_files.length across multiple skills', async () => {
+    await writeManifest(tmpDir, {
+      'skills/gsd-planner/SKILL.md': '# GSD Planner Skill\n',
+    });
+    await writeCustomFile(tmpDir, 'skills/test-custom/SKILL.md', '# Custom One\n');
+    await writeCustomFile(tmpDir, 'skills/another-custom/SKILL.md', '# Custom Two\n');
+
+    const { data } = await detectCustomFiles(['--config-dir', tmpDir], tmpDir);
+    const result = data as DetectResult;
+
+    expect(result.custom_count).toBe(result.custom_files.length);
+    const skillEntries = result.custom_files.filter(f => f.startsWith('skills/'));
+    expect(skillEntries).toHaveLength(2);
+  });
+});

--- a/sdk/src/query/detect-custom-files.ts
+++ b/sdk/src/query/detect-custom-files.ts
@@ -14,6 +14,7 @@ const GSD_MANAGED_DIRS = [
   'agents',
   join('commands', 'gsd'),
   'hooks',
+  'skills',
 ];
 
 function walkDir(dir: string, baseDir: string): string[] {


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #3317

The linked issue carries the `confirmed-bug` label.

---

## What was broken

`detect-custom-files` in `sdk/src/query/detect-custom-files.ts` declared `GSD_MANAGED_DIRS` without `'skills'`, while the canonical port source — `get-shit-done/bin/gsd-tools.cjs` (cited in the SDK file's own docstring) — already included it. Because `update.md` prefers `gsd-sdk` over the CJS shim, real-world users with the SDK installed never had their custom skills detected. The installer's `Installed N skills to skills/` step then wiped any non-manifest skill without backing it up to `gsd-user-files-backup/`.

Reporter incident: `skills/gsd-roadmap/SKILL.md` (fully user-owned) destroyed during a 1.40.0 → 1.41.0 update; recovery required a Time Machine snapshot.

## What this fix does

Adds `'skills'` to the SDK's `GSD_MANAGED_DIRS`, restoring parity with the CJS port the SDK file's docstring explicitly mirrors. `sdk/dist` is rebuilt as part of the SDK build step (gitignored, regenerated by `npm run build:sdk`).

## Root cause

Port drift. `'skills'` was added to the CJS `GSD_MANAGED_DIRS` (#2942 fix) after the SDK port was created. The SDK port docstring asserted parity but no test enforced it — the lint and the CJS-side regression test both ran against `gsd-tools.cjs`, so the SDK gap stayed invisible until a user actually lost data on `/gsd-update`. Adding the SDK-side vitest in this PR is the regression guard that prevents recurrence.

## Testing

### How I verified the fix

- New `sdk/src/query/detect-custom-files.test.ts` (vitest) covers the SDK handler directly with 4 tests:
  - detects `skills/<name>/SKILL.md` not in the manifest (was failing → now passing)
  - does not flag a manifest-tracked skill as custom
  - still detects custom files under `get-shit-done/workflows/` (regression guard)
  - `custom_count === custom_files.length` across multiple skills (was failing → now passing)
- TDD: the test commit (`d5f83ed7`) was authored first and confirmed RED (2/4 failing on current SDK source). The fix commit (`790f889b`) flips to 4/4 GREEN.
- Full `npm test`: 8640/8642 pass. The 2 remaining failures (`bug-3017-codex-hook-absolute-node`, `codex-config`) are the pre-existing Homebrew Cellar/symlink path mismatch documented in #3311's PR body — environment-specific, not introduced by this fix.

### Regression test added?

- [x] Yes — added a test that would have caught this bug (`sdk/src/query/detect-custom-files.test.ts`)

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #3317` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`) — pre-existing #3017 codex failures unaffected
- [x] `.changeset/` fragment added (`type: Fixed`, `pr: 3317`)
- [x] No unnecessary dependencies added

## Breaking changes

None. The fix expands the set of files `detect-custom-files` reports — strictly more information for the installer's backup step. Consumers that were ignoring `custom_files[i]` entries beginning with `skills/` (none in the codebase) would be unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Skills placed under the local skills directory are now detected during updates, preventing them from being removed without backup.
  * Custom skills are correctly counted and preserved during synchronization.

* **Tests**
  * Added regression tests to verify custom-skill detection and counting behave as expected.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3318)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->