### PR TITLE
fix(verifier): require direct probe execution

### DIFF
--- a/.changeset/fix-3321-verifier-probes.md
+++ b/.changeset/fix-3321-verifier-probes.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3350
+---
+The verifier now runs declared probe scripts directly instead of accepting SUMMARY-reported probe PASS markers as evidence.

--- a/agents/gsd-verifier.md
+++ b/agents/gsd-verifier.md
@@ -503,12 +503,12 @@ grep -R -n -E 'probe-[^[:space:]]+\.sh|scripts/.*/tests/probe-.*\.sh' "$PHASE_DI
 
 **Execution contract:**
 
-1. Build the probe list from explicit PLAN declarations first; include conventional `scripts/*/tests/probe-*.sh` when the phase is a migration/tooling phase or the success criteria mention probes.
-2. For every documented probe path, if the file is missing or not executable/readable, mark `MISSING_PROBE` and set `status: gaps_found`.
-3. Run each discovered probe from the repository root:
+1. Build the `PROBES` list from explicit PLAN declarations first; include conventional `scripts/*/tests/probe-*.sh` when the phase is a migration/tooling phase or the success criteria mention probes.
+2. For every documented probe path, if the file is missing or unreadable, mark `MISSING_PROBE` and set `status: gaps_found`. Do not require the executable bit because probes run through `bash "$probe"`.
+3. Run each probe from the built `PROBES` list (declared + conventional) from the repository root:
 
 ```bash
-for probe in $(find scripts -path '*/tests/probe-*.sh' -type f 2>/dev/null | sort); do
+for probe in "${PROBES[@]}"; do
   timeout 30s bash "$probe"
 done
 ```

--- a/agents/gsd-verifier.md
+++ b/agents/gsd-verifier.md
@@ -485,6 +485,43 @@ npm test -- --grep "$PHASE_TEST_PATTERN" 2>&1 | grep -q "passing"
 - Do not modify state (no writes, no mutations, no side effects)
 - If the project has no runnable entry points yet, skip with: "Step 7b: SKIPPED (no runnable entry points)"
 
+## Step 7c: Probe Execution
+
+SUMMARY.md probe pass claims are not evidence. If a phase declares or implies probe-based verification, the verifier must run the probe in its own process and record the command result.
+
+**When to run:** For migration phases, CLI/tooling phases, or any phase whose PLAN/SUMMARY/verification criteria mention probes, PASS markers, stage markers, runnable checks, or `scripts/*/tests/probe-*.sh`.
+
+**Probe discovery:**
+
+```bash
+# Conventional project probes
+find scripts -path '*/tests/probe-*.sh' -type f 2>/dev/null | sort
+
+# Phase-declared probes
+grep -R -n -E 'probe-[^[:space:]]+\.sh|scripts/.*/tests/probe-.*\.sh' "$PHASE_DIR"/*-PLAN.md "$PHASE_DIR"/*-SUMMARY.md 2>/dev/null
+```
+
+**Execution contract:**
+
+1. Build the probe list from explicit PLAN declarations first; include conventional `scripts/*/tests/probe-*.sh` when the phase is a migration/tooling phase or the success criteria mention probes.
+2. For every documented probe path, if the file is missing or not executable/readable, mark `MISSING_PROBE` and set `status: gaps_found`.
+3. Run each discovered probe from the repository root:
+
+```bash
+for probe in $(find scripts -path '*/tests/probe-*.sh' -type f 2>/dev/null | sort); do
+  timeout 30s bash "$probe"
+done
+```
+
+4. Exit code 0 is PASS. Any non-zero exit is FAILED and must include stdout/stderr evidence in VERIFICATION.md.
+5. Do not substitute executor narration, SUMMARY.md PASS-marker counts, or a different dry-run driver command for the probe result.
+
+**Probe status:**
+
+| Probe | Command | Result | Status |
+| ----- | ------- | ------ | ------ |
+| `scripts/.../probe-name.sh` | `bash "$probe"` | exit code/output | PASS / FAILED / MISSING_PROBE |
+
 ## Step 8: Identify Human Verification Needs
 
 **Always needs human:** Visual appearance, user flow completion, real-time behavior, external service integration, performance feel, error message clarity.
@@ -719,6 +756,11 @@ Only include this section if deferred items exist (from Step 9b).
 
 | Behavior | Command | Result | Status |
 | -------- | ------- | ------ | ------ |
+
+### Probe Execution
+
+| Probe | Command | Result | Status |
+| ----- | ------- | ------ | ------ |
 
 ### Requirements Coverage
 

--- a/tests/bug-3321-verifier-runs-probes.test.cjs
+++ b/tests/bug-3321-verifier-runs-probes.test.cjs
@@ -8,14 +8,51 @@ const path = require('node:path');
 const REPO_ROOT = path.join(__dirname, '..');
 const VERIFIER_AGENT = path.join(REPO_ROOT, 'agents', 'gsd-verifier.md');
 
