### PR TITLE
Fix(workflow): expose new-project agent diagnostics

### DIFF
--- a/.changeset/new-project-agent-diagnostics.md
+++ b/.changeset/new-project-agent-diagnostics.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3390
+---
+**`/gsd-new-project` now reports required-agent registration separately from configured agent skill payloads** - missing-agent warnings identify the runtime agents directory and whether prompt skill payloads are available.

--- a/get-shit-done/workflows/new-project.md
+++ b/get-shit-done/workflows/new-project.md
@@ -67,7 +67,7 @@ AGENT_SKILLS_ROADMAPPER=$(gsd-sdk query agent-skills gsd-roadmapper)
 Parse JSON for: `researcher_model`, `synthesizer_model`, `roadmapper_model`, `commit_docs`, `project_exists`, `has_codebase_map`, `planning_exists`, `has_existing_code`, `has_package_file`, `is_brownfield`, `needs_codebase_map`, `has_git`, `project_path`, `agents_installed`, `missing_agents`, `agent_runtime`, `agents_dir`, `required_agents`, `required_agents_installed`, `missing_required_agents`, `agent_skill_payloads_available`, `agent_skill_payload_agents`.
 
 **If `agents_installed` is false:** Display a warning before proceeding:
-```
+```text
 ⚠ GSD agents not installed. The following agents are missing from your agents directory:
   {missing_agents joined with newline}
 

--- a/get-shit-done/workflows/new-project.md
+++ b/get-shit-done/workflows/new-project.md
@@ -64,15 +64,27 @@ AGENT_SKILLS_SYNTHESIZER=$(gsd-sdk query agent-skills gsd-research-synthesizer)
 AGENT_SKILLS_ROADMAPPER=$(gsd-sdk query agent-skills gsd-roadmapper)
 ```
 
-Parse JSON for: `researcher_model`, `synthesizer_model`, `roadmapper_model`, `commit_docs`, `project_exists`, `has_codebase_map`, `planning_exists`, `has_existing_code`, `has_package_file`, `is_brownfield`, `needs_codebase_map`, `has_git`, `project_path`, `agents_installed`, `missing_agents`.
+Parse JSON for: `researcher_model`, `synthesizer_model`, `roadmapper_model`, `commit_docs`, `project_exists`, `has_codebase_map`, `planning_exists`, `has_existing_code`, `has_package_file`, `is_brownfield`, `needs_codebase_map`, `has_git`, `project_path`, `agents_installed`, `missing_agents`, `agent_runtime`, `agents_dir`, `required_agents`, `required_agents_installed`, `missing_required_agents`, `agent_skill_payloads_available`, `agent_skill_payload_agents`.
 
 **If `agents_installed` is false:** Display a warning before proceeding:
 ```
 ⚠ GSD agents not installed. The following agents are missing from your agents directory:
   {missing_agents joined with newline}
 
+Runtime checked: {agent_runtime}
+Agents directory checked: {agents_dir}
+Required new-project agents missing:
+  {missing_required_agents joined with newline, or "none"}
+
+Agent skill payloads available: {agent_skill_payloads_available}
+Agent skill payload agents:
+  {agent_skill_payload_agents joined with newline, or "none"}
+
+Skill payloads only provide prompt context. Named subagent spawns still require agent
+definitions to be installed for this runtime.
+
 Subagent spawns (gsd-project-researcher, gsd-research-synthesizer, gsd-roadmapper) will fail
-with "agent type not found". Run the installer with --global to make agents available:
+with "agent type not found" if `required_agents_installed` is false. Run the installer with --global to make agents available:
 
   npx get-shit-done-cc@latest --global
 

--- a/sdk/src/query/init-complex.test.ts
+++ b/sdk/src/query/init-complex.test.ts
@@ -12,8 +12,10 @@ import { tmpdir } from 'node:os';
 import { initNewProject, initProgress, initManager } from './init-complex.js';
 
 let tmpDir: string;
+let previousGsdAgentsDir: string | undefined;
 
 beforeEach(async () => {
+  previousGsdAgentsDir = process.env.GSD_AGENTS_DIR;
   tmpDir = await mkdtemp(join(tmpdir(), 'gsd-init-complex-'));
 
   // Create minimal .planning structure
@@ -83,6 +85,8 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  if (previousGsdAgentsDir === undefined) delete process.env.GSD_AGENTS_DIR;
+  else process.env.GSD_AGENTS_DIR = previousGsdAgentsDir;
   await rm(tmpDir, { recursive: true, force: true });
 });
 
