### PR TITLE
fix(gemini): drop Agent dispatcher tool

### DIFF
--- a/.changeset/fix-3344-gemini-agent-tool.md
+++ b/.changeset/fix-3344-gemini-agent-tool.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3349
+---
+Gemini and Antigravity agent conversion now drops Claude-only agent dispatcher tools instead of emitting invalid `agent` permissions.

--- a/bin/install.js
+++ b/bin/install.js
@@ -1240,7 +1240,7 @@ function convertToolName(claudeTool) {
  * Convert a Claude Code tool name to Gemini CLI format
  * - Applies Claude→Gemini mapping (Read→read_file, Bash→run_shell_command, etc.)
  * - Filters out MCP tools (mcp__*) — they are auto-discovered at runtime in Gemini
- * - Filters out Task — agents are auto-registered as tools in Gemini
+ * - Filters out Task/Agent — agents are auto-registered as tools in Gemini
  * @returns {string|null} Gemini tool name, or null if tool should be excluded
  */
 function convertGeminiToolName(claudeTool) {
@@ -1248,8 +1248,8 @@ function convertGeminiToolName(claudeTool) {
   if (claudeTool.startsWith('mcp__')) {
     return null;
   }
-  // Task: exclude — agents are auto-registered as callable tools
-  if (claudeTool === 'Task') {
+  // Task/Agent: exclude — agents are auto-registered as callable tools
+  if (claudeTool === 'Task' || claudeTool === 'Agent') {
     return null;
   }
   // Check for explicit mapping

--- a/tests/runtime-converters.test.cjs
+++ b/tests/runtime-converters.test.cjs
@@ -264,6 +264,28 @@ Use \${PHASE} in shell examples.
     assert.ok(result.includes('$PHASE'), 'escapes ${PHASE} shell variable for Gemini');
     assert.ok(!result.includes('${PHASE}'), 'removes Gemini template-string pattern');
   });
+
+  test('excludes Claude agent dispatcher tools from Gemini frontmatter', () => {
+    const input = `---
+name: gsd-debug-session-manager
+description: Manages debug sessions.
+tools: Read, Task, Agent, AskUserQuestion
+---
+
+<role>
+Coordinate debugger agents.
+</role>`;
+
+    const result = convertClaudeToGeminiAgent(input);
+    const frontmatter = result.split('---')[1] || '';
+
+    assert.ok(frontmatter.includes('  - read_file'), 'maps Read -> read_file');
+    assert.ok(frontmatter.includes('  - ask_user'), 'maps AskUserQuestion -> ask_user');
+    assert.ok(!frontmatter.includes('  - task'), 'does not emit invalid Gemini task tool');
+    assert.ok(!frontmatter.includes('  - agent'), 'does not emit invalid Gemini agent tool');
+    assert.ok(!frontmatter.includes('Task'), 'does not preserve Claude-only Task tool');
+    assert.ok(!frontmatter.includes('Agent'), 'does not preserve Claude-only Agent tool');
+  });
 });
 
 // ─── neutralizeAgentReferences (#766) ─────────────────────────────────────────


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #3344

## What was broken

Gemini agent conversion treated the Claude-only `Agent` dispatcher tool as an unknown tool and lowercased it to `agent`. Gemini rejects that invalid tool name when loading agents such as `gsd-debug-session-manager`.

## What this fix does

The shared Gemini tool mapper now filters both `Task` and `Agent`, so Gemini and Antigravity agent frontmatter only contains valid runtime tools.

## Root cause

The converter already knew Claude agent dispatch tools should be excluded for Gemini, but only handled the older `Task` spelling. Agents that declared the newer `Agent` spelling fell through to the lowercase fallback.

## Testing

### How I verified the fix

- `node --test tests/runtime-converters.test.cjs tests/antigravity-install.test.cjs`
- `npm run lint:changeset`

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [x] Gemini CLI
- [x] OpenCode
- [ ] Other: Antigravity converter coverage
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Gemini/Antigravity agent conversion to properly exclude Claude-only dispatcher tools, preventing generation of invalid agent permissions and ensuring only supported tools are emitted.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3349)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->