+function verifierProbeContract(content) {
+  const sectionStart = content.indexOf('## Step 7c: Probe Execution');
+  const sectionEnd = content.indexOf('## Step 8:', sectionStart);
+  assert.notEqual(sectionStart, -1, 'verifier must define Step 7c');
+  assert.notEqual(sectionEnd, -1, 'verifier must close Step 7c before Step 8');
+
+  const section = content.slice(sectionStart, sectionEnd);
+  const codeBlocks = [...section.matchAll(/```bash\n([\s\S]*?)\n```/g)].map((match) => match[1]);
+  const executionSteps = [...section.matchAll(/^\d+\.\s+(.+)$/gm)].map((match) => match[1]);
+  return {
+    title: 'Step 7c: Probe Execution',
+    conventionalDiscoveryCommand: codeBlocks[0]?.split('\n').find((line) => line.startsWith('find scripts')) || null,
+    declaredDiscoveryCommand: codeBlocks[0]?.split('\n').find((line) => line.startsWith('grep -R')) || null,
+    executionCommand: codeBlocks[1] || '',
+    executionSteps,
+    statusRows: [...section.matchAll(/^\|\s*`([^`]+)`\s*\|\s*`([^`]+)`\s*\|[^|]+\|\s*([^|]+)\|$/gm)]
+      .map((match) => ({ probe: match[1], command: match[2], statuses: match[3].trim() })),
+    summaryClaimsRejected: section.includes('SUMMARY.md probe pass claims are not evidence'),
+  };
+}
+
 describe('bug #3321: gsd-verifier runs probes instead of trusting SUMMARY claims', () => {
   test('verifier prompt requires direct probe discovery and execution', () => {
     const content = fs.readFileSync(VERIFIER_AGENT, 'utf8');
+    const contract = verifierProbeContract(content);
 
-    assert.match(content, /scripts\/\*\/tests\/probe-\*\.sh/, 'must discover conventional probe scripts');
-    assert.match(content, /bash "\$probe"/, 'must run each discovered probe in the verifier process');
-    assert.match(content, /MISSING_PROBE/, 'must distinguish documented but missing probes');
-    assert.match(content, /SUMMARY\.md[^.\n]*not evidence/i, 'must reject SUMMARY-reported probe passes as evidence');
-    assert.match(content, /Probe Execution/, 'must report probe execution results in VERIFICATION.md');
+    assert.equal(contract.title, 'Step 7c: Probe Execution');
+    assert.equal(contract.conventionalDiscoveryCommand, "find scripts -path '*/tests/probe-*.sh' -type f 2>/dev/null | sort");
+    assert.equal(
+      contract.declaredDiscoveryCommand,
+      "grep -R -n -E 'probe-[^[:space:]]+\\.sh|scripts/.*/tests/probe-.*\\.sh' \"$PHASE_DIR\"/*-PLAN.md \"$PHASE_DIR\"/*-SUMMARY.md 2>/dev/null",
+    );
+    assert.deepEqual(contract.executionSteps, [
+      'Build the `PROBES` list from explicit PLAN declarations first; include conventional `scripts/*/tests/probe-*.sh` when the phase is a migration/tooling phase or the success criteria mention probes.',
+      'For every documented probe path, if the file is missing or unreadable, mark `MISSING_PROBE` and set `status: gaps_found`. Do not require the executable bit because probes run through `bash "$probe"`.',
+      'Run each probe from the built `PROBES` list (declared + conventional) from the repository root:',
+      'Exit code 0 is PASS. Any non-zero exit is FAILED and must include stdout/stderr evidence in VERIFICATION.md.',
+      'Do not substitute executor narration, SUMMARY.md PASS-marker counts, or a different dry-run driver command for the probe result.',
+    ]);
+    assert.equal(contract.executionCommand, 'for probe in "${PROBES[@]}"; do\n  timeout 30s bash "$probe"\ndone');
+    assert.deepEqual(contract.statusRows, [{
+      probe: 'scripts/.../probe-name.sh',
+      command: 'bash "$probe"',
+      statuses: 'PASS / FAILED / MISSING_PROBE',
+    }]);
+    assert.equal(contract.summaryClaimsRejected, true);
   });
 });

--- a/tests/bug-3321-verifier-runs-probes.test.cjs
+++ b/tests/bug-3321-verifier-runs-probes.test.cjs
@@ -1,0 +1,21 @@
+'use strict';
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const VERIFIER_AGENT = path.join(REPO_ROOT, 'agents', 'gsd-verifier.md');
+
+describe('bug #3321: gsd-verifier runs probes instead of trusting SUMMARY claims', () => {
+  test('verifier prompt requires direct probe discovery and execution', () => {
+    const content = fs.readFileSync(VERIFIER_AGENT, 'utf8');
+
+    assert.match(content, /scripts\/\*\/tests\/probe-\*\.sh/, 'must discover conventional probe scripts');
+    assert.match(content, /bash "\$probe"/, 'must run each discovered probe in the verifier process');
+    assert.match(content, /MISSING_PROBE/, 'must distinguish documented but missing probes');
+    assert.match(content, /SUMMARY\.md[^.\n]*not evidence/i, 'must reject SUMMARY-reported probe passes as evidence');
+    assert.match(content, /Probe Execution/, 'must report probe execution results in VERIFICATION.md');
+  });
+});


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #3321

## What was broken

`gsd-verifier` warned not to trust SUMMARY files, but it did not give the verifier a concrete probe discovery and execution contract. That left SUMMARY-reported probe PASS markers easier to accept than running the actual probe.

## What this fix does

Adds a dedicated Probe Execution step requiring the verifier to discover declared/conventional probe scripts, run them with `bash` from its own process, mark missing documented probes as `MISSING_PROBE`, and report probe results in VERIFICATION.md.

## Root cause

The verifier prompt had generic behavioral spot-checks but no specific instruction tying probe-based success criteria to direct process execution.

## Testing

### How I verified the fix

- `node --test tests/bug-3321-verifier-runs-probes.test.cjs tests/agent-frontmatter.test.cjs`
- `npm run lint:changeset`

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Verification output now includes a dedicated probe execution section and automatic discovery of probe validation scripts.

* **Bug Fixes**
  * Verifier now executes probe scripts directly to validate phase claims and no longer treats summary-reported probe pass markers as evidence.

* **Documentation**
  * Updated verification template to include probe execution results and status.

* **Tests**
  * Added tests to assert probe execution, missing-probe handling, and result reporting.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3350)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->