### PR TITLE
Fix(workflow): normalize SDK init phase flags

### DIFF
--- a/.changeset/sdk-init-phase-flags.md
+++ b/.changeset/sdk-init-phase-flags.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3389
+---
+**`gsd-sdk query init.*` phase-scoped handlers now accept `--phase <N>` and `--phase=N`** - flag-style init queries no longer search for a phase literally named `--phase`.

--- a/sdk/src/query/init.test.ts
+++ b/sdk/src/query/init.test.ts
@@ -381,6 +381,13 @@ describe('initPlanPhase', () => {
     expect(data.phase_number).toBe('09');
   });
 
+  it('accepts --phase=value flag form for existing phase (#3387)', async () => {
+    const result = await initPlanPhase(['--phase=9'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+    expect(data.phase_found).toBe(true);
+    expect(data.phase_number).toBe('09');
+  });
+
   it('returns error when phase arg missing', async () => {
     const result = await initPlanPhase([], tmpDir);
     const data = result.data as Record<string, unknown>;
@@ -476,6 +483,13 @@ describe('initVerifyWork', () => {
     expect(data.phase_number).toBe('09');
   });
 
+  it('accepts --phase=value flag form for existing phase (#3387)', async () => {
+    const result = await initVerifyWork(['--phase=9'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+    expect(data.phase_found).toBe(true);
+    expect(data.phase_number).toBe('09');
+  });
+
   it('resolves workstream-scoped phases when workstream is provided', async () => {
     const wsDir = join(tmpDir, '.planning', 'workstreams', 'delivery');
     await mkdir(join(wsDir, 'phases', '32-shipment-creation-tracking-numbers-print-forms'), { recursive: true });
@@ -521,6 +535,13 @@ describe('initPhaseOp', () => {
 
   it('accepts --phase flag form for existing phase (#3387)', async () => {
     const result = await initPhaseOp(['--phase', '9'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+    expect(data.phase_found).toBe(true);
+    expect(data.phase_number).toBe('09');
+  });
+
+  it('accepts --phase=value flag form for existing phase (#3387)', async () => {
+    const result = await initPhaseOp(['--phase=9'], tmpDir);
     const data = result.data as Record<string, unknown>;
     expect(data.phase_found).toBe(true);
     expect(data.phase_number).toBe('09');

--- a/sdk/src/query/init.test.ts
+++ b/sdk/src/query/init.test.ts
@@ -325,6 +325,20 @@ describe('initExecutePhase', () => {
     expect(data.milestone_version).toBeDefined();
   });
 
+  it('accepts --phase flag form for existing phase (#3387)', async () => {
+    const result = await initExecutePhase(['--phase', '9'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+    expect(data.phase_found).toBe(true);
+    expect(data.phase_number).toBe('09');
+  });
+
+  it('accepts --phase=value flag form for existing phase (#3387)', async () => {
+    const result = await initExecutePhase(['--phase=9'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+    expect(data.phase_found).toBe(true);
+    expect(data.phase_number).toBe('09');
+  });
+
   it('returns error when phase arg missing', async () => {
     const result = await initExecutePhase([], tmpDir);
     const data = result.data as Record<string, unknown>;
@@ -358,6 +372,13 @@ describe('initPlanPhase', () => {
     expect(data.has_research).toBe(true);
     expect(data.has_context).toBe(true);
     expect(data.project_root).toBe(tmpDir);
+  });
+
+  it('accepts --phase flag form for existing phase (#3387)', async () => {
+    const result = await initPlanPhase(['--phase', '9'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+    expect(data.phase_found).toBe(true);
+    expect(data.phase_number).toBe('09');
   });
 
   it('returns error when phase arg missing', async () => {
@@ -448,6 +469,13 @@ describe('initVerifyWork', () => {
     expect(data.project_root).toBe(tmpDir);
   });
 
+  it('accepts --phase flag form for existing phase (#3387)', async () => {
+    const result = await initVerifyWork(['--phase', '9'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+    expect(data.phase_found).toBe(true);
+    expect(data.phase_number).toBe('09');
+  });
+
   it('resolves workstream-scoped phases when workstream is provided', async () => {
     const wsDir = join(tmpDir, '.planning', 'workstreams', 'delivery');
     await mkdir(join(wsDir, 'phases', '32-shipment-creation-tracking-numbers-print-forms'), { recursive: true });
@@ -489,6 +517,13 @@ describe('initPhaseOp', () => {
     expect(data.has_context).toBe(true);
     expect(data.plan_count).toBeGreaterThanOrEqual(1);
     expect(data.project_root).toBe(tmpDir);
+  });
+
+  it('accepts --phase flag form for existing phase (#3387)', async () => {
+    const result = await initPhaseOp(['--phase', '9'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+    expect(data.phase_found).toBe(true);
+    expect(data.phase_number).toBe('09');
   });
 });
 

--- a/sdk/src/query/init.ts
+++ b/sdk/src/query/init.ts
@@ -54,6 +54,23 @@ function generateSlugInternal(text: string): string {
     .substring(0, 60);
 }
 
+function extractPhaseArg(args: string[]): string | undefined {
+  const equalsArg = args.find((arg) => arg.startsWith('--phase='));
+  if (equalsArg) {
+    const value = equalsArg.slice('--phase='.length).trim();
+    return value || undefined;
+  }
+
+  const flagIndex = args.indexOf('--phase');
+  if (flagIndex !== -1) {
+    const value = args[flagIndex + 1];
+    return value && !value.startsWith('--') ? value : undefined;
+  }
+
+  const first = args[0];
+  return first && !first.startsWith('--') ? first : undefined;
+}
+
 /**
  * Check if a path exists on disk.
  */
@@ -293,7 +310,7 @@ export function withProjectRoot(
  * Port of cmdInitExecutePhase from init.cjs lines 50-171.
  */
 export const initExecutePhase: QueryHandler = async (args, projectDir, workstream) => {
-  const phase = args[0];
+  const phase = extractPhaseArg(args);
   if (!phase) {
     return { data: { error: 'phase required for init execute-phase' } };
   }
@@ -376,7 +393,7 @@ export const initExecutePhase: QueryHandler = async (args, projectDir, workstrea
  * Port of cmdInitPlanPhase from init.cjs lines 173-293.
  */
 export const initPlanPhase: QueryHandler = async (args, projectDir, workstream) => {
-  const phase = args[0];
+  const phase = extractPhaseArg(args);
   if (!phase) {
     return { data: { error: 'phase required for init plan-phase' } };
   }
@@ -623,7 +640,7 @@ export const initResume: QueryHandler = async (_args, projectDir) => {
  * Port of cmdInitVerifyWork from init.cjs lines 538-586.
  */
 export const initVerifyWork: QueryHandler = async (args, projectDir, workstream) => {
-  const phase = args[0];
+  const phase = extractPhaseArg(args);
   if (!phase) {
     return { data: { error: 'phase required for init verify-work' } };
   }
@@ -660,7 +677,7 @@ export const initVerifyWork: QueryHandler = async (args, projectDir, workstream)
  * Port of cmdInitPhaseOp from init.cjs lines 588-697.
  */
 export const initPhaseOp: QueryHandler = async (args, projectDir, workstream) => {
-  const phase = args[0];
+  const phase = extractPhaseArg(args);
   if (!phase) {
     return { data: { error: 'phase required for init phase-op' } };
   }


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3387

Linked issue labels: bug, area: workflow, confirmed-bug

## Confirmed Issue Description

## Summary

`gsd-sdk query init.execute-phase --phase 26` silently misbehaves: the handler treats the literal string `--phase` as the phase identifier (because `args[0]` is `--phase`), causing `findPhase` to return no match. Result: `phase_found: false` with no error, even though phase `26` exists on disk.

Positional form `gsd-sdk query init.execute-phase 26` works correctly.

## Repro

```bash
# Broken — silently returns phase_found: false
gsd-sdk query init.execute-phase --phase 26

# Broken — same
gsd-sdk query init.execute-phase --phase=26

# Works
gsd-sdk query init.execute-phase 26
```

Phase `26-spt-live-skill-...` exists on disk with 5 plans; `findPhase(['26'], ...)` returns the full record when called directly.

## Root cause

`sdk/dist/query/init.js` `initExecutePhase` (and `initPlanPhase`) read `args[0]` directly:

```js
export const initExecutePhase = async (args, projectDir, workstream) => {
    const phase = args[0];
    if (!phase) {
        return { data: { error: 'phase required for init execute-phase' } };
    }
    ...
    const { phaseInfo, roadmapPhase } = await getPhaseInfoWithFallback(phase, projectDir, workstream);
```

The query CLI layer passes argv verbatim with no flag normalization, so `--phase` becomes the phase token. `findPhase` then searches for a directory matching `--phase`, finds nothing, and the handler returns `phase_found: false` instead of surfacing the bad input.

## Impact

Workflow callers that follow flag-style conventions get a confusing "phase not found" result with no hint that the arg was malformed. Easy to misread as a missing phase / corrupt planning dir. Wasted ~15 min triaging on my end.

## Suggested fix

One of:

1. **Strip leading-flag args before treating `args[0]` as the phase token.** Cheapest. If `args[0]` starts with `--`, either skip past flags or error out with `unknown flag: --phase` / `did you mean: <phase> as positional?`.
2. **Recognize `--phase <N>` / `--phase=N` and resolve to the phase token** before calling `findPhase`. Matches what users naturally type.
3. **At minimum, validate `phase` doesn't start with `--` and return a clear error** ("phase identifier '--phase' is invalid; pass the phase as a positional arg, not a flag").

Same fix probably wants to apply to every `init.<workflow>` handler that takes a phase positional (`init.plan-phase`, `init.verify-work`, etc).

## Environment

- Platform: Windows 11
- Node: bundled with `gsd-sdk` npx install (`_npx/4db0de1f85c3165e/.../get-shit-done-cc`)
- Version: latest as of 2026-05-10

## Standards Followed

- `CONTEXT.md`: contributor gate order, changeset PR-number rule, and domain vocabulary requirements.
- `CONTRIBUTING.md`: issue-first process, typed PR template, closing keyword, one-concern scope, changeset fragment, and test requirements.
- `docs/contributor-standards.md`: CONTEXT/ADR hierarchy, isolated worktree expectation, AI-assisted PR body requirements, and architecture-aware testing guidance.

## What was broken

SDK init phase-scoped handlers treated the literal `--phase` flag as the phase identifier, returning `phase_found: false` even when the requested phase existed.

## What this fix does

Normalizes phase arguments for SDK phase-scoped init handlers so positional, `--phase <N>`, and `--phase=N` forms resolve the same phase token.

## Root cause

The SDK init handlers read `args[0]` directly before phase lookup, so flag-style invocation searched for a phase named `--phase`.

## Testing

### How I verified the fix

- `npm run test:unit -- src/query/init.test.ts`
- `npm run build:sdk`
- `npm run lint:tests`
- `npm run lint:changeset`
- `npm test`

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: SDK query handlers
- [ ] N/A (not runtime-specific)

## Scope Confirmation

- [x] This PR is one concern: workflow fix for #3387.
- [x] The fix is scoped to the confirmed bug report and does not add unrelated behavior.
- [x] No drive-by formatting or unrelated dependency changes are included.

## Checklist

- [x] Issue linked above with `Fixes #3387`.
- [x] Linked issue has the `confirmed-bug` label.
- [x] Fix is scoped to the reported bug.
- [x] Regression test added.
- [x] Existing tests were run as listed above.
- [x] `.changeset/` fragment added: `.changeset/sdk-init-phase-flags.md`.
- [x] PR title uses required typed scope prefix: `Fix(workflow):`.
- [x] No unnecessary dependencies added.

## Breaking changes

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Phase argument parsing in `gsd-sdk query init` commands now properly accepts both `--phase <N>` (with space) and `--phase=N` (with equals) flag formats, improving command compatibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3389)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->