@@ -118,6 +122,42 @@ describe('initNewProject', () => {
     const result = await initNewProject([], tmpDir);
     const data = result.data as Record<string, unknown>;
     expect(data.planning_exists).toBe(true);
+  });
+
+  it('separates required agent registration from skill payload availability (#3388)', async () => {
+    const emptyAgentsDir = join(tmpDir, 'empty-agents');
+    await mkdir(emptyAgentsDir, { recursive: true });
+    process.env.GSD_AGENTS_DIR = emptyAgentsDir;
+
+    const requiredAgents = [
+      'gsd-project-researcher',
+      'gsd-research-synthesizer',
+      'gsd-roadmapper',
+    ];
+    for (const agent of requiredAgents) {
+      await mkdir(join(tmpDir, '.claude', 'skills', agent), { recursive: true });
+      await writeFile(join(tmpDir, '.claude', 'skills', agent, 'SKILL.md'), `# ${agent}\n`);
+    }
+    await writeFile(join(tmpDir, '.planning', 'config.json'), JSON.stringify({
+      model_profile: 'balanced',
+      commit_docs: false,
+      agent_skills: {
+        'gsd-project-researcher': ['.claude/skills/gsd-project-researcher'],
+        'gsd-research-synthesizer': ['.claude/skills/gsd-research-synthesizer'],
+        'gsd-roadmapper': ['.claude/skills/gsd-roadmapper'],
+      },
+      workflow: { research: true, plan_check: true, verifier: true, nyquist_validation: true },
+    }));
+
+    const result = await initNewProject([], tmpDir);
+    const data = result.data as Record<string, unknown>;
+
+    expect(data.agents_installed).toBe(false);
+    expect(data.required_agents).toEqual(requiredAgents);
+    expect(data.required_agents_installed).toBe(false);
+    expect(data.missing_required_agents).toEqual(requiredAgents);
+    expect(data.agent_skill_payloads_available).toBe(true);
+    expect(data.agent_skill_payload_agents).toEqual(requiredAgents);
   });
 });
 

--- a/sdk/src/query/init-complex.ts
+++ b/sdk/src/query/init-complex.ts
@@ -25,13 +25,21 @@ import { homedir } from 'node:os';
 
 import { loadConfig } from '../config.js';
 import { resolveModel } from './config-query.js';
-import { planningPaths, normalizePhaseName, phaseTokenMatches, toPosixPath } from './helpers.js';
+import {
+  detectRuntime,
+  planningPaths,
+  normalizePhaseName,
+  phaseTokenMatches,
+  resolveAgentsDir,
+  toPosixPath,
+} from './helpers.js';
 import {
   getMilestoneInfo,
   extractCurrentMilestone,
   extractNextMilestoneSection,
   extractPhasesFromSection,
 } from './roadmap.js';
+import { agentSkills } from './skills.js';
 import { withProjectRoot } from './init.js';
 import type { QueryHandler } from './utils.js';
 
