### PR TITLE
fix(codex): remove legacy hooks json update hook

### DIFF
--- a/.changeset/fix-3357-codex-legacy-hooks-json.md
+++ b/.changeset/fix-3357-codex-legacy-hooks-json.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3364
+---
+**Codex installs now clean up legacy GSD-managed `hooks.json` update hooks after writing the TOML SessionStart hook** — reinstalling no longer leaves duplicate GSD update hooks across `hooks.json` and `config.toml`, while user-owned JSON hooks are preserved. (#3357)

--- a/bin/install.js
+++ b/bin/install.js
@@ -759,17 +759,21 @@ function rewriteLegacyCodexHookBlock(content, absoluteRunner) {
   return { content: updated, changed };
 }
 
-function isManagedCodexHookCommand(command) {
+function isManagedCodexHookCommand(command, targetDir) {
   if (typeof command !== 'string') return false;
-  return /(^|[\\/\s"'])(gsd-check-update\.js|gsd-update-check\.js)(?=$|[\s"'])/.test(command);
+  if (typeof targetDir !== 'string' || targetDir.length === 0) return false;
+  const normalizedCommand = command.replace(/\\/g, '/');
+  const managedHooksDir = `${path.join(targetDir, 'hooks').replace(/\\/g, '/')}/`;
+  if (!normalizedCommand.includes(managedHooksDir)) return false;
+  return /(^|[\\/\s"'])(gsd-check-update\.js|gsd-update-check\.js)(?=$|[\s"'])/.test(normalizedCommand);
 }
 
-function pruneGsdManagedHooksJsonValue(value) {
+function pruneGsdManagedHooksJsonValue(value, targetDir) {
   if (Array.isArray(value)) {
     let changed = false;
     const next = [];
     for (const item of value) {
-      const pruned = pruneGsdManagedHooksJsonValue(item);
+      const pruned = pruneGsdManagedHooksJsonValue(item, targetDir);
       if (pruned.changed) changed = true;
       if (!isStructurallyEmpty(pruned.value)) next.push(pruned.value);
       else changed = true;
@@ -778,14 +782,14 @@ function pruneGsdManagedHooksJsonValue(value) {
   }
 
   if (value && typeof value === 'object') {
-    if (isManagedCodexHookCommand(value.command)) {
+    if (isManagedCodexHookCommand(value.command, targetDir)) {
       return { value: null, changed: true };
     }
 
     let changed = false;
     const next = {};
     for (const [key, child] of Object.entries(value)) {
-      const pruned = pruneGsdManagedHooksJsonValue(child);
+      const pruned = pruneGsdManagedHooksJsonValue(child, targetDir);
       if (pruned.changed) changed = true;
       if (!isStructurallyEmpty(pruned.value)) next[key] = pruned.value;
       else changed = true;
@@ -813,7 +817,7 @@ function cleanupLegacyCodexHooksJson(targetDir) {
     return { changed: false, removedFile: false, skipped: 'invalid_json' };
   }
 
-  const pruned = pruneGsdManagedHooksJsonValue(parsed);
+  const pruned = pruneGsdManagedHooksJsonValue(parsed, targetDir);
   if (!pruned.changed) return { changed: false, removedFile: false };
 
   if (isStructurallyEmpty(pruned.value)) {
@@ -821,7 +825,7 @@ function cleanupLegacyCodexHooksJson(targetDir) {
     return { changed: true, removedFile: true };
   }
 
-  fs.writeFileSync(hooksPath, JSON.stringify(pruned.value, null, 2) + '\n');
+  atomicWriteFileSync(hooksPath, JSON.stringify(pruned.value, null, 2) + '\n', 'utf8');
   return { changed: true, removedFile: false };
 }
 

--- a/bin/install.js
+++ b/bin/install.js
@@ -759,6 +759,72 @@ function rewriteLegacyCodexHookBlock(content, absoluteRunner) {
   return { content: updated, changed };
 }
 
+function isManagedCodexHookCommand(command) {
+  if (typeof command !== 'string') return false;
+  return /(^|[\\/\s"'])(gsd-check-update\.js|gsd-update-check\.js)(?=$|[\s"'])/.test(command);
+}
+
+function pruneGsdManagedHooksJsonValue(value) {
+  if (Array.isArray(value)) {
+    let changed = false;
+    const next = [];
+    for (const item of value) {
+      const pruned = pruneGsdManagedHooksJsonValue(item);
+      if (pruned.changed) changed = true;
+      if (!isStructurallyEmpty(pruned.value)) next.push(pruned.value);
+      else changed = true;
+    }
+    return { value: next, changed };
+  }
+
+  if (value && typeof value === 'object') {
+    if (isManagedCodexHookCommand(value.command)) {
+      return { value: null, changed: true };
+    }
+
+    let changed = false;
+    const next = {};
+    for (const [key, child] of Object.entries(value)) {
+      const pruned = pruneGsdManagedHooksJsonValue(child);
+      if (pruned.changed) changed = true;
+      if (!isStructurallyEmpty(pruned.value)) next[key] = pruned.value;
+      else changed = true;
+    }
+    return { value: next, changed };
+  }
+
+  return { value, changed: false };
+}
+
+function isStructurallyEmpty(value) {
+  if (value === null || value === undefined) return true;
+  if (Array.isArray(value)) return value.length === 0;
+  return typeof value === 'object' && Object.keys(value).length === 0;
+}
+
+function cleanupLegacyCodexHooksJson(targetDir) {
+  const hooksPath = path.join(targetDir, 'hooks.json');
+  if (!fs.existsSync(hooksPath)) return { changed: false, removedFile: false };
+
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(hooksPath, 'utf8'));
+  } catch {
+    return { changed: false, removedFile: false, skipped: 'invalid_json' };
+  }
+
+  const pruned = pruneGsdManagedHooksJsonValue(parsed);
+  if (!pruned.changed) return { changed: false, removedFile: false };
+
+  if (isStructurallyEmpty(pruned.value)) {
+    fs.unlinkSync(hooksPath);
+    return { changed: true, removedFile: true };
+  }
+
+  fs.writeFileSync(hooksPath, JSON.stringify(pruned.value, null, 2) + '\n');
+  return { changed: true, removedFile: false };
+}
+
 /**
  * Build a hook command path using forward slashes for cross-platform compatibility.
  * On Windows, $HOME is not expanded by cmd.exe/PowerShell, so we use the actual path.
@@ -8586,6 +8652,10 @@ function install(isGlobal, runtime = 'claude') {
         throw wrapped;
       }
       console.log(`  ${green}✓${reset} Configured Codex hooks (SessionStart)`);
+      const legacyHooksCleanup = cleanupLegacyCodexHooksJson(targetDir);
+      if (legacyHooksCleanup.changed) {
+        console.log(`  ${green}✓${reset} Removed legacy GSD hooks.json entries`);
+      }
     } catch (e) {
       // #2760 — schema-validation and write failures must be loud and fatal
       // so the user is never left with a config Codex refuses to load (or no
@@ -10613,6 +10683,7 @@ if (process.env.GSD_TEST_MODE) {
     rewriteLegacyManagedNodeHookCommands,
     buildCodexHookBlock,
     rewriteLegacyCodexHookBlock,
+    cleanupLegacyCodexHooksJson,
   };
 } else {
 

--- a/tests/bug-3357-codex-legacy-hooks-json-migration.test.cjs
+++ b/tests/bug-3357-codex-legacy-hooks-json-migration.test.cjs
@@ -83,16 +83,25 @@ describe('#3357 — Codex install removes legacy GSD hooks.json entries', { conc
   });
 
   test('preserves user hooks.json entries while removing the legacy GSD hook', () => {
+    const userOwnedSameBasenameHook = {
+      hooks: [{
+        type: 'command',
+        command: 'node "/Users/example/bin/gsd-check-update.js"',
+      }],
+    };
     fs.writeFileSync(
       path.join(codexHome, 'hooks.json'),
-      JSON.stringify({ SessionStart: [legacyGsdHook(codexHome), userHook()] }, null, 2),
+      JSON.stringify({ SessionStart: [legacyGsdHook(codexHome), userHook(), userOwnedSameBasenameHook] }, null, 2),
     );
 
     withCodexHome(codexHome, () => install(true, 'codex'));
 
     const hooksJson = JSON.parse(fs.readFileSync(path.join(codexHome, 'hooks.json'), 'utf8'));
     const commands = hooksJson.SessionStart.flatMap((entry) => entry.hooks).map((hook) => hook.command);
-    assert.deepEqual(commands, ['node "/Users/example/bin/user-hook.js"']);
+    assert.deepEqual(commands, [
+      'node "/Users/example/bin/user-hook.js"',
+      'node "/Users/example/bin/gsd-check-update.js"',
+    ]);
     assert.equal(tomlGsdHookCount(codexHome), 1);
   });
 });

--- a/tests/bug-3357-codex-legacy-hooks-json-migration.test.cjs
+++ b/tests/bug-3357-codex-legacy-hooks-json-migration.test.cjs
@@ -1,0 +1,98 @@
+/**
+ * Regression test for bug #3357.
+ *
+ * Older Codex installs used hooks.json for SessionStart hooks. Current Codex
+ * installs write config.toml hooks. Reinstalling must remove only GSD-managed
+ * legacy hooks.json entries so users do not end up with duplicate GSD hooks.
+ */
+
+'use strict';
+
+process.env.GSD_TEST_MODE = '1';
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { install, parseTomlToObject } = require('../bin/install.js');
+const { createTempDir, cleanup } = require('./helpers.cjs');
+
+function withCodexHome(codexHome, fn) {
+  const previousCodexHome = process.env.CODEX_HOME;
+  process.env.CODEX_HOME = codexHome;
+  try {
+    return fn();
+  } finally {
+    if (previousCodexHome == null) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = previousCodexHome;
+  }
+}
+
+function legacyGsdHook(codexHome) {
+  return {
+    hooks: [{
+      type: 'command',
+      command: `node "${path.join(codexHome, 'hooks', 'gsd-check-update.js')}"`,
+    }],
+  };
+}
+
+function userHook() {
+  return {
+    hooks: [{
+      type: 'command',
+      command: 'node "/Users/example/bin/user-hook.js"',
+    }],
+  };
+}
+
+function tomlGsdHookCount(codexHome) {
+  const parsed = parseTomlToObject(fs.readFileSync(path.join(codexHome, 'config.toml'), 'utf8'));
+  const sessionStart = parsed.hooks?.SessionStart ?? [];
+  return sessionStart
+    .flatMap((entry) => Array.isArray(entry.hooks) ? entry.hooks : [])
+    .filter((hook) => typeof hook.command === 'string' && hook.command.includes('gsd-check-update.js'))
+    .length;
+}
+
+describe('#3357 — Codex install removes legacy GSD hooks.json entries', { concurrency: false }, () => {
+  let tmpRoot;
+  let codexHome;
+
+  beforeEach(() => {
+    tmpRoot = createTempDir('gsd-3357-');
+    codexHome = path.join(tmpRoot, '.codex');
+    fs.mkdirSync(codexHome, { recursive: true });
+  });
+
+  afterEach(() => {
+    cleanup(tmpRoot);
+  });
+
+  test('removes hooks.json when it only contained the legacy GSD SessionStart hook', () => {
+    fs.writeFileSync(
+      path.join(codexHome, 'hooks.json'),
+      JSON.stringify({ SessionStart: [legacyGsdHook(codexHome)] }, null, 2),
+    );
+
+    withCodexHome(codexHome, () => install(true, 'codex'));
+
+    assert.equal(fs.existsSync(path.join(codexHome, 'hooks.json')), false);
+    assert.equal(tomlGsdHookCount(codexHome), 1);
+  });
+
+  test('preserves user hooks.json entries while removing the legacy GSD hook', () => {
+    fs.writeFileSync(
+      path.join(codexHome, 'hooks.json'),
+      JSON.stringify({ SessionStart: [legacyGsdHook(codexHome), userHook()] }, null, 2),
+    );
+
+    withCodexHome(codexHome, () => install(true, 'codex'));
+
+    const hooksJson = JSON.parse(fs.readFileSync(path.join(codexHome, 'hooks.json'), 'utf8'));
+    const commands = hooksJson.SessionStart.flatMap((entry) => entry.hooks).map((hook) => hook.command);
+    assert.deepEqual(commands, ['node "/Users/example/bin/user-hook.js"']);
+    assert.equal(tomlGsdHookCount(codexHome), 1);
+  });
+});


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

Fixes #3357

---

## What was broken

Codex reinstall wrote the current TOML `SessionStart` update hook but left older GSD-managed `hooks.json` update hooks in place.

That could make Codex load duplicate GSD update hooks from both `config.toml` and `hooks.json`.

## What this fix does

After the TOML hook is successfully configured, Codex install now prunes only GSD-managed legacy `hooks.json` hook commands. User-owned JSON hooks are preserved, and `hooks.json` is removed only when it becomes structurally empty.

## Root cause

The Codex installer had cleanup/migration logic for stale GSD hooks in `config.toml`, but did not inspect the older JSON hook surface.

## Testing

### How I verified the fix

- `node --test tests/bug-3017-codex-hook-absolute-node.test.cjs tests/bug-2760-codex-install-defensive.test.cjs tests/bug-3357-codex-legacy-hooks-json-migration.test.cjs`
- `npm run lint:tests`
- `npm run lint:changeset`
- `git diff --check`

### Regression test added?

- [x] Yes — added install-level tests for removing GSD-only legacy `hooks.json` and preserving user hooks
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: Codex installer
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed duplicate hooks appearing after reinstalling Codex. Legacy update hooks are now properly cleaned up during installation, while user-configured hooks remain intact.

* **Tests**
  * Added regression test to verify clean hook migration behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3364)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->