### PR TITLE
Fix(hooks): resolve Windows Bash hook runner

### DIFF
--- a/.changeset/codex-windows-bash-runner.md
+++ b/.changeset/codex-windows-bash-runner.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3397
+---
+**Codex Windows Bash-backed hooks now resolve Git Bash instead of assuming bare bash is on PATH** - installs skip those hook commands when no supported Bash runner is found.

--- a/.changeset/codex-windows-bash-runner.md
+++ b/.changeset/codex-windows-bash-runner.md
@@ -2,4 +2,4 @@
 type: Fixed
 pr: 3397
 ---
-**Codex Windows Bash-backed hooks now resolve Git Bash instead of assuming bare bash is on PATH** - installs skip those hook commands when no supported Bash runner is found.
+**Codex Windows Bash-backed hooks now resolve Git Bash instead of assuming bare bash is on PATH** - installs skip those hook registrations when no supported Bash runner is found.

--- a/bin/install.js
+++ b/bin/install.js
@@ -613,6 +613,27 @@ function formatManagedHookScriptToken(scriptPath, opts) {
   return JSON.stringify(scriptPath.replace(/\\/g, '/'));
 }
 
+function resolveBashRunner(opts) {
+  const platform = (opts && opts.platform) || process.platform;
+  if (platform !== 'win32') return 'bash';
+
+  const env = (opts && opts.env) || process.env;
+  const exists = (opts && opts.existsSync) || fs.existsSync;
+  const candidates = [];
+  if (env.GSD_BASH_PATH) candidates.push(env.GSD_BASH_PATH);
+  if (env.ProgramFiles) candidates.push(path.join(env.ProgramFiles, 'Git', 'bin', 'bash.exe'));
+  if (env['ProgramFiles(x86)']) candidates.push(path.join(env['ProgramFiles(x86)'], 'Git', 'bin', 'bash.exe'));
+  candidates.push('C:\\Program Files\\Git\\bin\\bash.exe');
+  candidates.push('C:\\Program Files (x86)\\Git\\bin\\bash.exe');
+
+  for (const candidate of candidates) {
+    if (candidate && exists(candidate)) {
+      return JSON.stringify(candidate.replace(/\\/g, '/'));
+    }
+  }
+  return null;
+}
+
 function rewriteLegacyManagedNodeHookCommands(settings, absoluteRunner, opts) {
   if (!settings || !settings.hooks || !absoluteRunner) return false;
   if (!opts) opts = {};
@@ -803,21 +824,19 @@ function rewriteLegacyCodexHookBlock(content, absoluteRunner) {
  */
 function buildHookCommand(configDir, hookName, opts) {
   if (!opts) opts = {};
-  // .sh hooks run under bare `bash` (PATH-resolved). POSIX guarantees
-  // /bin/sh but not /bin/bash, and distros like NixOS do not ship
-  // /bin/bash by default — so PATH-resolved `bash` is more portable than
-  // an absolute /bin/bash. The wrapping `bash <path>` invocation also
-  // means the script's own shebang (#!/usr/bin/env bash) is read as a
-  // comment in this code path; it only matters when the script is run
-  // directly (e.g. tests or future installer changes). .js hooks still
-  // need the absolute node path because GUI-launched runtimes start with
-  // a minimal PATH that does not include nvm/Homebrew/Volta-installed
-  // node binaries (#2979).
+  // POSIX .sh hooks run under PATH-resolved `bash`: POSIX guarantees /bin/sh
+  // but not /bin/bash, and distros like NixOS do not ship /bin/bash by default.
+  // Windows Codex launches hooks from PowerShell/cmd environments where bare
+  // `bash` may not be on PATH, so resolve Git Bash explicitly or return null so
+  // callers skip registration instead of installing a known-broken hook (#3393).
+  // .js hooks still need the absolute node path because GUI-launched runtimes
+  // start with a minimal PATH that may not include nvm/Homebrew/Volta node
+  // binaries (#2979).
   const nodeRunner = resolveNodeRunner();
-  const runner = hookName.endsWith('.sh') ? 'bash' : nodeRunner;
-  // resolveNodeRunner returns null when process.execPath is unavailable.
+  const runner = hookName.endsWith('.sh') ? resolveBashRunner(opts) : nodeRunner;
+  // Runner resolvers return null when the executable path is unavailable.
   // Fall through with null so callers can skip registration with a warning
-  // instead of emitting bare `node` (which would recreate the #2979 bug).
+  // instead of emitting a command that recreates the original hook failure.
   if (runner === null) return null;
 
   if (opts.portableHooks) {

--- a/bin/install.js
+++ b/bin/install.js
@@ -9097,7 +9097,7 @@ function install(isGlobal, runtime = 'claude', options = {}) {
     // omitted the file (as happened in v1.32.0, bug #1817), registering a missing hook
     // causes a hook error on every Bash tool invocation.
     const validateCommitFile = path.join(targetDir, 'hooks', 'gsd-validate-commit.sh');
-    if (!hasValidateCommitHook && fs.existsSync(validateCommitFile)) {
+    if (!hasValidateCommitHook && fs.existsSync(validateCommitFile) && validateCommitCommand) {
       settings.hooks[preToolEvent].push({
         matcher: 'Bash',
         hooks: [
@@ -9111,6 +9111,8 @@ function install(isGlobal, runtime = 'claude', options = {}) {
       console.log(`  ${green}✓${reset} Configured commit validation hook (opt-in via config)`);
     } else if (!hasValidateCommitHook && !fs.existsSync(validateCommitFile)) {
       console.warn(`  ${yellow}⚠${reset}  Skipped commit validation hook — gsd-validate-commit.sh not found at target`);
+    } else if (!hasValidateCommitHook && !validateCommitCommand) {
+      console.warn(`  ${yellow}⚠${reset}  Skipped commit validation hook — Bash executable path unavailable (#3393)`);
     }
 
     // Configure session state orientation hook (opt-in)
@@ -9121,7 +9123,7 @@ function install(isGlobal, runtime = 'claude', options = {}) {
       entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-session-state'))
     );
     const sessionStateFile = path.join(targetDir, 'hooks', 'gsd-session-state.sh');
-    if (!hasSessionStateHook && fs.existsSync(sessionStateFile)) {
+    if (!hasSessionStateHook && fs.existsSync(sessionStateFile) && sessionStateCommand) {
       settings.hooks.SessionStart.push({
         hooks: [
           {
@@ -9133,6 +9135,8 @@ function install(isGlobal, runtime = 'claude', options = {}) {
       console.log(`  ${green}✓${reset} Configured session state orientation hook (opt-in via config)`);
     } else if (!hasSessionStateHook && !fs.existsSync(sessionStateFile)) {
       console.warn(`  ${yellow}⚠${reset}  Skipped session state hook — gsd-session-state.sh not found at target`);
+    } else if (!hasSessionStateHook && !sessionStateCommand) {
+      console.warn(`  ${yellow}⚠${reset}  Skipped session state hook — Bash executable path unavailable (#3393)`);
     }
 
     // Configure phase boundary detection hook (opt-in)
@@ -9143,7 +9147,7 @@ function install(isGlobal, runtime = 'claude', options = {}) {
       entry.hooks && entry.hooks.some(h => h.command && h.command.includes('gsd-phase-boundary'))
     );
     const phaseBoundaryFile = path.join(targetDir, 'hooks', 'gsd-phase-boundary.sh');
-    if (!hasPhaseBoundaryHook && fs.existsSync(phaseBoundaryFile)) {
+    if (!hasPhaseBoundaryHook && fs.existsSync(phaseBoundaryFile) && phaseBoundaryCommand) {
       settings.hooks[postToolEvent].push({
         matcher: 'Write|Edit',
         hooks: [
@@ -9157,6 +9161,8 @@ function install(isGlobal, runtime = 'claude', options = {}) {
       console.log(`  ${green}✓${reset} Configured phase boundary detection hook (opt-in via config)`);
     } else if (!hasPhaseBoundaryHook && !fs.existsSync(phaseBoundaryFile)) {
       console.warn(`  ${yellow}⚠${reset}  Skipped phase boundary hook — gsd-phase-boundary.sh not found at target`);
+    } else if (!hasPhaseBoundaryHook && !phaseBoundaryCommand) {
+      console.warn(`  ${yellow}⚠${reset}  Skipped phase boundary hook — Bash executable path unavailable (#3393)`);
     }
   }
 

--- a/bin/install.js
+++ b/bin/install.js
@@ -621,10 +621,12 @@ function resolveBashRunner(opts) {
   const exists = (opts && opts.existsSync) || fs.existsSync;
   const candidates = [];
   if (env.GSD_BASH_PATH) candidates.push(env.GSD_BASH_PATH);
-  if (env.ProgramFiles) candidates.push(path.join(env.ProgramFiles, 'Git', 'bin', 'bash.exe'));
-  if (env['ProgramFiles(x86)']) candidates.push(path.join(env['ProgramFiles(x86)'], 'Git', 'bin', 'bash.exe'));
-  candidates.push('C:\\Program Files\\Git\\bin\\bash.exe');
-  candidates.push('C:\\Program Files (x86)\\Git\\bin\\bash.exe');
+  if (env.ProgramFiles) candidates.push(path.win32.join(env.ProgramFiles, 'Git', 'bin', 'bash.exe'));
+  if (env['ProgramFiles(x86)']) candidates.push(path.win32.join(env['ProgramFiles(x86)'], 'Git', 'bin', 'bash.exe'));
+  if (env.SystemDrive) {
+    candidates.push(path.win32.join(env.SystemDrive, 'Program Files', 'Git', 'bin', 'bash.exe'));
+    candidates.push(path.win32.join(env.SystemDrive, 'Program Files (x86)', 'Git', 'bin', 'bash.exe'));
+  }
 
   for (const candidate of candidates) {
     if (candidate && exists(candidate)) {

--- a/tests/bug-2979-hook-absolute-node.test.cjs
+++ b/tests/bug-2979-hook-absolute-node.test.cjs
@@ -129,6 +129,27 @@ describe('Bug #2979: buildHookCommand for .sh hooks still uses bare "bash" (POSI
     const parsed = parseHookCommand(cmd);
     assert.equal(parsed.runner, 'bash');
   });
+
+  test('Windows .sh hook uses resolved Git Bash path instead of bare bash (#3393)', () => {
+    const cmd = buildHookCommand('C:/Users/me/.codex', 'gsd-validate-commit.sh', {
+      platform: 'win32',
+      env: { ProgramFiles: 'C:\\Program Files' },
+      existsSync: (candidate) => candidate === 'C:\\Program Files\\Git\\bin\\bash.exe',
+    });
+    assert.equal(
+      cmd,
+      '& "C:/Program Files/Git/bin/bash.exe" "C:/Users/me/.codex/hooks/gsd-validate-commit.sh"',
+    );
+  });
+
+  test('Windows .sh hook returns null when no supported Bash runner is found (#3393)', () => {
+    const cmd = buildHookCommand('C:/Users/me/.codex', 'gsd-phase-boundary.sh', {
+      platform: 'win32',
+      env: {},
+      existsSync: () => false,
+    });
+    assert.equal(cmd, null);
+  });
 });
 
 // ─── #3002 CR follow-up: legacy-bare-node migration ─────────────────────────


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3393

Linked issue labels: bug, area: hooks, confirmed-bug

## Confirmed Issue Description

## GSD Version

Installed hook scripts report `gsd-hook-version: 1.41.2`.

## Runtime

Codex CLI

## Operating System

Windows

## Shell

PowerShell / Windows shell invocation from Codex hooks

## What happened?

Some GSD-managed Codex hooks are emitted as shell scripts invoked with bare `bash`, for example:

```json
"command": "bash 'C:\\Users\\REDACTED\\.codex\\hooks\\gsd-validate-commit.sh'"
```

and:

```json
"command": "bash 'C:\\Users\\REDACTED\\.codex\\hooks\\gsd-phase-boundary.sh'"
```

On this Windows machine, Git for Windows is installed, but `bash` is not on PATH in the PowerShell/Codex environment. Direct reproduction:

```text
The term 'bash' is not recognized as a name of a cmdlet, function, script file, or executable program.
```

This surfaces in Codex as hook failures, including `SessionStart`, `PreToolUse`, and `PostToolUse` warnings:

```text
SessionStart hook (failed)
error: hook exited with code 1

PreToolUse hook (failed)
error: hook exited with code 1

PostToolUse hook (failed)
error: hook exited with code 1
```

The same scripts succeed when invoked with the resolved Git Bash executable:

```text
"C:/Program Files/Git/bin/bash.exe" "C:/Users/REDACTED/.codex/hooks/gsd-session-state.sh"
"C:/Program Files/Git/bin/bash.exe" "C:/Users/REDACTED/.codex/hooks/gsd-validate-commit.sh"
"C:/Program Files/Git/bin/bash.exe" "C:/Users/REDACTED/.codex/hooks/gsd-phase-boundary.sh"
```

## What did you expect?

On Windows, the GSD Codex installer/migrator should not emit bare `bash` unless it has verified that `bash` is available in the runtime PATH Codex will use.

Possible fixes:

- Resolve Git Bash and emit the absolute executable path, for example `C:/Program Files/Git/bin/bash.exe`.
- Prefer Node or PowerShell wrappers for these hooks on Windows.
- If no supported shell is found, skip the Bash-backed hooks with a clear install-time warning instead of installing commands that will fail every time.

## Steps to reproduce

1. Use Windows with Git Bash installed but not exposed as `bash` on PATH.
2. Install or migrate GSD Codex hooks that include `bash ...gsd-*.sh` commands.
3. Start Codex or trigger a matching tool event.
4. Hooks fail with exit code 1 because `bash` cannot be resolved.

Control check: running the same hook scripts with `C:/Program Files/Git/bin/bash.exe` exits 0.

## Impact

Moderate. Managed hooks are installed but fail noisily at runtime. Depending on which hook fires, this can affect session-state injection, commit validation, and phase-boundary reminders.

## Workaround

Manually edit `~/.codex/config.toml` and replace bare `bash` commands with the resolved Git Bash executable path, using double-quoted forward-slash paths.

## Related

Related to #3362, but this is a Codex runtime/install issue with GSD-managed Bash-backed hooks. #3362 is Gemini-focused and mentions Bash ambiguity as a workaround note; this report captures the concrete Codex failure and successful resolved-path workaround.

## Privacy Checklist

- [x] I have reviewed pasted output for PII and redacted local usernames/paths where appropriate.

## Standards Followed

- `CONTEXT.md`: contributor gate order, changeset PR-number rule, and domain vocabulary requirements.
- `CONTRIBUTING.md`: issue-first process, typed PR template, closing keyword, one-concern scope, changeset fragment, and test requirements.
- `docs/contributor-standards.md`: CONTEXT/ADR hierarchy, isolated worktree expectation, AI-assisted PR body requirements, and architecture-aware testing guidance.

## What was broken

Windows `.sh` hook commands were emitted with bare `bash`, assuming Codex could resolve Bash from PATH.

## What this fix does

The installer resolves a Windows Git Bash executable for managed `.sh` hook commands and emits that absolute runner path; if none is found, registration can be skipped instead of installing a guaranteed-failing command.

## Root cause

`buildHookCommand()` treated `.sh` hooks the same on all platforms and used a POSIX-friendly PATH-resolved `bash` runner for Windows Codex hook environments.

## Testing

### How I verified the fix

- `node --test tests/bug-2979-hook-absolute-node.test.cjs`
- `node --test tests/sh-hook-paths.test.cjs`
- `npm run lint:tests`
- `git diff --check`

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [x] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: installer hook command generation
- [ ] N/A (not runtime-specific)

## Scope Confirmation

- [x] This PR is one concern: hooks fix for #3393.
- [x] The fix is scoped to the confirmed bug report and does not add unrelated behavior.
- [x] No drive-by formatting or unrelated dependency changes are included.

## Checklist

- [x] Issue linked above with `Fixes #3393`.
- [x] Linked issue has the `confirmed-bug` label.
- [x] Fix is scoped to the reported bug.
- [x] Regression test added.
- [x] Existing tests were run as listed above.
- [x] `.changeset/` fragment added: `.changeset/codex-windows-bash-runner.md`.
- [x] PR title uses required typed scope prefix: `Fix(hooks):`.
- [x] No unnecessary dependencies added.

## Breaking changes

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows support for Bash-based hooks by correctly detecting Git Bash installations instead of assuming a bare bash on PATH.
  * Installer now gracefully handles missing Bash on Windows: it shows a clear warning and skips registering Bash-backed hooks to avoid invalid hook commands.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3397)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->