@@ -51,6 +59,31 @@ async function getModelAlias(agentType: string, projectDir: string): Promise<str
  */
 function pathExists(base: string, relPath: string): boolean {
   return existsSync(join(base, relPath));
+}
+
+const NEW_PROJECT_REQUIRED_AGENTS = [
+  'gsd-project-researcher',
+  'gsd-research-synthesizer',
+  'gsd-roadmapper',
+];
+
+function hasAgentDefinition(agentsDir: string, agent: string): boolean {
+  return existsSync(join(agentsDir, `${agent}.md`)) ||
+    existsSync(join(agentsDir, `${agent}.agent.md`));
+}
+
+async function resolveAgentSkillPayloadAgents(
+  requiredAgents: string[],
+  projectDir: string,
+): Promise<string[]> {
+  const available: string[] = [];
+  for (const agent of requiredAgents) {
+    const result = await agentSkills([agent], projectDir);
+    if (typeof result.data === 'string' && result.data.trim() !== '') {
+      available.push(agent);
+    }
+  }
+  return available;
 }
 
 /**
@@ -190,6 +223,15 @@ export const initNewProject: QueryHandler = async (_args, projectDir, workstream
     getModelAlias('gsd-research-synthesizer', projectDir),
     getModelAlias('gsd-roadmapper', projectDir),
   ]);
+  const runtime = detectRuntime(config as { runtime?: unknown });
+  const agentsDir = resolveAgentsDir(runtime);
+  const missingRequiredAgents = NEW_PROJECT_REQUIRED_AGENTS.filter(
+    agent => !hasAgentDefinition(agentsDir, agent),
+  );
+  const agentSkillPayloadAgents = await resolveAgentSkillPayloadAgents(
+    NEW_PROJECT_REQUIRED_AGENTS,
+    projectDir,
+  );
 
   const result: Record<string, unknown> = {
     researcher_model: researcherModel,
@@ -215,6 +257,13 @@ export const initNewProject: QueryHandler = async (_args, projectDir, workstream
     exa_search_available: hasExaSearch,
 
     project_path: '.planning/PROJECT.md',
+    agent_runtime: runtime,
+    agents_dir: agentsDir,
+    required_agents: NEW_PROJECT_REQUIRED_AGENTS,
+    required_agents_installed: missingRequiredAgents.length === 0,
+    missing_required_agents: missingRequiredAgents,
+    agent_skill_payloads_available: agentSkillPayloadAgents.length === NEW_PROJECT_REQUIRED_AGENTS.length,
+    agent_skill_payload_agents: agentSkillPayloadAgents,
   };
 
   return { data: withProjectRoot(projectDir, result, config as Record<string, unknown>) };

--- a/tests/bug-2419-project-researcher-agent.test.cjs
+++ b/tests/bug-2419-project-researcher-agent.test.cjs
@@ -58,6 +58,18 @@ describe('gsd-project-researcher agent registration (#2419)', () => {
     );
   });
 
+  test('new-project.md reports required-agent and skill-payload diagnostics separately', () => {
+    const content = fs.readFileSync(NEW_PROJECT_PATH, 'utf-8');
+    assert.ok(content.includes('required_agents_installed'),
+      'new-project.md must parse required_agents_installed from init JSON');
+    assert.ok(content.includes('missing_required_agents'),
+      'new-project.md must report missing required new-project agents separately');
+    assert.ok(content.includes('agent_skill_payloads_available'),
+      'new-project.md must distinguish skill payload availability from agent definitions');
+    assert.ok(content.includes('agents_dir'),
+      'new-project.md must show which agents directory was checked');
+  });
+
   test('new-milestone.md parses agents_installed from init JSON', () => {
     const content = fs.readFileSync(NEW_MILESTONE_PATH, 'utf-8');
     assert.ok(


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3388

Linked issue labels: bug, area: workflow, confirmed-bug

## Confirmed Issue Description

## Summary

`gsd-sdk query init.new-project` reports `agents_installed: false` and blocks `/gsd-new-project --auto`, even though `gsd-sdk query agent-skills` resolves the required GSD agent skill payloads successfully.

This looks like a mismatch between the install/agent registry check used by `init.new-project` and the skill payload resolution used by `agent-skills`.

## Why this matters

The `new-project` workflow explicitly depends on these subagents in auto mode:

- `gsd-project-researcher`
- `gsd-research-synthesizer`
- `gsd-roadmapper`

When `init.new-project` reports the agent installation gate as failed, `/gsd-new-project --auto` must stop before generating `.planning/PROJECT.md`, `.planning/REQUIREMENTS.md`, and `.planning/ROADMAP.md`.

In the observed run, the workflow was intentionally stopped because the user had instructed: “if any GSD flow problem happens, stop and report.”

## Environment / context observed

Repository state at time of failure:

```json
{
  "project_exists": false,
  "planning_exists": true,
  "has_codebase_map": true,
  "has_existing_code": true,
  "has_package_file": false,
  "is_brownfield": true,
  "needs_codebase_map": false,
  "has_git": true,
  "brave_search_available": false,
  "firecrawl_available": false,
  "exa_search_available": false,
  "project_path": ".planning/PROJECT.md"
}
```

Planning artifacts present:

```text
.planning/config.json
.planning/codebase/STACK.md
.planning/codebase/INTEGRATIONS.md
.planning/codebase/ARCHITECTURE.md
.planning/codebase/STRUCTURE.md
.planning/codebase/CONVENTIONS.md
.planning/codebase/TESTING.md
.planning/codebase/CONCERNS.md
```

Planning artifacts absent:

```text
.planning/PROJECT.md
.planning/REQUIREMENTS.md
.planning/ROADMAP.md
.planning/STATE.md
.planning/phases/
.planning/reports/SESSION_REPORT.md
```

Relevant `.planning/config.json` values:

```json
{
  "model_profile": "balanced",
  "commit_docs": false,
  "parallelization": true,
  "workflow": {
    "research": true,
    "plan_check": true,
    "verifier": true,
    "auto_advance": true,
    "ui_phase": true,
    "_auto_chain_active": true
  },
  "mode": "yolo",
  "granularity": "coarse",
  "branching_strategy": "phase"
}
```

## Reproduction commands

Run:

```bash
gsd-sdk query init.new-project
```

Then compare with:

```bash
gsd-sdk query agent-skills gsd-project-researcher
gsd-sdk query agent-skills gsd-research-synthesizer
gsd-sdk query agent-skills gsd-roadmapper
```

## Actual behavior

`init.new-project` returns:

```json
{
  "researcher_model": "sonnet",
  "synthesizer_model": "sonnet",
  "roadmapper_model": "sonnet",
  "commit_docs": false,
  "project_exists": false,
  "has_codebase_map": true,
  "planning_exists": true,
  "has_existing_code": true,
  "has_package_file": false,
  "is_brownfield": true,
  "needs_codebase_map": false,
  "has_git": true,
  "brave_search_available": false,
  "firecrawl_available": false,
  "exa_search_available": false,
  "project_path": ".planning/PROJECT.md",
  "agents_installed": false,
  "missing_agents": [
    "gsd-planner",
    "gsd-roadmapper",
    "gsd-executor",
    "gsd-phase-researcher",
    "gsd-project-researcher",
    "gsd-research-synthesizer",
    "gsd-debugger",
    "gsd-codebase-mapper",
    "gsd-verifier",
    "gsd-plan-checker",
    "gsd-integration-checker",
    "gsd-nyquist-auditor",
    "gsd-ui-researcher",
    "gsd-ui-checker",
    "gsd-ui-auditor",
    "gsd-doc-writer",
    "gsd-doc-verifier"
  ]
}
```

But the following probes succeed:

```text
gsd-project-researcher: skill ok
gsd-research-synthesizer: skill ok
gsd-roadmapper: skill ok
```

Those probes were executed by redirecting each command to a temp file and checking the process exit status:

```bash
gsd-sdk query agent-skills gsd-project-researcher >/tmp/gsd_researcher_skills.txt && echo "researcher: ok" || echo "researcher: fail"
gsd-sdk query agent-skills gsd-research-synthesizer >/tmp/gsd_synth_skills.txt && echo "synthesizer: ok" || echo "synthesizer: fail"
gsd-sdk query agent-skills gsd-roadmapper >/tmp/gsd_roadmapper_skills.txt && echo "roadmapper: ok" || echo "roadmapper: fail"
```

Observed output:

```text
researcher: ok
synthesizer: ok
roadmapper: ok
```

## Expected behavior

The init gate should avoid reporting a misleading single-state failure when the SDK can resolve the required skill payloads.

Expected behavior should be one of:

1. `init.new-project` returns `agents_installed: true` when required GSD agent skill payloads are installed and usable by the current runtime; or
2. `init.new-project` separates these checks explicitly, for example:

```json
{
  "agent_skill_payloads_available": true,
  "agent_types_registered": false,
  "agents_spawnable": false,
  "agents_installed": false
}
```

That would make the actionable failure clear: skill files exist, but the runtime cannot register/spawn those agent types.

## Impact

This blocks `/gsd-new-project --auto` before project initialization completes.

In the observed workflow, it prevented creation of:

- `.planning/PROJECT.md`
- `.planning/REQUIREMENTS.md`
- `.planning/ROADMAP.md`
- `.planning/STATE.md`

It also makes the remediation ambiguous. The output suggests “missing agents,” but `agent-skills` proves at least some expected agent assets are available.

## Forensic findings

A local forensic run classified the issue as:

### 1. Agent Installation Gate Blocks Auto Workflow — HIGH confidence

Evidence: `init.new-project` returned `agents_installed: false` and listed the workflow-required agents as missing.

### 2. Inconsistent Agent Availability Signals — MEDIUM confidence

Evidence: `agent-skills` returned success for the required `new-project` agents.

Interpretation: there may be a difference between:

- skill payload available;
- agent definition installed;
- agent type registered in the runtime;
- subagent spawnability.

### 3. Partial GSD Initialization State — HIGH confidence

Evidence: `.planning/config.json` and `.planning/codebase/*.md` exist, but project-level GSD artifacts do not.

This means the repo is not fully initialized but has enough planning context for `new-project` to continue if the agent gate passes.

## Possible root cause

The most likely root cause is an install/materialization/registry drift:

- `gsd-sdk query agent-skills` can find skill payloads for GSD agents;
- `gsd-sdk query init.new-project` checks a different installation/registry surface and concludes the agents are missing.

This may be related to the runtime install policy / runtime metadata deduplication work, but the current user-facing symptom is concrete and workflow-blocking.

## Related work

Possibly related:

- #3370
- #3371
- #3373
- #3377

Especially #3371 because it mentions deduplicating metadata across install and SDK query surfaces.

However, this issue tracks the concrete failure mode where `init.new-project` blocks while `agent-skills` resolves required agents.

## Suggested acceptance criteria

- [ ] Add a regression test where `init.new-project` and `agent-skills` cannot disagree silently for required GSD agents.
- [ ] If skill payload availability is insufficient for spawning agents, expose distinct diagnostic fields rather than only `agents_installed: false`.
- [ ] The `/gsd-new-project --auto` preflight output should tell the user whether the fix is reinstalling global agents, repairing runtime registry, or resolving missing skill payloads.
- [ ] The result should explicitly identify the runtime/config surface being checked for agent type registration.

## Workaround

Recommended local workaround was to reinstall/repair the global GSD runtime assets:

```bash
npx get-shit-done-cc@latest --global
```

Then re-run:

```bash
gsd-sdk query init.new-project
```

Expected after repair:

```json
{
  "agents_installed": true
}
```

## Standards Followed

- `CONTEXT.md`: contributor gate order, changeset PR-number rule, and domain vocabulary requirements.
- `CONTRIBUTING.md`: issue-first process, typed PR template, closing keyword, one-concern scope, changeset fragment, and test requirements.
- `docs/contributor-standards.md`: CONTEXT/ADR hierarchy, isolated worktree expectation, AI-assisted PR body requirements, and architecture-aware testing guidance.

## What was broken

`init.new-project` collapsed runtime agent registration and agent skill payload availability into one missing-agents warning, blocking `/gsd-new-project --auto` without actionable diagnostics.

## What this fix does

The SDK now reports required new-project agents, the checked runtime agents directory, missing required agent definitions, and configured skill payload availability separately.

## Root cause

The init query exposed generic `agents_installed` and `missing_agents` fields even though new-project depends on a narrower required-agent contract.

## Testing

### How I verified the fix

- `npm run test:unit -- src/query/init-complex.test.ts`
- `node --test tests/bug-2419-project-researcher-agent.test.cjs`
- `npm run build:sdk`
- `npm run lint:tests`
- `git diff --check`
- `npm test`

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: SDK query init surface
- [ ] N/A (not runtime-specific)

## Scope Confirmation

- [x] This PR is one concern: workflow fix for #3388.
- [x] The fix is scoped to the confirmed bug report and does not add unrelated behavior.
- [x] No drive-by formatting or unrelated dependency changes are included.

## Checklist

- [x] Issue linked above with `Fixes #3388`.
- [x] Linked issue has the `confirmed-bug` label.
- [x] Fix is scoped to the reported bug.
- [x] Regression test added.
- [x] Existing tests were run as listed above.
- [x] `.changeset/` fragment added: `.changeset/new-project-agent-diagnostics.md`.
- [x] PR title uses required typed scope prefix: `Fix(workflow):`.
- [x] No unnecessary dependencies added.

## Breaking changes

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent diagnostics in the new-project workflow with separate reporting for required agent registration and skill payload availability.
  * Enhanced warning messages now display the agents directory path and clearer indicators of missing required agents versus available skill payloads.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3390)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->