### PR TITLE
Fix(hooks): normalize Windows managed hook script paths

### DIFF
--- a/.changeset/codex-windows-hook-script-paths.md
+++ b/.changeset/codex-windows-hook-script-paths.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3396
+---
+**Codex Windows managed Node hooks now use double-quoted forward-slash script paths** - migrated hook commands no longer preserve POSIX single quotes that Windows treats as literal path characters.

--- a/.changeset/codex-windows-hook-script-paths.md
+++ b/.changeset/codex-windows-hook-script-paths.md
@@ -2,4 +2,4 @@
 type: Fixed
 pr: 3396
 ---
-**Codex Windows managed Node hooks now use double-quoted forward-slash script paths** - migrated hook commands no longer preserve POSIX single quotes that Windows treats as literal path characters.
+**Codex Windows-managed Node hooks now use double-quoted forward-slash script paths** - migrated hook commands no longer preserve POSIX single quotes that Windows treats as literal path characters.

--- a/bin/install.js
+++ b/bin/install.js
@@ -599,6 +599,12 @@ function formatHookCommandForShell(command, opts) {
   return platform === 'win32' ? `& ${command}` : command;
 }
 
+function formatManagedHookScriptToken(scriptPath, opts) {
+  const platform = (opts && opts.platform) || process.platform;
+  if (platform !== 'win32') return null;
+  return JSON.stringify(scriptPath.replace(/\\/g, '/'));
+}
+
 function rewriteLegacyManagedNodeHookCommands(settings, absoluteRunner, opts) {
   if (!settings || !settings.hooks || !absoluteRunner) return false;
   if (!opts) opts = {};
@@ -672,7 +678,8 @@ function rewriteLegacyManagedNodeHookCommands(settings, absoluteRunner, opts) {
           if (platform !== 'win32' || hadPowerShellCallOperator) continue;
         }
 
-        h.command = formatHookCommandForShell(`${absoluteRunner} ${scriptToken}`, opts);
+        const safeScriptToken = formatManagedHookScriptToken(scriptPath, opts) || scriptToken;
+        h.command = formatHookCommandForShell(`${absoluteRunner} ${safeScriptToken}`, opts);
         changed = true;
       }
     }

--- a/tests/bug-2979-hook-absolute-node.test.cjs
+++ b/tests/bug-2979-hook-absolute-node.test.cjs
@@ -335,6 +335,26 @@ describe('Bug #2979 (#3002 CR): rewriteLegacyManagedNodeHookCommands rewrites ba
     const changed = rewriteLegacyManagedNodeHookCommands(settings, runner);
     assert.equal(changed, true);
   });
