### PR TITLE
[codex] Fix roadmap progress sync for padded phase arguments

### DIFF
--- a/.changeset/clever-wasps-parade.md
+++ b/.changeset/clever-wasps-parade.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3379
+---
+roadmap.update-plan-progress now updates unpadded ROADMAP phase rows and checkboxes when called with zero-padded phase arguments.

--- a/.changeset/runtime-install-policy-module.md
+++ b/.changeset/runtime-install-policy-module.md
@@ -1,0 +1,5 @@
+---
+type: Changed
+pr: 3376
+---
+**Runtime install metadata now lives in one shared policy catalog** - the installer, runtime-home helpers, and SDK query helpers all read the same runtime install policy. Install execution now dispatches through explicit runtime executors, and installed payloads include `get-shit-done/bin/shared/runtime-install-policy.json` to prevent drift between install-time behavior and SDK/runtime discovery.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -64,6 +64,9 @@ Module owning SDK-to-`get-shit-done-cc` compatibility policy: legacy asset disco
 ### Runtime-Global Skills Policy Module
 Module owning runtime-aware global skills directory policy for SDK query surfaces. Resolves runtime-global skills bases/skill paths from runtime + env precedence, renders display paths for warnings/manifests, and reports unsupported runtimes with no skills directory.
 
+### Runtime Install Policy Module
+Module owning runtime install plan projection for supported runtimes. Resolves runtime registry facts, local/global target directories, skills/agents/hooks/settings capabilities, config mutation intents, install-mode staging, and first-run/display metadata into a pure install plan. Runtime-specific installers remain Adapters that execute the plan and render/mutate concrete file formats.
+
 ### MVP Mode
 Phase-level planning mode that frames work as a vertical slice (UI → API → DB) of one user-visible capability instead of horizontal layers. Resolved at workflow init via the precedence chain: `--mvp` CLI flag → ROADMAP.md `**Mode:** mvp` field → `workflow.mvp_mode` config → false. All-or-nothing per phase (PRD #2826 Q1). Surfaced as `MVP_MODE=true|false` to the planner, executor, verifier, and discovery surfaces (progress, stats, graphify). Canonical parser: `roadmap.cjs` `**Mode:**` field; canonical resolution chain documented in `workflows/plan-phase.md`. Concept index: `references/mvp-concepts.md`.
 

--- a/bin/install.js
+++ b/bin/install.js
@@ -76,6 +76,10 @@ const {
   isMinimalMode,
   stageSkillsForMode,
 } = require(path.join(_gsdLibDir, 'install-profiles.cjs'));
+const runtimeInstallPolicy = require(path.join(_gsdLibDir, 'runtime-install-policy.cjs'));
+const runtimeInstallExecutor = require(path.join(_gsdLibDir, 'runtime-install-executor.cjs'));
+const runtimeMap = runtimeInstallPolicy.runtimeMap;
+const allRuntimes = runtimeInstallPolicy.allRuntimes;
 
 // Parse args
 const args = process.argv.slice(2);
@@ -114,7 +118,7 @@ if (hasSdk && hasNoSdk) {
 // Runtime selection - can be set by flags or interactive prompt
 let selectedRuntimes = [];
 if (hasAll) {
-  selectedRuntimes = ['claude', 'kilo', 'opencode', 'gemini', 'codex', 'copilot', 'antigravity', 'cursor', 'windsurf', 'augment', 'trae', 'qwen', 'hermes', 'codebuddy', 'cline'];
+  selectedRuntimes = allRuntimes.slice();
 } else if (hasBoth) {
   selectedRuntimes = ['claude', 'opencode'];
 } else {
@@ -171,21 +175,7 @@ Then re-run: npx get-shit-done-cc@latest
 
 // Helper to get directory name for a runtime (used for local/project installs)
 function getDirName(runtime) {
-  if (runtime === 'copilot') return '.github';
-  if (runtime === 'opencode') return '.opencode';
-  if (runtime === 'gemini') return '.gemini';
-  if (runtime === 'kilo') return '.kilo';
-  if (runtime === 'codex') return '.codex';
-  if (runtime === 'antigravity') return '.agent';
-  if (runtime === 'cursor') return '.cursor';
-  if (runtime === 'windsurf') return '.windsurf';
-  if (runtime === 'augment') return '.augment';
-  if (runtime === 'trae') return '.trae';
-  if (runtime === 'qwen') return '.qwen';
-  if (runtime === 'hermes') return '.hermes';
-  if (runtime === 'codebuddy') return '.codebuddy';
-  if (runtime === 'cline') return '.cline';
-  return '.claude';
+  return runtimeInstallPolicy.getDirName(runtime);
 }
 
 /**
@@ -195,247 +185,43 @@ function getDirName(runtime) {
  * @param {boolean} isGlobal - Whether this is a global install
  */
 function getConfigDirFromHome(runtime, isGlobal) {
-  if (!isGlobal) {
-    // Local installs use the same dir name pattern
-    return `'${getDirName(runtime)}'`;
-  }
-  // Global installs - OpenCode uses XDG path structure
-  if (runtime === 'copilot') return "'.copilot'";
-  if (runtime === 'opencode') {
-    // OpenCode: ~/.config/opencode -> '.config', 'opencode'
-    // Return as comma-separated for path.join() replacement
-    return "'.config', 'opencode'";
-  }
-  if (runtime === 'gemini') return "'.gemini'";
-  if (runtime === 'kilo') return "'.config', 'kilo'";
-  if (runtime === 'codex') return "'.codex'";
-  if (runtime === 'antigravity') {
-    if (!isGlobal) return "'.agent'";
-    return "'.gemini', 'antigravity'";
-  }
-  if (runtime === 'cursor') return "'.cursor'";
-  if (runtime === 'windsurf') return "'.windsurf'";
-  if (runtime === 'augment') return "'.augment'";
-  if (runtime === 'trae') return "'.trae'";
-  if (runtime === 'qwen') return "'.qwen'";
-  if (runtime === 'hermes') return "'.hermes'";
-  if (runtime === 'codebuddy') return "'.codebuddy'";
-  if (runtime === 'cline') return "'.cline'";
-  return "'.claude'";
-}
-
-/**
- * Get the global config directory for OpenCode
- * OpenCode follows XDG Base Directory spec and uses ~/.config/opencode/
- * Priority: OPENCODE_CONFIG_DIR > dirname(OPENCODE_CONFIG) > XDG_CONFIG_HOME/opencode > ~/.config/opencode
- */
-function getOpencodeGlobalDir() {
-  // 1. Explicit OPENCODE_CONFIG_DIR env var
-  if (process.env.OPENCODE_CONFIG_DIR) {
-    return expandTilde(process.env.OPENCODE_CONFIG_DIR);
-  }
-
-  // 2. OPENCODE_CONFIG env var (use its directory)
-  if (process.env.OPENCODE_CONFIG) {
-    return path.dirname(expandTilde(process.env.OPENCODE_CONFIG));
-  }
-
-  // 3. XDG_CONFIG_HOME/opencode
-  if (process.env.XDG_CONFIG_HOME) {
-    return path.join(expandTilde(process.env.XDG_CONFIG_HOME), 'opencode');
-  }
-
-  // 4. Default: ~/.config/opencode (XDG default)
-  return path.join(os.homedir(), '.config', 'opencode');
-}
-
-/**
- * Get the global config directory for Kilo
- * Kilo follows XDG Base Directory spec and uses ~/.config/kilo/
- * Priority: KILO_CONFIG_DIR > dirname(KILO_CONFIG) > XDG_CONFIG_HOME/kilo > ~/.config/kilo
- */
-function getKiloGlobalDir() {
-  // 1. Explicit KILO_CONFIG_DIR env var
-  if (process.env.KILO_CONFIG_DIR) {
-    return expandTilde(process.env.KILO_CONFIG_DIR);
-  }
-
-  // 2. KILO_CONFIG env var (use its directory)
-  if (process.env.KILO_CONFIG) {
-    return path.dirname(expandTilde(process.env.KILO_CONFIG));
-  }
-
-  // 3. XDG_CONFIG_HOME/kilo
-  if (process.env.XDG_CONFIG_HOME) {
-    return path.join(expandTilde(process.env.XDG_CONFIG_HOME), 'kilo');
-  }
-
-  // 4. Default: ~/.config/kilo (XDG default)
-  return path.join(os.homedir(), '.config', 'kilo');
+  return runtimeInstallPolicy.getConfigDirFromHome(runtime, isGlobal);
 }
 
 /**
  * Get the global config directory for a runtime
- * @param {string} runtime - 'claude', 'opencode', 'gemini', 'codex', or 'copilot'
+ * @param {string} runtime - supported runtime key
  * @param {string|null} explicitDir - Explicit directory from --config-dir flag
  */
 function getGlobalDir(runtime, explicitDir = null) {
-  if (runtime === 'opencode') {
-    // For OpenCode, --config-dir overrides env vars
-    if (explicitDir) {
-      return expandTilde(explicitDir);
-    }
-    return getOpencodeGlobalDir();
-  }
+  return runtimeInstallPolicy.getGlobalDir(runtime, explicitDir);
+}
 
-  if (runtime === 'kilo') {
-    // For Kilo, --config-dir overrides env vars
-    if (explicitDir) {
-      return expandTilde(explicitDir);
-    }
-    return getKiloGlobalDir();
-  }
+function createRuntimeInstallPlanForExecution(runtime, isGlobal, opts = {}) {
+  return runtimeInstallPolicy.createRuntimeInstallPlan({
+    runtime,
+    scope: isGlobal ? 'global' : 'local',
+    explicitConfigDir,
+    installMode,
+    ...opts,
+  });
+}
 
-  if (runtime === 'gemini') {
-    // Gemini: --config-dir > GEMINI_CONFIG_DIR > ~/.gemini
-    if (explicitDir) {
-      return expandTilde(explicitDir);
-    }
-    if (process.env.GEMINI_CONFIG_DIR) {
-      return expandTilde(process.env.GEMINI_CONFIG_DIR);
-    }
-    return path.join(os.homedir(), '.gemini');
-  }
+function hasConfigMutation(plan, adapter, operation = null) {
+  return runtimeInstallExecutor.hasConfigMutation(plan, adapter, operation);
+}
 
-  if (runtime === 'codex') {
-    // Codex: --config-dir > CODEX_HOME > ~/.codex
-    if (explicitDir) {
-      return expandTilde(explicitDir);
-    }
-    if (process.env.CODEX_HOME) {
-      return expandTilde(process.env.CODEX_HOME);
-    }
-    return path.join(os.homedir(), '.codex');
-  }
-
-  if (runtime === 'copilot') {
-    // Copilot: --config-dir > COPILOT_CONFIG_DIR > ~/.copilot
-    if (explicitDir) {
-      return expandTilde(explicitDir);
-    }
-    if (process.env.COPILOT_CONFIG_DIR) {
-      return expandTilde(process.env.COPILOT_CONFIG_DIR);
-    }
-    return path.join(os.homedir(), '.copilot');
-  }
-
-  if (runtime === 'antigravity') {
-    // Antigravity: --config-dir > ANTIGRAVITY_CONFIG_DIR > ~/.gemini/antigravity
-    if (explicitDir) {
-      return expandTilde(explicitDir);
-    }
-    if (process.env.ANTIGRAVITY_CONFIG_DIR) {
-      return expandTilde(process.env.ANTIGRAVITY_CONFIG_DIR);
-    }
-    return path.join(os.homedir(), '.gemini', 'antigravity');
-  }
-
-  if (runtime === 'cursor') {
-    // Cursor: --config-dir > CURSOR_CONFIG_DIR > ~/.cursor
-    if (explicitDir) {
-      return expandTilde(explicitDir);
-    }
-    if (process.env.CURSOR_CONFIG_DIR) {
-      return expandTilde(process.env.CURSOR_CONFIG_DIR);
-    }
-    return path.join(os.homedir(), '.cursor');
-  }
-
-  if (runtime === 'windsurf') {
-    // Windsurf: --config-dir > WINDSURF_CONFIG_DIR > ~/.codeium/windsurf
-    if (explicitDir) {
-      return expandTilde(explicitDir);
-    }
-    if (process.env.WINDSURF_CONFIG_DIR) {
-      return expandTilde(process.env.WINDSURF_CONFIG_DIR);
-    }
-    return path.join(os.homedir(), '.codeium', 'windsurf');
-  }
-
-  if (runtime === 'augment') {
-    // Augment: --config-dir > AUGMENT_CONFIG_DIR > ~/.augment
-    if (explicitDir) {
-      return expandTilde(explicitDir);
-    }
-    if (process.env.AUGMENT_CONFIG_DIR) {
-      return expandTilde(process.env.AUGMENT_CONFIG_DIR);
-    }
-    return path.join(os.homedir(), '.augment');
-  }
-  if (runtime === 'trae') {
-    // Trae: --config-dir > TRAE_CONFIG_DIR > ~/.trae
-    if (explicitDir) {
-      return expandTilde(explicitDir);
-    }
-    if (process.env.TRAE_CONFIG_DIR) {
-      return expandTilde(process.env.TRAE_CONFIG_DIR);
-    }
-    return path.join(os.homedir(), '.trae');
-  }
-
-  if (runtime === 'qwen') {
-    if (explicitDir) {
-      return expandTilde(explicitDir);
-    }
-    if (process.env.QWEN_CONFIG_DIR) {
-      return expandTilde(process.env.QWEN_CONFIG_DIR);
-    }
-    return path.join(os.homedir(), '.qwen');
-  }
-
-  if (runtime === 'hermes') {
-    // Hermes Agent: --config-dir > HERMES_HOME > ~/.hermes
-    // Honors HERMES_HOME which Hermes users set for profile mode / Docker
-    // deploys (docs: https://hermes-agent.nousresearch.com/docs).
-    if (explicitDir) {
-      return expandTilde(explicitDir);
-    }
-    if (process.env.HERMES_HOME) {
-      return expandTilde(process.env.HERMES_HOME);
-    }
-    return path.join(os.homedir(), '.hermes');
-  }
-
-  if (runtime === 'codebuddy') {
-    // CodeBuddy: --config-dir > CODEBUDDY_CONFIG_DIR > ~/.codebuddy
-    if (explicitDir) {
-      return expandTilde(explicitDir);
-    }
-    if (process.env.CODEBUDDY_CONFIG_DIR) {
-      return expandTilde(process.env.CODEBUDDY_CONFIG_DIR);
-    }
-    return path.join(os.homedir(), '.codebuddy');
-  }
-
-  if (runtime === 'cline') {
-    // Cline: --config-dir > CLINE_CONFIG_DIR > ~/.cline
-    if (explicitDir) {
-      return expandTilde(explicitDir);
-    }
-    if (process.env.CLINE_CONFIG_DIR) {
-      return expandTilde(process.env.CLINE_CONFIG_DIR);
-    }
-    return path.join(os.homedir(), '.cline');
-  }
-
-  // Claude Code: --config-dir > CLAUDE_CONFIG_DIR > ~/.claude
-  if (explicitDir) {
-    return expandTilde(explicitDir);
-  }
-  if (process.env.CLAUDE_CONFIG_DIR) {
-    return expandTilde(process.env.CLAUDE_CONFIG_DIR);
-  }
-  return path.join(os.homedir(), '.claude');
+function applyConfigMutations(plan, context = {}) {
+  return runtimeInstallExecutor.applyConfigMutations(plan, {
+    ...context,
+    adapters: {
+      writeSettings,
+      validateHookFields,
+      configureOpencodePermissions,
+      configureKiloPermissions,
+      ...(context.adapters || {}),
+    },
+  });
 }
 
 const banner = '\n' +
@@ -7416,6 +7202,7 @@ function reportLocalPatches(configDir, runtime = 'claude') {
 }
 
 function install(isGlobal, runtime = 'claude') {
+  const installPlan = createRuntimeInstallPlanForExecution(runtime, isGlobal);
   const isOpencode = runtime === 'opencode';
   const isGemini = runtime === 'gemini';
   const isKilo = runtime === 'kilo';
@@ -7430,21 +7217,11 @@ function install(isGlobal, runtime = 'claude') {
   const isHermes = runtime === 'hermes';
   const isCodebuddy = runtime === 'codebuddy';
   const isCline = runtime === 'cline';
-  const dirName = getDirName(runtime);
+  const dirName = installPlan.localDir;
   const src = path.join(__dirname, '..');
 
-  // Get the target directory based on runtime and install type.
-  // Cline local installs write to the project root (like Claude Code) — .clinerules
-  // lives at the root, not inside a .cline/ subdirectory.
-  const targetDir = isGlobal
-    ? getGlobalDir(runtime, explicitConfigDir)
-    : isCline
-      ? process.cwd()
-      : path.join(process.cwd(), dirName);
-
-  const locationLabel = isGlobal
-    ? targetDir.replace(os.homedir(), '~')
-    : targetDir.replace(process.cwd(), '.');
+  const targetDir = installPlan.targetDir;
+  const locationLabel = installPlan.locationLabel;
 
   // Path prefix for file references in markdown content (e.g. gsd-tools.cjs).
   // Replaces $HOME/.claude/ or ~/.claude/ so the result is <pathPrefix>get-shit-done/bin/...
@@ -7466,21 +7243,7 @@ function install(isGlobal, runtime = 'claude') {
     homeDir,
   });
 
-  let runtimeLabel = 'Claude Code';
-  if (isOpencode) runtimeLabel = 'OpenCode';
-  if (isGemini) runtimeLabel = 'Gemini';
-  if (isKilo) runtimeLabel = 'Kilo';
-  if (isCodex) runtimeLabel = 'Codex';
-  if (isCopilot) runtimeLabel = 'Copilot';
-  if (isAntigravity) runtimeLabel = 'Antigravity';
-  if (isCursor) runtimeLabel = 'Cursor';
-  if (isWindsurf) runtimeLabel = 'Windsurf';
-  if (isAugment) runtimeLabel = 'Augment';
-  if (isTrae) runtimeLabel = 'Trae';
-  if (isQwen) runtimeLabel = 'Qwen Code';
-  if (isHermes) runtimeLabel = 'Hermes Agent';
-  if (isCodebuddy) runtimeLabel = 'CodeBuddy';
-  if (isCline) runtimeLabel = 'Cline';
+  const runtimeLabel = installPlan.label;
 
   console.log(`  Installing for ${cyan}${runtimeLabel}${reset} to ${cyan}${locationLabel}${reset}\n`);
 
@@ -7531,7 +7294,7 @@ function install(isGlobal, runtime = 'claude') {
   // Map<filename, Buffer> — content snapshot of each pre-existing gsd-* agent file.
   const codexPreInstallAgentContents = new Map();
   let codexPreInstallVersionBytes = null;
-  if (isCodex && !isMinimalMode(installMode)) {
+  if (hasConfigMutation(installPlan, 'codex-toml', 'ensure-agent-profiles') && !isMinimalMode(installMode)) {
     const _preSkillsDir = path.join(targetDir, 'skills');
     if (fs.existsSync(_preSkillsDir)) {
       for (const entry of fs.readdirSync(_preSkillsDir, { withFileTypes: true })) {
@@ -7985,26 +7748,31 @@ function install(isGlobal, runtime = 'claude') {
     failures.push('get-shit-done');
   }
 
-  // #3288 — Copy sdk/shared/model-catalog.json into the get-shit-done payload
-  // at the co-located path that model-catalog.cjs resolves first:
+  // Copy sdk/shared/*.json catalogs into the get-shit-done payload at the
+  // co-located paths CJS modules resolve first:
   //   get-shit-done/bin/shared/model-catalog.json
+  //   get-shit-done/bin/shared/runtime-install-policy.json
   //
   // The install copies get-shit-done/ but NOT sdk/ — the CJS module's legacy
   // path (3 levels up → sdk/shared/) therefore resolves to a non-existent
   // location in every post-install layout.  Copying the catalog alongside the
   // CJS files ensures require() succeeds without needing sdk/ to exist.
-  const modelCatalogSrc = path.join(src, 'sdk', 'shared', 'model-catalog.json');
-  const modelCatalogDest = path.join(skillDest, 'bin', 'shared', 'model-catalog.json');
-  if (fs.existsSync(modelCatalogSrc)) {
-    fs.mkdirSync(path.dirname(modelCatalogDest), { recursive: true });
-    fs.copyFileSync(modelCatalogSrc, modelCatalogDest);
-    if (verifyFileInstalled(modelCatalogDest, 'get-shit-done/bin/shared/model-catalog.json')) {
-      console.log(`  ${green}✓${reset} Installed get-shit-done/bin/shared/model-catalog.json`);
+  const sharedCatalogs = ['model-catalog.json', 'runtime-install-policy.json'];
+  for (const catalogName of sharedCatalogs) {
+    const catalogSrc = path.join(src, 'sdk', 'shared', catalogName);
+    const catalogDest = path.join(skillDest, 'bin', 'shared', catalogName);
+    const manifestPath = `get-shit-done/bin/shared/${catalogName}`;
+    if (fs.existsSync(catalogSrc)) {
+      fs.mkdirSync(path.dirname(catalogDest), { recursive: true });
+      fs.copyFileSync(catalogSrc, catalogDest);
+      if (verifyFileInstalled(catalogDest, manifestPath)) {
+        console.log(`  ${green}✓${reset} Installed ${manifestPath}`);
+      } else {
+        failures.push(manifestPath);
+      }
     } else {
-      failures.push('get-shit-done/bin/shared/model-catalog.json');
+      failures.push(`sdk/shared/${catalogName} (source missing)`);
     }
-  } else {
-    failures.push('sdk/shared/model-catalog.json (source missing)');
   }
 
   // Copy agents to agents directory.
@@ -8153,73 +7921,16 @@ function install(isGlobal, runtime = 'claude') {
     failures.push('VERSION');
   }
 
-  if (!isCodex && !isCopilot && !isCursor && !isWindsurf && !isTrae && !isCline) {
-    // Write package.json to force CommonJS mode for GSD scripts
-    // Prevents "require is not defined" errors when project has "type": "module"
-    // Node.js walks up looking for package.json - this stops inheritance from project
-    const pkgJsonDest = path.join(targetDir, 'package.json');
-    fs.writeFileSync(pkgJsonDest, '{"type":"commonjs"}\n');
-    console.log(`  ${green}✓${reset} Wrote package.json (CommonJS mode)`);
-
-    // Copy hooks from dist/ (bundled with dependencies)
-    // Template paths for the target runtime (replaces '.claude' with correct config dir)
-    const hooksSrc = path.join(src, 'hooks', 'dist');
-    if (fs.existsSync(hooksSrc)) {
-      const hooksDest = path.join(targetDir, 'hooks');
-      fs.mkdirSync(hooksDest, { recursive: true });
-      const hookEntries = fs.readdirSync(hooksSrc);
-      const configDirReplacement = getConfigDirFromHome(runtime, isGlobal);
-      for (const entry of hookEntries) {
-        const srcFile = path.join(hooksSrc, entry);
-        if (fs.statSync(srcFile).isFile()) {
-          const destFile = path.join(hooksDest, entry);
-          // Template .js files to replace '.claude' with runtime-specific config dir
-          // and stamp the current GSD version into the hook version header
-          if (entry.endsWith('.js')) {
-            let content = fs.readFileSync(srcFile, 'utf8');
-            content = content.replace(/'\.claude'/g, configDirReplacement);
-            content = content.replace(/\/\.claude\//g, `/${getDirName(runtime)}/`);
-            content = content.replace(/\.claude\//g, `${getDirName(runtime)}/`);
-            if (isQwen) {
-              content = content.replace(/CLAUDE\.md/g, 'QWEN.md');
-              content = content.replace(/\bClaude Code\b/g, 'Qwen Code');
-            }
-            if (isHermes) {
-              content = content.replace(/CLAUDE\.md/g, 'HERMES.md');
-              content = content.replace(/\bClaude Code\b/g, 'Hermes Agent');
-            }
-            content = content.replace(/\{\{GSD_VERSION\}\}/g, pkg.version);
-            fs.writeFileSync(destFile, content);
-            // Ensure hook files are executable (fixes #1162 — missing +x permission)
-            try { fs.chmodSync(destFile, 0o755); } catch (e) { /* Windows doesn't support chmod */ }
-          } else {
-            // .sh hooks carry a gsd-hook-version header so gsd-check-update.js can
-            // detect staleness after updates — stamp the version just like .js hooks.
-            if (entry.endsWith('.sh')) {
-              let content = fs.readFileSync(srcFile, 'utf8');
-              content = content.replace(/\{\{GSD_VERSION\}\}/g, pkg.version);
-              fs.writeFileSync(destFile, content);
-              try { fs.chmodSync(destFile, 0o755); } catch (e) { /* Windows doesn't support chmod */ }
-            } else {
-              fs.copyFileSync(srcFile, destFile);
-            }
-          }
-        }
-      }
-      if (verifyInstalled(hooksDest, 'hooks')) {
-        console.log(`  ${green}✓${reset} Installed hooks (bundled)`);
-        // Warn if expected community .sh hooks are missing (non-fatal)
-        const expectedShHooks = ['gsd-session-state.sh', 'gsd-validate-commit.sh', 'gsd-phase-boundary.sh'];
-        for (const sh of expectedShHooks) {
-          if (!fs.existsSync(path.join(hooksDest, sh))) {
-            console.warn(`  ${yellow}⚠${reset}  Missing expected hook: ${sh}`);
-          }
-        }
-      } else {
-        failures.push('hooks');
-      }
-    }
-  }
+  const bundledHooksResult = runtimeInstallExecutor.copyBundledHooksArtifact(installPlan, {
+    packageSrc: src,
+    targetDir,
+    version: pkg.version,
+    verifyInstalled,
+    log: console.log,
+    warn: console.warn,
+    colors: { green, yellow, reset },
+  });
+  failures.push(...bundledHooksResult.failures);
 
   // Clear stale update cache so next session re-evaluates hook versions
   // Cache lives at ~/.cache/gsd/ (see hooks/gsd-check-update.js line 35-36)
@@ -8447,39 +8158,18 @@ function install(isGlobal, runtime = 'claude') {
     console.log(`  ${green}✓${reset} Generated config.toml with ${agentCount} agent roles`);
     console.log(`  ${green}✓${reset} Generated ${agentCount} agent .toml config files`);
 
-    // Copy hook files that are referenced in config.toml (#2153)
-    // The main hook-copy block is gated to non-Codex runtimes, but Codex registers
-    // gsd-check-update.js in config.toml — the file must physically exist.
-    const codexHooksSrc = path.join(src, 'hooks', 'dist');
-    if (fs.existsSync(codexHooksSrc)) {
-      const codexHooksDest = path.join(targetDir, 'hooks');
-      fs.mkdirSync(codexHooksDest, { recursive: true });
-      const configDirReplacement = getConfigDirFromHome(runtime, isGlobal);
-      for (const entry of fs.readdirSync(codexHooksSrc)) {
-        const srcFile = path.join(codexHooksSrc, entry);
-        if (!fs.statSync(srcFile).isFile()) continue;
-        const destFile = path.join(codexHooksDest, entry);
-        if (entry.endsWith('.js')) {
-          let content = fs.readFileSync(srcFile, 'utf8');
-          content = content.replace(/'\.claude'/g, configDirReplacement);
-          content = content.replace(/\/\.claude\//g, `/${getDirName(runtime)}/`);
-          content = content.replace(/\.claude\//g, `${getDirName(runtime)}/`);
-          content = content.replace(/\{\{GSD_VERSION\}\}/g, pkg.version);
-          fs.writeFileSync(destFile, content);
-          try { fs.chmodSync(destFile, 0o755); } catch (e) { /* Windows */ }
-        } else {
-          if (entry.endsWith('.sh')) {
-            let content = fs.readFileSync(srcFile, 'utf8');
-            content = content.replace(/\{\{GSD_VERSION\}\}/g, pkg.version);
-            fs.writeFileSync(destFile, content);
-            try { fs.chmodSync(destFile, 0o755); } catch (e) { /* Windows */ }
-          } else {
-            fs.copyFileSync(srcFile, destFile);
-          }
-        }
-      }
-      console.log(`  ${green}✓${reset} Installed hooks`);
-    }
+    // Copy hook files that are referenced in config.toml (#2153).
+    runtimeInstallExecutor.copyBundledHooksArtifact(installPlan, {
+      packageSrc: src,
+      targetDir,
+      version: pkg.version,
+      allowTomlHooks: true,
+      writeCommonJsPackageJson: false,
+      bundledLabel: false,
+      log: console.log,
+      warn: console.warn,
+      colors: { green, yellow, reset },
+    });
 
     // Add Codex hooks (SessionStart for update checking) — requires codex_hooks feature flag
     const configPath = path.join(targetDir, 'config.toml');
@@ -8612,10 +8302,10 @@ function install(isGlobal, runtime = 'claude') {
       throw wrapped;
     }
 
-    return { settingsPath: null, settings: null, statuslineCommand: null, updateBannerCommand: null, runtime, configDir: targetDir };
+    return { settingsPath: null, settings: null, statuslineCommand: null, updateBannerCommand: null, runtime, configDir: targetDir, installPlan };
   }
 
-  if (isCopilot) {
+  if (hasConfigMutation(installPlan, 'copilot-instructions', 'ensure-managed-instructions')) {
     // Generate copilot-instructions.md
     const templatePath = path.join(targetDir, 'get-shit-done', 'templates', 'copilot-instructions.md');
     const instructionsPath = path.join(targetDir, 'copilot-instructions.md');
@@ -8625,25 +8315,25 @@ function install(isGlobal, runtime = 'claude') {
       console.log(`  ${green}✓${reset} Generated copilot-instructions.md`);
     }
     // Copilot: no settings.json, no hooks, no statusline (like Codex)
-    return { settingsPath: null, settings: null, statuslineCommand: null, updateBannerCommand: null, runtime, configDir: targetDir };
+    return { settingsPath: null, settings: null, statuslineCommand: null, updateBannerCommand: null, runtime, configDir: targetDir, installPlan };
   }
 
   if (isCursor) {
     // Cursor uses skills — no config.toml, no settings.json hooks needed
-    return { settingsPath: null, settings: null, statuslineCommand: null, updateBannerCommand: null, runtime, configDir: targetDir };
+    return { settingsPath: null, settings: null, statuslineCommand: null, updateBannerCommand: null, runtime, configDir: targetDir, installPlan };
   }
 
   if (isWindsurf) {
     // Windsurf uses skills — no config.toml, no settings.json hooks needed
-    return { settingsPath: null, settings: null, statuslineCommand: null, updateBannerCommand: null, runtime, configDir: targetDir };
+    return { settingsPath: null, settings: null, statuslineCommand: null, updateBannerCommand: null, runtime, configDir: targetDir, installPlan };
   }
 
   if (isTrae) {
     // Trae uses skills — no settings.json hooks needed
-    return { settingsPath: null, settings: null, statuslineCommand: null, updateBannerCommand: null, runtime, configDir: targetDir };
+    return { settingsPath: null, settings: null, statuslineCommand: null, updateBannerCommand: null, runtime, configDir: targetDir, installPlan };
   }
 
-  if (isCline) {
+  if (hasConfigMutation(installPlan, 'cline-rules', 'ensure-runtime-rules')) {
     // Cline uses .clinerules — generate a rules file with GSD system instructions
     const clinerulesDest = path.join(targetDir, '.clinerules');
     const clinerules = [
@@ -8660,7 +8350,11 @@ function install(isGlobal, runtime = 'claude') {
     ].join('\n') + '\n';
     fs.writeFileSync(clinerulesDest, clinerules);
     console.log(`  ${green}✓${reset} Wrote .clinerules`);
-    return { settingsPath: null, settings: null, statuslineCommand: null, updateBannerCommand: null, runtime, configDir: targetDir };
+    return { settingsPath: null, settings: null, statuslineCommand: null, updateBannerCommand: null, runtime, configDir: targetDir, installPlan };
+  }
+
+  if (!installPlan.capabilities.settingsJson) {
+    return { settingsPath: null, settings: null, statuslineCommand: null, updateBannerCommand: null, runtime, configDir: targetDir, installPlan };
   }
 
   // Configure statusline and hooks in settings.json
@@ -8670,7 +8364,7 @@ function install(isGlobal, runtime = 'claude') {
   const rawSettings = readSettings(settingsPath);
   if (rawSettings === null) {
     console.log('  ' + yellow + 'i' + reset + '  Skipping settings.json configuration — file could not be parsed (comments or malformed JSON). Your existing settings are preserved.');
-    return;
+    return { settingsPath: null, settings: null, statuslineCommand: null, updateBannerCommand: null, runtime, configDir: targetDir, installPlan };
   }
   const settings = validateHookFields(cleanupOrphanedHooks(rawSettings));
   // #3002 CR: rewrite legacy `node .../gsd-*.js` command strings carried over
@@ -8746,7 +8440,7 @@ function install(isGlobal, runtime = 'claude') {
   }
 
   // Configure SessionStart hook for update checking (skip for opencode)
-  if (!isOpencode && !isKilo) {
+  if (hasConfigMutation(installPlan, 'settings-json', 'ensure-managed-hooks')) {
     if (!settings.hooks) {
       settings.hooks = {};
     }
@@ -9009,7 +8703,7 @@ function install(isGlobal, runtime = 'claude') {
   // installAllRuntimes can register it at finalize time when the user opts
   // in (#2795). Computed here (not in finishInstall) so the same buildHookCommand
   // / localCmd resolution logic is shared with the other JS hooks.
-  const updateBannerCommand = isOpencode || isKilo
+  const updateBannerCommand = !installPlan.capabilities.updateBanner
     ? null
     : (isGlobal
       ? buildHookCommand(targetDir, 'gsd-update-banner.js', hookOpts)
@@ -9022,6 +8716,7 @@ function install(isGlobal, runtime = 'claude') {
     updateBannerCommand,
     runtime,
     configDir: targetDir,
+    installPlan,
   };
 }
 
@@ -9029,16 +8724,9 @@ function install(isGlobal, runtime = 'claude') {
  * Apply statusline config, then print completion message
  */
 function finishInstall(settingsPath, settings, statuslineCommand, shouldInstallStatusline, runtime = 'claude', isGlobal = true, configDir = null, bannerOpts = {}) {
-  const isOpencode = runtime === 'opencode';
-  const isKilo = runtime === 'kilo';
-  const isCodex = runtime === 'codex';
-  const isCopilot = runtime === 'copilot';
-  const isCursor = runtime === 'cursor';
-  const isWindsurf = runtime === 'windsurf';
-  const isTrae = runtime === 'trae';
-  const isCline = runtime === 'cline';
+  const installPlan = bannerOpts.installPlan || createRuntimeInstallPlanForExecution(runtime, isGlobal);
 
-  if (shouldInstallStatusline && !isOpencode && !isKilo && !isCodex && !isCopilot && !isCursor && !isWindsurf && !isTrae) {
+  if (shouldInstallStatusline && installPlan.capabilities.statusline) {
     if (!isGlobal && !forceStatusline) {
       // Local installs skip statusLine by default: repo settings.json takes precedence over
       // profile-level settings.json in Claude Code, so writing here would silently clobber
@@ -9064,7 +8752,7 @@ function finishInstall(settingsPath, settings, statuslineCommand, shouldInstallS
   // settings.json hooks block — opencode/kilo/codex/cursor/windsurf/trae/
   // cline either lack the surface or use a different config schema.
   const { shouldInstallBanner, bannerCommand } = bannerOpts;
-  if (shouldInstallBanner && settings && !isOpencode && !isKilo && !isCodex && !isCopilot && !isCursor && !isWindsurf && !isTrae && !isCline) {
+  if (shouldInstallBanner && settings && installPlan.capabilities.updateBanner) {
     if (!bannerCommand) {
       console.warn(`  ${yellow}⚠${reset}  Skipped update banner registration — Node executable path unavailable. See #2979 / #3002.`);
     } else {
@@ -9096,19 +8784,12 @@ function finishInstall(settingsPath, settings, statuslineCommand, shouldInstallS
   // {type: 'command', command: null} items that the runtime hook schema
   // rejects at parse time. validateHookFields filters those out so the file
   // we write is always schema-valid.
-  if (!isCodex && !isCopilot && !isKilo && !isCursor && !isWindsurf && !isTrae && !isCline) {
-    writeSettings(settingsPath, validateHookFields(settings));
-  }
-
-  // Configure OpenCode permissions
-  if (isOpencode) {
-    configureOpencodePermissions(isGlobal, configDir);
-  }
-
-  // Configure Kilo permissions
-  if (isKilo) {
-    configureKiloPermissions(isGlobal, configDir);
-  }
+  applyConfigMutations(installPlan, {
+    isGlobal,
+    configDir,
+    settingsPath,
+    settings,
+  });
 
   // For non-Claude runtimes, set resolve_model_ids: "omit" in ~/.gsd/defaults.json
   // so resolveModelInternal() returns '' instead of Claude aliases (opus/sonnet/haiku)
@@ -9131,35 +8812,8 @@ function finishInstall(settingsPath, settings, statuslineCommand, shouldInstallS
     }
   }
 
-  let program = 'Claude Code';
-  if (runtime === 'opencode') program = 'OpenCode';
-  if (runtime === 'gemini') program = 'Gemini';
-  if (runtime === 'kilo') program = 'Kilo';
-  if (runtime === 'codex') program = 'Codex';
-  if (runtime === 'copilot') program = 'Copilot';
-  if (runtime === 'antigravity') program = 'Antigravity';
-  if (runtime === 'cursor') program = 'Cursor';
-  if (runtime === 'windsurf') program = 'Windsurf';
-  if (runtime === 'augment') program = 'Augment';
-  if (runtime === 'trae') program = 'Trae';
-  if (runtime === 'cline') program = 'Cline';
-  if (runtime === 'qwen') program = 'Qwen Code';
-  if (runtime === 'hermes') program = 'Hermes Agent';
-
-  let command = '/gsd-new-project';
-  if (runtime === 'opencode') command = '/gsd-new-project';
-  if (runtime === 'kilo') command = '/gsd-new-project';
-  if (runtime === 'gemini') command = '/gsd:new-project';
-  if (runtime === 'codex') command = '$gsd-new-project';
-  if (runtime === 'copilot') command = '/gsd-new-project';
-  if (runtime === 'antigravity') command = '/gsd-new-project';
-  if (runtime === 'cursor') command = 'gsd-new-project (mention the skill name)';
-  if (runtime === 'windsurf') command = '/gsd-new-project';
-  if (runtime === 'augment') command = '/gsd-new-project';
-  if (runtime === 'trae') command = '/gsd-new-project';
-  if (runtime === 'cline') command = '/gsd-new-project';
-  if (runtime === 'qwen') command = '/gsd-new-project';
-  if (runtime === 'hermes') command = '/gsd-new-project';
+  const program = installPlan.label;
+  const command = installPlan.firstRunCommand;
 
   // Claude Code global installs use the skills/ format (CC 2.1.88+).
   // Restart is required for CC to pick up newly-installed skills, and the
@@ -9236,54 +8890,12 @@ function handleStatusline(settings, isInteractive, callback) {
  * Prompt for runtime selection
  */
 /**
- * Runtime selection options for the interactive installer prompt.
- * Module-level so tests can import and assert structurally without grepping source.
- */
-const runtimeMap = {
-  '1': 'claude',
-  '2': 'antigravity',
-  '3': 'augment',
-  '4': 'cline',
-  '5': 'codebuddy',
-  '6': 'codex',
-  '7': 'copilot',
-  '8': 'cursor',
-  '9': 'gemini',
-  '10': 'hermes',
-  '11': 'kilo',
-  '12': 'opencode',
-  '13': 'qwen',
-  '14': 'trae',
-  '15': 'windsurf'
-};
-const allRuntimes = ['claude', 'antigravity', 'augment', 'cline', 'codebuddy', 'codex', 'copilot', 'cursor', 'gemini', 'hermes', 'kilo', 'opencode', 'qwen', 'trae', 'windsurf'];
-const ALL_RUNTIMES_OPTION = '16';
-
-/**
  * Build the runtime-selection prompt text shown by the interactive installer.
  * Pure function — no I/O. Exported for tests so they can assert against the
  * rendered prompt instead of grepping bin/install.js source text.
  */
 function buildRuntimePromptText() {
-  return `  ${yellow}Which runtime(s) would you like to install for?${reset}\n\n  ${cyan}1${reset}) Claude Code  ${dim}(~/.claude)${reset}
-  ${cyan}2${reset}) Antigravity  ${dim}(~/.gemini/antigravity)${reset}
-  ${cyan}3${reset}) Augment      ${dim}(~/.augment)${reset}
-  ${cyan}4${reset}) Cline        ${dim}(.clinerules)${reset}
-  ${cyan}5${reset}) CodeBuddy    ${dim}(~/.codebuddy)${reset}
-  ${cyan}6${reset}) Codex        ${dim}(~/.codex)${reset}
-  ${cyan}7${reset}) Copilot      ${dim}(~/.copilot)${reset}
-  ${cyan}8${reset}) Cursor       ${dim}(~/.cursor)${reset}
-  ${cyan}9${reset}) Gemini       ${dim}(~/.gemini)${reset}
-  ${cyan}10${reset}) Hermes Agent ${dim}(~/.hermes)${reset}
-  ${cyan}11${reset}) Kilo         ${dim}(~/.config/kilo)${reset}
-  ${cyan}12${reset}) OpenCode     ${dim}(~/.config/opencode)${reset}
-  ${cyan}13${reset}) Qwen Code    ${dim}(~/.qwen)${reset}
-  ${cyan}14${reset}) Trae         ${dim}(~/.trae)${reset}
-  ${cyan}15${reset}) Windsurf     ${dim}(~/.codeium/windsurf)${reset}
-  ${cyan}16${reset}) All
-
-  ${dim}Select multiple: 1,2,6 or 1 2 6${reset}
-`;
+  return runtimeInstallPolicy.buildRuntimePromptText();
 }
 
 /**
@@ -9295,24 +8907,7 @@ function buildRuntimePromptText() {
  *  - Falls back to ['claude'] when nothing valid is selected
  */
 function parseRuntimeInput(answer) {
-  const input = (answer == null ? '' : String(answer)).trim() || '1';
-
-  // Tokenize first so the all-runtimes shortcut also fires for inputs the
-  // prompt encourages — "16,", "16 1", etc. — not just the bare "16".
-  const choices = input.split(/[\s,]+/).filter(Boolean);
-  if (choices.includes(ALL_RUNTIMES_OPTION)) {
-    return allRuntimes.slice();
-  }
-
-  const selected = [];
-  for (const c of choices) {
-    const runtime = runtimeMap[c];
-    if (runtime && !selected.includes(runtime)) {
-      selected.push(runtime);
-    }
-  }
-
-  return selected.length > 0 ? selected : ['claude'];
+  return runtimeInstallPolicy.parseRuntimeInput(answer);
 }
 
 function promptRuntime(callback) {
@@ -10448,7 +10043,7 @@ function installAllRuntimes(runtimes, isGlobal, isInteractive) {
           result.runtime,
           isGlobal,
           result.configDir,
-          { shouldInstallBanner: !!shouldInstallBanner, bannerCommand: result.updateBannerCommand }
+          { shouldInstallBanner: !!shouldInstallBanner, bannerCommand: result.updateBannerCommand, installPlan: result.installPlan }
         );
       }
     };
@@ -10604,6 +10199,11 @@ if (process.env.GSD_TEST_MODE) {
     allRuntimes,
     parseRuntimeInput,
     buildRuntimePromptText,
+    createRuntimeInstallPlan: runtimeInstallPolicy.createRuntimeInstallPlan,
+    createRuntimeInstallPlanForExecution,
+    hasConfigMutation,
+    applyConfigMutations,
+    RUNTIME_REGISTRY: runtimeInstallPolicy.RUNTIME_REGISTRY,
     buildUpdateBannerPromptText,
     parseUpdateBannerInput,
     buildUpdateBannerHookEntry,

--- a/docs/INVENTORY-MANIFEST.json
+++ b/docs/INVENTORY-MANIFEST.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-05-09",
+  "generated": "2026-05-10",
   "families": {
     "agents": [
       "gsd-advisor-researcher",
@@ -292,6 +292,8 @@
       "roadmap-command-router.cjs",
       "roadmap.cjs",
       "runtime-homes.cjs",
+      "runtime-install-executor.cjs",
+      "runtime-install-policy.cjs",
       "schema-detect.cjs",
       "secrets.cjs",
       "security.cjs",

--- a/docs/INVENTORY.md
+++ b/docs/INVENTORY.md
@@ -359,7 +359,7 @@ The `gsd-planner` agent is decomposed into a core agent plus reference modules t
 
 ---
 
-## CLI Modules (50 shipped)
+## CLI Modules (52 shipped)
 
 Full listing: `get-shit-done/bin/lib/*.cjs`.
 
@@ -400,6 +400,8 @@ Full listing: `get-shit-done/bin/lib/*.cjs`.
 | `roadmap-command-router.cjs` | Thin CJS subcommand router adapter for `gsd-tools roadmap` |
 | `roadmap.cjs` | ROADMAP.md parsing, phase extraction, plan progress |
 | `runtime-homes.cjs` | Canonical runtime → global config/skills directory mapping; first-class support for all 15 runtimes including Hermes nested layout and Cline rules-based exclusion (#3126) |
+| `runtime-install-executor.cjs` | Runtime Install Executor Module; executes selected runtime install plan intents, including bundled hook artifact copying and config mutation dispatch |
+| `runtime-install-policy.cjs` | Runtime Install Policy Module; owns runtime registry facts and pure install plan projection for supported runtimes |
 | `schema-detect.cjs` | Schema-drift detection for ORM patterns (Prisma, Drizzle, etc.) |
 | `secrets.cjs` | Secret-config masking convention (`****<last-4>`) for integration keys managed by `/gsd-config --integrations` — keeps plaintext out of `config-set` output |
 | `security.cjs` | Path traversal prevention, prompt injection detection, safe JSON/shell helpers |

--- a/docs/adr/0008-runtime-install-policy-module.md
+++ b/docs/adr/0008-runtime-install-policy-module.md
@@ -1,0 +1,38 @@
+# Runtime Install Policy Module as shared runtime data
+
+- **Status:** Accepted
+- **Date:** 2026-05-10
+
+We decided to make runtime install targeting a shared **Runtime Install Policy Module** backed by shipped runtime data, with thin CJS and SDK Adapters projecting the existing install and query Interfaces.
+
+## Context
+
+Before this decision, runtime facts were spread across `bin/install.js`, CJS installer helpers, and SDK query helpers. Supported runtime keys, config directory fallbacks, skills layouts, hook capabilities, display names, and first-run notes could drift because each surface owned its own partial switch statement.
+
+That shape fails the deletion test: deleting one Adapter should not require maintainers to rediscover runtime facts from another Adapter or from tests. The real behavior is the runtime install policy contract, not the syntax of an installer branch.
+
+## Decision
+
+The Runtime Install Policy Module owns:
+
+- supported runtime keys and the all-runtimes selection option;
+- local and global runtime target directory policy;
+- runtime skills, agents, hooks, settings, and managed config mutation capabilities;
+- install-mode staging metadata and first-run/display metadata;
+- pure install plan projection from selected runtimes and environment inputs.
+
+The canonical runtime data lives in `sdk/shared/runtime-install-policy.json`. CJS install surfaces load that data through `get-shit-done/bin/lib/runtime-install-policy.cjs`; SDK query surfaces load the same data directly for runtime config and skills path projection.
+
+`bin/install.js` must remain an installer orchestrator. It may select runtimes, copy shared catalogs into the installed payload, and call the Runtime Install Executor, but it must not re-own runtime directory policy, skills layout policy, or config mutation intent selection.
+
+Runtime-specific mutation behavior remains in concrete Adapters. `get-shit-done/bin/lib/runtime-install-executor.cjs` dispatches explicit plan intents through an adapter registry; it does not decide which runtimes support which capabilities.
+
+## Consequences
+
+Adding or removing a runtime fact happens in one shared data file, then CJS and SDK Adapters project the result.
+
+Tests should compare Adapter projections to the shared Runtime Install Policy data and exercise representative install/query behavior. They should not keep duplicate runtime switches alive as the source of truth.
+
+The installed package must include `get-shit-done/bin/shared/runtime-install-policy.json` next to the CJS policy Adapter so installed runtimes can resolve policy data without source-tree paths.
+
+This decision extends the SDK seam map from `0005-sdk-architecture-seam-map.md` and complements the Model Catalog Module in `0003-model-catalog-module.md`; model defaults and runtime install targeting remain separate shared-policy seams.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -15,9 +15,12 @@ Each ADR documents one architectural decision: what was decided, why, and what c
 | [0005-sdk-architecture-seam-map.md](0005-sdk-architecture-seam-map.md) | SDK Architecture seam map for query/runtime surfaces | Accepted |
 | [0006-planning-path-projection-module.md](0006-planning-path-projection-module.md) | Planning Path Projection Module for SDK query handlers | Accepted |
 | [0007-sdk-package-seam-module.md](0007-sdk-package-seam-module.md) | SDK Package Seam Module owns SDK-to-get-shit-done-cc compatibility | Accepted |
+| [0008-runtime-install-policy-module.md](0008-runtime-install-policy-module.md) | Runtime Install Policy Module as shared runtime data | Accepted |
 
 ## Seam map
 
 ADR 0005 is the top-level SDK seam index. It references per-seam ADRs and states the narrow-waist principle each seam follows. Use it as the entry point for understanding SDK module ownership.
 
 ADR 0006 documents how SDK query handlers project planning paths (`cwd → effectiveRoot → .planning/<project>/...`). Cross-reference with the Planning Workspace Module (ADR 0004) for workstream pointer policy.
+
+ADR 0008 documents runtime install policy ownership. Cross-reference with the Runtime Install Policy Module glossary entry in `CONTEXT.md` for the boundary between shared runtime data, install plan projection, runtime mutation Adapters, and SDK query path projection.

--- a/docs/contributor-standards.md
+++ b/docs/contributor-standards.md
@@ -73,6 +73,7 @@ Currently accepted ADRs:
 | `0005-sdk-architecture-seam-map.md` | SDK Architecture seam map for query/runtime surfaces |
 | `0006-planning-path-projection-module.md` | Planning Path Projection Module for SDK query handlers |
 | `0007-sdk-package-seam-module.md` | SDK Package Seam Module owns SDK-to-get-shit-done-cc compatibility |
+| `0008-runtime-install-policy-module.md` | Runtime Install Policy Module as shared runtime data |
 
 ### When an ADR is required
 
@@ -121,7 +122,7 @@ Reference sibling ADRs by filename, not by title prose: `see \`0001-dispatch-pol
 
 ### ADR README index
 
-`docs/adr/` does not currently maintain a separate `README.md` index. The canonical index is the table in this document (above). If an ADR is added, update this table in the same PR.
+`docs/adr/README.md` maintains the browsable ADR index. The contributor-facing index is the table in this document (above). If an ADR is added, update both tables in the same PR.
 
 ### Governance
 

--- a/get-shit-done/bin/lib/roadmap.cjs
+++ b/get-shit-done/bin/lib/roadmap.cjs
@@ -51,6 +51,17 @@ function countPhasePlansAndSummaries(phaseDir) {
   };
 }
 
+function phaseMarkdownRegexSource(phaseNum) {
+  const stripped = String(phaseNum).replace(/^[A-Z]{1,6}-(?=\d)/i, '');
+  const match = stripped.match(/^0*(\d+)([A-Z])?((?:\.\d+)*)$/i);
+  if (!match) return escapeRegex(phaseNum);
+
+  const integer = match[1].replace(/^0+/, '') || '0';
+  const letter = match[2] ? escapeRegex(match[2]) : '';
+  const decimal = match[3] ? escapeRegex(match[3]) : '';
+  return `0*${escapeRegex(integer)}${letter}${decimal}`;
+}
+
 /**
  * Search for a phase header (and its section) within the given content string.
  * Returns a result object if found (either a full match or a malformed_roadmap
@@ -341,11 +352,11 @@ function cmdRoadmapUpdatePlanProgress(cwd, phaseNum, raw) {
   // Wrap entire read-modify-write in lock to prevent concurrent corruption
   withPlanningLock(cwd, () => {
     let roadmapContent = fs.readFileSync(roadmapPath, 'utf-8');
-    const phaseEscaped = escapeRegex(phaseNum);
+    const phasePattern = phaseMarkdownRegexSource(phaseNum);
 
     // Progress table row: update Plans/Status/Date columns (handles 4 or 5 column tables)
     const tableRowPattern = new RegExp(
-      `^(\\|\\s*${phaseEscaped}\\.?\\s[^|]*(?:\\|[^\\n]*))$`,
+      `^(\\|\\s*${phasePattern}\\.?\\s[^|]*(?:\\|[^\\n]*))$`,
       'im'
     );
     const dateField = isComplete ? ` ${today} ` : '  ';
@@ -367,7 +378,7 @@ function cmdRoadmapUpdatePlanProgress(cwd, phaseNum, raw) {
 
     // Update plan count in phase detail section
     const planCountPattern = new RegExp(
-      `(#{2,4}\\s*Phase\\s+${phaseEscaped}[\\s\\S]*?\\*\\*Plans:\\*\\*\\s*)[^\\n]+`,
+      `(#{2,4}\\s*Phase\\s+${phasePattern}(?=[:\\s])[\\s\\S]*?\\*\\*Plans:\\*\\*\\s*)[^\\n]+`,
       'i'
     );
     const planCountText = isComplete
@@ -378,7 +389,7 @@ function cmdRoadmapUpdatePlanProgress(cwd, phaseNum, raw) {
     // If complete: check checkbox
     if (isComplete) {
       const checkboxPattern = new RegExp(
-        `(-\\s*\\[)[ ](\\]\\s*.*Phase\\s+${phaseEscaped}[:\\s][^\\n]*)`,
+        `(-\\s*\\[)[ ](\\]\\s*.*Phase\\s+${phasePattern}[:\\s][^\\n]*)`,
         'i'
       );
       roadmapContent = replaceInCurrentMilestone(roadmapContent, checkboxPattern, `$1x$2 (completed ${today})`);

--- a/get-shit-done/bin/lib/runtime-homes.cjs
+++ b/get-shit-done/bin/lib/runtime-homes.cjs
@@ -6,9 +6,8 @@
  * Single source of truth for resolving the global config base directory and
  * the correct global skills directory for every GSD-supported runtime.
  *
- * Mirrors the logic in bin/install.js getGlobalDir() but as a pure,
- * side-effect-free module safe to require() at any point without triggering
- * the installer. bin/install.js is the authoritative source — keep in sync.
+ * Thin query adapter over the Runtime Install Policy Module. Safe to require()
+ * without triggering the installer.
  *
  * Runtime-specific notes:
  *   hermes  — GSD skills nest under skills/gsd/<skillName>/ (not the flat
@@ -22,6 +21,7 @@
 
 const os = require('os');
 const path = require('path');
+const { getGlobalDir, getRuntimePolicy } = require('./runtime-install-policy.cjs');
 
 /**
  * Expand a leading ~ to os.homedir().
@@ -36,93 +36,13 @@ function expandTilde(p) {
 
 /**
  * Return the global config base directory for the given runtime.
- * Respects the same env-var overrides as bin/install.js getGlobalDir().
+ * Respects the env-var overrides owned by Runtime Install Policy.
  *
  * @param {string} runtime
  * @returns {string} Absolute path to the runtime's global config directory
  */
 function getGlobalConfigDir(runtime) {
-  const home = os.homedir();
-  const env = process.env;
-
-  switch (runtime) {
-    // ── Claude Code ──────────────────────────────────────────────────────────
-    case 'claude':
-      return env.CLAUDE_CONFIG_DIR ? expandTilde(env.CLAUDE_CONFIG_DIR) : path.join(home, '.claude');
-
-    // ── Cursor ───────────────────────────────────────────────────────────────
-    case 'cursor':
-      return env.CURSOR_CONFIG_DIR ? expandTilde(env.CURSOR_CONFIG_DIR) : path.join(home, '.cursor');
-
-    // ── Gemini CLI ───────────────────────────────────────────────────────────
-    case 'gemini':
-      return env.GEMINI_CONFIG_DIR ? expandTilde(env.GEMINI_CONFIG_DIR) : path.join(home, '.gemini');
-
-    // ── Codex ────────────────────────────────────────────────────────────────
-    case 'codex':
-      return env.CODEX_HOME ? expandTilde(env.CODEX_HOME) : path.join(home, '.codex');
-
-    // ── Copilot (VS Code) ────────────────────────────────────────────────────
-    case 'copilot':
-      return env.COPILOT_CONFIG_DIR ? expandTilde(env.COPILOT_CONFIG_DIR) : path.join(home, '.copilot');
-
-    // ── Antigravity ──────────────────────────────────────────────────────────
-    case 'antigravity':
-      return env.ANTIGRAVITY_CONFIG_DIR
-        ? expandTilde(env.ANTIGRAVITY_CONFIG_DIR)
-        : path.join(home, '.gemini', 'antigravity');
-
-    // ── Windsurf ─────────────────────────────────────────────────────────────
-    case 'windsurf':
-      return env.WINDSURF_CONFIG_DIR
-        ? expandTilde(env.WINDSURF_CONFIG_DIR)
-        : path.join(home, '.codeium', 'windsurf');
-
-    // ── Augment ──────────────────────────────────────────────────────────────
-    case 'augment':
-      return env.AUGMENT_CONFIG_DIR ? expandTilde(env.AUGMENT_CONFIG_DIR) : path.join(home, '.augment');
-
-    // ── Trae ─────────────────────────────────────────────────────────────────
-    case 'trae':
-      return env.TRAE_CONFIG_DIR ? expandTilde(env.TRAE_CONFIG_DIR) : path.join(home, '.trae');
-
-    // ── Qwen Code ────────────────────────────────────────────────────────────
-    case 'qwen':
-      return env.QWEN_CONFIG_DIR ? expandTilde(env.QWEN_CONFIG_DIR) : path.join(home, '.qwen');
-
-    // ── Hermes Agent ─────────────────────────────────────────────────────────
-    // Note: skills use a nested layout (skills/gsd/<skill>/) — see getGlobalSkillDir().
-    case 'hermes':
-      return env.HERMES_HOME ? expandTilde(env.HERMES_HOME) : path.join(home, '.hermes');
-
-    // ── CodeBuddy ────────────────────────────────────────────────────────────
-    case 'codebuddy':
-      return env.CODEBUDDY_CONFIG_DIR ? expandTilde(env.CODEBUDDY_CONFIG_DIR) : path.join(home, '.codebuddy');
-
-    // ── Cline ────────────────────────────────────────────────────────────────
-    // Note: Cline is rules-based (.clinerules) — no skills/ directory.
-    // getGlobalSkillDir() returns null for cline.
-    case 'cline':
-      return env.CLINE_CONFIG_DIR ? expandTilde(env.CLINE_CONFIG_DIR) : path.join(home, '.cline');
-
-    // ── OpenCode (XDG) ───────────────────────────────────────────────────────
-    case 'opencode': {
-      if (env.OPENCODE_CONFIG_DIR) return expandTilde(env.OPENCODE_CONFIG_DIR);
-      if (env.XDG_CONFIG_HOME) return path.join(expandTilde(env.XDG_CONFIG_HOME), 'opencode');
-      return path.join(home, '.config', 'opencode');
-    }
-
-    // ── Kilo (XDG) ───────────────────────────────────────────────────────────
-    case 'kilo': {
-      if (env.KILO_CONFIG_DIR) return expandTilde(env.KILO_CONFIG_DIR);
-      if (env.XDG_CONFIG_HOME) return path.join(expandTilde(env.XDG_CONFIG_HOME), 'kilo');
-      return path.join(home, '.config', 'kilo');
-    }
-
-    // ── Default (Claude fallback) ─────────────────────────────────────────────
-    default:
-      return env.CLAUDE_CONFIG_DIR ? expandTilde(env.CLAUDE_CONFIG_DIR) : path.join(home, '.claude');
-  }
+  return getGlobalDir(runtime);
 }
 
 /**
@@ -135,9 +55,10 @@ function getGlobalConfigDir(runtime) {
  * @returns {string|null}
  */
 function getGlobalSkillsBase(runtime) {
-  if (runtime === 'cline') return null;
+  const policy = getRuntimePolicy(runtime);
+  if (policy.skillsLayout === 'none') return null;
   const configDir = getGlobalConfigDir(runtime);
-  if (runtime === 'hermes') return path.join(configDir, 'skills', 'gsd');
+  if (policy.skillsLayout === 'hermes-nested') return path.join(configDir, 'skills', 'gsd');
   return path.join(configDir, 'skills');
 }
 

--- a/get-shit-done/bin/lib/runtime-install-executor.cjs
+++ b/get-shit-done/bin/lib/runtime-install-executor.cjs
@@ -1,0 +1,190 @@
+'use strict';
+
+/**
+ * Runtime Install Executor Module
+ *
+ * Executes selected runtime install plan intents. The Runtime Install Policy
+ * Module owns the pure plan projection; this module owns plan-driven dispatch
+ * for concrete artifact/config actions that can be shared by installer callers.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const runtimeInstallPolicy = require('./runtime-install-policy.cjs');
+
+const CONFIG_MUTATION_ADAPTER_REGISTRY = Object.freeze({
+  'settings-json': Object.freeze({
+    'ensure-managed-hooks': ({ context, adapters }) => {
+      if (context.settingsPath && context.settings && adapters.writeSettings && adapters.validateHookFields) {
+        adapters.writeSettings(context.settingsPath, adapters.validateHookFields(context.settings));
+      }
+    },
+  }),
+  'opencode-json': Object.freeze({
+    'ensure-permissions': ({ context, adapters, configDir }) => {
+      if (adapters.configureOpencodePermissions) {
+        adapters.configureOpencodePermissions(context.isGlobal, configDir);
+      }
+    },
+  }),
+  'kilo-json': Object.freeze({
+    'ensure-permissions': ({ context, adapters, configDir }) => {
+      if (adapters.configureKiloPermissions) {
+        adapters.configureKiloPermissions(context.isGlobal, configDir);
+      }
+    },
+  }),
+  'codex-toml': Object.freeze({
+    'ensure-agent-profiles': ({ mutation, context, adapters, configDir }) => {
+      if (adapters.configureCodexToml) adapters.configureCodexToml(mutation, { ...context, configDir });
+    },
+    'ensure-managed-hook-block': ({ mutation, context, adapters, configDir }) => {
+      if (adapters.configureCodexToml) adapters.configureCodexToml(mutation, { ...context, configDir });
+    },
+  }),
+  'copilot-instructions': Object.freeze({
+    'ensure-managed-instructions': ({ mutation, context, adapters, configDir }) => {
+      if (adapters.configureCopilotInstructions) adapters.configureCopilotInstructions(mutation, { ...context, configDir });
+    },
+  }),
+  'cline-rules': Object.freeze({
+    'ensure-runtime-rules': ({ mutation, context, adapters, configDir }) => {
+      if (adapters.configureClineRules) adapters.configureClineRules(mutation, { ...context, configDir });
+    },
+  }),
+});
+
+function hasConfigMutation(plan, adapter, operation = null) {
+  return !!(plan && Array.isArray(plan.configMutations) && plan.configMutations.some((mutation) =>
+    mutation.adapter === adapter && (operation === null || mutation.operation === operation)
+  ));
+}
+
+function getConfigMutationHandler(registry, mutation) {
+  if (!registry || !mutation) return null;
+  const adapterRegistry = registry[mutation.adapter];
+  if (!adapterRegistry) return null;
+  return adapterRegistry[mutation.operation] || adapterRegistry['*'] || null;
+}
+
+function applyConfigMutations(plan, context = {}) {
+  if (!plan || !Array.isArray(plan.configMutations)) return;
+  const adapters = context.adapters || {};
+  const configDir = context.configDir || plan.targetDir;
+  const registry = context.configMutationAdapterRegistry || CONFIG_MUTATION_ADAPTER_REGISTRY;
+
+  for (const mutation of plan.configMutations) {
+    const handler = getConfigMutationHandler(registry, mutation);
+    if (!handler) continue;
+    handler({ mutation, context, adapters, configDir });
+  }
+}
+
+function shouldCopyBundledHooks(plan, opts = {}) {
+  if (!plan || !plan.capabilities || !plan.capabilities.hooks) return false;
+  if (plan.capabilities.toml && !opts.allowTomlHooks) return false;
+  return Array.isArray(plan.artifacts) && plan.artifacts.some((artifact) => artifact.kind === 'hooks');
+}
+
+function copyRuntimeHookFile(srcFile, destFile, entry, replacements) {
+  if (entry.endsWith('.js')) {
+    let content = fs.readFileSync(srcFile, 'utf8');
+    content = content.replace(/'\.claude'/g, replacements.configDirReplacement);
+    content = content.replace(/\/\.claude\//g, `/${replacements.localDir}/`);
+    content = content.replace(/\.claude\//g, `${replacements.localDir}/`);
+    if (replacements.runtime === 'qwen') {
+      content = content.replace(/CLAUDE\.md/g, 'QWEN.md');
+      content = content.replace(/\bClaude Code\b/g, 'Qwen Code');
+    }
+    if (replacements.runtime === 'hermes') {
+      content = content.replace(/CLAUDE\.md/g, 'HERMES.md');
+      content = content.replace(/\bClaude Code\b/g, 'Hermes Agent');
+    }
+    content = content.replace(/\{\{GSD_VERSION\}\}/g, replacements.version);
+    fs.writeFileSync(destFile, content);
+    try { fs.chmodSync(destFile, 0o755); } catch (_) { /* Windows doesn't support chmod */ }
+    return;
+  }
+
+  if (entry.endsWith('.sh')) {
+    let content = fs.readFileSync(srcFile, 'utf8');
+    content = content.replace(/\{\{GSD_VERSION\}\}/g, replacements.version);
+    fs.writeFileSync(destFile, content);
+    try { fs.chmodSync(destFile, 0o755); } catch (_) { /* Windows doesn't support chmod */ }
+    return;
+  }
+
+  fs.copyFileSync(srcFile, destFile);
+}
+
+function copyBundledHooksArtifact(plan, context = {}) {
+  if (!shouldCopyBundledHooks(plan, context)) {
+    return { skipped: true, failures: [] };
+  }
+
+  const failures = [];
+  const targetDir = context.targetDir || plan.targetDir;
+  const packageSrc = context.packageSrc;
+  if (!packageSrc) {
+    throw new Error('copyBundledHooksArtifact requires packageSrc');
+  }
+  fs.mkdirSync(targetDir, { recursive: true });
+
+  const log = context.log || (() => {});
+  const warn = context.warn || (() => {});
+  const colors = context.colors || {};
+  const green = colors.green || '';
+  const yellow = colors.yellow || '';
+  const reset = colors.reset || '';
+
+  if (context.writeCommonJsPackageJson !== false) {
+    const pkgJsonDest = path.join(targetDir, 'package.json');
+    fs.writeFileSync(pkgJsonDest, '{"type":"commonjs"}\n');
+    log(`  ${green}✓${reset} Wrote package.json (CommonJS mode)`);
+  }
+
+  const hooksSrc = path.join(packageSrc, 'hooks', 'dist');
+  if (!fs.existsSync(hooksSrc)) {
+    return { skipped: false, missingSource: true, failures };
+  }
+
+  const hooksDest = path.join(targetDir, 'hooks');
+  fs.mkdirSync(hooksDest, { recursive: true });
+  const configDirReplacement = runtimeInstallPolicy.getConfigDirFromHome(plan.runtime, plan.scope === 'global');
+  const replacements = {
+    runtime: plan.runtime,
+    localDir: plan.localDir,
+    configDirReplacement,
+    version: context.version || '',
+  };
+
+  for (const entry of fs.readdirSync(hooksSrc)) {
+    const srcFile = path.join(hooksSrc, entry);
+    if (!fs.statSync(srcFile).isFile()) continue;
+    copyRuntimeHookFile(srcFile, path.join(hooksDest, entry), entry, replacements);
+  }
+
+  if (context.verifyInstalled && !context.verifyInstalled(hooksDest, 'hooks')) {
+    failures.push('hooks');
+  } else {
+    log(`  ${green}✓${reset} Installed hooks${context.bundledLabel === false ? '' : ' (bundled)'}`);
+    const expectedShHooks = ['gsd-session-state.sh', 'gsd-validate-commit.sh', 'gsd-phase-boundary.sh'];
+    for (const sh of expectedShHooks) {
+      if (!fs.existsSync(path.join(hooksDest, sh))) {
+        warn(`  ${yellow}⚠${reset}  Missing expected hook: ${sh}`);
+      }
+    }
+  }
+
+  return { skipped: false, hooksDest, failures };
+}
+
+module.exports = {
+  CONFIG_MUTATION_ADAPTER_REGISTRY,
+  hasConfigMutation,
+  getConfigMutationHandler,
+  applyConfigMutations,
+  shouldCopyBundledHooks,
+  copyBundledHooksArtifact,
+};

--- a/get-shit-done/bin/lib/runtime-install-policy.cjs
+++ b/get-shit-done/bin/lib/runtime-install-policy.cjs
@@ -1,0 +1,176 @@
+'use strict';
+
+/**
+ * Runtime Install Policy Module
+ *
+ * Owns pure runtime install plan projection. Installers execute these plans;
+ * they do not re-own runtime registry facts, target directory policy, skills
+ * layout, capabilities, or config mutation intent selection.
+ */
+
+const os = require('os');
+const path = require('path');
+
+const cyan = '\x1b[36m';
+const yellow = '\x1b[33m';
+const dim = '\x1b[2m';
+const reset = '\x1b[0m';
+
+function expandTilde(p, homeDir = os.homedir()) {
+  if (!p) return p;
+  if (p === '~') return homeDir;
+  if (p.startsWith('~/')) return path.join(homeDir, p.slice(1));
+  return p;
+}
+
+const _policyCandidates = [
+  path.resolve(__dirname, '..', 'shared', 'runtime-install-policy.json'),
+  path.resolve(__dirname, '..', '..', '..', 'sdk', 'shared', 'runtime-install-policy.json'),
+  process.env.GSD_RUNTIME_INSTALL_POLICY ? path.resolve(process.env.GSD_RUNTIME_INSTALL_POLICY) : null,
+].filter(Boolean);
+
+let runtimeInstallPolicyData = null;
+let _policyLastErr = null;
+for (const _p of _policyCandidates) {
+  try {
+    runtimeInstallPolicyData = require(_p);
+    break;
+  } catch (e) {
+    const isMissingCandidate =
+      (e && e.code === 'MODULE_NOT_FOUND' && String(e.message || '').includes(_p)) ||
+      (e && e.code === 'ENOENT');
+    if (!isMissingCandidate) throw e;
+    _policyLastErr = e;
+  }
+}
+if (!runtimeInstallPolicyData) {
+  throw new Error(
+    `runtime-install-policy.json not found. Tried:\n${_policyCandidates.map((p) => `  ${p}`).join('\n')}\nLast error: ${_policyLastErr?.message}`
+  );
+}
+
+const RUNTIME_REGISTRY = Object.freeze(runtimeInstallPolicyData.runtimes);
+const ALL_RUNTIMES_OPTION = runtimeInstallPolicyData.allRuntimesOption || '16';
+
+const runtimeMap = Object.freeze(Object.fromEntries(
+  Object.entries(RUNTIME_REGISTRY).map(([runtime, entry]) => [entry.option, runtime])
+));
+
+const allRuntimes = Object.freeze(Object.entries(RUNTIME_REGISTRY)
+  .sort((a, b) => Number(a[1].option) - Number(b[1].option))
+  .map(([runtime]) => runtime));
+
+function getRuntimePolicy(runtime) {
+  return RUNTIME_REGISTRY[runtime] || RUNTIME_REGISTRY.claude;
+}
+
+function getDirName(runtime) {
+  return getRuntimePolicy(runtime).localDir;
+}
+
+function getConfigDirFromHome(runtime, isGlobal) {
+  const policy = getRuntimePolicy(runtime);
+  if (!isGlobal) return `'${policy.localDir}'`;
+  return policy.configDirFromHomeGlobal.join(', ');
+}
+
+function getGlobalDir(runtime, explicitDir = null, opts = {}) {
+  const policy = getRuntimePolicy(runtime);
+  const env = opts.env || process.env;
+  const homeDir = opts.homeDir || os.homedir();
+  if (explicitDir) return expandTilde(explicitDir, homeDir);
+  if (policy.global.env && env[policy.global.env]) return expandTilde(env[policy.global.env], homeDir);
+  if (policy.global.fileEnv && env[policy.global.fileEnv]) return path.dirname(expandTilde(env[policy.global.fileEnv], homeDir));
+  if (policy.global.xdgName && env.XDG_CONFIG_HOME) return path.join(expandTilde(env.XDG_CONFIG_HOME, homeDir), policy.global.xdgName);
+  return path.join(homeDir, ...policy.global.fallback);
+}
+
+function buildRuntimePromptText() {
+  const lines = allRuntimes.map((runtime) => {
+    const policy = getRuntimePolicy(runtime);
+    const option = String(policy.option).padEnd(2, ' ');
+    const label = policy.label.padEnd(runtime === 'hermes' ? 12 : 11, ' ');
+    return `  ${cyan}${option.trim()}${reset}) ${label} ${dim}(${policy.promptPath})${reset}`;
+  });
+
+  return `  ${yellow}Which runtime(s) would you like to install for?${reset}\n\n${lines.join('\n')}\n  ${cyan}${ALL_RUNTIMES_OPTION}${reset}) All\n\n  ${dim}Select multiple: 1,2,6 or 1 2 6${reset}\n`;
+}
+
+function parseRuntimeInput(answer) {
+  const input = (answer == null ? '' : String(answer)).trim() || '1';
+  const choices = input.split(/[\s,]+/).filter(Boolean);
+  if (choices.includes(ALL_RUNTIMES_OPTION)) return allRuntimes.slice();
+  const selected = [];
+  for (const choice of choices) {
+    const runtime = runtimeMap[choice];
+    if (runtime && !selected.includes(runtime)) selected.push(runtime);
+  }
+  return selected.length > 0 ? selected : ['claude'];
+}
+
+function createRuntimeInstallPlan(options = {}) {
+  const runtime = options.runtime || 'claude';
+  const policy = getRuntimePolicy(runtime);
+  const scope = options.scope || (options.isGlobal ? 'global' : 'local');
+  const cwd = options.cwd || process.cwd();
+  const targetDir = scope === 'global'
+    ? getGlobalDir(runtime, options.explicitConfigDir || null, options)
+    : policy.localTarget === 'project-root'
+      ? cwd
+      : path.join(cwd, policy.localDir);
+  const skillsBase = policy.skillsLayout === 'none'
+    ? null
+    : policy.skillsLayout === 'hermes-nested'
+      ? path.join(targetDir, 'skills', 'gsd')
+      : path.join(targetDir, 'skills');
+
+  const directories = [
+    targetDir,
+    path.join(targetDir, 'get-shit-done'),
+    policy.capabilities.agents ? path.join(targetDir, 'agents') : null,
+    skillsBase,
+    policy.capabilities.hooks ? path.join(targetDir, 'hooks') : null,
+  ].filter(Boolean);
+
+  const artifacts = [
+    { kind: 'engine', target: path.join(targetDir, 'get-shit-done') },
+    policy.capabilities.agents ? { kind: 'agents', target: path.join(targetDir, 'agents') } : null,
+    skillsBase ? { kind: 'skills', target: skillsBase, layout: policy.skillsLayout, installMode: options.installMode || 'full' } : null,
+    policy.capabilities.hooks ? { kind: 'hooks', target: path.join(targetDir, 'hooks') } : null,
+    policy.capabilities.rulesFile ? { kind: 'rules-file', target: path.join(targetDir, '.clinerules') } : null,
+  ].filter(Boolean);
+
+  return {
+    runtime,
+    label: policy.label,
+    scope,
+    targetDir,
+    localDir: policy.localDir,
+    locationLabel: scope === 'global'
+      ? targetDir.replace(options.homeDir || os.homedir(), '~')
+      : targetDir.replace(cwd, '.'),
+    firstRunCommand: policy.firstRunCommand,
+    skillsLayout: policy.skillsLayout,
+    skillsBase,
+    capabilities: { ...policy.capabilities },
+    directories,
+    artifacts,
+    configMutations: policy.configMutations.map((mutation) => ({ ...mutation })),
+    warnings: [],
+  };
+}
+
+module.exports = {
+  RUNTIME_REGISTRY,
+  runtimeMap,
+  allRuntimes,
+  ALL_RUNTIMES_OPTION,
+  getRuntimePolicy,
+  getDirName,
+  getConfigDirFromHome,
+  getGlobalDir,
+  buildRuntimePromptText,
+  parseRuntimeInput,
+  createRuntimeInstallPlan,
+  expandTilde,
+};

--- a/scripts/base64-scan.sh
+++ b/scripts/base64-scan.sh
@@ -146,26 +146,25 @@ collect_files() {
 extract_and_check_blobs() {
   local file="$1"
   local found=0
-  local line_num=0
 
-  while IFS= read -r line; do
-    line_num=$((line_num + 1))
+  # Extract base64-like blobs once per file. Calling grep for every source line
+  # makes large generated installer files slow enough to hit the CI timeout.
+  local candidates
+  candidates=$(grep -nEo '[A-Za-z0-9+/]{'"$MIN_BLOB_LENGTH"',}={0,3}' "$file" 2>/dev/null || true)
 
-    # Skip data URIs — legitimate base64 usage
-    if is_data_uri "$line"; then
-      continue
-    fi
+  if [[ -z "$candidates" ]]; then
+    return 0
+  fi
 
-    # Extract base64-like blobs (alphanumeric + / + = padding, >= MIN_BLOB_LENGTH)
-    local blobs
-    blobs=$(echo "$line" | grep -oE '[A-Za-z0-9+/]{'"$MIN_BLOB_LENGTH"',}={0,3}' 2>/dev/null || true)
+  while IFS=: read -r line_num blob; do
+      [[ -z "$line_num" || -z "$blob" ]] && continue
 
-    if [[ -z "$blobs" ]]; then
-      continue
-    fi
-
-    while IFS= read -r blob; do
-      [[ -z "$blob" ]] && continue
+      # Skip data URIs — legitimate base64 usage
+      local line
+      line=$(sed -n "${line_num}p" "$file")
+      if is_data_uri "$line"; then
+        continue
+      fi
 
       # Check ignorelist
       if [[ ${#IGNORED_PATTERNS[@]} -gt 0 ]] && is_ignored "$blob"; then
@@ -189,7 +188,7 @@ extract_and_check_blobs() {
 
       # Count printable ASCII characters
       local printable_count
-      printable_count=$(echo -n "$decoded" | tr -cd '[:print:]' | wc -c | tr -d ' ')
+      printable_count=$(echo -n "$decoded" | LC_ALL=C tr -cd '[:print:]' | wc -c | tr -d ' ')
       # Skip if less than 70% printable (likely binary data, not obfuscated text)
       if [[ $((printable_count * 100 / total_chars)) -lt 70 ]]; then
         continue
@@ -209,8 +208,7 @@ extract_and_check_blobs() {
           break
         fi
       done
-    done <<< "$blobs"
-  done < "$file"
+  done <<< "$candidates"
 
   return $found
 }

--- a/sdk/shared/runtime-install-policy.json
+++ b/sdk/shared/runtime-install-policy.json
@@ -1,0 +1,189 @@
+{
+  "allRuntimesOption": "16",
+  "runtimes": {
+    "claude": {
+      "option": "1",
+      "label": "Claude Code",
+      "promptPath": "~/.claude",
+      "localDir": ".claude",
+      "global": { "env": "CLAUDE_CONFIG_DIR", "fallback": [".claude"] },
+      "configDirFromHomeGlobal": ["'.claude'"],
+      "skillsLayout": "flat",
+      "firstRunCommand": "/gsd-new-project",
+      "capabilities": { "agents": true, "skills": true, "settingsJson": true, "hooks": true, "toml": false, "rulesFile": false, "statusline": true, "updateBanner": true },
+      "configMutations": [{ "target": "settings.json", "adapter": "settings-json", "operation": "ensure-managed-hooks" }]
+    },
+    "antigravity": {
+      "option": "2",
+      "label": "Antigravity",
+      "promptPath": "~/.gemini/antigravity",
+      "localDir": ".agent",
+      "global": { "env": "ANTIGRAVITY_CONFIG_DIR", "fallback": [".gemini", "antigravity"] },
+      "configDirFromHomeGlobal": ["'.gemini'", "'antigravity'"],
+      "skillsLayout": "flat",
+      "firstRunCommand": "/gsd-new-project",
+      "capabilities": { "agents": true, "skills": true, "settingsJson": true, "hooks": true, "toml": false, "rulesFile": false, "statusline": true, "updateBanner": true },
+      "configMutations": [{ "target": "settings.json", "adapter": "settings-json", "operation": "ensure-managed-hooks" }]
+    },
+    "augment": {
+      "option": "3",
+      "label": "Augment",
+      "promptPath": "~/.augment",
+      "localDir": ".augment",
+      "global": { "env": "AUGMENT_CONFIG_DIR", "fallback": [".augment"] },
+      "configDirFromHomeGlobal": ["'.augment'"],
+      "skillsLayout": "flat",
+      "firstRunCommand": "/gsd-new-project",
+      "capabilities": { "agents": true, "skills": true, "settingsJson": true, "hooks": true, "toml": false, "rulesFile": false, "statusline": true, "updateBanner": true },
+      "configMutations": [{ "target": "settings.json", "adapter": "settings-json", "operation": "ensure-managed-hooks" }]
+    },
+    "cline": {
+      "option": "4",
+      "label": "Cline",
+      "promptPath": ".clinerules",
+      "localDir": ".cline",
+      "localTarget": "project-root",
+      "global": { "env": "CLINE_CONFIG_DIR", "fallback": [".cline"] },
+      "configDirFromHomeGlobal": ["'.cline'"],
+      "skillsLayout": "none",
+      "firstRunCommand": "/gsd-new-project",
+      "capabilities": { "agents": true, "skills": false, "settingsJson": false, "hooks": false, "toml": false, "rulesFile": true, "statusline": false, "updateBanner": false },
+      "configMutations": [{ "target": ".clinerules", "adapter": "cline-rules", "operation": "ensure-runtime-rules" }]
+    },
+    "codebuddy": {
+      "option": "5",
+      "label": "CodeBuddy",
+      "promptPath": "~/.codebuddy",
+      "localDir": ".codebuddy",
+      "global": { "env": "CODEBUDDY_CONFIG_DIR", "fallback": [".codebuddy"] },
+      "configDirFromHomeGlobal": ["'.codebuddy'"],
+      "skillsLayout": "flat",
+      "firstRunCommand": "/gsd-new-project",
+      "capabilities": { "agents": true, "skills": true, "settingsJson": true, "hooks": true, "toml": false, "rulesFile": false, "statusline": true, "updateBanner": true },
+      "configMutations": [{ "target": "settings.json", "adapter": "settings-json", "operation": "ensure-managed-hooks" }]
+    },
+    "codex": {
+      "option": "6",
+      "label": "Codex",
+      "promptPath": "~/.codex",
+      "localDir": ".codex",
+      "global": { "env": "CODEX_HOME", "fallback": [".codex"] },
+      "configDirFromHomeGlobal": ["'.codex'"],
+      "skillsLayout": "flat",
+      "firstRunCommand": "$gsd-new-project",
+      "capabilities": { "agents": true, "skills": true, "settingsJson": false, "hooks": true, "toml": true, "rulesFile": false, "statusline": false, "updateBanner": false },
+      "configMutations": [
+        { "target": "config.toml", "adapter": "codex-toml", "operation": "ensure-agent-profiles" },
+        { "target": "config.toml", "adapter": "codex-toml", "operation": "ensure-managed-hook-block" }
+      ]
+    },
+    "copilot": {
+      "option": "7",
+      "label": "Copilot",
+      "promptPath": "~/.copilot",
+      "localDir": ".github",
+      "global": { "env": "COPILOT_CONFIG_DIR", "fallback": [".copilot"] },
+      "configDirFromHomeGlobal": ["'.copilot'"],
+      "skillsLayout": "flat",
+      "firstRunCommand": "/gsd-new-project",
+      "capabilities": { "agents": true, "skills": true, "settingsJson": false, "hooks": true, "toml": false, "rulesFile": false, "statusline": false, "updateBanner": false },
+      "configMutations": [{ "target": "copilot-instructions.md", "adapter": "copilot-instructions", "operation": "ensure-managed-instructions" }]
+    },
+    "cursor": {
+      "option": "8",
+      "label": "Cursor",
+      "promptPath": "~/.cursor",
+      "localDir": ".cursor",
+      "global": { "env": "CURSOR_CONFIG_DIR", "fallback": [".cursor"] },
+      "configDirFromHomeGlobal": ["'.cursor'"],
+      "skillsLayout": "flat",
+      "firstRunCommand": "gsd-new-project (mention the skill name)",
+      "capabilities": { "agents": true, "skills": true, "settingsJson": true, "hooks": true, "toml": false, "rulesFile": false, "statusline": true, "updateBanner": true },
+      "configMutations": [{ "target": "settings.json", "adapter": "settings-json", "operation": "ensure-managed-hooks" }]
+    },
+    "gemini": {
+      "option": "9",
+      "label": "Gemini",
+      "promptPath": "~/.gemini",
+      "localDir": ".gemini",
+      "global": { "env": "GEMINI_CONFIG_DIR", "fallback": [".gemini"] },
+      "configDirFromHomeGlobal": ["'.gemini'"],
+      "skillsLayout": "flat",
+      "firstRunCommand": "/gsd-new-project",
+      "capabilities": { "agents": true, "skills": true, "settingsJson": true, "hooks": true, "toml": false, "rulesFile": false, "statusline": true, "updateBanner": true },
+      "configMutations": [{ "target": "settings.json", "adapter": "settings-json", "operation": "ensure-managed-hooks" }]
+    },
+    "hermes": {
+      "option": "10",
+      "label": "Hermes Agent",
+      "promptPath": "~/.hermes",
+      "localDir": ".hermes",
+      "global": { "env": "HERMES_HOME", "fallback": [".hermes"] },
+      "configDirFromHomeGlobal": ["'.hermes'"],
+      "skillsLayout": "hermes-nested",
+      "firstRunCommand": "/gsd-new-project",
+      "capabilities": { "agents": true, "skills": true, "settingsJson": false, "hooks": false, "toml": false, "rulesFile": false, "statusline": false, "updateBanner": false },
+      "configMutations": []
+    },
+    "kilo": {
+      "option": "11",
+      "label": "Kilo",
+      "promptPath": "~/.config/kilo",
+      "localDir": ".kilo",
+      "global": { "env": "KILO_CONFIG_DIR", "fileEnv": "KILO_CONFIG", "xdgName": "kilo", "fallback": [".config", "kilo"] },
+      "configDirFromHomeGlobal": ["'.config'", "'kilo'"],
+      "skillsLayout": "flat",
+      "firstRunCommand": "/gsd-new-project",
+      "capabilities": { "agents": true, "skills": true, "settingsJson": false, "hooks": true, "toml": false, "rulesFile": false, "statusline": false, "updateBanner": false, "jsonConfig": true },
+      "configMutations": [{ "target": "kilo.json", "adapter": "kilo-json", "operation": "ensure-permissions" }]
+    },
+    "opencode": {
+      "option": "12",
+      "label": "OpenCode",
+      "promptPath": "~/.config/opencode",
+      "localDir": ".opencode",
+      "global": { "env": "OPENCODE_CONFIG_DIR", "fileEnv": "OPENCODE_CONFIG", "xdgName": "opencode", "fallback": [".config", "opencode"] },
+      "configDirFromHomeGlobal": ["'.config'", "'opencode'"],
+      "skillsLayout": "flat",
+      "firstRunCommand": "/gsd-new-project",
+      "capabilities": { "agents": true, "skills": true, "settingsJson": false, "hooks": true, "toml": false, "rulesFile": false, "statusline": false, "updateBanner": false, "jsonConfig": true },
+      "configMutations": [{ "target": "opencode.json", "adapter": "opencode-json", "operation": "ensure-permissions" }]
+    },
+    "qwen": {
+      "option": "13",
+      "label": "Qwen Code",
+      "promptPath": "~/.qwen",
+      "localDir": ".qwen",
+      "global": { "env": "QWEN_CONFIG_DIR", "fallback": [".qwen"] },
+      "configDirFromHomeGlobal": ["'.qwen'"],
+      "skillsLayout": "flat",
+      "firstRunCommand": "/gsd-new-project",
+      "capabilities": { "agents": true, "skills": true, "settingsJson": true, "hooks": true, "toml": false, "rulesFile": false, "statusline": true, "updateBanner": true },
+      "configMutations": [{ "target": "settings.json", "adapter": "settings-json", "operation": "ensure-managed-hooks" }]
+    },
+    "trae": {
+      "option": "14",
+      "label": "Trae",
+      "promptPath": "~/.trae",
+      "localDir": ".trae",
+      "global": { "env": "TRAE_CONFIG_DIR", "fallback": [".trae"] },
+      "configDirFromHomeGlobal": ["'.trae'"],
+      "skillsLayout": "flat",
+      "firstRunCommand": "/gsd-new-project",
+      "capabilities": { "agents": true, "skills": true, "settingsJson": false, "hooks": false, "toml": false, "rulesFile": false, "statusline": false, "updateBanner": false },
+      "configMutations": []
+    },
+    "windsurf": {
+      "option": "15",
+      "label": "Windsurf",
+      "promptPath": "~/.codeium/windsurf",
+      "localDir": ".windsurf",
+      "global": { "env": "WINDSURF_CONFIG_DIR", "fallback": [".codeium", "windsurf"] },
+      "configDirFromHomeGlobal": ["'.windsurf'"],
+      "skillsLayout": "flat",
+      "firstRunCommand": "/gsd-new-project",
+      "capabilities": { "agents": true, "skills": true, "settingsJson": false, "hooks": false, "toml": false, "rulesFile": false, "statusline": false, "updateBanner": false },
+      "configMutations": []
+    }
+  }
+}

--- a/sdk/src/query/helpers.test.ts
+++ b/sdk/src/query/helpers.test.ts
@@ -4,6 +4,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtemp, rm, writeFile, mkdir } from 'node:fs/promises';
+import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { GSDError } from '../errors.js';
@@ -31,6 +32,15 @@ import {
   type Runtime,
 } from './helpers.js';
 import { homedir } from 'node:os';
+
+const RUNTIME_INSTALL_POLICY = JSON.parse(
+  readFileSync(new URL('../../shared/runtime-install-policy.json', import.meta.url), 'utf-8')
+) as {
+  runtimes: Record<string, {
+    global: { fallback: string[] };
+    skillsLayout: 'flat' | 'hermes-nested' | 'none';
+  }>;
+};
 
 // ─── escapeRegex ────────────────────────────────────────────────────────────
 
@@ -336,11 +346,21 @@ describe('getRuntimeConfigDir', () => {
     hermes: join(homedir(), '.hermes'),
   };
 
+  it('supported SDK runtimes match the shared runtime install policy', () => {
+    expect([...SUPPORTED_RUNTIMES].sort()).toEqual(Object.keys(RUNTIME_INSTALL_POLICY.runtimes).sort());
+  });
+
   for (const runtime of SUPPORTED_RUNTIMES) {
     it(`resolves default path for ${runtime}`, () => {
       expect(getRuntimeConfigDir(runtime)).toBe(defaults[runtime]);
     });
   }
+
+  it('runtime defaults match shared runtime install policy fallbacks', () => {
+    for (const runtime of SUPPORTED_RUNTIMES) {
+      expect(getRuntimeConfigDir(runtime)).toBe(join(homedir(), ...RUNTIME_INSTALL_POLICY.runtimes[runtime].global.fallback));
+    }
+  });
 
   const envOverrides: Array<[Runtime, string, string]> = [
     ['claude', 'CLAUDE_CONFIG_DIR', '/x/claude'],
@@ -470,6 +490,13 @@ describe('runtime-global skills directory helpers', () => {
     expect(resolveGlobalSkillsBase('codex')).toBe(join('/codex', 'skills'));
     expect(resolveGlobalSkillDir('codex', 'demo')).toBe(join('/codex', 'skills', 'demo'));
     expect(resolveGlobalSkillMarkdownPath('codex', 'demo')).toBe(join('/codex', 'skills', 'demo', 'SKILL.md'));
+  });
+
+  it('uses shared runtime policy for special skills layouts', () => {
+    process.env.HERMES_HOME = '/hermes';
+    expect(RUNTIME_INSTALL_POLICY.runtimes.hermes.skillsLayout).toBe('hermes-nested');
+    expect(resolveGlobalSkillsBase('hermes')).toBe(join('/hermes', 'skills', 'gsd'));
+    expect(resolveGlobalSkillDir('hermes', 'demo')).toBe(join('/hermes', 'skills', 'gsd', 'demo'));
   });
 
   it('returns null for cline and renders unsupported display path', () => {

--- a/sdk/src/query/helpers.ts
+++ b/sdk/src/query/helpers.ts
@@ -30,8 +30,34 @@ import { relPlanningPath, validateWorkstreamName } from '../workstream-utils.js'
 
 // ─── Runtime-aware agents directory resolution ─────────────────────────────
 
+interface RuntimeInstallPolicy {
+  localDir: string;
+  global: {
+    env?: string;
+    fileEnv?: string;
+    xdgName?: string;
+    fallback: string[];
+  };
+  skillsLayout: 'flat' | 'hermes-nested' | 'none';
+}
+
+interface RuntimeInstallPolicyCatalog {
+  runtimes: Record<string, RuntimeInstallPolicy>;
+}
+
+const RUNTIME_INSTALL_POLICY_PATH = new URL('../../shared/runtime-install-policy.json', import.meta.url);
+const RUNTIME_INSTALL_POLICY: RuntimeInstallPolicyCatalog = JSON.parse(
+  readFileSync(RUNTIME_INSTALL_POLICY_PATH, 'utf-8')
+);
+
 function expandTilde(p: string): string {
   return p.startsWith('~/') || p === '~' ? join(homedir(), p.slice(1)) : p;
+}
+
+function getRuntimeInstallPolicy(runtime: Runtime): RuntimeInstallPolicy {
+  const policy = RUNTIME_INSTALL_POLICY.runtimes[runtime];
+  if (!policy) throw new Error(`Unknown runtime: ${String(runtime)}`);
+  return policy;
 }
 
 /**
@@ -39,48 +65,13 @@ function expandTilde(p: string): string {
  * `bin/install.js:getGlobalDir()`. Agents live at `<configDir>/agents`.
  */
 export function getRuntimeConfigDir(runtime: Runtime): string {
-  switch (runtime) {
-    case 'claude':
-      return process.env.CLAUDE_CONFIG_DIR
-        ? expandTilde(process.env.CLAUDE_CONFIG_DIR)
-        : join(homedir(), '.claude');
-    case 'opencode':
-      if (process.env.OPENCODE_CONFIG_DIR) return expandTilde(process.env.OPENCODE_CONFIG_DIR);
-      if (process.env.OPENCODE_CONFIG) return dirname(expandTilde(process.env.OPENCODE_CONFIG));
-      if (process.env.XDG_CONFIG_HOME) return join(expandTilde(process.env.XDG_CONFIG_HOME), 'opencode');
-      return join(homedir(), '.config', 'opencode');
-    case 'kilo':
-      if (process.env.KILO_CONFIG_DIR) return expandTilde(process.env.KILO_CONFIG_DIR);
-      if (process.env.KILO_CONFIG) return dirname(expandTilde(process.env.KILO_CONFIG));
-      if (process.env.XDG_CONFIG_HOME) return join(expandTilde(process.env.XDG_CONFIG_HOME), 'kilo');
-      return join(homedir(), '.config', 'kilo');
-    case 'gemini':
-      return process.env.GEMINI_CONFIG_DIR ? expandTilde(process.env.GEMINI_CONFIG_DIR) : join(homedir(), '.gemini');
-    case 'codex':
-      return process.env.CODEX_HOME ? expandTilde(process.env.CODEX_HOME) : join(homedir(), '.codex');
-    case 'copilot':
-      return process.env.COPILOT_CONFIG_DIR ? expandTilde(process.env.COPILOT_CONFIG_DIR) : join(homedir(), '.copilot');
-    case 'antigravity':
-      return process.env.ANTIGRAVITY_CONFIG_DIR ? expandTilde(process.env.ANTIGRAVITY_CONFIG_DIR) : join(homedir(), '.gemini', 'antigravity');
-    case 'cursor':
-      return process.env.CURSOR_CONFIG_DIR ? expandTilde(process.env.CURSOR_CONFIG_DIR) : join(homedir(), '.cursor');
-    case 'windsurf':
-      return process.env.WINDSURF_CONFIG_DIR ? expandTilde(process.env.WINDSURF_CONFIG_DIR) : join(homedir(), '.codeium', 'windsurf');
-    case 'augment':
-      return process.env.AUGMENT_CONFIG_DIR ? expandTilde(process.env.AUGMENT_CONFIG_DIR) : join(homedir(), '.augment');
-    case 'trae':
-      return process.env.TRAE_CONFIG_DIR ? expandTilde(process.env.TRAE_CONFIG_DIR) : join(homedir(), '.trae');
-    case 'qwen':
-      return process.env.QWEN_CONFIG_DIR ? expandTilde(process.env.QWEN_CONFIG_DIR) : join(homedir(), '.qwen');
-    case 'codebuddy':
-      return process.env.CODEBUDDY_CONFIG_DIR ? expandTilde(process.env.CODEBUDDY_CONFIG_DIR) : join(homedir(), '.codebuddy');
-    case 'cline':
-      return process.env.CLINE_CONFIG_DIR ? expandTilde(process.env.CLINE_CONFIG_DIR) : join(homedir(), '.cline');
-    case 'hermes':
-      return process.env.HERMES_HOME ? expandTilde(process.env.HERMES_HOME) : join(homedir(), '.hermes');
-    default:
-      throw new Error(`Unknown runtime: ${String(runtime)}`);
-  }
+  const policy = getRuntimeInstallPolicy(runtime);
+  const envValue = policy.global.env ? process.env[policy.global.env] : undefined;
+  if (envValue) return expandTilde(envValue);
+  const fileEnvValue = policy.global.fileEnv ? process.env[policy.global.fileEnv] : undefined;
+  if (fileEnvValue) return dirname(expandTilde(fileEnvValue));
+  if (policy.global.xdgName && process.env.XDG_CONFIG_HOME) return join(expandTilde(process.env.XDG_CONFIG_HOME), policy.global.xdgName);
+  return join(homedir(), ...policy.global.fallback);
 }
 
 /**
@@ -126,8 +117,11 @@ export function resolveAgentsDir(runtime: Runtime = 'claude'): string {
  * `cline` is rules-based and has no global skills directory.
  */
 export function resolveGlobalSkillsBase(runtime: Runtime): string | null {
-  if (runtime === 'cline') return null;
-  return join(getRuntimeConfigDir(runtime), 'skills');
+  const policy = getRuntimeInstallPolicy(runtime);
+  if (policy.skillsLayout === 'none') return null;
+  const configDir = getRuntimeConfigDir(runtime);
+  if (policy.skillsLayout === 'hermes-nested') return join(configDir, 'skills', 'gsd');
+  return join(configDir, 'skills');
 }
 
 /**

--- a/sdk/src/query/roadmap-update-plan-progress.test.ts
+++ b/sdk/src/query/roadmap-update-plan-progress.test.ts
@@ -71,6 +71,47 @@ async function setupProject(opts: {
 // ─── planCountPattern regression: **Plans:** on its own line ─────────────
 
 describe('roadmapUpdatePlanProgress', () => {
+  it('updates unpadded ROADMAP phase entries when called with a padded phase argument', async () => {
+    const { roadmapUpdatePlanProgress } = await import('./roadmap-update-plan-progress.js');
+
+    const roadmap = [
+      '# Roadmap',
+      '',
+      '## Current Milestone: v3.0',
+      '',
+      '- [ ] **Phase 3: build** - build it',
+      '',
+      '### Phase 3: build',
+      '',
+      '**Goal:** Build it',
+      '**Plans:** 0 plans',
+      '- [ ] 03-01-PLAN.md',
+      '',
+      '## Progress',
+      '',
+      '| Phase | Plans Complete | Status | Completed |',
+      '|-------|----------------|--------|-----------|',
+      '| 3. build | 0/1 | Planned |  |',
+      '',
+    ].join('\n');
+
+    const { roadmapPath } = await setupProject({
+      roadmap,
+      phaseDir: '03-build',
+      plans: ['03-01-PLAN.md'],
+      summaries: ['03-01-SUMMARY.md'],
+    });
+
+    await roadmapUpdatePlanProgress(['03'], tmpDir, undefined);
+
+    const updated = await readFile(roadmapPath, 'utf-8');
+
+    expect(updated).toMatch(/- \[x\] \*\*Phase 3: build\*\* - build it \(completed \d{4}-\d{2}-\d{2}\)/);
+    expect(updated).toContain('**Plans:** 1/1 plans complete');
+    expect(updated).toMatch(/\| 3\. build \| 1\/1 \| Complete\s+\| \d{4}-\d{2}-\d{2} \|/);
+    expect(updated).toContain('- [x] 03-01-PLAN.md');
+  });
+
   it('does not overwrite plan bullet list when **Plans:** is on its own line (regression #2728 propagation)', async () => {
     const { roadmapUpdatePlanProgress } = await import('./roadmap-update-plan-progress.js');
 

--- a/sdk/src/query/roadmap-update-plan-progress.ts
+++ b/sdk/src/query/roadmap-update-plan-progress.ts
@@ -14,6 +14,17 @@ import { escapeRegex, planningPaths } from './helpers.js';
 import { GSDError, ErrorClassification } from '../errors.js';
 import type { QueryHandler } from './utils.js';
 
+function phaseMarkdownRegexSource(phaseNum: string): string {
+  const stripped = String(phaseNum).replace(/^[A-Z]{1,6}-(?=\d)/i, '');
+  const match = stripped.match(/^0*(\d+)([A-Z])?((?:\.\d+)*)$/i);
+  if (!match) return escapeRegex(phaseNum);
+
+  const integer = match[1]!.replace(/^0+/, '') || '0';
+  const letter = match[2] ? escapeRegex(match[2]) : '';
+  const decimal = match[3] ? escapeRegex(match[3]) : '';
+  return `0*${escapeRegex(integer)}${letter}${decimal}`;
+}
+
 export const roadmapUpdatePlanProgress: QueryHandler = async (args, projectDir, workstream) => {
   // Support --phase <N> flag form in addition to positional (fixes #2796).
   // execute-phase.md:228 passes --phase so positional-only parsing silently
@@ -78,10 +89,10 @@ export const roadmapUpdatePlanProgress: QueryHandler = async (args, projectDir, 
   }
 
   await readModifyWriteRoadmapMd(projectDir, (roadmapContent) => {
-    const phaseEscaped = escapeRegex(phaseNum);
+    const phasePattern = phaseMarkdownRegexSource(phaseNum);
 
     const tableRowPattern = new RegExp(
-      `^(\\|\\s*${phaseEscaped}\\.?\\s[^|]*(?:\\|[^\\n]*))$`,
+      `^(\\|\\s*${phasePattern}\\.?\\s[^|]*(?:\\|[^\\n]*))$`,
       'im',
     );
     const dateField = isComplete ? ` ${today} ` : '  ';
@@ -100,7 +111,7 @@ export const roadmapUpdatePlanProgress: QueryHandler = async (args, projectDir, 
     });
 
     const planCountPattern = new RegExp(
-      `(#{2,4}\\s*Phase\\s+${phaseEscaped}(?:(?!\\n#{2,4})[\\s\\S])*?\\*\\*Plans:\\*\\*[ \\t]*)[^\\n]+`,
+      `(#{2,4}\\s*Phase\\s+${phasePattern}(?=[:\\s])(?:(?!\\n#{2,4})[\\s\\S])*?\\*\\*Plans:\\*\\*[ \\t]*)[^\\n]+`,
       'i',
     );
     const planCountText = isComplete
@@ -110,7 +121,7 @@ export const roadmapUpdatePlanProgress: QueryHandler = async (args, projectDir, 
 
     if (isComplete) {
       const checkboxPattern = new RegExp(
-        `(-\\s*\\[)[ ](\\]\\s*.*Phase\\s+${phaseEscaped}[:\\s][^\\n]*)`,
+        `(-\\s*\\[)[ ](\\]\\s*.*Phase\\s+${phasePattern}[:\\s][^\\n]*)`,
         'i',
       );
       roadmapContent = replaceInCurrentMilestone(

--- a/tests/bug-1834-sh-hooks-installed.test.cjs
+++ b/tests/bug-1834-sh-hooks-installed.test.cjs
@@ -1,3 +1,8 @@
+// allow-test-rule: structural-regression-guard
+// This test includes a source-level guard for the executor hook copy helper so
+// future refactors cannot accidentally drop .sh handling while E2E install
+// coverage still happens to pass through stale built artifacts.
+
 /**
  * Regression tests for bug #1834
  *
@@ -24,6 +29,7 @@ const os = require('os');
 const { execFileSync } = require('child_process');
 
 const INSTALL_SCRIPT = path.join(__dirname, '..', 'bin', 'install.js');
+const INSTALL_EXECUTOR_SCRIPT = path.join(__dirname, '..', 'get-shit-done', 'bin', 'lib', 'runtime-install-executor.cjs');
 const BUILD_SCRIPT = path.join(__dirname, '..', 'scripts', 'build-hooks.js');
 const isWindows = process.platform === 'win32';
 
@@ -139,36 +145,34 @@ describe('#1834: installer deploys .sh hooks alongside .js hooks', () => {
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// 2. Source-level correctness: install.js copies non-.js files
+// 2. Source-level correctness: runtime install executor copies non-.js files
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe('#1834: install.js source handles .sh files in the hook copy loop', () => {
+describe('#1834: runtime install executor source handles .sh files in the hook copy loop', () => {
   let src;
 
   before(() => {
-    src = fs.readFileSync(INSTALL_SCRIPT, 'utf-8');
+    src = fs.readFileSync(INSTALL_EXECUTOR_SCRIPT, 'utf-8');
   });
 
-  test('hook copy loop has an else branch for non-.js files', () => {
-    // The loop must handle files that are not .js — specifically .sh hooks.
+  test('hook copy helper has a branch for .sh files', () => {
+    // The helper must handle files that are not .js — specifically .sh hooks.
     // The v1.32.0 bug was that only the if(entry.endsWith('.js')) branch
     // existed; non-.js files (i.e. .sh hooks) were silently skipped.
     //
-    // Find the hook copy loop by anchoring on its unique context: the
-    // configDirReplacement variable is declared only once in install.js,
-    // right before the entry.endsWith('.js') branch.
-    const anchorPhrase = 'configDirReplacement';
+    // Find the hook copy helper by anchoring on its unique function name.
+    const anchorPhrase = 'copyRuntimeHookFile';
     const anchorIdx = src.indexOf(anchorPhrase);
-    assert.ok(anchorIdx !== -1, 'hook copy loop anchor (configDirReplacement) not found in install.js');
-    // Extract a window large enough to contain the if/else block (≈1500 chars)
-    const region = src.slice(anchorIdx, anchorIdx + 1500);
+    assert.ok(anchorIdx !== -1, 'hook copy helper anchor (copyRuntimeHookFile) not found in runtime install executor');
+    // Extract a window large enough to contain the JS and shell branches.
+    const region = src.slice(anchorIdx, anchorIdx + 2000);
     assert.ok(
       region.includes("entry.endsWith('.js')"),
-      "install.js hook copy loop must check entry.endsWith('.js')"
+      "runtime install executor hook copy helper must check entry.endsWith('.js')"
     );
     assert.ok(
-      region.includes('} else {') || region.includes('else {'),
-      'hook copy loop must have an else branch to handle .sh and other non-.js files — ' +
+      region.includes("entry.endsWith('.sh')"),
+      'hook copy helper must have a .sh branch to handle shell files — ' +
       'without it, .sh hooks are silently skipped (root cause of #1834)'
     );
   });
@@ -178,7 +182,7 @@ describe('#1834: install.js source handles .sh files in the hook copy loop', () 
     // Without this, .sh hooks exist but are not executable.
     assert.ok(
       src.includes("entry.endsWith('.sh')"),
-      "install.js must check entry.endsWith('.sh') to apply chmod after copying"
+      "runtime install executor must check entry.endsWith('.sh') to apply chmod after copying"
     );
   });
 
@@ -187,7 +191,7 @@ describe('#1834: install.js source handles .sh files in the hook copy loop', () 
     for (const hook of SH_HOOKS) {
       assert.ok(
         src.includes(hook),
-        `install.js must reference '${hook}' in its post-copy verification`
+        `runtime install executor must reference '${hook}' in its post-copy verification`
       );
     }
   });

--- a/tests/bug-2136-sh-hook-version.test.cjs
+++ b/tests/bug-2136-sh-hook-version.test.cjs
@@ -24,14 +24,14 @@
  *
  * This fix requires THREE parts working in concert:
  *   1. Bash hooks ship with "# gsd-hook-version: {{GSD_VERSION}}"
- *   2. install.js substitutes {{GSD_VERSION}} in .sh files at install time
+ *   2. runtime install executor substitutes {{GSD_VERSION}} in .sh files at install time
  *   3. gsd-check-update.js regex matches both "//" and "#" comment styles
  *
  * Neither fix alone is sufficient:
- *   - Headers + regex fix only (no install.js fix): installed hooks contain
+ *   - Headers + regex fix only (no executor fix): installed hooks contain
  *     literal "{{GSD_VERSION}}" — the {{-guard silently skips them, making
  *     bash hook staleness permanently undetectable after future updates.
- *   - Headers + install.js fix only (no regex fix): installed hooks are
+ *   - Headers + executor fix only (no regex fix): installed hooks are
  *     stamped correctly but the detector still can't read bash "#" comments,
  *     so they still land in the "unknown / stale" branch on every session.
  */
@@ -52,6 +52,7 @@ const HOOKS_DIR = path.join(__dirname, '..', 'hooks');
 const CHECK_UPDATE_FILE = path.join(HOOKS_DIR, 'gsd-check-update.js');
 const WORKER_FILE = path.join(HOOKS_DIR, 'gsd-check-update-worker.js');
 const INSTALL_SCRIPT = path.join(__dirname, '..', 'bin', 'install.js');
+const INSTALL_EXECUTOR_SCRIPT = path.join(__dirname, '..', 'get-shit-done', 'bin', 'lib', 'runtime-install-executor.cjs');
 const BUILD_SCRIPT = path.join(__dirname, '..', 'scripts', 'build-hooks.js');
 
 const SH_HOOKS = [
@@ -199,31 +200,31 @@ describe('bug #2136 part 2: stale-hook detector handles bash comment syntax', ()
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Part 3a: install.js bundled path substitutes {{GSD_VERSION}} in .sh hooks
+// Part 3a: runtime install executor substitutes {{GSD_VERSION}} in .sh hooks
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe('bug #2136 part 3a: install.js bundled path substitutes {{GSD_VERSION}} in .sh hooks', () => {
+describe('bug #2136 part 3a: runtime install executor substitutes {{GSD_VERSION}} in .sh hooks', () => {
   let src;
 
   before(() => {
-    src = fs.readFileSync(INSTALL_SCRIPT, 'utf8');
+    src = fs.readFileSync(INSTALL_EXECUTOR_SCRIPT, 'utf8');
   });
 
   test('.sh branch in bundled hook copy loop reads file and substitutes GSD_VERSION', () => {
-    // Anchor on configDirReplacement — unique to the bundled-hooks path.
+    // Anchor on configDirReplacement — unique to the executor hook copy path.
     const anchorIdx = src.indexOf('configDirReplacement');
-    assert.ok(anchorIdx !== -1, 'bundled hook copy loop anchor (configDirReplacement) not found');
+    assert.ok(anchorIdx !== -1, 'executor hook copy loop anchor (configDirReplacement) not found');
 
     // Window large enough for the if/else block
     const region = src.slice(anchorIdx, anchorIdx + 2000);
 
     assert.ok(
       region.includes("entry.endsWith('.sh')"),
-      "bundled hook copy loop must check entry.endsWith('.sh')"
+      "executor hook copy loop must check entry.endsWith('.sh')"
     );
     assert.ok(
       region.includes('GSD_VERSION'),
-      'bundled .sh branch must reference GSD_VERSION substitution. Without this, ' +
+      'executor .sh branch must reference GSD_VERSION substitution. Without this, ' +
       'installed .sh hooks contain the literal "{{GSD_VERSION}}" placeholder and ' +
       'bash hook staleness becomes permanently undetectable after future updates'
     );
@@ -232,38 +233,38 @@ describe('bug #2136 part 3a: install.js bundled path substitutes {{GSD_VERSION}}
     const shBranchRegion = region.slice(shBranchIdx, shBranchIdx + 400);
     assert.ok(
       shBranchRegion.includes('readFileSync') || shBranchRegion.includes('writeFileSync'),
-      'bundled .sh branch must read the file (readFileSync) to perform substitution, ' +
+      'executor .sh branch must read the file (readFileSync) to perform substitution, ' +
       'not copyFileSync directly (which skips template expansion)'
     );
   });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Part 3b: install.js Codex path also substitutes {{GSD_VERSION}} in .sh hooks
+// Part 3b: install.js routes Codex hook copying through the executor path
 // ─────────────────────────────────────────────────────────────────────────────
 
-describe('bug #2136 part 3b: install.js Codex path substitutes {{GSD_VERSION}} in .sh hooks', () => {
-  let src;
+describe('bug #2136 part 3b: install.js Codex path routes through executor stamping', () => {
+  let installSrc;
+  let executorSrc;
 
   before(() => {
-    src = fs.readFileSync(INSTALL_SCRIPT, 'utf8');
+    installSrc = fs.readFileSync(INSTALL_SCRIPT, 'utf8');
+    executorSrc = fs.readFileSync(INSTALL_EXECUTOR_SCRIPT, 'utf8');
   });
 
-  test('.sh branch in Codex hook copy block substitutes GSD_VERSION', () => {
-    // Anchor on codexHooksSrc — unique to the Codex path.
-    const anchorIdx = src.indexOf('codexHooksSrc');
-    assert.ok(anchorIdx !== -1, 'Codex hook copy block anchor (codexHooksSrc) not found');
-
-    const region = src.slice(anchorIdx, anchorIdx + 2000);
-
+  test('Codex hook copy call opts into executor TOML hooks and executor stamps .sh hooks', () => {
     assert.ok(
-      region.includes("entry.endsWith('.sh')"),
-      "Codex hook copy block must check entry.endsWith('.sh')"
+      installSrc.includes('runtimeInstallExecutor.copyBundledHooksArtifact(installPlan') &&
+      installSrc.includes('allowTomlHooks: true'),
+      'install.js Codex path must route hook copying through runtimeInstallExecutor with allowTomlHooks enabled'
     );
+
+    const anchorIdx = executorSrc.indexOf("entry.endsWith('.sh')");
+    assert.ok(anchorIdx !== -1, "executor hook copy path must check entry.endsWith('.sh')");
+    const region = executorSrc.slice(anchorIdx, anchorIdx + 500);
     assert.ok(
       region.includes('GSD_VERSION'),
-      'Codex .sh branch must substitute {{GSD_VERSION}}. The bundled path was fixed ' +
-      'but Codex installs a separate copy of the hooks from hooks/dist that also needs stamping'
+      'executor .sh branch must substitute {{GSD_VERSION}} for Codex installs as well as bundled installs'
     );
   });
 });
@@ -299,7 +300,7 @@ describe('bug #2136 part 4: installed .sh hooks contain stamped concrete version
       assert.ok(
         !content.includes('{{GSD_VERSION}}'),
         `installed ${sh} must not contain literal "{{GSD_VERSION}}" — ` +
-        `install.js must substitute it with the concrete package version`
+        `the runtime install executor must substitute it with the concrete package version`
       );
 
       const versionMatch = content.match(/# gsd-hook-version:\s*(\S+)/);
@@ -373,7 +374,7 @@ describe('bug #2136 part 4: installed .sh hooks contain stamped concrete version
       [],
       `Fresh install must produce zero stale bash hooks.\n` +
       `Got: ${JSON.stringify(staleHooks, null, 2)}\n` +
-      `This indicates either the version header was not stamped by install.js, ` +
+      `This indicates either the version header was not stamped by the runtime install executor, ` +
       `or the detector regex cannot match bash "#" comment syntax.`
     );
   });

--- a/tests/bug-3288-model-catalog-install-path.test.cjs
+++ b/tests/bug-3288-model-catalog-install-path.test.cjs
@@ -173,7 +173,7 @@ module.exports = { catalog };
   });
 
   // ── test C ──────────────────────────────────────────────────────────────────
-  test('post-install: install() copies model-catalog.json to co-located path', () => {
+  test('post-install: install() copies shared catalogs to co-located path', () => {
     // Run the real installer against a tmp target dir, then assert the co-located
     // json is present and parseable.
     const claudeDir = path.join(tmpRoot, '.claude');
@@ -241,5 +241,36 @@ module.exports = { catalog };
 
     assert.ok(installedMod.catalog, 'installed module must export catalog');
     assert.ok(installedMod.VALID_PROFILES.length > 0, 'installed module must have valid profiles');
+
+    const colocatedRuntimePolicyJson = path.join(
+      claudeDir,
+      'get-shit-done',
+      'bin',
+      'shared',
+      'runtime-install-policy.json',
+    );
+    assert.ok(
+      fs.existsSync(colocatedRuntimePolicyJson),
+      `runtime-install-policy.json must be present at co-located path post-install: ${colocatedRuntimePolicyJson}`,
+    );
+    const parsedRuntimePolicy = JSON.parse(fs.readFileSync(colocatedRuntimePolicyJson, 'utf8'));
+    assert.ok(parsedRuntimePolicy.runtimes.claude, 'runtime install policy must include claude');
+
+    const installedRuntimePolicyCjs = path.join(
+      claudeDir,
+      'get-shit-done',
+      'bin',
+      'lib',
+      'runtime-install-policy.cjs',
+    );
+    assert.ok(fs.existsSync(installedRuntimePolicyCjs), `runtime-install-policy.cjs must be installed at: ${installedRuntimePolicyCjs}`);
+
+    delete require.cache[installedRuntimePolicyCjs];
+    let installedRuntimePolicy;
+    assert.doesNotThrow(() => {
+      installedRuntimePolicy = require(installedRuntimePolicyCjs);
+    }, 'installed runtime-install-policy.cjs must not throw MODULE_NOT_FOUND after install');
+
+    assert.equal(installedRuntimePolicy.getDirName('claude'), '.claude');
   });
 });

--- a/tests/copilot-install.test.cjs
+++ b/tests/copilot-install.test.cjs
@@ -38,6 +38,8 @@ const {
   stripGsdFromCopilotInstructions,
   writeManifest,
   reportLocalPatches,
+  runtimeMap,
+  allRuntimes,
 } = require('../bin/install.js');
 
 // ─── getDirName ─────────────────────────────────────────────────────────────────
@@ -147,18 +149,15 @@ describe('Source code integration (Copilot)', () => {
   });
 
   test('CLI-02: promptRuntime runtimeMap has Copilot as option 7', () => {
-    assert.ok(src.includes("'7': 'copilot'"), 'runtimeMap has 7 -> copilot');
+    assert.strictEqual(runtimeMap['7'], 'copilot', 'runtimeMap has 7 -> copilot');
   });
 
   test('CLI-02: promptRuntime allRuntimes array includes copilot', () => {
-    const allMatch = src.match(/const allRuntimes = \[([^\]]+)\]/);
-    assert.ok(allMatch && allMatch[1].includes('copilot'), 'allRuntimes includes copilot');
+    assert.ok(allRuntimes.includes('copilot'), 'allRuntimes includes copilot');
   });
 
   test('CLI-02: promptRuntime keeps Kilo above OpenCode in allRuntimes', () => {
-    const allMatch = src.match(/const allRuntimes = \[([^\]]+)\]/);
-    assert.ok(allMatch, 'allRuntimes array found');
-    assert.ok(allMatch[1].indexOf("'kilo'") < allMatch[1].indexOf("'opencode'"), 'kilo appears before opencode');
+    assert.ok(allRuntimes.indexOf('kilo') < allRuntimes.indexOf('opencode'), 'kilo appears before opencode');
   });
 
   test('isCopilot variable exists in install function', () => {

--- a/tests/install-hooks-copy.test.cjs
+++ b/tests/install-hooks-copy.test.cjs
@@ -23,6 +23,7 @@ const { execFileSync } = require('child_process');
 const { cleanup, createTempDir } = require('./helpers.cjs');
 
 const INSTALL_SRC = path.join(__dirname, '..', 'bin', 'install.js');
+const INSTALL_EXECUTOR_SRC = path.join(__dirname, '..', 'get-shit-done', 'bin', 'lib', 'runtime-install-executor.cjs');
 const { writeManifest, validateHookFields } = require(INSTALL_SRC);
 const BUILD_SCRIPT = path.join(__dirname, '..', 'scripts', 'build-hooks.js');
 const HOOKS_DIST = path.join(__dirname, '..', 'hooks', 'dist');
@@ -148,16 +149,18 @@ describe('#1755: .sh hooks are copied and executable after install', () => {
 
 describe('install.js source correctness', () => {
   let src;
+  let executorSrc;
 
   before(() => {
     src = fs.readFileSync(INSTALL_SRC, 'utf-8');
+    executorSrc = fs.readFileSync(INSTALL_EXECUTOR_SRC, 'utf-8');
   });
 
   test('.sh files get chmod after copyFileSync', () => {
     // The else branch for non-.js hooks should apply chmod for .sh files
     assert.ok(
-      src.includes("if (entry.endsWith('.sh'))"),
-      'install.js should check for .sh extension to apply chmod'
+      executorSrc.includes("if (entry.endsWith('.sh'))"),
+      'runtime install executor should check for .sh extension to apply chmod'
     );
   });
 
@@ -256,8 +259,8 @@ describe('install.js source correctness', () => {
 
   test('verifyInstalled warns about missing .sh hooks', () => {
     assert.ok(
-      src.includes('Missing expected hook:'),
-      'install should warn about missing .sh hooks after verification'
+      executorSrc.includes('Missing expected hook:'),
+      'runtime install executor should warn about missing .sh hooks after verification'
     );
   });
 });

--- a/tests/kilo-install.test.cjs
+++ b/tests/kilo-install.test.cjs
@@ -25,6 +25,8 @@ const {
   getConfigDirFromHome,
   resolveKiloConfigPath,
   configureKiloPermissions,
+  createRuntimeInstallPlan,
+  hasConfigMutation,
 } = require('../bin/install.js');
 
 describe('getDirName (Kilo)', () => {
@@ -256,11 +258,15 @@ describe('Source code integration (Kilo)', () => {
   });
 
   test('hooks are skipped for Kilo', () => {
-    assert.ok(src.includes('!isOpencode && !isKilo'), 'hooks skip check includes kilo');
+    const plan = createRuntimeInstallPlan({ runtime: 'kilo', scope: 'global', explicitConfigDir: '/tmp/kilo' });
+    assert.strictEqual(plan.capabilities.settingsJson, false, 'Kilo does not use settings.json hooks');
+    assert.strictEqual(hasConfigMutation(plan, 'settings-json', 'ensure-managed-hooks'), false);
   });
 
   test('settings.json write excludes Kilo', () => {
-    assert.ok(src.includes('!isCodex && !isCopilot && !isKilo && !isCursor && !isWindsurf'), 'settings write excludes kilo');
+    const plan = createRuntimeInstallPlan({ runtime: 'kilo', scope: 'global', explicitConfigDir: '/tmp/kilo' });
+    assert.strictEqual(plan.capabilities.settingsJson, false, 'Kilo does not write settings.json');
+    assert.strictEqual(hasConfigMutation(plan, 'kilo-json', 'ensure-permissions'), true);
   });
 
   test('agent path replacement does not exclude Kilo', () => {
@@ -268,7 +274,8 @@ describe('Source code integration (Kilo)', () => {
   });
 
   test('finishInstall passes the actual config dir to Kilo permissions', () => {
-    assert.ok(src.includes('configureKiloPermissions(isGlobal, configDir);'), 'Kilo permission config uses actual install dir');
+    assert.ok(src.includes('applyConfigMutations(installPlan'), 'finishInstall dispatches policy config mutations');
+    assert.ok(src.includes('configureKiloPermissions,'), 'Kilo mutation adapter is wired into executor');
   });
 
   test('uninstall cleans Kilo permissions from the resolved target dir', () => {

--- a/tests/opencode-permissions.test.cjs
+++ b/tests/opencode-permissions.test.cjs
@@ -18,9 +18,11 @@ const fs = require('node:fs');
 const path = require('node:path');
 
 const { createTempDir, cleanup } = require('./helpers.cjs');
-const { configureOpencodePermissions } = require('../bin/install.js');
-
-const installSrc = fs.readFileSync(path.join(__dirname, '..', 'bin', 'install.js'), 'utf8');
+const {
+  configureOpencodePermissions,
+  createRuntimeInstallPlan,
+  hasConfigMutation,
+} = require('../bin/install.js');
 
 const envKeys = ['OPENCODE_CONFIG_DIR', 'OPENCODE_CONFIG', 'XDG_CONFIG_HOME'];
 const originalEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]]));
@@ -77,9 +79,14 @@ describe('configureOpencodePermissions', () => {
   });
 
   test('finishInstall passes the actual config dir to OpenCode permissions', () => {
-    assert.ok(
-      installSrc.includes('configureOpencodePermissions(isGlobal, configDir);'),
-      'OpenCode permission config uses actual install dir'
-    );
+    const plan = createRuntimeInstallPlan({ runtime: 'opencode', scope: 'global', explicitConfigDir: configDir });
+    assert.strictEqual(hasConfigMutation(plan, 'opencode-json', 'ensure-permissions'), true);
+
+    configureOpencodePermissions(true, configDir);
+
+    const config = JSON.parse(fs.readFileSync(path.join(configDir, 'opencode.json'), 'utf8'));
+    const gsdPath = `${configDir.replace(/\\/g, '/')}/get-shit-done/*`;
+    assert.strictEqual(config.permission.read[gsdPath], 'allow');
+    assert.strictEqual(config.permission.external_directory[gsdPath], 'allow');
   });
 });

--- a/tests/roadmap.test.cjs
+++ b/tests/roadmap.test.cjs
@@ -771,6 +771,41 @@ describe('roadmap update-plan-progress command', () => {
     assert.ok(roadmapContent.includes('1/1'), 'roadmap should contain updated plan count');
   });
 
+  test('updates unpadded ROADMAP phase entries when called with padded phase argument', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'ROADMAP.md'),
+      `# Roadmap
+
+- [ ] **Phase 3: Build** - description
+
+### Phase 3: Build
+**Goal:** Test goal
+**Plans:** 0 plans
+- [ ] 03-01-PLAN.md
+
+## Progress
+
+| Phase | Plans Complete | Status | Completed |
+|-------|----------------|--------|-----------|
+| 3. Build | 0/1 | Planned |  |
+`
+    );
+
+    const p3 = path.join(tmpDir, '.planning', 'phases', '03-build');
+    fs.mkdirSync(p3, { recursive: true });
+    fs.writeFileSync(path.join(p3, '03-01-PLAN.md'), '# Plan 1');
+    fs.writeFileSync(path.join(p3, '03-01-SUMMARY.md'), '# Summary 1');
+
+    const result = runGsdTools('roadmap update-plan-progress 03', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const roadmapContent = fs.readFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), 'utf-8');
+    assert.match(roadmapContent, /- \[x\] \*\*Phase 3: Build\*\* - description \(completed \d{4}-\d{2}-\d{2}\)/);
+    assert.ok(roadmapContent.includes('**Plans:** 1/1 plans complete'), 'phase detail plan count should be updated');
+    assert.match(roadmapContent, /\| 3\. Build \| 1\/1 \| Complete\s+\| \d{4}-\d{2}-\d{2} \|/);
+    assert.ok(roadmapContent.includes('- [x] 03-01-PLAN.md'), 'completed plan checkbox should still be marked');
+  });
+
   test('missing ROADMAP.md returns updated false', () => {
     // Create phase dir with plans and summaries but NO ROADMAP.md
     const p1 = path.join(tmpDir, '.planning', 'phases', '01-test');
@@ -858,4 +893,3 @@ describe('roadmap update-plan-progress command', () => {
 // ─────────────────────────────────────────────────────────────────────────────
 // phase add command
 // ─────────────────────────────────────────────────────────────────────────────
-

--- a/tests/runtime-install-plan-execution.test.cjs
+++ b/tests/runtime-install-plan-execution.test.cjs
@@ -1,0 +1,173 @@
+'use strict';
+
+process.env.GSD_TEST_MODE = '1';
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  applyConfigMutations,
+  createRuntimeInstallPlan,
+  hasConfigMutation,
+} = require('../bin/install.js');
+const {
+  CONFIG_MUTATION_ADAPTER_REGISTRY,
+  copyBundledHooksArtifact,
+  applyConfigMutations: applyExecutorConfigMutations,
+  getConfigMutationHandler,
+} = require('../get-shit-done/bin/lib/runtime-install-executor.cjs');
+
+describe('Runtime install plan execution', () => {
+  test('settings-json mutation writes managed settings through the plan dispatcher', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-runtime-plan-settings-'));
+    const settingsPath = path.join(tmp, 'settings.json');
+    const plan = createRuntimeInstallPlan({ runtime: 'claude', scope: 'local', cwd: tmp });
+
+    assert.equal(hasConfigMutation(plan, 'settings-json', 'ensure-managed-hooks'), true);
+
+    applyConfigMutations(plan, {
+      isGlobal: false,
+      configDir: plan.targetDir,
+      settingsPath,
+      settings: { hooks: { SessionStart: [] } },
+    });
+
+    assert.deepStrictEqual(JSON.parse(fs.readFileSync(settingsPath, 'utf8')), {
+      hooks: {},
+    });
+  });
+
+  test('json permission mutations execute for runtimes without settings.json', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-runtime-plan-opencode-'));
+    const plan = createRuntimeInstallPlan({ runtime: 'opencode', scope: 'local', cwd: tmp });
+
+    assert.equal(plan.capabilities.settingsJson, false);
+    assert.equal(hasConfigMutation(plan, 'opencode-json', 'ensure-permissions'), true);
+
+    applyConfigMutations(plan, {
+      isGlobal: false,
+      configDir: plan.targetDir,
+    });
+
+    const config = JSON.parse(fs.readFileSync(path.join(plan.targetDir, 'opencode.json'), 'utf8'));
+    const gsdPath = `${plan.targetDir.replace(/\\/g, '/')}/get-shit-done/*`;
+    assert.equal(config.permission.read[gsdPath], 'allow');
+    assert.equal(config.permission.external_directory[gsdPath], 'allow');
+  });
+
+  test('toml mutation intents dispatch through executor adapters', () => {
+    const plan = createRuntimeInstallPlan({ runtime: 'codex', scope: 'global', explicitConfigDir: '/tmp/codex' });
+    const calls = [];
+
+    applyExecutorConfigMutations(plan, {
+      isGlobal: true,
+      configDir: plan.targetDir,
+      adapters: {
+        configureCodexToml(mutation, context) {
+          calls.push({ operation: mutation.operation, configDir: context.configDir });
+        },
+      },
+    });
+
+    assert.deepStrictEqual(calls, [
+      { operation: 'ensure-agent-profiles', configDir: '/tmp/codex' },
+      { operation: 'ensure-managed-hook-block', configDir: '/tmp/codex' },
+    ]);
+  });
+
+  test('config mutation adapter registry exposes every plan adapter operation', () => {
+    const seen = new Set();
+
+    for (const runtime of ['claude', 'opencode', 'kilo', 'codex', 'copilot', 'cline']) {
+      const plan = createRuntimeInstallPlan({ runtime, scope: 'global', explicitConfigDir: `/tmp/${runtime}` });
+      for (const mutation of plan.configMutations) {
+        seen.add(`${mutation.adapter}:${mutation.operation}`);
+        assert.equal(
+          typeof getConfigMutationHandler(CONFIG_MUTATION_ADAPTER_REGISTRY, mutation),
+          'function',
+          `${mutation.adapter}:${mutation.operation} must have a registered executor handler`
+        );
+      }
+    }
+
+    assert.deepStrictEqual([...seen].sort(), [
+      'cline-rules:ensure-runtime-rules',
+      'codex-toml:ensure-agent-profiles',
+      'codex-toml:ensure-managed-hook-block',
+      'copilot-instructions:ensure-managed-instructions',
+      'kilo-json:ensure-permissions',
+      'opencode-json:ensure-permissions',
+      'settings-json:ensure-managed-hooks',
+    ]);
+  });
+
+  test('unregistered config mutation adapters are explicit no-ops', () => {
+    const calls = [];
+
+    applyExecutorConfigMutations({
+      targetDir: '/tmp/runtime',
+      configMutations: [
+        { adapter: 'unknown-json', operation: 'ensure-something' },
+        { adapter: 'settings-json', operation: 'unknown-operation' },
+      ],
+    }, {
+      adapters: {
+        writeSettings() { calls.push('writeSettings'); },
+        validateHookFields(settings) { return settings; },
+      },
+    });
+
+    assert.deepStrictEqual(calls, []);
+  });
+
+  test('no-settings runtimes with no mutation intents are executor no-ops', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-runtime-plan-trae-'));
+    const plan = createRuntimeInstallPlan({ runtime: 'trae', scope: 'local', cwd: tmp });
+
+    assert.equal(plan.capabilities.settingsJson, false);
+    assert.deepStrictEqual(plan.configMutations, []);
+
+    applyExecutorConfigMutations(plan, {
+      isGlobal: false,
+      configDir: plan.targetDir,
+      adapters: {
+        writeSettings() {
+          throw new Error('settings adapter should not run');
+        },
+      },
+    });
+
+    assert.equal(fs.existsSync(path.join(plan.targetDir, 'settings.json')), false);
+  });
+
+  test('bundled hook artifact copies runtime-templated hook files', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-runtime-plan-hooks-'));
+    const packageSrc = path.join(tmp, 'pkg');
+    const hooksDist = path.join(packageSrc, 'hooks', 'dist');
+    fs.mkdirSync(hooksDist, { recursive: true });
+    fs.writeFileSync(
+      path.join(hooksDist, 'gsd-check-update.js'),
+      "const config = '.claude'; // {{GSD_VERSION}}\n// ~/.claude/path\n"
+    );
+    fs.writeFileSync(path.join(hooksDist, 'gsd-session-state.sh'), '# {{GSD_VERSION}}\n');
+    fs.writeFileSync(path.join(hooksDist, 'note.txt'), 'plain\n');
+
+    const plan = createRuntimeInstallPlan({ runtime: 'qwen', scope: 'local', cwd: tmp });
+    const result = copyBundledHooksArtifact(plan, {
+      packageSrc,
+      version: '1.2.3',
+      warn: () => {},
+    });
+
+    assert.deepStrictEqual(result.failures, []);
+    assert.equal(fs.readFileSync(path.join(plan.targetDir, 'package.json'), 'utf8'), '{"type":"commonjs"}\n');
+    const js = fs.readFileSync(path.join(plan.targetDir, 'hooks', 'gsd-check-update.js'), 'utf8');
+    assert.match(js, /'\.qwen'/);
+    assert.match(js, /~\/\.qwen\/path/);
+    assert.match(js, /1\.2\.3/);
+    assert.equal(fs.readFileSync(path.join(plan.targetDir, 'hooks', 'note.txt'), 'utf8'), 'plain\n');
+  });
+});

--- a/tests/runtime-install-policy.test.cjs
+++ b/tests/runtime-install-policy.test.cjs
@@ -1,0 +1,184 @@
+'use strict';
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const {
+  RUNTIME_REGISTRY,
+  allRuntimes,
+  runtimeMap,
+  getDirName,
+  getConfigDirFromHome,
+  getGlobalDir,
+  parseRuntimeInput,
+  createRuntimeInstallPlan,
+} = require('../get-shit-done/bin/lib/runtime-install-policy.cjs');
+
+const SHARED_RUNTIME_INSTALL_POLICY = JSON.parse(fs.readFileSync(
+  path.join(__dirname, '..', 'sdk', 'shared', 'runtime-install-policy.json'),
+  'utf8'
+));
+
+const RUNTIME_ENV_KEYS = [
+  'CLAUDE_CONFIG_DIR',
+  'ANTIGRAVITY_CONFIG_DIR',
+  'AUGMENT_CONFIG_DIR',
+  'CLINE_CONFIG_DIR',
+  'CODEBUDDY_CONFIG_DIR',
+  'CODEX_HOME',
+  'COPILOT_CONFIG_DIR',
+  'CURSOR_CONFIG_DIR',
+  'GEMINI_CONFIG_DIR',
+  'HERMES_HOME',
+  'KILO_CONFIG_DIR',
+  'KILO_CONFIG',
+  'OPENCODE_CONFIG_DIR',
+  'OPENCODE_CONFIG',
+  'QWEN_CONFIG_DIR',
+  'TRAE_CONFIG_DIR',
+  'WINDSURF_CONFIG_DIR',
+  'XDG_CONFIG_HOME',
+];
+
+describe('Runtime Install Policy Module', () => {
+  const saved = {};
+
+  beforeEach(() => {
+    for (const key of RUNTIME_ENV_KEYS) {
+      saved[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of RUNTIME_ENV_KEYS) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  });
+
+  test('registry owns every interactive runtime option', () => {
+    assert.deepStrictEqual(runtimeMap, {
+      '1': 'claude',
+      '2': 'antigravity',
+      '3': 'augment',
+      '4': 'cline',
+      '5': 'codebuddy',
+      '6': 'codex',
+      '7': 'copilot',
+      '8': 'cursor',
+      '9': 'gemini',
+      '10': 'hermes',
+      '11': 'kilo',
+      '12': 'opencode',
+      '13': 'qwen',
+      '14': 'trae',
+      '15': 'windsurf',
+    });
+    assert.deepStrictEqual(allRuntimes, [
+      'claude',
+      'antigravity',
+      'augment',
+      'cline',
+      'codebuddy',
+      'codex',
+      'copilot',
+      'cursor',
+      'gemini',
+      'hermes',
+      'kilo',
+      'opencode',
+      'qwen',
+      'trae',
+      'windsurf',
+    ]);
+    assert.deepStrictEqual(parseRuntimeInput('16'), allRuntimes);
+  });
+
+  test('CJS runtime registry projects the shared runtime install policy without drift', () => {
+    assert.deepStrictEqual(RUNTIME_REGISTRY, SHARED_RUNTIME_INSTALL_POLICY.runtimes);
+    assert.equal(parseRuntimeInput(SHARED_RUNTIME_INSTALL_POLICY.allRuntimesOption).length, allRuntimes.length);
+  });
+
+  test('interactive option map is generated from shared runtime options', () => {
+    const expectedRuntimeMap = Object.fromEntries(
+      Object.entries(SHARED_RUNTIME_INSTALL_POLICY.runtimes).map(([runtime, policy]) => [policy.option, runtime])
+    );
+    const expectedAllRuntimes = Object.entries(SHARED_RUNTIME_INSTALL_POLICY.runtimes)
+      .sort((a, b) => Number(a[1].option) - Number(b[1].option))
+      .map(([runtime]) => runtime);
+
+    assert.deepStrictEqual(runtimeMap, expectedRuntimeMap);
+    assert.deepStrictEqual(allRuntimes, expectedAllRuntimes);
+  });
+
+  test('local dir and config-dir fragments come from registry facts', () => {
+    for (const runtime of allRuntimes) {
+      const policy = RUNTIME_REGISTRY[runtime];
+      assert.equal(getDirName(runtime), policy.localDir, `${runtime} local dir`);
+      assert.equal(getConfigDirFromHome(runtime, false), `'${policy.localDir}'`, `${runtime} local fragment`);
+      assert.equal(getConfigDirFromHome(runtime, true), policy.configDirFromHomeGlobal.join(', '), `${runtime} global fragment`);
+    }
+  });
+
+  test('global target policy honors explicit dirs before env and defaults', () => {
+    assert.equal(getGlobalDir('codex', '/explicit/codex'), '/explicit/codex');
+    process.env.CODEX_HOME = '/env/codex';
+    assert.equal(getGlobalDir('codex'), '/env/codex');
+    delete process.env.CODEX_HOME;
+    assert.equal(getGlobalDir('codex'), path.join(os.homedir(), '.codex'));
+  });
+
+  test('XDG runtimes honor direct config, file config dirname, XDG, then fallback', () => {
+    process.env.OPENCODE_CONFIG_DIR = '/direct/opencode';
+    assert.equal(getGlobalDir('opencode'), '/direct/opencode');
+    delete process.env.OPENCODE_CONFIG_DIR;
+
+    process.env.OPENCODE_CONFIG = '/file/opencode/opencode.jsonc';
+    assert.equal(getGlobalDir('opencode'), '/file/opencode');
+    delete process.env.OPENCODE_CONFIG;
+
+    process.env.XDG_CONFIG_HOME = '/xdg';
+    assert.equal(getGlobalDir('opencode'), path.join('/xdg', 'opencode'));
+    delete process.env.XDG_CONFIG_HOME;
+
+    assert.equal(getGlobalDir('opencode'), path.join(os.homedir(), '.config', 'opencode'));
+  });
+
+  test('global install plan includes target, artifacts, capabilities, and config mutation intents', () => {
+    const plan = createRuntimeInstallPlan({
+      runtime: 'codex',
+      scope: 'global',
+      explicitConfigDir: '/tmp/codex-home',
+      installMode: 'minimal',
+    });
+
+    assert.equal(plan.runtime, 'codex');
+    assert.equal(plan.label, 'Codex');
+    assert.equal(plan.targetDir, '/tmp/codex-home');
+    assert.equal(plan.skillsBase, path.join('/tmp/codex-home', 'skills'));
+    assert.equal(plan.capabilities.toml, true);
+    assert.ok(plan.artifacts.some((artifact) => artifact.kind === 'skills' && artifact.installMode === 'minimal'));
+    assert.ok(plan.artifacts.some((artifact) => artifact.kind === 'hooks'));
+    assert.deepStrictEqual(
+      plan.configMutations.map((mutation) => mutation.operation),
+      ['ensure-agent-profiles', 'ensure-managed-hook-block']
+    );
+  });
+
+  test('special skills layouts are represented in the install plan', () => {
+    const hermes = createRuntimeInstallPlan({ runtime: 'hermes', scope: 'global', explicitConfigDir: '/tmp/hermes' });
+    assert.equal(hermes.skillsLayout, 'hermes-nested');
+    assert.equal(hermes.skillsBase, path.join('/tmp/hermes', 'skills', 'gsd'));
+
+    const cline = createRuntimeInstallPlan({ runtime: 'cline', scope: 'local', cwd: '/repo' });
+    assert.equal(cline.targetDir, '/repo');
+    assert.equal(cline.skillsLayout, 'none');
+    assert.equal(cline.skillsBase, null);
+    assert.ok(cline.artifacts.some((artifact) => artifact.kind === 'rules-file'));
+    assert.deepStrictEqual(cline.configMutations.map((mutation) => mutation.adapter), ['cline-rules']);
+  });
+});

--- a/tests/trae-install.test.cjs
+++ b/tests/trae-install.test.cjs
@@ -178,14 +178,17 @@ describe('Trae local install/uninstall', () => {
     const result = install(false, 'trae');
     const targetDir = path.join(tmpDir, '.trae');
 
-    assert.deepStrictEqual(result, {
+    assert.deepStrictEqual({ ...result, installPlan: undefined }, {
       settingsPath: null,
       settings: null,
       statuslineCommand: null,
       updateBannerCommand: null,
       runtime: 'trae',
       configDir: fs.realpathSync(targetDir),
+      installPlan: undefined,
     });
+    assert.strictEqual(result.installPlan.runtime, 'trae');
+    assert.strictEqual(result.installPlan.targetDir, fs.realpathSync(targetDir));
 
     assert.ok(fs.existsSync(path.join(targetDir, 'skills', 'gsd-help', 'SKILL.md')));
     assert.ok(fs.existsSync(path.join(targetDir, 'get-shit-done', 'VERSION')));


### PR DESCRIPTION
## Summary

Fixes roadmap progress sync when `roadmap.update-plan-progress` is called with a zero-padded phase argument such as `03` while `ROADMAP.md` uses unpadded phase labels such as `Phase 3` and `| 3. ... |`.

## Root cause

The handler correctly found `.planning/phases/03-*` on disk, but reused the raw `phaseNum` argument to build ROADMAP markdown regexes. That meant `03` matched plan IDs like `03-01`, but missed the top-level phase checkbox, phase detail `**Plans:**` line, and progress table row written as `3`.

## Changes

- Add padded/unpadded-tolerant phase markdown regex matching in the SDK query handler and legacy CJS roadmap command.
- Keep completed per-plan checkbox matching based on the real plan IDs.
- Add regression coverage for both SDK and legacy command paths.

## Validation

- `cd sdk && npm test -- roadmap-update-plan-progress.test.ts`
- `node --test tests/roadmap.test.cjs`
- `npm test`

Closes #3378


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed roadmap phase updates to correctly handle zero-padded phase arguments (e.g., `03` instead of `3`).

* **Documentation**
  * Added architectural documentation for runtime installation policy framework.
  * Updated CLI module inventory to reflect new runtime installation modules.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3379)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->