+
+  test('normalizes single-quoted Windows managed hook paths to double-quoted forward-slash paths (#3392)', () => {
+    const settings = {
+      hooks: {
+        PreToolUse: [{
+          hooks: [{
+            type: 'command',
+            command: "node 'C:\\Users\\me\\.codex\\hooks\\gsd-prompt-guard.js'",
+          }],
+        }],
+      },
+    };
+    const runner = '"C:/nvm4w/nodejs/node.exe"';
+    const changed = rewriteLegacyManagedNodeHookCommands(settings, runner, { platform: 'win32' });
+    assert.equal(changed, true);
+    assert.equal(
+      settings.hooks.PreToolUse[0].hooks[0].command,
+      '& "C:/nvm4w/nodejs/node.exe" "C:/Users/me/.codex/hooks/gsd-prompt-guard.js"',
+    );
+  });
 });
 
 describe('Bug #2979 (#3002 CR): resolveNodeRunner returns null when execPath unavailable', () => {


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3392

Linked issue labels: bug, area: hooks, confirmed-bug

## Confirmed Issue Description

## GSD Version

Installed hook scripts report `gsd-hook-version: 1.41.2`.

## Runtime

Codex CLI

## Operating System

Windows

## Shell

PowerShell / Windows shell invocation from Codex hooks

## What happened?

GSD-managed Codex hooks on Windows can be emitted with POSIX-style single quotes around the hook script path, for example:

```toml
command = "\"C:/nvm4w/nodejs/node.exe\" 'C:\\Users\\REDACTED\\.codex\\hooks\\gsd-prompt-guard.js'"
```

When Codex/Windows executes this command, the single quotes are passed as literal path characters. Node then resolves the hook argument relative to the current working directory and fails with `MODULE_NOT_FOUND`.

Observed failure shape:

```text
Error: Cannot find module 'C:\Users\REDACTED\Documents\projects\rebno\'C:\Users\REDACTED\.codex\hooks\gsd-prompt-guard.js''
```

This surfaced in Codex as repeated hook warnings:

```text
PreToolUse hook (failed)
error: hook exited with code 1

PostToolUse hook (failed)
error: hook exited with code 1
```

The affected local commands included GSD Node hooks such as:

- `gsd-prompt-guard.js`
- `gsd-read-guard.js`
- `gsd-workflow-guard.js`
- `gsd-context-monitor.js`

## What did you expect?

For Windows Codex installs, GSD should emit hook commands using Windows-compatible quoting. For example:

```toml
command = "\"C:/nvm4w/nodejs/node.exe\" \"C:/Users/REDACTED/.codex/hooks/gsd-prompt-guard.js\""
```

or otherwise use a command builder that avoids POSIX single-quote assumptions on Windows.

## Steps to reproduce

1. On Windows, have a GSD-managed Codex hook command with a single-quoted script path:

   ```text
   "C:/nvm4w/nodejs/node.exe" 'C:\Users\REDACTED\.codex\hooks\gsd-prompt-guard.js'
   ```

2. Execute it through the Windows command shell from a project directory.
3. Node treats the single quotes as literal path characters and fails to load the hook module.

Control check: replacing the script argument with a double-quoted forward-slash path exits successfully:

```text
"C:/nvm4w/nodejs/node.exe" "C:/Users/REDACTED/.codex/hooks/gsd-prompt-guard.js"
```

## Impact

Moderate. The hooks are installed and loaded, but several managed PreToolUse/PostToolUse hooks fail every time they run, adding noisy Codex warnings and disabling the intended guard/context behavior.

## Workaround

Manually edit `~/.codex/config.toml` or the migrated hook command source and replace single-quoted Windows paths with double-quoted forward-slash paths.

## Related

Adjacent to #3362, but this is the Codex-specific Node hook path quoting failure. #3362 discusses PowerShell hook parsing in Gemini and does not cover Node receiving a literal single-quoted Windows path and throwing `MODULE_NOT_FOUND`.

## Privacy Checklist

- [x] I have reviewed pasted output for PII and redacted local usernames/paths where appropriate.

## Standards Followed

- `CONTEXT.md`: contributor gate order, changeset PR-number rule, and domain vocabulary requirements.
- `CONTRIBUTING.md`: issue-first process, typed PR template, closing keyword, one-concern scope, changeset fragment, and test requirements.
- `docs/contributor-standards.md`: CONTEXT/ADR hierarchy, isolated worktree expectation, AI-assisted PR body requirements, and architecture-aware testing guidance.

## What was broken

Managed hook command migration preserved legacy single-quoted Windows script paths when rewriting Node hook commands, causing Node to treat quote characters as part of the module path.

## What this fix does

When rewriting managed hook commands on Windows, the installer now emits the script path as a double-quoted, forward-slash-normalized token while preserving POSIX behavior elsewhere.

## Root cause

`rewriteLegacyManagedNodeHookCommands()` extracted the script path to identify managed hooks but reused the original script token when writing the migrated command.

## Testing

### How I verified the fix

- `node --test tests/bug-2979-hook-absolute-node.test.cjs`
- `node --test tests/bug-3017-codex-hook-absolute-node.test.cjs`
- `npm run lint:tests`
- `git diff --check`

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [x] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: installer hook command generation
- [ ] N/A (not runtime-specific)

## Scope Confirmation

- [x] This PR is one concern: hooks fix for #3392.
- [x] The fix is scoped to the confirmed bug report and does not add unrelated behavior.
- [x] No drive-by formatting or unrelated dependency changes are included.

## Checklist

- [x] Issue linked above with `Fixes #3392`.
- [x] Linked issue has the `confirmed-bug` label.
- [x] Fix is scoped to the reported bug.
- [x] Regression test added.
- [x] Existing tests were run as listed above.
- [x] `.changeset/` fragment added: `.changeset/codex-windows-hook-script-paths.md`.
- [x] PR title uses required typed scope prefix: `Fix(hooks):`.
- [x] No unnecessary dependencies added.

## Breaking changes

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Windows managed Node hooks during legacy hook migration to use properly quoted and escaped script paths. Script paths now use double-quoted forward-slash formatting instead of preserving POSIX single quotes, preventing them from being misinterpreted as literal path characters on Windows systems.

* **Tests**
  * Added test case verifying correct Windows managed Node hook behavior when single-quoted paths are used.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3396)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->