### PR TITLE
Feat(installer): Phase 3 first-time baseline scanner

### DIFF
--- a/.changeset/gentle-jays-zip.md
+++ b/.changeset/gentle-jays-zip.md
@@ -1,0 +1,5 @@
+---
+type: Added
+pr: 3399
+---
+**Installer migrations now handle legacy Codex hooks cleanup transactionally** - GSD-owned hooks.json entries are removed through the migration runner with runtime filtering, rollback, and checksum drift protection.

--- a/.changeset/merry-quails-roam.md
+++ b/.changeset/merry-quails-roam.md
@@ -1,0 +1,5 @@
+---
+type: Added
+pr: 3398
+---
+**Installer upgrades now run manifest-backed migration records** - stale managed files can be removed or backed up without deleting unknown user data.

--- a/.changeset/steady-yaks-caper.md
+++ b/.changeset/steady-yaks-caper.md
@@ -1,0 +1,5 @@
+---
+type: Added
+pr: 3400
+---
+Add a first-time installer baseline migration that records managed files, preserves unknown/user-owned artifacts, and blocks stale GSD-looking files for explicit user choice.

--- a/bin/install.js
+++ b/bin/install.js
@@ -76,6 +76,9 @@ const {
   isMinimalMode,
   stageSkillsForMode,
 } = require(path.join(_gsdLibDir, 'install-profiles.cjs'));
+const {
+  runInstallerMigrations,
+} = require(path.join(_gsdLibDir, 'installer-migrations.cjs'));
 
 // Parse args
 const args = process.argv.slice(2);
@@ -6174,24 +6177,6 @@ function copyWithPathReplacement(srcDir, destDir, pathPrefix, runtime, isCommand
 }
 
 /**
- * Clean up orphaned files from previous GSD versions
- */
-function cleanupOrphanedFiles(configDir) {
-  const orphanedFiles = [
-    'hooks/gsd-notify.sh',  // Removed in v1.6.x
-    'hooks/statusline.js',  // Renamed to gsd-statusline.js in v1.9.0
-  ];
-
-  for (const relPath of orphanedFiles) {
-    const fullPath = path.join(configDir, relPath);
-    if (fs.existsSync(fullPath)) {
-      fs.unlinkSync(fullPath);
-      console.log(`  ${green}✓${reset} Removed orphaned ${relPath}`);
-    }
-  }
-}
-
-/**
  * Clean up orphaned hook registrations from settings.json
  */
 function cleanupOrphanedHooks(settings) {
@@ -7191,6 +7176,32 @@ function generateManifest(dir, baseDir) {
   return manifest;
 }
 
+function normalizeInstallRelativePath(relPath) {
+  if (typeof relPath !== 'string' || relPath.trim() === '' || relPath.includes('\0')) {
+    return null;
+  }
+  if (path.isAbsolute(relPath) || path.win32.isAbsolute(relPath)) {
+    return null;
+  }
+  const normalized = relPath.replace(/\\/g, '/');
+  const segments = normalized.split('/');
+  if (segments.some((segment) => segment === '' || segment === '.' || segment === '..')) {
+    return null;
+  }
+  return segments.join('/');
+}
+
+function resolveInstallRelativePath(baseDir, relPath) {
+  const normalized = normalizeInstallRelativePath(relPath);
+  if (!normalized) return null;
+  const root = path.resolve(baseDir);
+  const fullPath = path.resolve(root, normalized);
+  if (fullPath !== root && !fullPath.startsWith(root + path.sep)) {
+    return null;
+  }
+  return { relPath: normalized, fullPath };
+}
+
 /**
  * Write file manifest after installation for future modification detection
  */
@@ -7333,8 +7344,11 @@ function populatePristineDir({ packageSrc, pristineDir, modified, runtime, pathP
   let written = 0;
   try {
     const topLevels = new Set();
+    const safeModified = [];
     for (const relPath of modified) {
-      const norm = relPath.replace(/\\/g, '/');
+      const norm = normalizeInstallRelativePath(relPath);
+      if (!norm) continue;
+      safeModified.push(norm);
       const slash = norm.indexOf('/');
       topLevels.add(slash === -1 ? '' : norm.slice(0, slash));
     }
@@ -7344,14 +7358,16 @@ function populatePristineDir({ packageSrc, pristineDir, modified, runtime, pathP
         // Root-level files — copy directly from package source. The transform
         // pipeline is directory-oriented; root files don't need path-prefix
         // substitution (they're not markdown content with embedded paths).
-        for (const relPath of modified) {
-          const norm = relPath.replace(/\\/g, '/');
+        for (const relPath of safeModified) {
+          const norm = normalizeInstallRelativePath(relPath);
+          if (!norm) continue;
           if (norm.includes('/')) continue;
-          const src = path.join(packageSrc, relPath);
-          if (!fs.existsSync(src)) continue;
-          const stagedFile = path.join(stageRoot, relPath);
+          const srcRef = resolveInstallRelativePath(packageSrc, norm);
+          const stagedRef = resolveInstallRelativePath(stageRoot, norm);
+          if (!srcRef || !stagedRef || !fs.existsSync(srcRef.fullPath)) continue;
+          const stagedFile = stagedRef.fullPath;
           fs.mkdirSync(path.dirname(stagedFile), { recursive: true });
-          fs.copyFileSync(src, stagedFile);
+          fs.copyFileSync(srcRef.fullPath, stagedFile);
         }
         continue;
       }
@@ -7361,15 +7377,15 @@ function populatePristineDir({ packageSrc, pristineDir, modified, runtime, pathP
       copyWithPathReplacement(srcDir, stageDir, pathPrefix, runtime, false, isGlobal);
     }
 
-    for (const relPath of modified) {
+    for (const relPath of safeModified) {
       // Only populate pristine for paths we successfully staged. If a path's
       // source dir does not exist (obsolete manifest entry), skip silently
       // rather than corrupting pristine with stale data.
-      const stagedPath = path.join(stageRoot, relPath);
-      if (!fs.existsSync(stagedPath)) continue;
-      const out = path.join(pristineDir, relPath);
-      fs.mkdirSync(path.dirname(out), { recursive: true });
-      fs.copyFileSync(stagedPath, out);
+      const stagedRef = resolveInstallRelativePath(stageRoot, relPath);
+      const outRef = resolveInstallRelativePath(pristineDir, relPath);
+      if (!stagedRef || !outRef || !fs.existsSync(stagedRef.fullPath)) continue;
+      fs.mkdirSync(path.dirname(outRef.fullPath), { recursive: true });
+      fs.copyFileSync(stagedRef.fullPath, outRef.fullPath);
       written++;
     }
   } finally {
@@ -7408,17 +7424,23 @@ function saveLocalPatches(configDir, pristineCtx) {
   const patchesDir = path.join(configDir, PATCHES_DIR_NAME);
   const pristineDir = path.join(configDir, 'gsd-pristine');
   const modified = [];
+  const pristineHashes = {};
 
   for (const [relPath, originalHash] of Object.entries(manifest.files || {})) {
-    const fullPath = path.join(configDir, relPath);
+    const safeRef = resolveInstallRelativePath(configDir, relPath);
+    if (!safeRef) continue;
+    const { relPath: safeRelPath, fullPath } = safeRef;
     if (!fs.existsSync(fullPath)) continue;
     const currentHash = fileHash(fullPath);
     if (currentHash !== originalHash) {
       // Back up the user's modified version
-      const backupPath = path.join(patchesDir, relPath);
+      const backupRef = resolveInstallRelativePath(patchesDir, safeRelPath);
+      if (!backupRef) continue;
+      const backupPath = backupRef.fullPath;
       fs.mkdirSync(path.dirname(backupPath), { recursive: true });
       fs.copyFileSync(fullPath, backupPath);
-      modified.push(relPath);
+      modified.push(safeRelPath);
+      pristineHashes[safeRelPath] = originalHash;
     }
   }
 
@@ -7438,7 +7460,7 @@ function saveLocalPatches(configDir, pristineCtx) {
     // Record the original (pristine) hash for each modified file
     // This lets the reapply workflow verify reconstructed pristine files
     for (const relPath of modified) {
-      meta.pristine_hashes[relPath] = manifest.files[relPath];
+      meta.pristine_hashes[relPath] = pristineHashes[relPath];
     }
     fs.writeFileSync(path.join(patchesDir, 'backup-meta.json'), JSON.stringify(meta, null, 2));
     console.log('  ' + yellow + 'i' + reset + '  Found ' + modified.length + ' locally modified GSD file(s) — backed up to ' + PATCHES_DIR_NAME + '/');
@@ -7598,8 +7620,8 @@ function install(isGlobal, runtime = 'claude') {
     isGlobal,
   });
 
-  // Clean up orphaned files from previous versions
-  cleanupOrphanedFiles(targetDir);
+  // Run manifest-backed cleanup migrations before package materialization.
+  runInstallerMigrations({ configDir: targetDir });
 
   // #3245 — Codex idempotent rollback. Capture pre-install state of ALL
   // directories and files GSD will mutate so that any post-install validation
@@ -10749,6 +10771,7 @@ if (process.env.GSD_TEST_MODE) {
     convertClaudeToCliineMarkdown,
     convertClaudeAgentToClineAgent,
     writeManifest,
+    saveLocalPatches,
     reportLocalPatches,
     validateHookFields,
     preserveUserArtifacts,

--- a/bin/install.js
+++ b/bin/install.js
@@ -777,76 +777,6 @@ function rewriteLegacyCodexHookBlock(content, absoluteRunner) {
   return { content: updated, changed };
 }
 
-function isManagedCodexHookCommand(command, targetDir) {
-  if (typeof command !== 'string') return false;
-  if (typeof targetDir !== 'string' || targetDir.length === 0) return false;
-  const normalizedCommand = command.replace(/\\/g, '/');
-  const managedHooksDir = `${path.join(targetDir, 'hooks').replace(/\\/g, '/')}/`;
-  if (!normalizedCommand.includes(managedHooksDir)) return false;
-  return /(^|[\\/\s"'])(gsd-check-update\.js|gsd-update-check\.js)(?=$|[\s"'])/.test(normalizedCommand);
-}
-
-function pruneGsdManagedHooksJsonValue(value, targetDir) {
-  if (Array.isArray(value)) {
-    let changed = false;
-    const next = [];
-    for (const item of value) {
-      const pruned = pruneGsdManagedHooksJsonValue(item, targetDir);
-      if (pruned.changed) changed = true;
-      if (!isStructurallyEmpty(pruned.value)) next.push(pruned.value);
-      else changed = true;
-    }
-    return { value: next, changed };
-  }
-
-  if (value && typeof value === 'object') {
-    if (isManagedCodexHookCommand(value.command, targetDir)) {
-      return { value: null, changed: true };
-    }
-
-    let changed = false;
-    const next = {};
-    for (const [key, child] of Object.entries(value)) {
-      const pruned = pruneGsdManagedHooksJsonValue(child, targetDir);
-      if (pruned.changed) changed = true;
-      if (!isStructurallyEmpty(pruned.value)) next[key] = pruned.value;
-      else changed = true;
-    }
-    return { value: next, changed };
-  }
-
-  return { value, changed: false };
-}
-
-function isStructurallyEmpty(value) {
-  if (value === null || value === undefined) return true;
-  if (Array.isArray(value)) return value.length === 0;
-  return typeof value === 'object' && Object.keys(value).length === 0;
-}
-
-function cleanupLegacyCodexHooksJson(targetDir) {
-  const hooksPath = path.join(targetDir, 'hooks.json');
-  if (!fs.existsSync(hooksPath)) return { changed: false, removedFile: false };
-
-  let parsed;
-  try {
-    parsed = JSON.parse(fs.readFileSync(hooksPath, 'utf8'));
-  } catch {
-    return { changed: false, removedFile: false, skipped: 'invalid_json' };
-  }
-
-  const pruned = pruneGsdManagedHooksJsonValue(parsed, targetDir);
-  if (!pruned.changed) return { changed: false, removedFile: false };
-
-  if (isStructurallyEmpty(pruned.value)) {
-    fs.unlinkSync(hooksPath);
-    return { changed: true, removedFile: true };
-  }
-
-  atomicWriteFileSync(hooksPath, JSON.stringify(pruned.value, null, 2) + '\n', 'utf8');
-  return { changed: true, removedFile: false };
-}
-
 /**
  * Build a hook command path using forward slashes for cross-platform compatibility.
  * On Windows, $HOME is not expanded by cmd.exe/PowerShell, so we use the actual path.
@@ -7620,9 +7550,6 @@ function install(isGlobal, runtime = 'claude') {
     isGlobal,
   });
 
-  // Run manifest-backed cleanup migrations before package materialization.
-  runInstallerMigrations({ configDir: targetDir });
-
   // #3245 — Codex idempotent rollback. Capture pre-install state of ALL
   // directories and files GSD will mutate so that any post-install validation
   // failure (config.toml schema check, write failure, etc.) can revert the
@@ -7653,6 +7580,13 @@ function install(isGlobal, runtime = 'claude') {
   // Map<filename, Buffer> — content snapshot of each pre-existing gsd-* agent file.
   const codexPreInstallAgentContents = new Map();
   let codexPreInstallVersionBytes = null;
+  let installerMigrationResult = null;
+  const rollbackInstallerMigrations = () => {
+    if (!installerMigrationResult || typeof installerMigrationResult.rollback !== 'function') return;
+    const rollback = installerMigrationResult.rollback;
+    installerMigrationResult = null;
+    rollback();
+  };
   if (isCodex && !isMinimalMode(installMode)) {
     const _preSkillsDir = path.join(targetDir, 'skills');
     if (fs.existsSync(_preSkillsDir)) {
@@ -7708,6 +7642,7 @@ function install(isGlobal, runtime = 'claude') {
   // The full restoreCodexSnapshot() (defined inside the config block) additionally
   // handles config.toml, which is not yet touched at this point in the pipeline.
   const _codexPreConfigRollback = !isCodex || isMinimalMode(installMode) ? null : () => {
+    rollbackInstallerMigrations();
     // skills/gsd-* — pass 1: restore snapshot entries (may be absent if deleted mid-install).
     const _earlySkillsDir = path.join(targetDir, 'skills');
     for (const skillName of codexPreInstallSkillNames) {
@@ -7783,6 +7718,15 @@ function install(isGlobal, runtime = 'claude') {
     }
     _earlyCleanTmpFiles(targetDir);
   };
+
+  // Run manifest-backed cleanup migrations after rollback snapshots exist and
+  // before package materialization. Codex rollback paths invoke the migration
+  // rollback handle if a later install step fails.
+  installerMigrationResult = runInstallerMigrations({
+    configDir: targetDir,
+    runtime,
+    scope: isGlobal ? 'global' : 'local',
+  });
 
   // #3245 CR finding 2 — wrap the pre-config install operations in a try/catch so
   // that ANY throw between snapshot capture and the Codex config block triggers rollback.
@@ -8445,6 +8389,7 @@ function install(isGlobal, runtime = 'claude') {
     // existence checks. Safe to call before any snapshots are captured (variables
     // default to empty Set / null). Does NOT touch non-gsd-* user content.
     const restoreCodexSnapshot = () => {
+      rollbackInstallerMigrations();
       // 1. config.toml
       if (codexConfigPreInstallSnapshot !== null) {
         try { fs.writeFileSync(codexConfigPathPreInstall, codexConfigPreInstallSnapshot); }
@@ -8708,10 +8653,6 @@ function install(isGlobal, runtime = 'claude') {
         throw wrapped;
       }
       console.log(`  ${green}✓${reset} Configured Codex hooks (SessionStart)`);
-      const legacyHooksCleanup = cleanupLegacyCodexHooksJson(targetDir);
-      if (legacyHooksCleanup.changed) {
-        console.log(`  ${green}✓${reset} Removed legacy GSD hooks.json entries`);
-      }
     } catch (e) {
       // #2760 — schema-validation and write failures must be loud and fatal
       // so the user is never left with a config Codex refuses to load (or no
@@ -10804,7 +10745,6 @@ if (process.env.GSD_TEST_MODE) {
     rewriteLegacyManagedNodeHookCommands,
     buildCodexHookBlock,
     rewriteLegacyCodexHookBlock,
-    cleanupLegacyCodexHooksJson,
   };
 } else {
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -609,6 +609,11 @@ The installer (`bin/install.js`, ~3,000 lines) handles:
 8. **Manifest tracking** — Writes `gsd-file-manifest.json` for clean uninstall
 9. **Uninstall mode** — `--uninstall` removes all GSD files, hooks, and settings
 
+Install-time file moves, stale-artifact cleanup, config rewrites, and user-data
+preservation are governed by the Installer Migration Module. See
+[Installer Migrations](installer-migrations.md) and
+[ADR 0008](adr/0008-installer-migration-module.md).
+
 ### Platform Handling
 
 - **Windows:** `windowsHide` on child processes, EPERM/EACCES protection on protected directories, path separator normalization

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -484,7 +484,8 @@ UI-SPEC.md (per phase) ───────────────────
 
 ```
 ~/.claude/                          # Claude Code (global install)
-├── commands/gsd/*.md               # Slash commands (authoritative roster: docs/INVENTORY.md)
+├── skills/gsd-*/SKILL.md           # Global skills (authoritative roster: docs/INVENTORY.md)
+├── commands/gsd/*.md               # Local Claude installs use slash commands instead of global skills
 ├── get-shit-done/
 │   ├── bin/gsd-tools.cjs           # CLI utility
 │   ├── bin/lib/*.cjs               # Domain modules (authoritative roster: docs/INVENTORY.md)
@@ -500,12 +501,20 @@ UI-SPEC.md (per phase) ───────────────────
 
 Equivalent paths for other runtimes:
 
-- **OpenCode:** `~/.config/opencode/` or `~/.opencode/`
-- **Kilo:** `~/.config/kilo/` or `~/.kilo/`
-- **Gemini CLI:** `~/.gemini/`
-- **Codex:** `~/.codex/` (uses skills instead of commands)
-- **Copilot:** `~/.github/`
-- **Antigravity:** `~/.gemini/antigravity/` (global) or `./.agent/` (local)
+- **OpenCode:** `~/.config/opencode/` global or `./.opencode/` local
+- **Kilo:** `~/.config/kilo/` global or `./.kilo/` local
+- **Gemini CLI:** `~/.gemini/` global or `./.gemini/` local
+- **Codex:** `~/.codex/` global or `./.codex/` local
+- **Copilot:** `~/.copilot/` global or `./.github/` local
+- **Antigravity:** `~/.gemini/antigravity/` global or `./.agent/` local
+- **Cursor:** `~/.cursor/` global or `./.cursor/` local
+- **Windsurf:** `~/.codeium/windsurf/` global or `./.windsurf/` local
+- **Augment Code:** `~/.augment/` global or `./.augment/` local
+- **Trae:** `~/.trae/` global or `./.trae/` local
+- **Qwen Code:** `~/.qwen/` global or `./.qwen/` local
+- **Hermes Agent:** `~/.hermes/` global or `./.hermes/` local
+- **CodeBuddy:** `~/.codebuddy/` global or `./.codebuddy/` local
+- **Cline:** `~/.cline/` global or project-root `.clinerules` local
 
 ### Project Files (`.planning/`)
 
@@ -587,11 +596,11 @@ verification.
 
 ## Installer Architecture
 
-The installer (`bin/install.js`, ~3,000 lines) handles:
+The installer (`bin/install.js`, ~10,700 lines) handles:
 
-1. **Runtime detection** — Interactive prompt or CLI flags (`--claude`, `--opencode`, `--gemini`, `--kilo`, `--codex`, `--copilot`, `--antigravity`, `--cursor`, `--windsurf`, `--trae`, `--cline`, `--augment`, `--all`)
+1. **Runtime detection** — Interactive prompt or CLI flags (`--claude`, `--opencode`, `--gemini`, `--kilo`, `--codex`, `--copilot`, `--antigravity`, `--cursor`, `--windsurf`, `--augment`, `--trae`, `--qwen`, `--hermes`, `--codebuddy`, `--cline`, `--all`)
 2. **Location selection** — Global (`--global`) or local (`--local`)
-3. **File deployment** — Copies commands, workflows, references, templates, agents, hooks
+3. **File deployment** — Copies commands, skills, workflows, references, templates, agents, and hooks
 4. **Runtime adaptation** — Transforms file content per runtime:
   - Claude Code: Uses as-is
   - OpenCode: Converts commands/agents to OpenCode-compatible flat command + subagent format
@@ -600,7 +609,12 @@ The installer (`bin/install.js`, ~3,000 lines) handles:
   - Copilot: Maps tool names (Read→read, Bash→execute, etc.)
   - Gemini: Adjusts hook event names (`AfterTool` instead of `PostToolUse`)
   - Antigravity: Skills-first with Google model equivalents
+  - Cursor: Skills-first with Cursor rule references
+  - Windsurf: Skills-first with Windsurf rule references
   - Trae: Skills-first install to `~/.trae` / `./.trae` with no `settings.json` or hook integration
+  - Qwen Code: Skills-first with Qwen-branded path and prompt rewrites
+  - Hermes Agent: Category-based skills under `skills/gsd/`
+  - CodeBuddy: Skills-first with CodeBuddy path and prompt rewrites
   - Cline: Writes `.clinerules` for rule-based integration
   - Augment Code: Skills-first with full skill conversion and config management
 5. **Path normalization** — Replaces `~/.claude/` paths with runtime-specific paths
@@ -708,20 +722,46 @@ The researcher → planner → executor pipeline includes a supply-chain gate ag
 
 GSD supports multiple AI coding runtimes through a unified command/workflow architecture:
 
+### Runtime Install Contract Matrix
 
-| Runtime      | Command Format | Agent System     | Config Location          |
-| ------------ | -------------- | ---------------- | ------------------------ |
-| Claude Code  | `/gsd-command` | Task spawning    | `~/.claude/`             |
-| OpenCode     | `/gsd-command` | Subagent mode    | `~/.config/opencode/`    |
-| Kilo         | `/gsd-command` | Subagent mode    | `~/.config/kilo/`        |
-| Gemini CLI   | `/gsd-command` | Task spawning    | `~/.gemini/`             |
-| Codex        | `$gsd-command` | Skills           | `~/.codex/`              |
-| Copilot      | `/gsd-command` | Agent delegation | `~/.github/`             |
-| Antigravity  | Skills         | Skills           | `~/.gemini/antigravity/` |
-| Trae         | Skills         | Skills           | `~/.trae/`               |
-| Cline        | Rules          | Rules            | `.clinerules`            |
-| Augment Code | Skills         | Skills           | Augment config           |
+This matrix describes the runtime surfaces the installer materializes today.
+The migration-specific ownership and source snapshots live in
+[Installer Migrations](installer-migrations.md#runtime-configuration-contract-registry).
 
+| Runtime | Global root | Local root | Invocation surface | Agent surface | Config and hooks |
+| --- | --- | --- | --- | --- | --- |
+| Claude Code | `~/.claude` | `./.claude` | Global `skills/gsd-*/SKILL.md`; local `commands/gsd/*.md` | `agents/gsd-*.md` | `settings.json` hook and statusLine entries |
+| OpenCode | `~/.config/opencode` | `./.opencode` | `command/gsd-*.md` | `agents/gsd-*.md` | `opencode.json` or `opencode.jsonc`; no GSD hooks |
+| Kilo | `~/.config/kilo` | `./.kilo` | `command/gsd-*.md` | `agents/gsd-*.md` | `kilo.json` or `kilo.jsonc`; no GSD hooks |
+| Gemini CLI | `~/.gemini` | `./.gemini` | `commands/gsd/*.toml` | `agents/gsd-*.md` | `settings.json` feature flag, hooks, and statusline |
+| Codex | `~/.codex` | `./.codex` | `skills/gsd-*/SKILL.md` | `agents/` source markdown plus per-agent TOML | `config.toml` `[agents.gsd-*]`, `[features].codex_hooks`, and hook tables |
+| GitHub Copilot | `~/.copilot` | `./.github` | `skills/gsd-*/SKILL.md` and `copilot-instructions.md` | `.agent.md` files | No GSD hooks or statusline |
+| Antigravity | `~/.gemini/antigravity` | `./.agent` | `skills/gsd-*/SKILL.md` | `agents/gsd-*.md` | Gemini-style `settings.json` hook entries when installed by GSD |
+| Cursor | `~/.cursor` | `./.cursor` | `skills/gsd-*/SKILL.md` | `agents/gsd-*.md` | Rule references under `rules/`; no GSD hooks |
+| Windsurf | `~/.codeium/windsurf` | `./.windsurf` | `skills/gsd-*/SKILL.md` | `agents/gsd-*.md` | Rule references under `rules/`; no GSD hooks |
+| Augment Code | `~/.augment` | `./.augment` | `skills/gsd-*/SKILL.md` | `agents/gsd-*.md` | No GSD hooks or statusline |
+| Trae | `~/.trae` | `./.trae` | `skills/gsd-*/SKILL.md` | `agents/gsd-*.md` | Rule references under `rules/`; no GSD hooks |
+| Qwen Code | `~/.qwen` | `./.qwen` | `skills/gsd-*/SKILL.md` | `agents/gsd-*.md` | Common GSD settings and hook entries where supported |
+| Hermes Agent | `~/.hermes` | `./.hermes` | `skills/gsd/DESCRIPTION.md` plus `skills/gsd/gsd-*/SKILL.md` | `agents/gsd-*.md` | Common GSD settings and hook entries where supported |
+| CodeBuddy | `~/.codebuddy` | `./.codebuddy` | `skills/gsd-*/SKILL.md` | `agents/gsd-*.md` | Common GSD settings and hook entries where supported |
+| Cline | `~/.cline` | project root | `.clinerules` | Rules only | No GSD hooks or statusline |
+
+### Upstream Contract Sources
+
+Runtime install expectations are checked against primary documentation where
+available. The current source snapshot is 2026-05-11:
+
+- Claude Code: Anthropic slash commands, settings, hooks, and subagents docs.
+- OpenCode and Kilo: OpenCode config docs and Kilo custom subagent docs.
+- Gemini CLI and Qwen Code: command/config docs; Qwen command docs were last
+  updated 2026-05-06.
+- Codex: OpenAI Codex docs and `config-schema.json`; the installer also carries
+  Codex 0.124.0 compatibility for agent table shape.
+- Copilot, Cursor, Cline, Augment, Hermes, and CodeBuddy: vendor docs for
+  custom instructions, rules, skills, or config.
+- Antigravity, Windsurf, and Trae: source-limited rows. The installer documents
+  current compatibility shims, and migrations must refresh those sources before
+  rewriting their config.
 
 ### Abstraction Points
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -627,6 +627,9 @@ Install-time file moves, stale-artifact cleanup, config rewrites, and user-data
 preservation are governed by the Installer Migration Module. See
 [Installer Migrations](installer-migrations.md) and
 [ADR 0008](adr/0008-installer-migration-module.md).
+The migration module also owns the gated first-time baseline scan for legacy
+installs, classifying known runtime install surfaces before later migrations
+remove or rewrite anything.
 
 ### Platform Handling
 

--- a/docs/INVENTORY-MANIFEST.json
+++ b/docs/INVENTORY-MANIFEST.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-05-09",
+  "generated": "2026-05-11",
   "families": {
     "agents": [
       "gsd-advisor-researcher",
@@ -277,6 +277,7 @@
       "init-command-router.cjs",
       "init.cjs",
       "install-profiles.cjs",
+      "installer-migrations.cjs",
       "intel.cjs",
       "learnings.cjs",
       "milestone.cjs",

--- a/docs/INVENTORY.md
+++ b/docs/INVENTORY.md
@@ -359,7 +359,7 @@ The `gsd-planner` agent is decomposed into a core agent plus reference modules t
 
 ---
 
-## CLI Modules (50 shipped)
+## CLI Modules (51 shipped)
 
 Full listing: `get-shit-done/bin/lib/*.cjs`.
 
@@ -385,6 +385,7 @@ Full listing: `get-shit-done/bin/lib/*.cjs`.
 | `init-command-router.cjs` | Thin CJS subcommand router adapter for `gsd-tools init` |
 | `init.cjs` | Compound context loading for each workflow type |
 | `install-profiles.cjs` | Install profile allowlist + skill staging for `--minimal` install (#2762); single source of truth for which `gsd-*` skills/agents land in runtime config dirs |
+| `installer-migrations.cjs` | Installer migration planning, artifact classification, install-state persistence, journaled apply, and rollback helpers |
 | `intel.cjs` | Codebase intel store backing `/gsd-map-codebase --query` and `gsd-intel-updater` |
 | `learnings.cjs` | Cross-phase learnings extraction for `/gsd-extract-learnings` |
 | `milestone.cjs` | Milestone archival, requirements marking |

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ Language versions: [English](README.md) · [Português (pt-BR)](pt-BR/README.md)
 | Document | Audience | Description |
 |----------|----------|-------------|
 | [Architecture](ARCHITECTURE.md) | Contributors, advanced users | System architecture, agent model, data flow, and internal design |
+| [Installer Migrations](installer-migrations.md) | Contributors | Architecture for safe install-time migrations, cleanup, preservation, dry-run planning, and rollback |
 | [Feature Reference](FEATURES.md) | All users | Feature narratives and requirements for released features (see [CHANGELOG](../CHANGELOG.md) for latest additions) |
 | [Command Reference](COMMANDS.md) | All users | Stable commands with syntax, flags, options, and examples |
 | [Configuration Reference](CONFIGURATION.md) | All users | Full config schema, workflow toggles, model profiles, git branching |

--- a/docs/adr/0008-installer-migration-module.md
+++ b/docs/adr/0008-installer-migration-module.md
@@ -1,0 +1,32 @@
+# Installer Migration Module owns install-time upgrade safety
+
+- **Status:** Accepted
+- **Date:** 2026-05-11
+
+We decided to introduce an explicit Installer Migration Module for install-time file moves, removals, config rewrites, and user-data preservation. Installer upgrade behavior must be represented as versioned migration records that produce a dry-run plan before applying changes.
+
+## Decision
+
+- Add an Installer Migration Module as the owner for upgrade migrations.
+- Keep the existing installer materialization pipeline, but move cleanup and feature-retirement behavior into migration records over time.
+- Track applied migrations in an install-state file next to the existing file manifest.
+- Treat the existing file manifest as the managed-file ownership baseline.
+- Treat user-owned artifacts as a single shared policy consumed by preservation and manifest writing.
+- Require migrations to plan first, then apply through a shared executor that owns backup, rollback, and reporting.
+- Default ambiguous or unknown files to preserve; destructive changes need managed-file evidence or explicit user choice.
+- Support dry-run output using the same planner used by apply mode.
+
+## Consequences
+
+- Retiring features requires an explicit migration instead of a hidden cleanup block.
+- The installer can remove stale GSD-owned artifacts without guessing about user files.
+- Locally modified managed files get a consistent backup path before removal or replacement.
+- Future rollback work can become runtime-neutral instead of Codex-specific.
+- Migration authors must define ownership evidence, conflict behavior, runtime scope, and non-interactive behavior.
+- The installer gains another state file, so tests must cover missing, legacy, and checksum-mismatch state.
+
+## Scope
+
+The first implementation should extract manifest/user-owned helpers, add install-state persistence, add migration planning, and port one existing orphan cleanup into the migration runner. It should not rewrite every runtime installer branch in the first pass.
+
+The detailed module contract lives in `docs/installer-migrations.md`.

--- a/docs/adr/0008-installer-migration-module.md
+++ b/docs/adr/0008-installer-migration-module.md
@@ -15,6 +15,22 @@ We decided to introduce an explicit Installer Migration Module for install-time 
 - Require migrations to plan first, then apply through a shared executor that owns backup, rollback, and reporting.
 - Default ambiguous or unknown files to preserve; destructive changes need managed-file evidence or explicit user choice.
 - Support dry-run output using the same planner used by apply mode.
+- Treat the runtime configuration contract registry in `docs/installer-migrations.md` as the source of truth for migrations that touch host runtime config.
+
+## Runtime Contract Decision
+
+Every migration that rewrites runtime config, moves an invocation surface, or
+retires a generated runtime artifact must cite the registry row in
+`docs/installer-migrations.md`. If the migration changes where a runtime loads
+commands, skills, agents, hooks, or rules, the PR must update both the registry
+and `docs/ARCHITECTURE.md`.
+
+The registry records what GSD installs, where it installs it, when migrations
+may touch it, who owns the surrounding config, and why the shape matches the
+host runtime. When upstream docs do not publish an API or docs version, the
+checked date is the drift sentinel. A later upstream docs or CLI release that
+changes command, skill, agent, hook, or rule loading requires a new registry
+snapshot before migration work proceeds.
 
 ## Consequences
 
@@ -23,6 +39,7 @@ We decided to introduce an explicit Installer Migration Module for install-time 
 - Locally modified managed files get a consistent backup path before removal or replacement.
 - Future rollback work can become runtime-neutral instead of Codex-specific.
 - Migration authors must define ownership evidence, conflict behavior, runtime scope, and non-interactive behavior.
+- Migration authors must also define which runtime contract they are relying on and whether the upstream documentation is versioned.
 - The installer gains another state file, so tests must cover missing, legacy, and checksum-mismatch state.
 
 ## Scope

--- a/docs/adr/0008-installer-migration-module.md
+++ b/docs/adr/0008-installer-migration-module.md
@@ -15,6 +15,7 @@ We decided to introduce an explicit Installer Migration Module for install-time 
 - Require migrations to plan first, then apply through a shared executor that owns backup, rollback, and reporting.
 - Default ambiguous or unknown files to preserve; destructive changes need managed-file evidence or explicit user choice.
 - Support dry-run output using the same planner used by apply mode.
+- Include a first-time baseline scanner for legacy installs that need classification before destructive migrations can be trusted.
 - Treat the runtime configuration contract registry in `docs/installer-migrations.md` as the source of truth for migrations that touch host runtime config.
 
 ## Runtime Contract Decision

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -15,9 +15,12 @@ Each ADR documents one architectural decision: what was decided, why, and what c
 | [0005-sdk-architecture-seam-map.md](0005-sdk-architecture-seam-map.md) | SDK Architecture seam map for query/runtime surfaces | Accepted |
 | [0006-planning-path-projection-module.md](0006-planning-path-projection-module.md) | Planning Path Projection Module for SDK query handlers | Accepted |
 | [0007-sdk-package-seam-module.md](0007-sdk-package-seam-module.md) | SDK Package Seam Module owns SDK-to-get-shit-done-cc compatibility | Accepted |
+| [0008-installer-migration-module.md](0008-installer-migration-module.md) | Installer Migration Module owns install-time upgrade safety | Accepted |
 
 ## Seam map
 
 ADR 0005 is the top-level SDK seam index. It references per-seam ADRs and states the narrow-waist principle each seam follows. Use it as the entry point for understanding SDK module ownership.
 
 ADR 0006 documents how SDK query handlers project planning paths (`cwd → effectiveRoot → .planning/<project>/...`). Cross-reference with the Planning Workspace Module (ADR 0004) for workstream pointer policy.
+
+ADR 0008 documents the Installer Migration Module for safe install-time moves, removals, config rewrites, and user-data preservation.

--- a/docs/installer-migrations.md
+++ b/docs/installer-migrations.md
@@ -1,0 +1,376 @@
+# Installer Migration Architecture
+
+This document defines the migration layer for GSD installs and upgrades.
+It is for contributors who need to retire files, move install surfaces,
+rewrite runtime config, or preserve user data while changing how GSD is
+installed.
+
+After reading this document, a contributor should be able to add a new
+installer migration without guessing which files are safe to remove or how
+to protect local user changes.
+
+## Problem
+
+The installer already handles several upgrade behaviors:
+
+- replacing GSD-managed command, skill, agent, hook, and engine files
+- backing up locally modified managed files before replacement
+- preserving known user-owned artifacts
+- cleaning old hook files and hook registrations
+- rewriting runtime-specific configuration formats
+- rolling back some failed Codex installs
+
+Those behaviors are currently distributed across install branches. That
+works for isolated fixes, but it makes feature retirement risky. A future
+change can remove a file from the package while leaving stale installed
+copies behind, or delete a user-created file because it happens to live
+inside a GSD-managed directory.
+
+The migration layer exists to make upgrade behavior explicit, reviewed, and
+repeatable.
+
+## Design Goals
+
+1. Protect user data by default.
+2. Remove stale GSD-managed files when a feature is retired.
+3. Make destructive actions visible before they run.
+4. Record what happened so future installs do not re-run the same migration.
+5. Give each runtime the same safety model, even when the concrete files differ.
+6. Keep migration authoring small enough that contributors use it instead of
+   adding another one-off cleanup block.
+
+## Non-Goals
+
+- This is not a general package manager.
+- This is not a database migration system.
+- This does not automatically infer every historical install layout.
+- This does not remove arbitrary user files.
+- This does not replace the existing install transforms in one step.
+
+## Terms
+
+**Managed file**
+
+A file that GSD installed and recorded in the install manifest. Managed files
+can be replaced automatically when unchanged. If changed locally, they must be
+backed up or merged.
+
+**User-owned file**
+
+A file created or maintained by a user workflow or by the user directly. These
+files must never be removed just because they sit under a GSD directory.
+
+**Unknown file**
+
+A file found under an install root that is not in the manifest and is not
+classified as user-owned. Unknown files are preserved unless a migration
+explicitly classifies them with evidence.
+
+**Migration**
+
+A versioned change set that can inspect the current install, produce a plan,
+and apply that plan after safety checks pass.
+
+**Plan**
+
+A list of proposed filesystem and config actions. A plan is safe to show to a
+user. It describes what will happen and why, without mutating disk.
+
+**Journal**
+
+A per-run record of applied actions and rollback data. It exists so failed
+installs can restore the pre-run state where possible.
+
+## State Files
+
+The migration layer uses the existing file manifest and adds one install-state
+record.
+
+### File Manifest
+
+The existing manifest remains the ownership baseline. It records the installed
+GSD version, install mode, and hashes for distribution-owned files.
+
+The invariant is strict:
+
+- distribution-owned files are manifest-tracked
+- user-owned files are preserved and omitted from manifest hashes
+- a path cannot be both
+
+### Install State
+
+The installer writes an install-state file next to the manifest.
+
+Required fields:
+
+```json
+{
+  "schema": 1,
+  "runtime": "codex",
+  "scope": "global",
+  "installed_version": "1.50.0",
+  "install_mode": "full",
+  "applied_migrations": [
+    {
+      "id": "2026-05-11-codex-hooks-layout",
+      "package_version": "1.50.0",
+      "checksum": "sha256:...",
+      "applied_at": "2026-05-11T00:00:00.000Z"
+    }
+  ]
+}
+```
+
+The checksum is calculated from the migration definition. If an applied
+migration's checksum changes, the installer must warn and refuse to silently
+re-run it. Fix-forward migrations should use a new migration id.
+
+## Migration Record
+
+Each migration exports a plain record plus pure planning logic.
+
+Required fields:
+
+```js
+module.exports = {
+  id: '2026-05-11-runtime-layout-example',
+  title: 'Move legacy commands into runtime skills',
+  introducedIn: '1.50.0',
+  runtimes: ['claude', 'codex', 'gemini'],
+  scopes: ['global', 'local'],
+  destructive: true,
+  plan(ctx) {
+    return [];
+  }
+};
+```
+
+The `plan(ctx)` function receives an install context with runtime, scope,
+target directory, previous manifest, install state, package manifest, and
+filesystem helpers. It returns actions. It must not mutate disk.
+
+Migrations may use helper predicates such as:
+
+- `isManaged(relPath)`
+- `isUserOwned(relPath)`
+- `hashMatchesManifest(relPath)`
+- `exists(relPath)`
+- `readJson(relPath)`
+- `readToml(relPath)`
+
+## Action Types
+
+Migrations produce a small set of action types. The executor owns mutation,
+backup, rollback, and reporting.
+
+### remove-managed
+
+Remove a path only when it is known to be GSD-managed and unchanged from the
+previous manifest, or when the migration provides a purpose-built detector for
+an old GSD-owned shape.
+
+Use for retired hooks, old generated agents, deprecated command files, and
+stale runtime-specific generated artifacts.
+
+### backup-and-remove
+
+Back up a managed path before removal because the file differs from the
+previous manifest. The user gets a clear report and can inspect the backup.
+
+Use when a feature retires a managed file that users may have patched.
+
+### move-managed
+
+Move a managed path to a new managed path. If the source was locally modified,
+the action becomes `backup-and-move` or a conflict.
+
+Use for layout migrations such as command directories moving into skills.
+
+### rewrite-config
+
+Rewrite a structured config file through a parser or existing structural helper.
+String replacement is only acceptable for narrowly-scoped marker blocks with
+tests for line-ending and ordering variations.
+
+Use for runtime config, hook registrations, feature flags, and generated
+agent registration blocks.
+
+### preserve-user
+
+Declare that a path is user-owned and must survive surrounding directory
+replacement. This action is informational in dry-run output and becomes a
+copy-through or restore operation during apply.
+
+Use for profile, preferences, hand-authored instructions, and future workflow
+outputs.
+
+### prompt-user
+
+Stop non-interactive destructive migration and ask in interactive mode. The
+prompt must present concrete choices such as preserve, back up, remove, or
+move. The default is preserve.
+
+Use when classification is ambiguous and guessing could lose data.
+
+## Execution Flow
+
+The installer runs migrations before materializing the new package payload.
+
+1. Build install context.
+2. Read prior manifest and install state.
+3. Build a pre-run snapshot for paths that may be touched.
+4. Discover pending migrations by runtime, scope, and applied state.
+5. Ask each pending migration for a plan.
+6. Merge plans and validate them.
+7. Print the plan in dry-run form.
+8. Apply safe non-interactive actions.
+9. Prompt or stop for ambiguous actions.
+10. Write the new package payload.
+11. Write the new manifest and install state.
+12. Report backups, preserved files, removed stale files, and skipped actions.
+
+If any apply step fails, the executor uses the journal to restore modified
+paths where possible. Rollback must never delete files that were not created
+or modified by the current installer run.
+
+## Dry Run
+
+The migration runner supports a dry-run mode that prints the plan and exits
+without changes.
+
+Dry-run output groups actions by risk:
+
+- will preserve
+- will replace unchanged managed files
+- will remove stale managed files
+- will back up locally modified files
+- needs user choice
+- blocked
+
+The same planner powers dry-run and apply. There must not be a separate
+"preview-only" code path.
+
+## Safety Policy
+
+### Ownership
+
+Never remove an unknown file. Unknown files are preserved unless a migration
+contains a specific detector proving the file is a stale GSD artifact.
+
+### Modification Detection
+
+When a path is in the previous manifest:
+
+- hash match means unchanged managed file
+- hash mismatch means locally modified managed file
+- missing means already removed by the user and should stay removed unless a
+  migration explicitly needs to recreate it
+
+### User-Owned Artifacts
+
+User-owned artifacts are defined once and consumed by both preservation and
+manifest-writing code. Adding a user-owned artifact requires a regression test
+that proves it is preserved across reinstall and omitted from the manifest.
+
+### Config Files
+
+Runtime config is mixed ownership. GSD may own marker blocks, generated agent
+sections, or hook entries, but it does not own the whole file unless the file
+was created as a GSD-only file. Config migrations should remove or rewrite
+only the owned portion.
+
+### Rollback
+
+Before applying a migration, the executor records enough data to restore:
+
+- file bytes before overwrite
+- directory membership before removing generated directories
+- config bytes before structured rewrite
+- paths created by the current run
+- temporary files created by atomic writes
+
+Rollback is best-effort but must be loud when incomplete.
+
+## First-Time Baseline Migration
+
+The first migration should classify an existing install rather than attempt
+to fix every historical layout.
+
+It should:
+
+1. read the current manifest if present
+2. scan known runtime install surfaces
+3. classify files as managed, user-owned, or unknown
+4. report stale GSD-looking files that are not in the current manifest
+5. offer actions for ambiguous files instead of deleting them
+6. write install state after successful classification
+
+This baseline is the escape hatch for old installs that predate full migration
+tracking. It gives the user a reviewable redistribution/removal plan without
+requiring the installer to infer every past release transition perfectly.
+
+## Authoring Workflow
+
+When a feature removes or moves install artifacts, the PR must include:
+
+1. a migration record
+2. tests for dry-run plan output
+3. tests for apply behavior
+4. tests for locally modified managed files
+5. tests for user-owned files near the changed path
+6. an update to release notes if the migration affects user-visible install
+   behavior
+
+The author must answer these questions in the migration file:
+
+- What old artifact or config shape is being retired?
+- How do we prove it is GSD-owned?
+- What happens if the user modified it?
+- What happens if it is missing?
+- What runtime and scope does it affect?
+- Is the action safe in non-interactive install?
+
+## Test Matrix
+
+Every migration runner change should cover:
+
+- fresh install with no prior state
+- reinstall with matching manifest
+- upgrade with pending migration
+- locally modified managed file
+- unknown file under a GSD directory
+- user-owned file under a wiped directory
+- failed apply with rollback
+- global and local install scopes when applicable
+- Windows path separators when paths are serialized
+- CRLF input when config files are rewritten
+
+## Implementation Sequence
+
+1. Extract install ownership helpers around the manifest and user-owned artifact list.
+2. Add install-state read/write helpers.
+3. Add migration record discovery and checksum calculation.
+4. Add planner-only dry-run support.
+5. Add executor with journaled file actions.
+6. Port orphaned hook/file cleanup into the first explicit migration.
+7. Port one structured config rewrite into the migration runner.
+8. Add the baseline classifier for existing installs.
+9. Make new install-affecting PRs require migrations when artifacts are moved,
+   renamed, or retired.
+
+This sequence keeps the first implementation small: the existing installer
+continues to materialize files, while the migration runner takes ownership of
+cleanup, classification, and reviewable destructive changes.
+
+## Prior Art
+
+The design borrows from established upgrade systems:
+
+- Flyway versioned migrations: ordered, once-only changes tracked by checksum.
+- Flyway dry runs: preview planned mutations before applying them.
+- Liquibase changesets and preconditions: declarative changes gated by current
+  system state.
+- Debian conffile policy: preserve local configuration and distinguish package
+  ownership from user ownership.
+- npm lifecycle scripts: useful as packaging context, but not sufficient as the
+  migration mechanism because uninstall and upgrade context are limited.

--- a/docs/installer-migrations.md
+++ b/docs/installer-migrations.md
@@ -195,11 +195,20 @@ tests for line-ending and ordering variations.
 Use for runtime config, hook registrations, feature flags, and generated
 agent registration blocks.
 
+The initial executor support is `rewrite-json`: a migration reads JSON through
+`readJson(relPath)`, returns the next parsed value in the action, and may set
+`deleteIfEmpty: true` when the remaining structure is empty. The executor owns
+the disk write, journal entry, rollback snapshot, and runtime/scope filtering.
+Use this for legacy JSON config cleanup such as Codex `hooks.json`, where GSD
+can prove ownership of individual generated hook commands but not the whole
+file.
+
 ### preserve-user
 
 Declare that a path is user-owned and must survive surrounding directory
-replacement. This action is informational in dry-run output and becomes a
-copy-through or restore operation during apply.
+replacement. This action is informational in dry-run output and blocks
+non-interactive apply until a later interactive baseline migration can ask for
+an explicit user choice.
 
 Use for profile, preferences, hand-authored instructions, and future workflow
 outputs.
@@ -278,6 +287,57 @@ Runtime config is mixed ownership. GSD may own marker blocks, generated agent
 sections, or hook entries, but it does not own the whole file unless the file
 was created as a GSD-only file. Config migrations should remove or rewrite
 only the owned portion.
+
+## Runtime Configuration Contract Registry
+
+Last upstream documentation check: 2026-05-11.
+
+This registry is the source of truth for migrations that touch host runtime
+configuration. Each row records:
+
+- **What:** the GSD invocation, agent, skill, rule, hook, or config surface
+- **Where:** the global and local roots the installer targets
+- **When:** install, upgrade, uninstall, and migration touch points
+- **Who:** the ownership boundary for surrounding user config
+- **Why:** the upstream loader contract or current GSD compatibility shim
+
+Migration authors must read the matching row before producing a
+`rewrite-config`, `move-managed`, or destructive cleanup action. If upstream
+docs change, update this registry, update `docs/ARCHITECTURE.md`, and add tests
+for the new shape before changing migration behavior.
+
+| Runtime | What GSD installs | Where GSD installs it | Config ownership boundary | Upstream contract snapshot |
+| --- | --- | --- | --- | --- |
+| Claude Code | Global skills in `skills/gsd-*/SKILL.md`; local slash commands in `commands/gsd/*.md`; agents in `agents/gsd-*.md`; hooks in `hooks/`; `settings.json` registrations | Global `CLAUDE_CONFIG_DIR` or `~/.claude`; local `./.claude` | GSD owns only generated skills, local commands, `gsd-*` agents, hook files, and GSD hook/statusLine entries in `settings.json` | [Slash commands](https://docs.anthropic.com/en/docs/claude-code/slash-commands), [settings](https://docs.anthropic.com/en/docs/claude-code/settings), [hooks](https://docs.anthropic.com/en/docs/claude-code/hooks), [subagents](https://docs.anthropic.com/en/docs/claude-code/sub-agents); docs not versioned, checked 2026-05-11 |
+| OpenCode | Flat markdown commands in `command/gsd-*.md`; agents in `agents/gsd-*.md`; config updates in `opencode.json` or `opencode.jsonc` | Global `OPENCODE_CONFIG_DIR`, `dirname(OPENCODE_CONFIG)`, `XDG_CONFIG_HOME/opencode`, or `~/.config/opencode`; local `./.opencode` | GSD owns generated command/agent files and GSD entries in structured config only | [Config](https://opencode.ai/docs/config/); docs published 2026-05, checked 2026-05-11 |
+| Kilo | OpenCode-style flat markdown commands in `command/gsd-*.md`; agents in `agents/gsd-*.md`; config updates in `kilo.json` or `kilo.jsonc` | Global `KILO_CONFIG_DIR`, `dirname(KILO_CONFIG)`, `XDG_CONFIG_HOME/kilo`, or `~/.config/kilo`; local `./.kilo` | GSD owns generated command/agent files and GSD entries in structured config only | [Custom subagents](https://docs.kilo.ai/docs/customize/custom-subagents); docs not versioned, checked 2026-05-11 |
+| Gemini CLI | TOML slash commands in `commands/gsd/*.toml`; agents in `agents/gsd-*.md`; `settings.json` feature flag, hooks, and statusline | Global `GEMINI_CONFIG_DIR` or `~/.gemini`; local `./.gemini` | GSD owns generated commands/agents/hooks and only GSD settings entries; local command copy may be skipped when global GSD commands already exist | [Custom commands](https://google-gemini.github.io/gemini-cli/docs/cli/custom-commands.html), [configuration](https://google-gemini.github.io/gemini-cli/docs/cli/configuration.html); docs checked 2026-05-11 |
+| Codex | Skills in `skills/gsd-*/SKILL.md`; agents as source markdown plus per-agent TOML in `agents/`; `[agents.gsd-*]` and hooks in `config.toml` | Global `CODEX_HOME` or `~/.codex`; local `./.codex` | GSD owns generated skills, generated agent TOML, `agents.gsd-*` config sections, `[features].codex_hooks` when added by GSD, and GSD hook entries | [Codex config schema](https://developers.openai.com/codex/config-schema.json), [Codex developer docs](https://developers.openai.com/codex/); docs not versioned, checked 2026-05-11; installer compatibility sentinel: Codex 0.124.0 agent table shape |
+| GitHub Copilot | Skills in `skills/gsd-*/SKILL.md`; agents as `.agent.md`; repository instructions in `copilot-instructions.md` | Global `COPILOT_CONFIG_DIR` or `~/.copilot`; local `./.github` | GSD owns generated skill/agent files and GSD-authored instruction files; no hook/statusline ownership | [Repository custom instructions](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions/add-repository-instructions), [Copilot CLI custom instructions](https://docs.github.com/en/copilot/how-tos/copilot-cli/add-custom-instructions); GitHub Docs product docs, checked 2026-05-11 |
+| Antigravity | Skills in `skills/gsd-*/SKILL.md`; agents in `agents/`; Gemini-style `settings.json` hooks when installed by GSD | Global `ANTIGRAVITY_CONFIG_DIR` or `~/.gemini/antigravity`; local `./.agent` | GSD owns generated skills/agents/hooks and GSD settings entries only | Public Antigravity install/config docs for this file layout were not stable or complete as of 2026-05-11; GSD uses the Gemini-compatible settings contract as a compatibility shim |
+| Cursor | Skills in `skills/gsd-*/SKILL.md`; agents in `agents/`; rule references under `rules/` | Global `CURSOR_CONFIG_DIR` or `~/.cursor`; local `./.cursor` | GSD owns generated skills/agents and GSD rule files or references; no hook/statusline ownership | [Cursor rules](https://docs.cursor.com/context/rules); docs not versioned, checked 2026-05-11 |
+| Windsurf | Skills in `skills/gsd-*/SKILL.md`; agents in `agents/`; rule references under `rules/` | Global `WINDSURF_CONFIG_DIR` or `~/.codeium/windsurf`; local `./.windsurf` | GSD owns generated skills/agents and GSD rule files or references; no hook/statusline ownership | Windsurf public rule docs were source-limited in search results as of 2026-05-11; installer targets the common workspace rules convention `./.windsurf/rules` and must be rechecked before migrations rewrite rules |
+| Augment Code | Skills in `skills/gsd-*/SKILL.md`; agents in `agents/` | Global `AUGMENT_CONFIG_DIR` or `~/.augment`; local `./.augment` | GSD owns generated skills/agents only; no hook/statusline ownership | [Augment Agent Skills](https://docs.augmentcode.com/cli/skills), [Augment IDE skills](https://docs.augmentcode.com/using-augment/skills); IDE skills public beta in VS Code 0.789.0+, checked 2026-05-11 |
+| Trae | Skills in `skills/gsd-*/SKILL.md`; agents in `agents/`; rule references under `rules/` | Global `TRAE_CONFIG_DIR` or `~/.trae`; local `./.trae` | GSD owns generated skills/agents and GSD rule files or references; no hook/statusline ownership | Public Trae docs expose AI settings and `.rules` announcements, but no stable skills/config API was found as of 2026-05-11; migrations must treat this row as source-limited |
+| Qwen Code | Claude-compatible skills in `skills/gsd-*/SKILL.md`; agents in `agents/`; optional common hook/settings integration through GSD | Global `QWEN_CONFIG_DIR` or `~/.qwen`; local `./.qwen` | GSD owns generated skills/agents/hooks and GSD settings entries only | [Qwen commands and skills](https://qwenlm.github.io/qwen-code-docs/en/users/features/commands/); docs last updated 2026-05-06 |
+| Hermes Agent | Category skills under `skills/gsd/` with `DESCRIPTION.md` plus nested `gsd-*/SKILL.md`; agents in `agents/`; optional common hook/settings integration through GSD | Global `HERMES_HOME` or `~/.hermes`; local `./.hermes` | GSD owns generated `skills/gsd/` category content, generated agents, and GSD settings entries only | [Hermes configuration](https://hermes-agent.nousresearch.com/docs/user-guide/configuration), [Hermes skills](https://hermes-agent.nousresearch.com/docs/zh-Hans/user-guide/features/skills), [working with skills](https://hermes-agent.nousresearch.com/docs/guides/work-with-skills); docs checked 2026-05-11 |
+| CodeBuddy | Skills in `skills/gsd-*/SKILL.md`; agents in `agents/`; optional common hook/settings integration through GSD | Global `CODEBUDDY_CONFIG_DIR` or `~/.codebuddy`; local `./.codebuddy` | GSD owns generated skills/agents/hooks and GSD settings entries only | [CodeBuddy CLI skills](https://www.codebuddy.ai/docs/cli/skills), [CodeBuddy IDE skills](https://www.codebuddy.ai/docs/ide/Features/Skills); docs checked 2026-05-11 |
+| Cline | Rule-based integration via `.clinerules` for current installer output | Global `CLINE_CONFIG_DIR` or `~/.cline`; local project root `.clinerules` | GSD owns the generated `.clinerules` file only when it created or manifest-tracked it; no hooks/statusline ownership | [Cline rules](https://docs.cline.bot/customization/cline-rules); docs prefer `.clinerules/` directory and still detect legacy rule files, checked 2026-05-11 |
+
+### Registry Authoring Rules
+
+- Use structured parsers for config files whenever the runtime provides JSON,
+  JSONC, TOML, or YAML. Marker-block rewrites need line-ending and ordering
+  tests.
+- Do not claim ownership of a mixed config file. Own only generated entries,
+  generated files, and explicit marker blocks.
+- Preserve unknown user config, even when it sits inside a GSD-managed runtime
+  root.
+- Add or update the upstream snapshot date and version note when a runtime's
+  docs, CLI schema, or loader behavior changes.
+- Treat source-limited rows as high-risk. A migration that rewrites those
+  runtimes needs either a new primary source or an installer-level probe with
+  tests.
 
 ### Rollback
 

--- a/docs/installer-migrations.md
+++ b/docs/installer-migrations.md
@@ -213,6 +213,22 @@ an explicit user choice.
 Use for profile, preferences, hand-authored instructions, and future workflow
 outputs.
 
+### record-baseline
+
+Record a manifest-managed file in the first-time baseline without mutating it.
+The executor writes a journal entry and install-state entry so later upgrades
+know the baseline scan completed.
+
+Use only from the first-time baseline scanner.
+
+### baseline-preserve-user
+
+Record a user-owned or unknown file discovered under a known install surface
+without mutating it. Unknown files default to this action unless they look like
+retired GSD-generated artifacts that need an explicit user choice.
+
+Use only from the first-time baseline scanner.
+
 ### prompt-user
 
 Stop non-interactive destructive migration and ask in interactive mode. The
@@ -364,6 +380,18 @@ It should:
 4. report stale GSD-looking files that are not in the current manifest
 5. offer actions for ambiguous files instead of deleting them
 6. write install state after successful classification
+
+The Phase 3 implementation adds a gated baseline migration record,
+`2026-05-11-first-time-baseline-scan`. The runner passes `baselineScan: true`
+when the installer wants this first-time scan. Without that flag, discovery is
+safe for normal migration runs and the baseline record plans no actions.
+
+The baseline action contract is:
+
+- `record-baseline` for manifest-managed files
+- `baseline-preserve-user` for known user-owned files and unknown files that do
+  not look like stale GSD-generated artifacts
+- `prompt-user` for stale GSD-looking artifacts that are not manifest-proven
 
 This baseline is the escape hatch for old installs that predate full migration
 tracking. It gives the user a reviewable redistribution/removal plan without

--- a/get-shit-done/bin/lib/installer-migrations.cjs
+++ b/get-shit-done/bin/lib/installer-migrations.cjs
@@ -1,0 +1,348 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const MANIFEST_NAME = 'gsd-file-manifest.json';
+const INSTALL_STATE_NAME = 'gsd-install-state.json';
+const DEFAULT_MIGRATIONS_DIR = path.join(__dirname, 'installer-migrations');
+
+function sha256File(filePath) {
+  return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+function readJsonIfPresent(filePath, fallback) {
+  if (!fs.existsSync(filePath)) return fallback;
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return fallback;
+  }
+}
+
+function readInstallManifest(configDir) {
+  const manifest = readJsonIfPresent(path.join(configDir, MANIFEST_NAME), null);
+  if (!manifest || typeof manifest !== 'object') {
+    return { version: null, timestamp: null, mode: null, files: {} };
+  }
+  return {
+    version: manifest.version || null,
+    timestamp: manifest.timestamp || null,
+    mode: manifest.mode || null,
+    files: manifest.files && typeof manifest.files === 'object' ? manifest.files : {},
+  };
+}
+
+function readInstallState(configDir) {
+  const state = readJsonIfPresent(path.join(configDir, INSTALL_STATE_NAME), null);
+  if (!state || typeof state !== 'object') {
+    return { schemaVersion: 1, appliedMigrations: [] };
+  }
+  return {
+    schemaVersion: state.schemaVersion || 1,
+    appliedMigrations: Array.isArray(state.appliedMigrations) ? state.appliedMigrations : [],
+  };
+}
+
+function writeInstallState(configDir, state) {
+  fs.mkdirSync(configDir, { recursive: true });
+  fs.writeFileSync(path.join(configDir, INSTALL_STATE_NAME), JSON.stringify(state, null, 2) + '\n', 'utf8');
+  return state;
+}
+
+function normalizeRelPath(relPath) {
+  if (typeof relPath !== 'string' || relPath.trim() === '') {
+    throw new Error('migration action relPath must be a non-empty string');
+  }
+  const normalized = relPath.replace(/\\/g, '/');
+  if (normalized.startsWith('/') || normalized.includes('../') || normalized === '..') {
+    throw new Error(`migration action relPath must stay inside configDir: ${relPath}`);
+  }
+  return normalized;
+}
+
+function classifyArtifact(configDir, relPath, manifest) {
+  const normalized = normalizeRelPath(relPath);
+  const originalHash = manifest.files[normalized] || null;
+  const fullPath = path.join(configDir, normalized);
+  if (!fs.existsSync(fullPath)) {
+    return { classification: originalHash ? 'managed-missing' : 'missing', originalHash, currentHash: null };
+  }
+  const currentHash = sha256File(fullPath);
+  if (!originalHash) {
+    return { classification: 'unknown', originalHash: null, currentHash };
+  }
+  if (currentHash === originalHash) {
+    return { classification: 'managed-pristine', originalHash, currentHash };
+  }
+  return { classification: 'managed-modified', originalHash, currentHash };
+}
+
+function appliedMigrationIds(state) {
+  return new Set(
+    state.appliedMigrations
+      .filter((entry) => entry && typeof entry.id === 'string')
+      .map((entry) => entry.id)
+  );
+}
+
+function validateMigrationRecord(record, source) {
+  if (!record || typeof record !== 'object') {
+    throw new Error(`migration record must export an object: ${source}`);
+  }
+  if (typeof record.id !== 'string' || record.id.trim() === '') {
+    throw new Error(`migration record must include a non-empty id: ${source}`);
+  }
+  if (typeof record.plan !== 'function') {
+    throw new Error(`migration record must include a plan function: ${source}`);
+  }
+  return record;
+}
+
+function discoverInstallerMigrations({ migrationsDir }) {
+  if (!migrationsDir || !fs.existsSync(migrationsDir)) return [];
+  return fs.readdirSync(migrationsDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith('.cjs'))
+    .map((entry) => entry.name)
+    .sort()
+    .flatMap((fileName) => {
+      const source = path.join(migrationsDir, fileName);
+      delete require.cache[require.resolve(source)];
+      const exported = require(source);
+      const records = Array.isArray(exported) ? exported : [exported];
+      return records.map((record) => validateMigrationRecord(record, source));
+    });
+}
+
+function journalTimestamp(now) {
+  return now().replace(/[:.]/g, '-');
+}
+
+function ensureInsideConfig(configDir, relPath) {
+  const normalized = normalizeRelPath(relPath);
+  const fullPath = path.resolve(configDir, normalized);
+  const root = path.resolve(configDir);
+  if (fullPath !== root && !fullPath.startsWith(root + path.sep)) {
+    throw new Error(`migration path escapes configDir: ${relPath}`);
+  }
+  return { normalized, fullPath };
+}
+
+function planInstallerMigrations({ configDir, migrations, now = () => new Date().toISOString() }) {
+  if (!configDir) throw new Error('configDir is required');
+  if (!Array.isArray(migrations)) throw new Error('migrations must be an array');
+
+  const manifest = readInstallManifest(configDir);
+  const state = readInstallState(configDir);
+  const applied = appliedMigrationIds(state);
+  const pending = migrations.filter((migration) => migration && !applied.has(migration.id));
+  const actions = [];
+  const blocked = [];
+  const classifications = new Map();
+  const classify = (relPath) => {
+    const normalized = normalizeRelPath(relPath);
+    if (!classifications.has(normalized)) {
+      classifications.set(normalized, classifyArtifact(configDir, normalized, manifest));
+    }
+    return classifications.get(normalized);
+  };
+
+  for (const migration of pending) {
+    if (typeof migration.id !== 'string' || migration.id.trim() === '') {
+      throw new Error('migration id must be a non-empty string');
+    }
+    if (typeof migration.plan !== 'function') {
+      throw new Error(`migration ${migration.id} must provide a plan function`);
+    }
+    const plannedActions = migration.plan({
+      configDir,
+      manifest,
+      state,
+      now,
+      classifyArtifact: classify,
+    });
+    if (!Array.isArray(plannedActions)) {
+      throw new Error(`migration ${migration.id} plan must return an array`);
+    }
+    for (const rawAction of plannedActions) {
+      const relPath = normalizeRelPath(rawAction.relPath);
+      const classification = classify(relPath);
+      let protectedType = rawAction.type;
+      if (rawAction.type === 'remove-managed' && classification.classification === 'managed-modified') {
+        protectedType = 'backup-and-remove';
+      }
+      if (rawAction.type === 'remove-managed' && classification.classification === 'unknown') {
+        protectedType = 'preserve-user';
+      }
+      const action = {
+        migrationId: migration.id,
+        type: protectedType,
+        relPath,
+        reason: rawAction.reason || migration.description || '',
+        classification: classification.classification,
+        originalHash: classification.originalHash,
+        currentHash: classification.currentHash,
+      };
+      if (action.type !== rawAction.type) {
+        action.requestedType = rawAction.type;
+      }
+      if (action.type === 'backup-and-remove') {
+        action.backupRelPath = path.posix.join('gsd-migration-backups', migration.id, relPath);
+      }
+      if (action.classification === 'unknown') blocked.push(action);
+      actions.push(action);
+    }
+  }
+
+  return {
+    generatedAt: now(),
+    manifest,
+    state,
+    pendingMigrationIds: pending.map((migration) => migration.id),
+    actions,
+    blocked,
+  };
+}
+
+function uniqueActionMigrationIds(actions) {
+  return [...new Set(actions.map((action) => action.migrationId).filter(Boolean))];
+}
+
+function applyInstallerMigrationPlan({ configDir, plan, now = () => new Date().toISOString() }) {
+  if (!configDir) throw new Error('configDir is required');
+  if (!plan || !Array.isArray(plan.actions)) throw new Error('plan with actions is required');
+  if (Array.isArray(plan.blocked) && plan.blocked.length > 0) {
+    throw new Error(`migration plan has ${plan.blocked.length} blocked action(s)`);
+  }
+
+  const appliedAt = now();
+  const journalRelPath = path.posix.join('gsd-migration-journal', `${journalTimestamp(() => appliedAt)}.json`);
+  const journalPath = path.join(configDir, journalRelPath);
+  const rollbackRootRelPath = path.posix.join('gsd-migration-journal', `${journalTimestamp(() => appliedAt)}-rollback`);
+  const rollbackRoot = path.join(configDir, rollbackRootRelPath);
+  const journal = {
+    schemaVersion: 1,
+    appliedAt,
+    appliedMigrationIds: uniqueActionMigrationIds(plan.actions),
+    actions: [],
+  };
+  const rollback = [];
+
+  try {
+    for (const action of plan.actions) {
+      if (action.type === 'preserve-user') {
+        journal.actions.push({ ...action, status: 'preserved' });
+        continue;
+      }
+      if (action.type !== 'remove-managed' && action.type !== 'backup-and-remove') {
+        throw new Error(`unsupported migration action type: ${action.type}`);
+      }
+
+      const { normalized, fullPath } = ensureInsideConfig(configDir, action.relPath);
+      if (!fs.existsSync(fullPath)) {
+        journal.actions.push({ ...action, status: 'missing' });
+        continue;
+      }
+
+      const rollbackPath = path.join(rollbackRoot, normalized);
+      fs.mkdirSync(path.dirname(rollbackPath), { recursive: true });
+      fs.copyFileSync(fullPath, rollbackPath);
+      rollback.push({ relPath: normalized, rollbackPath });
+
+      if (action.type === 'backup-and-remove') {
+        const backupRelPath = action.backupRelPath || path.posix.join('gsd-migration-backups', action.migrationId, normalized);
+        const backupPath = path.join(configDir, backupRelPath);
+        fs.mkdirSync(path.dirname(backupPath), { recursive: true });
+        fs.copyFileSync(fullPath, backupPath);
+        journal.actions.push({ ...action, backupRelPath, rollbackRelPath: path.posix.join(rollbackRootRelPath, normalized), status: 'removed' });
+      } else {
+        journal.actions.push({ ...action, rollbackRelPath: path.posix.join(rollbackRootRelPath, normalized), status: 'removed' });
+      }
+      fs.rmSync(fullPath, { force: true });
+    }
+
+    fs.mkdirSync(path.dirname(journalPath), { recursive: true });
+    fs.writeFileSync(journalPath, JSON.stringify(journal, null, 2) + '\n', 'utf8');
+
+    const state = readInstallState(configDir);
+    const applied = appliedMigrationIds(state);
+    const nextApplied = [...state.appliedMigrations];
+    for (const id of journal.appliedMigrationIds) {
+      if (!applied.has(id)) {
+        nextApplied.push({ id, appliedAt, journal: journalRelPath });
+      }
+    }
+    writeInstallState(configDir, {
+      schemaVersion: 1,
+      appliedMigrations: nextApplied,
+    });
+
+    return {
+      appliedMigrationIds: journal.appliedMigrationIds,
+      journalRelPath,
+    };
+  } catch (error) {
+    const rollbackFailures = [];
+    for (const entry of rollback.reverse()) {
+      const dest = path.join(configDir, entry.relPath);
+      try {
+        fs.mkdirSync(path.dirname(dest), { recursive: true });
+        fs.copyFileSync(entry.rollbackPath, dest);
+      } catch (rollbackError) {
+        rollbackFailures.push({
+          relPath: entry.relPath,
+          rollbackPath: entry.rollbackPath,
+          error: rollbackError.message,
+        });
+      }
+    }
+    if (rollbackFailures.length > 0) {
+      const rollbackError = new Error(`migration apply failed and rollback incomplete: ${error.message}`);
+      rollbackError.cause = error;
+      rollbackError.rollbackFailures = rollbackFailures;
+      throw rollbackError;
+    }
+    throw error;
+  }
+}
+
+function runInstallerMigrations({
+  configDir,
+  migrationsDir = DEFAULT_MIGRATIONS_DIR,
+  migrations = discoverInstallerMigrations({ migrationsDir }),
+  now = () => new Date().toISOString(),
+} = {}) {
+  const plan = planInstallerMigrations({ configDir, migrations, now });
+  if (plan.actions.length === 0) {
+    return {
+      appliedMigrationIds: [],
+      journalRelPath: null,
+      plan,
+    };
+  }
+  if (plan.blocked.length > 0) {
+    return {
+      appliedMigrationIds: [],
+      journalRelPath: null,
+      plan,
+      blocked: plan.blocked,
+    };
+  }
+  const result = applyInstallerMigrationPlan({ configDir, plan, now });
+  return { ...result, plan };
+}
+
+module.exports = {
+  DEFAULT_MIGRATIONS_DIR,
+  INSTALL_STATE_NAME,
+  MANIFEST_NAME,
+  applyInstallerMigrationPlan,
+  classifyArtifact,
+  discoverInstallerMigrations,
+  planInstallerMigrations,
+  readInstallManifest,
+  readInstallState,
+  runInstallerMigrations,
+  writeInstallState,
+};

--- a/get-shit-done/bin/lib/installer-migrations.cjs
+++ b/get-shit-done/bin/lib/installer-migrations.cjs
@@ -12,6 +12,10 @@ function sha256File(filePath) {
   return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
 }
 
+function sha256Text(value) {
+  return crypto.createHash('sha256').update(value).digest('hex');
+}
+
 function readJsonIfPresent(filePath, fallback) {
   if (!fs.existsSync(filePath)) return fallback;
   try {
@@ -47,8 +51,20 @@ function readInstallState(configDir) {
 
 function writeInstallState(configDir, state) {
   fs.mkdirSync(configDir, { recursive: true });
-  fs.writeFileSync(path.join(configDir, INSTALL_STATE_NAME), JSON.stringify(state, null, 2) + '\n', 'utf8');
+  writeFileAtomicSync(path.join(configDir, INSTALL_STATE_NAME), JSON.stringify(state, null, 2) + '\n');
   return state;
+}
+
+function readJson(configDir, relPath) {
+  const { fullPath } = ensureInsideConfig(configDir, relPath);
+  if (!fs.existsSync(fullPath)) {
+    return { exists: false, value: null, error: null };
+  }
+  try {
+    return { exists: true, value: JSON.parse(fs.readFileSync(fullPath, 'utf8')), error: null };
+  } catch (error) {
+    return { exists: true, value: null, error };
+  }
 }
 
 function normalizeRelPath(relPath) {
@@ -87,6 +103,56 @@ function appliedMigrationIds(state) {
   );
 }
 
+function appliedMigrationEntries(state) {
+  const entries = new Map();
+  for (const entry of state.appliedMigrations) {
+    if (entry && typeof entry.id === 'string' && !entries.has(entry.id)) {
+      entries.set(entry.id, entry);
+    }
+  }
+  return entries;
+}
+
+function migrationChecksum(migration) {
+  if (typeof migration.checksum === 'string' && migration.checksum) return migration.checksum;
+  const serializable = {
+    id: migration.id,
+    title: migration.title || null,
+    description: migration.description || null,
+    introducedIn: migration.introducedIn || null,
+    runtimes: migration.runtimes || null,
+    scopes: migration.scopes || null,
+    destructive: migration.destructive === true,
+    runtimeContract: migration.runtimeContract || null,
+    plan: typeof migration.plan === 'function' ? migration.plan.toString() : null,
+  };
+  return `sha256:${sha256Text(JSON.stringify(serializable))}`;
+}
+
+function assertAppliedMigrationChecksums(state, migrations) {
+  const applied = appliedMigrationEntries(state);
+  for (const migration of migrations) {
+    const entry = applied.get(migration.id);
+    if (!entry || !entry.checksum) continue;
+    const checksum = migrationChecksum(migration);
+    if (entry.checksum !== checksum) {
+      throw new Error(
+        `applied migration checksum changed for ${migration.id}; create a new fix-forward migration id`
+      );
+    }
+  }
+}
+
+function migrationMatchesContext(migration, { runtime, scope }) {
+  if (Array.isArray(migration.runtimes) && migration.runtimes.length > 0) {
+    if (!runtime || !migration.runtimes.includes(runtime)) return false;
+  }
+  if (Array.isArray(migration.scopes) && migration.scopes.length > 0) {
+    if (!scope || !migration.scopes.includes(scope)) return false;
+  }
+  return true;
+}
+
 function validateMigrationRecord(record, source) {
   if (!record || typeof record !== 'object') {
     throw new Error(`migration record must export an object: ${source}`);
@@ -108,10 +174,11 @@ function discoverInstallerMigrations({ migrationsDir }) {
     .sort()
     .flatMap((fileName) => {
       const source = path.join(migrationsDir, fileName);
+      const checksum = `sha256:${sha256File(source)}`;
       delete require.cache[require.resolve(source)];
       const exported = require(source);
       const records = Array.isArray(exported) ? exported : [exported];
-      return records.map((record) => validateMigrationRecord(record, source));
+      return records.map((record) => validateMigrationRecord({ ...record, checksum: record.checksum || checksum }, source));
     });
 }
 
@@ -129,14 +196,44 @@ function ensureInsideConfig(configDir, relPath) {
   return { normalized, fullPath };
 }
 
-function planInstallerMigrations({ configDir, migrations, now = () => new Date().toISOString() }) {
+function isStructurallyEmpty(value) {
+  if (value === null || value === undefined) return true;
+  if (Array.isArray(value)) return value.length === 0;
+  return typeof value === 'object' && Object.keys(value).length === 0;
+}
+
+function writeFileAtomicSync(filePath, content) {
+  const tmpPath = `${filePath}.tmp-${process.pid}-${Date.now()}`;
+  try {
+    fs.writeFileSync(tmpPath, content, 'utf8');
+    fs.renameSync(tmpPath, filePath);
+  } catch (error) {
+    try {
+      fs.rmSync(tmpPath, { force: true });
+    } catch {
+      // best-effort cleanup only; preserve the original write failure
+    }
+    throw error;
+  }
+}
+
+function journalAction(action, status, extras = {}) {
+  const { value, ...safeAction } = action;
+  return { ...safeAction, ...extras, status };
+}
+
+function planInstallerMigrations({ configDir, runtime = null, scope = null, migrations, now = () => new Date().toISOString() }) {
   if (!configDir) throw new Error('configDir is required');
   if (!Array.isArray(migrations)) throw new Error('migrations must be an array');
 
   const manifest = readInstallManifest(configDir);
   const state = readInstallState(configDir);
+  const scopedMigrations = migrations.filter((migration) =>
+    migration && migrationMatchesContext(migration, { runtime, scope })
+  );
+  assertAppliedMigrationChecksums(state, scopedMigrations);
   const applied = appliedMigrationIds(state);
-  const pending = migrations.filter((migration) => migration && !applied.has(migration.id));
+  const pending = scopedMigrations.filter((migration) => !applied.has(migration.id));
   const actions = [];
   const blocked = [];
   const classifications = new Map();
@@ -157,10 +254,13 @@ function planInstallerMigrations({ configDir, migrations, now = () => new Date()
     }
     const plannedActions = migration.plan({
       configDir,
+      runtime,
+      scope,
       manifest,
       state,
       now,
       classifyArtifact: classify,
+      readJson: (relPath) => readJson(configDir, relPath),
     });
     if (!Array.isArray(plannedActions)) {
       throw new Error(`migration ${migration.id} plan must return an array`);
@@ -177,6 +277,7 @@ function planInstallerMigrations({ configDir, migrations, now = () => new Date()
       }
       const action = {
         migrationId: migration.id,
+        migrationChecksum: migrationChecksum(migration),
         type: protectedType,
         relPath,
         reason: rawAction.reason || migration.description || '',
@@ -190,7 +291,11 @@ function planInstallerMigrations({ configDir, migrations, now = () => new Date()
       if (action.type === 'backup-and-remove') {
         action.backupRelPath = path.posix.join('gsd-migration-backups', migration.id, relPath);
       }
-      if (action.classification === 'unknown') blocked.push(action);
+      if (action.type === 'rewrite-json') {
+        action.value = rawAction.value;
+        action.deleteIfEmpty = rawAction.deleteIfEmpty === true;
+      }
+      if (action.classification === 'unknown' && action.type !== 'rewrite-json') blocked.push(action);
       actions.push(action);
     }
   }
@@ -207,6 +312,54 @@ function planInstallerMigrations({ configDir, migrations, now = () => new Date()
 
 function uniqueActionMigrationIds(actions) {
   return [...new Set(actions.map((action) => action.migrationId).filter(Boolean))];
+}
+
+function rollbackAppliedMigrationResult({ configDir, journal, journalPath, rollbackRoot, previousInstallStateBytes }) {
+  const failures = [];
+  for (const action of [...journal.actions].reverse()) {
+    if (!action.rollbackRelPath) continue;
+    const rollbackPath = path.join(configDir, action.rollbackRelPath);
+    const dest = path.join(configDir, action.relPath);
+    try {
+      if (fs.existsSync(rollbackPath)) {
+        fs.mkdirSync(path.dirname(dest), { recursive: true });
+        fs.copyFileSync(rollbackPath, dest);
+      }
+    } catch (error) {
+      failures.push({ relPath: action.relPath, error: error.message });
+    }
+    if (action.backupRelPath) {
+      try {
+        fs.rmSync(path.join(configDir, action.backupRelPath), { force: true });
+      } catch {
+        // backup cleanup is best-effort; preserve restore failures above
+      }
+    }
+  }
+
+  try {
+    if (previousInstallStateBytes === null) {
+      fs.rmSync(path.join(configDir, INSTALL_STATE_NAME), { force: true });
+    } else {
+      fs.mkdirSync(configDir, { recursive: true });
+      writeFileAtomicSync(path.join(configDir, INSTALL_STATE_NAME), previousInstallStateBytes);
+    }
+  } catch (error) {
+    failures.push({ relPath: INSTALL_STATE_NAME, error: error.message });
+  }
+
+  try {
+    fs.rmSync(journalPath, { force: true });
+    fs.rmSync(rollbackRoot, { recursive: true, force: true });
+  } catch {
+    // journal cleanup is best-effort; the rollback above is the safety-critical part
+  }
+
+  if (failures.length > 0) {
+    const error = new Error('migration rollback incomplete');
+    error.rollbackFailures = failures;
+    throw error;
+  }
 }
 
 function applyInstallerMigrationPlan({ configDir, plan, now = () => new Date().toISOString() }) {
@@ -228,20 +381,20 @@ function applyInstallerMigrationPlan({ configDir, plan, now = () => new Date().t
     actions: [],
   };
   const rollback = [];
+  const installStatePath = path.join(configDir, INSTALL_STATE_NAME);
+  const previousInstallStateBytes = fs.existsSync(installStatePath)
+    ? fs.readFileSync(installStatePath)
+    : null;
 
   try {
     for (const action of plan.actions) {
-      if (action.type === 'preserve-user') {
-        journal.actions.push({ ...action, status: 'preserved' });
-        continue;
-      }
-      if (action.type !== 'remove-managed' && action.type !== 'backup-and-remove') {
+      if (action.type !== 'remove-managed' && action.type !== 'backup-and-remove' && action.type !== 'rewrite-json') {
         throw new Error(`unsupported migration action type: ${action.type}`);
       }
 
       const { normalized, fullPath } = ensureInsideConfig(configDir, action.relPath);
       if (!fs.existsSync(fullPath)) {
-        journal.actions.push({ ...action, status: 'missing' });
+        journal.actions.push(journalAction(action, 'missing'));
         continue;
       }
 
@@ -250,14 +403,34 @@ function applyInstallerMigrationPlan({ configDir, plan, now = () => new Date().t
       fs.copyFileSync(fullPath, rollbackPath);
       rollback.push({ relPath: normalized, rollbackPath });
 
+      if (action.type === 'rewrite-json') {
+        if (action.deleteIfEmpty && isStructurallyEmpty(action.value)) {
+          fs.rmSync(fullPath, { force: true });
+          journal.actions.push(journalAction(action, 'removed', {
+            rollbackRelPath: path.posix.join(rollbackRootRelPath, normalized),
+          }));
+        } else {
+          writeFileAtomicSync(fullPath, JSON.stringify(action.value, null, 2) + '\n');
+          journal.actions.push(journalAction(action, 'rewritten', {
+            rollbackRelPath: path.posix.join(rollbackRootRelPath, normalized),
+          }));
+        }
+        continue;
+      }
+
       if (action.type === 'backup-and-remove') {
         const backupRelPath = action.backupRelPath || path.posix.join('gsd-migration-backups', action.migrationId, normalized);
         const backupPath = path.join(configDir, backupRelPath);
         fs.mkdirSync(path.dirname(backupPath), { recursive: true });
         fs.copyFileSync(fullPath, backupPath);
-        journal.actions.push({ ...action, backupRelPath, rollbackRelPath: path.posix.join(rollbackRootRelPath, normalized), status: 'removed' });
+        journal.actions.push(journalAction(action, 'removed', {
+          backupRelPath,
+          rollbackRelPath: path.posix.join(rollbackRootRelPath, normalized),
+        }));
       } else {
-        journal.actions.push({ ...action, rollbackRelPath: path.posix.join(rollbackRootRelPath, normalized), status: 'removed' });
+        journal.actions.push(journalAction(action, 'removed', {
+          rollbackRelPath: path.posix.join(rollbackRootRelPath, normalized),
+        }));
       }
       fs.rmSync(fullPath, { force: true });
     }
@@ -270,7 +443,13 @@ function applyInstallerMigrationPlan({ configDir, plan, now = () => new Date().t
     const nextApplied = [...state.appliedMigrations];
     for (const id of journal.appliedMigrationIds) {
       if (!applied.has(id)) {
-        nextApplied.push({ id, appliedAt, journal: journalRelPath });
+        const action = plan.actions.find((candidate) => candidate.migrationId === id);
+        nextApplied.push({
+          id,
+          appliedAt,
+          journal: journalRelPath,
+          checksum: action && action.migrationChecksum ? action.migrationChecksum : null,
+        });
       }
     }
     writeInstallState(configDir, {
@@ -281,6 +460,7 @@ function applyInstallerMigrationPlan({ configDir, plan, now = () => new Date().t
     return {
       appliedMigrationIds: journal.appliedMigrationIds,
       journalRelPath,
+      rollback: () => rollbackAppliedMigrationResult({ configDir, journal, journalPath, rollbackRoot, previousInstallStateBytes }),
     };
   } catch (error) {
     const rollbackFailures = [];
@@ -309,11 +489,13 @@ function applyInstallerMigrationPlan({ configDir, plan, now = () => new Date().t
 
 function runInstallerMigrations({
   configDir,
+  runtime = null,
+  scope = null,
   migrationsDir = DEFAULT_MIGRATIONS_DIR,
   migrations = discoverInstallerMigrations({ migrationsDir }),
   now = () => new Date().toISOString(),
 } = {}) {
-  const plan = planInstallerMigrations({ configDir, migrations, now });
+  const plan = planInstallerMigrations({ configDir, runtime, scope, migrations, now });
   if (plan.actions.length === 0) {
     return {
       appliedMigrationIds: [],

--- a/get-shit-done/bin/lib/installer-migrations.cjs
+++ b/get-shit-done/bin/lib/installer-migrations.cjs
@@ -222,7 +222,14 @@ function journalAction(action, status, extras = {}) {
   return { ...safeAction, ...extras, status };
 }
 
-function planInstallerMigrations({ configDir, runtime = null, scope = null, migrations, now = () => new Date().toISOString() }) {
+function planInstallerMigrations({
+  configDir,
+  runtime = null,
+  scope = null,
+  migrations,
+  baselineScan = false,
+  now = () => new Date().toISOString(),
+}) {
   if (!configDir) throw new Error('configDir is required');
   if (!Array.isArray(migrations)) throw new Error('migrations must be an array');
 
@@ -258,6 +265,7 @@ function planInstallerMigrations({ configDir, runtime = null, scope = null, migr
       scope,
       manifest,
       state,
+      baselineScan,
       now,
       classifyArtifact: classify,
       readJson: (relPath) => readJson(configDir, relPath),
@@ -267,7 +275,13 @@ function planInstallerMigrations({ configDir, runtime = null, scope = null, migr
     }
     for (const rawAction of plannedActions) {
       const relPath = normalizeRelPath(rawAction.relPath);
-      const classification = classify(relPath);
+      const classification = rawAction.classification
+        ? {
+            classification: rawAction.classification,
+            originalHash: rawAction.originalHash || null,
+            currentHash: rawAction.currentHash || null,
+          }
+        : classify(relPath);
       let protectedType = rawAction.type;
       if (rawAction.type === 'remove-managed' && classification.classification === 'managed-modified') {
         protectedType = 'backup-and-remove';
@@ -295,7 +309,18 @@ function planInstallerMigrations({ configDir, runtime = null, scope = null, migr
         action.value = rawAction.value;
         action.deleteIfEmpty = rawAction.deleteIfEmpty === true;
       }
-      if (action.classification === 'unknown' && action.type !== 'rewrite-json') blocked.push(action);
+      if (rawAction.prompt) action.prompt = rawAction.prompt;
+      if (Array.isArray(rawAction.choices)) action.choices = rawAction.choices;
+      if (action.type === 'prompt-user') {
+        blocked.push(action);
+      } else if (
+        action.classification === 'unknown' &&
+        action.type !== 'rewrite-json' &&
+        action.type !== 'record-baseline' &&
+        action.type !== 'baseline-preserve-user'
+      ) {
+        blocked.push(action);
+      }
       actions.push(action);
     }
   }
@@ -388,13 +413,24 @@ function applyInstallerMigrationPlan({ configDir, plan, now = () => new Date().t
 
   try {
     for (const action of plan.actions) {
-      if (action.type !== 'remove-managed' && action.type !== 'backup-and-remove' && action.type !== 'rewrite-json') {
+      if (
+        action.type !== 'remove-managed' &&
+        action.type !== 'backup-and-remove' &&
+        action.type !== 'rewrite-json' &&
+        action.type !== 'record-baseline' &&
+        action.type !== 'baseline-preserve-user'
+      ) {
         throw new Error(`unsupported migration action type: ${action.type}`);
       }
 
       const { normalized, fullPath } = ensureInsideConfig(configDir, action.relPath);
       if (!fs.existsSync(fullPath)) {
         journal.actions.push(journalAction(action, 'missing'));
+        continue;
+      }
+
+      if (action.type === 'record-baseline' || action.type === 'baseline-preserve-user') {
+        journal.actions.push(journalAction(action, action.type === 'record-baseline' ? 'recorded' : 'preserved'));
         continue;
       }
 
@@ -441,9 +477,15 @@ function applyInstallerMigrationPlan({ configDir, plan, now = () => new Date().t
     const state = readInstallState(configDir);
     const applied = appliedMigrationIds(state);
     const nextApplied = [...state.appliedMigrations];
+    const actionsByMigrationId = new Map();
+    for (const action of plan.actions) {
+      if (action.migrationId && !actionsByMigrationId.has(action.migrationId)) {
+        actionsByMigrationId.set(action.migrationId, action);
+      }
+    }
     for (const id of journal.appliedMigrationIds) {
       if (!applied.has(id)) {
-        const action = plan.actions.find((candidate) => candidate.migrationId === id);
+        const action = actionsByMigrationId.get(id);
         nextApplied.push({
           id,
           appliedAt,
@@ -493,9 +535,10 @@ function runInstallerMigrations({
   scope = null,
   migrationsDir = DEFAULT_MIGRATIONS_DIR,
   migrations = discoverInstallerMigrations({ migrationsDir }),
+  baselineScan = false,
   now = () => new Date().toISOString(),
 } = {}) {
-  const plan = planInstallerMigrations({ configDir, runtime, scope, migrations, now });
+  const plan = planInstallerMigrations({ configDir, runtime, scope, migrations, baselineScan, now });
   if (plan.actions.length === 0) {
     return {
       appliedMigrationIds: [],

--- a/get-shit-done/bin/lib/installer-migrations/000-first-time-baseline.cjs
+++ b/get-shit-done/bin/lib/installer-migrations/000-first-time-baseline.cjs
@@ -1,0 +1,173 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
+
+const BASELINE_MIGRATION_ID = '2026-05-11-first-time-baseline-scan';
+
+const RUNTIME_SURFACES = {
+  claude: ['get-shit-done', 'commands/gsd', 'skills', 'agents', 'hooks', 'settings.json'],
+  codex: ['get-shit-done', 'skills', 'agents', 'hooks', 'config.toml', 'hooks.json'],
+  gemini: ['get-shit-done', 'commands/gsd', 'hooks'],
+  opencode: ['get-shit-done', 'command', 'skills', 'agents'],
+  kilo: ['get-shit-done', 'command', 'skills', 'agents'],
+  copilot: ['get-shit-done', 'skills', 'agents'],
+  antigravity: ['get-shit-done', 'skills', 'agents'],
+  cursor: ['get-shit-done', 'skills', 'agents'],
+  windsurf: ['get-shit-done', 'skills', 'agents', 'rules'],
+  augment: ['get-shit-done', 'skills', 'agents'],
+  trae: ['get-shit-done', 'skills', 'agents', 'rules'],
+  qwen: ['get-shit-done', 'skills', 'agents'],
+  hermes: ['get-shit-done', 'skills/gsd', 'agents'],
+  cline: ['get-shit-done', 'skills', 'agents'],
+  codebuddy: ['get-shit-done', 'skills', 'agents'],
+};
+
+const COMMON_SURFACES = ['get-shit-done', 'skills', 'agents', 'hooks'];
+const INTERNAL_TOP_LEVEL_NAMES = new Set([
+  'gsd-file-manifest.json',
+  'gsd-install-state.json',
+  'gsd-migration-backups',
+  'gsd-migration-journal',
+]);
+const USER_OWNED_PATHS = new Set([
+  'get-shit-done/USER-PROFILE.md',
+  'commands/gsd/dev-preferences.md',
+  'skills/gsd-dev-preferences/SKILL.md',
+]);
+
+function sha256File(filePath) {
+  return crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex');
+}
+
+function normalizeRelPath(relPath) {
+  return relPath.replace(/\\/g, '/').replace(/^\/+/, '');
+}
+
+function baselineInstallSurfaces(runtime) {
+  if (runtime && RUNTIME_SURFACES[runtime]) return RUNTIME_SURFACES[runtime];
+  return COMMON_SURFACES;
+}
+
+function walkFiles(root, relDir, files) {
+  const dir = path.join(root, relDir);
+  if (!fs.existsSync(dir)) return;
+  const entries = fs.readdirSync(dir, { withFileTypes: true })
+    .sort((a, b) => a.name.localeCompare(b.name));
+  for (const entry of entries) {
+    const relPath = path.posix.join(relDir, entry.name);
+    if (relDir === '' && INTERNAL_TOP_LEVEL_NAMES.has(entry.name)) continue;
+    const fullPath = path.join(root, relPath);
+    if (entry.isDirectory()) {
+      walkFiles(root, relPath, files);
+    } else if (entry.isFile()) {
+      files.add(normalizeRelPath(relPath));
+    }
+  }
+}
+
+function scanBaselineFiles(configDir, runtime) {
+  const relPaths = new Set();
+  for (const surface of baselineInstallSurfaces(runtime)) {
+    const normalized = normalizeRelPath(surface);
+    const fullPath = path.join(configDir, normalized);
+    if (!fs.existsSync(fullPath)) continue;
+    const stat = fs.statSync(fullPath);
+    if (stat.isDirectory()) {
+      walkFiles(configDir, normalized, relPaths);
+    } else if (stat.isFile() && !INTERNAL_TOP_LEVEL_NAMES.has(normalized)) {
+      relPaths.add(normalized);
+    }
+  }
+  return [...relPaths].sort();
+}
+
+function isUserOwnedBaselinePath(relPath) {
+  if (USER_OWNED_PATHS.has(relPath)) return true;
+  const parts = relPath.split('/');
+  if (parts[0] === 'skills' && parts[1] && !parts[1].startsWith('gsd-')) return true;
+  if (parts[0] === 'agents' && parts[1] && !parts[1].startsWith('gsd-')) return true;
+  return false;
+}
+
+function isStaleGsdLookingPath(relPath) {
+  const baseName = path.posix.basename(relPath);
+  if (/^gsd[-_]/.test(baseName)) return true;
+  const parts = relPath.split('/');
+  if ((parts[0] === 'skills' || parts[0] === 'agents') && parts[1] && parts[1].startsWith('gsd-')) {
+    return true;
+  }
+  return false;
+}
+
+function baselineActionRank(action) {
+  if (action.type === 'record-baseline') return 0;
+  if (action.type === 'baseline-preserve-user') return 1;
+  return 2;
+}
+
+module.exports = {
+  id: BASELINE_MIGRATION_ID,
+  title: 'Record first-time installer migration baseline',
+  description: 'Classify existing install surfaces before destructive installer migrations run.',
+  introducedIn: '1.50.0',
+  scopes: ['global', 'local'],
+  destructive: false,
+  plan: ({ configDir, runtime, baselineScan, classifyArtifact }) => {
+    if (!baselineScan) return [];
+
+    const actions = [];
+    for (const relPath of scanBaselineFiles(configDir, runtime)) {
+      const artifact = classifyArtifact(relPath);
+      if (artifact.classification === 'managed-pristine' || artifact.classification === 'managed-modified') {
+        actions.push({
+          type: 'record-baseline',
+          relPath,
+          reason: 'existing manifest-managed file included in first-time migration baseline',
+        });
+        continue;
+      }
+
+      const currentHash = fs.existsSync(path.join(configDir, relPath)) ? sha256File(path.join(configDir, relPath)) : null;
+      if (isUserOwnedBaselinePath(relPath)) {
+        actions.push({
+          type: 'baseline-preserve-user',
+          relPath,
+          reason: 'known user-owned artifact preserved by first-time migration baseline',
+          classification: 'user-owned',
+          originalHash: null,
+          currentHash,
+        });
+        continue;
+      }
+
+      if (isStaleGsdLookingPath(relPath)) {
+        actions.push({
+          type: 'prompt-user',
+          relPath,
+          reason: 'GSD-looking file is not proven manifest-managed and needs explicit user choice',
+          classification: 'stale-gsd-looking',
+          originalHash: artifact.originalHash,
+          currentHash,
+          prompt: 'Choose whether to remove this stale-looking GSD artifact or keep it as user-owned.',
+          choices: ['keep', 'remove'],
+        });
+        continue;
+      }
+
+      actions.push({
+        type: 'baseline-preserve-user',
+        relPath,
+        reason: 'unknown install-surface file preserved by first-time migration baseline',
+        classification: artifact.classification,
+        originalHash: artifact.originalHash,
+        currentHash,
+      });
+    }
+
+    return actions.sort((left, right) =>
+      baselineActionRank(left) - baselineActionRank(right) || left.relPath.localeCompare(right.relPath)
+    );
+  },
+};

--- a/get-shit-done/bin/lib/installer-migrations/001-legacy-orphan-files.cjs
+++ b/get-shit-done/bin/lib/installer-migrations/001-legacy-orphan-files.cjs
@@ -1,0 +1,25 @@
+'use strict';
+
+const LEGACY_ORPHAN_FILES = [
+  'hooks/gsd-notify.sh',
+  'hooks/statusline.js',
+];
+
+module.exports = {
+  id: '2026-05-11-legacy-orphan-files',
+  description: 'Remove legacy orphan hook files that are still manifest-managed.',
+  plan: ({ classifyArtifact }) => {
+    const actions = [];
+    for (const relPath of LEGACY_ORPHAN_FILES) {
+      const artifact = classifyArtifact(relPath);
+      if (artifact.classification === 'managed-pristine' || artifact.classification === 'managed-modified') {
+        actions.push({
+          type: 'remove-managed',
+          relPath,
+          reason: 'legacy orphan hook file retired by installer migration',
+        });
+      }
+    }
+    return actions;
+  },
+};

--- a/get-shit-done/bin/lib/installer-migrations/001-legacy-orphan-files.cjs
+++ b/get-shit-done/bin/lib/installer-migrations/001-legacy-orphan-files.cjs
@@ -7,7 +7,11 @@ const LEGACY_ORPHAN_FILES = [
 
 module.exports = {
   id: '2026-05-11-legacy-orphan-files',
+  title: 'Remove manifest-managed legacy orphan hook files',
   description: 'Remove legacy orphan hook files that are still manifest-managed.',
+  introducedIn: '1.50.0',
+  scopes: ['global', 'local'],
+  destructive: true,
   plan: ({ classifyArtifact }) => {
     const actions = [];
     for (const relPath of LEGACY_ORPHAN_FILES) {

--- a/get-shit-done/bin/lib/installer-migrations/002-codex-legacy-hooks-json.cjs
+++ b/get-shit-done/bin/lib/installer-migrations/002-codex-legacy-hooks-json.cjs
@@ -1,0 +1,80 @@
+'use strict';
+
+const path = require('path');
+
+function isStructurallyEmpty(value) {
+  if (value === null || value === undefined) return true;
+  if (Array.isArray(value)) return value.length === 0;
+  if (typeof value !== 'object') return false;
+  for (const _key in value) return false;
+  return true;
+}
+
+function isManagedCodexHookCommand(command, configDir) {
+  if (typeof command !== 'string') return false;
+  if (typeof configDir !== 'string' || configDir.length === 0) return false;
+  const normalizedCommand = command.replace(/\\/g, '/');
+  const managedHooksDir = `${path.join(configDir, 'hooks').replace(/\\/g, '/')}/`;
+  if (!normalizedCommand.includes(managedHooksDir)) return false;
+  return /(^|[\\/\s"'])(gsd-check-update\.js|gsd-update-check\.js)(?=$|[\s"'])/.test(normalizedCommand);
+}
+
+function pruneLegacyCodexHooksJsonValue(value, configDir) {
+  if (Array.isArray(value)) {
+    let changed = false;
+    const next = [];
+    for (const item of value) {
+      const pruned = pruneLegacyCodexHooksJsonValue(item, configDir);
+      if (pruned.changed) changed = true;
+      if (!isStructurallyEmpty(pruned.value)) next.push(pruned.value);
+      else changed = true;
+    }
+    return { value: next, changed };
+  }
+
+  if (value && typeof value === 'object') {
+    if (isManagedCodexHookCommand(value.command, configDir)) {
+      return { value: null, changed: true };
+    }
+
+    let changed = false;
+    const next = {};
+    for (const [key, child] of Object.entries(value)) {
+      const pruned = pruneLegacyCodexHooksJsonValue(child, configDir);
+      if (pruned.changed) changed = true;
+      if (!isStructurallyEmpty(pruned.value)) next[key] = pruned.value;
+      else changed = true;
+    }
+    return { value: next, changed };
+  }
+
+  return { value, changed: false };
+}
+
+module.exports = {
+  id: '2026-05-11-codex-legacy-hooks-json',
+  title: 'Remove legacy Codex hooks.json GSD hook registrations',
+  description: 'Remove legacy Codex hooks.json GSD hook registrations after config.toml migration.',
+  introducedIn: '1.50.0',
+  runtimes: ['codex'],
+  scopes: ['global', 'local'],
+  destructive: true,
+  runtimeContract: 'docs/installer-migrations.md#runtime-configuration-contract-registry Codex row',
+  plan: ({ configDir, readJson }) => {
+    const hooksJson = readJson('hooks.json');
+    if (!hooksJson.exists || hooksJson.error) return [];
+
+    const pruned = pruneLegacyCodexHooksJsonValue(hooksJson.value, configDir);
+    if (!pruned.changed) return [];
+
+    return [
+      {
+        type: 'rewrite-json',
+        relPath: 'hooks.json',
+        value: pruned.value,
+        deleteIfEmpty: true,
+        reason: 'legacy Codex hooks.json GSD registration retired by installer migration',
+      },
+    ];
+  },
+};

--- a/tests/bug-2771-user-profile-manifest.test.cjs
+++ b/tests/bug-2771-user-profile-manifest.test.cjs
@@ -217,3 +217,43 @@ describe('#2771: USER_OWNED_ARTIFACTS is a single source of truth', () => {
     );
   });
 });
+
+describe('manifest path safety', () => {
+  let tmpDir;
+
+  beforeEach(() => { tmpDir = createTempDir('gsd-manifest-path-safety-'); });
+  afterEach(() => { cleanup(tmpDir); });
+
+  test('saveLocalPatches ignores manifest entries that escape the install root', () => {
+    const origMode = process.env.GSD_TEST_MODE;
+    process.env.GSD_TEST_MODE = '1';
+    let mod;
+    try {
+      delete require.cache[require.resolve(INSTALL_SCRIPT)];
+      mod = require(INSTALL_SCRIPT);
+    } finally {
+      if (origMode === undefined) delete process.env.GSD_TEST_MODE;
+      else process.env.GSD_TEST_MODE = origMode;
+    }
+
+    const outside = path.join(tmpDir, '..', 'outside-managed-file.txt');
+    fs.writeFileSync(outside, 'outside user data\n', 'utf8');
+    fs.writeFileSync(
+      path.join(tmpDir, MANIFEST_NAME),
+      JSON.stringify({
+        version: 'legacy',
+        timestamp: '2026-05-11T00:00:00.000Z',
+        files: {
+          '../outside-managed-file.txt': 'deadbeef',
+        },
+      }, null, 2),
+      'utf8'
+    );
+
+    const modified = mod.saveLocalPatches(tmpDir);
+
+    assert.deepEqual(modified, []);
+    assert.equal(fs.readFileSync(outside, 'utf8'), 'outside user data\n');
+    assert.equal(fs.existsSync(path.join(tmpDir, PATCHES_DIR_NAME, '..', 'outside-managed-file.txt')), false);
+  });
+});

--- a/tests/bug-3357-codex-legacy-hooks-json-migration.test.cjs
+++ b/tests/bug-3357-codex-legacy-hooks-json-migration.test.cjs
@@ -15,7 +15,9 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 
-const { install, parseTomlToObject } = require('../bin/install.js');
+const installModule = require('../bin/install.js');
+const { readInstallState } = require('../get-shit-done/bin/lib/installer-migrations.cjs');
+const { install, parseTomlToObject } = installModule;
 const { createTempDir, cleanup } = require('./helpers.cjs');
 
 function withCodexHome(codexHome, fn) {
@@ -67,6 +69,7 @@ describe('#3357 — Codex install removes legacy GSD hooks.json entries', { conc
   });
 
   afterEach(() => {
+    delete installModule.__codexSchemaValidator;
     cleanup(tmpRoot);
   });
 
@@ -103,5 +106,26 @@ describe('#3357 — Codex install removes legacy GSD hooks.json entries', { conc
       'node "/Users/example/bin/gsd-check-update.js"',
     ]);
     assert.equal(tomlGsdHookCount(codexHome), 1);
+  });
+
+  test('restores migrated hooks.json and install state when later Codex validation fails', () => {
+    const before = JSON.stringify({ SessionStart: [legacyGsdHook(codexHome)] }, null, 2);
+    fs.writeFileSync(path.join(codexHome, 'hooks.json'), before);
+
+    installModule.__codexSchemaValidator = () => ({
+      ok: false,
+      reason: 'forced migration rollback test',
+    });
+
+    assert.throws(
+      () => withCodexHome(codexHome, () => install(true, 'codex')),
+      /forced migration rollback test/
+    );
+
+    assert.equal(fs.readFileSync(path.join(codexHome, 'hooks.json'), 'utf8'), before);
+    assert.equal(
+      readInstallState(codexHome).appliedMigrations.some((entry) => entry.id === '2026-05-11-codex-legacy-hooks-json'),
+      false
+    );
   });
 });

--- a/tests/installer-migrations.test.cjs
+++ b/tests/installer-migrations.test.cjs
@@ -1,0 +1,431 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const crypto = require('crypto');
+
+const {
+  applyInstallerMigrationPlan,
+  discoverInstallerMigrations,
+  planInstallerMigrations,
+  readInstallState,
+  runInstallerMigrations,
+  writeInstallState,
+} = require('../get-shit-done/bin/lib/installer-migrations.cjs');
+
+function createTempInstall() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-installer-migrations-'));
+}
+
+function cleanup(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function sha256(content) {
+  return crypto.createHash('sha256').update(content).digest('hex');
+}
+
+function writeFile(root, relPath, content) {
+  const fullPath = path.join(root, relPath);
+  fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+  fs.writeFileSync(fullPath, content, 'utf8');
+}
+
+function writeManifest(root, files) {
+  fs.writeFileSync(
+    path.join(root, 'gsd-file-manifest.json'),
+    JSON.stringify({
+      version: '1.49.0',
+      timestamp: '2026-05-10T00:00:00.000Z',
+      mode: 'full',
+      files,
+    }, null, 2),
+    'utf8'
+  );
+}
+
+test('plans a pending migration against an unchanged managed file', () => {
+  const configDir = createTempInstall();
+  try {
+    writeFile(configDir, 'hooks/old-hook.js', 'managed hook\n');
+    writeManifest(configDir, {
+      'hooks/old-hook.js': sha256('managed hook\n'),
+    });
+
+    const plan = planInstallerMigrations({
+      configDir,
+      migrations: [
+        {
+          id: '2026-05-11-remove-old-hook',
+          description: 'Remove retired hook',
+          plan: () => [
+            {
+              type: 'remove-managed',
+              relPath: 'hooks/old-hook.js',
+              reason: 'retired hook',
+            },
+          ],
+        },
+      ],
+      now: () => '2026-05-11T00:00:00.000Z',
+    });
+
+    assert.deepEqual(plan.pendingMigrationIds, ['2026-05-11-remove-old-hook']);
+    assert.equal(plan.blocked.length, 0);
+    assert.deepEqual(plan.actions, [
+      {
+        migrationId: '2026-05-11-remove-old-hook',
+        type: 'remove-managed',
+        relPath: 'hooks/old-hook.js',
+        reason: 'retired hook',
+        classification: 'managed-pristine',
+        originalHash: sha256('managed hook\n'),
+        currentHash: sha256('managed hook\n'),
+      },
+    ]);
+  } finally {
+    cleanup(configDir);
+  }
+});
+
+test('plans backup before removal for a modified managed file', () => {
+  const configDir = createTempInstall();
+  try {
+    writeFile(configDir, 'hooks/old-hook.js', 'user changed hook\n');
+    writeManifest(configDir, {
+      'hooks/old-hook.js': sha256('managed hook\n'),
+    });
+
+    const plan = planInstallerMigrations({
+      configDir,
+      migrations: [
+        {
+          id: '2026-05-11-remove-old-hook',
+          description: 'Remove retired hook',
+          plan: () => [
+            {
+              type: 'remove-managed',
+              relPath: 'hooks/old-hook.js',
+              reason: 'retired hook',
+            },
+          ],
+        },
+      ],
+      now: () => '2026-05-11T00:00:00.000Z',
+    });
+
+    assert.equal(plan.blocked.length, 0);
+    assert.equal(plan.actions.length, 1);
+    assert.equal(plan.actions[0].type, 'backup-and-remove');
+    assert.equal(plan.actions[0].classification, 'managed-modified');
+    assert.equal(plan.actions[0].originalHash, sha256('managed hook\n'));
+    assert.equal(plan.actions[0].currentHash, sha256('user changed hook\n'));
+    assert.equal(plan.actions[0].backupRelPath, 'gsd-migration-backups/2026-05-11-remove-old-hook/hooks/old-hook.js');
+  } finally {
+    cleanup(configDir);
+  }
+});
+
+test('blocks removal of unknown files by preserving them by default', () => {
+  const configDir = createTempInstall();
+  try {
+    writeFile(configDir, 'hooks/custom-user-hook.js', 'user hook\n');
+    writeManifest(configDir, {});
+
+    const plan = planInstallerMigrations({
+      configDir,
+      migrations: [
+        {
+          id: '2026-05-11-remove-old-hook',
+          description: 'Remove retired hook',
+          plan: () => [
+            {
+              type: 'remove-managed',
+              relPath: 'hooks/custom-user-hook.js',
+              reason: 'retired hook',
+            },
+          ],
+        },
+      ],
+      now: () => '2026-05-11T00:00:00.000Z',
+    });
+
+    assert.equal(plan.actions.length, 1);
+    assert.equal(plan.actions[0].type, 'preserve-user');
+    assert.equal(plan.actions[0].requestedType, 'remove-managed');
+    assert.equal(plan.actions[0].classification, 'unknown');
+    assert.deepEqual(plan.blocked, [plan.actions[0]]);
+  } finally {
+    cleanup(configDir);
+  }
+});
+
+test('applies an unblocked plan with a journal and install-state update', () => {
+  const configDir = createTempInstall();
+  try {
+    writeFile(configDir, 'hooks/old-hook.js', 'managed hook\n');
+    writeManifest(configDir, {
+      'hooks/old-hook.js': sha256('managed hook\n'),
+    });
+
+    const plan = planInstallerMigrations({
+      configDir,
+      migrations: [
+        {
+          id: '2026-05-11-remove-old-hook',
+          description: 'Remove retired hook',
+          plan: () => [
+            {
+              type: 'remove-managed',
+              relPath: 'hooks/old-hook.js',
+              reason: 'retired hook',
+            },
+          ],
+        },
+      ],
+      now: () => '2026-05-11T00:00:00.000Z',
+    });
+
+    const result = applyInstallerMigrationPlan({
+      configDir,
+      plan,
+      now: () => '2026-05-11T00:00:01.000Z',
+    });
+
+    assert.equal(fs.existsSync(path.join(configDir, 'hooks/old-hook.js')), false);
+    assert.deepEqual(result.appliedMigrationIds, ['2026-05-11-remove-old-hook']);
+    assert.equal(result.journalRelPath, 'gsd-migration-journal/2026-05-11T00-00-01-000Z.json');
+
+    const journal = JSON.parse(fs.readFileSync(path.join(configDir, result.journalRelPath), 'utf8'));
+    assert.deepEqual(journal.appliedMigrationIds, ['2026-05-11-remove-old-hook']);
+    assert.equal(journal.actions[0].relPath, 'hooks/old-hook.js');
+
+    const state = readInstallState(configDir);
+    assert.deepEqual(state.appliedMigrations.map((entry) => entry.id), ['2026-05-11-remove-old-hook']);
+  } finally {
+    cleanup(configDir);
+  }
+});
+
+test('rolls back touched files and leaves state unchanged when apply fails', () => {
+  const configDir = createTempInstall();
+  try {
+    writeFile(configDir, 'hooks/old-hook.js', 'managed hook\n');
+    writeManifest(configDir, {
+      'hooks/old-hook.js': sha256('managed hook\n'),
+    });
+
+    const plan = {
+      pendingMigrationIds: ['2026-05-11-remove-old-hook'],
+      blocked: [],
+      actions: [
+        {
+          migrationId: '2026-05-11-remove-old-hook',
+          type: 'remove-managed',
+          relPath: 'hooks/old-hook.js',
+          reason: 'retired hook',
+          classification: 'managed-pristine',
+          originalHash: sha256('managed hook\n'),
+          currentHash: sha256('managed hook\n'),
+        },
+        {
+          migrationId: '2026-05-11-remove-old-hook',
+          type: 'unsupported-test-action',
+          relPath: 'hooks/other.js',
+          reason: 'force failure',
+          classification: 'managed-pristine',
+          originalHash: null,
+          currentHash: null,
+        },
+      ],
+    };
+
+    assert.throws(
+      () => applyInstallerMigrationPlan({
+        configDir,
+        plan,
+        now: () => '2026-05-11T00:00:02.000Z',
+      }),
+      /unsupported migration action type/
+    );
+
+    assert.equal(fs.readFileSync(path.join(configDir, 'hooks/old-hook.js'), 'utf8'), 'managed hook\n');
+    assert.deepEqual(readInstallState(configDir).appliedMigrations, []);
+    assert.equal(fs.existsSync(path.join(configDir, 'gsd-migration-journal', '2026-05-11T00-00-02-000Z.json')), false);
+  } finally {
+    cleanup(configDir);
+  }
+});
+
+test('reports rollback restore failures instead of swallowing them', () => {
+  const configDir = createTempInstall();
+  const originalCopyFileSync = fs.copyFileSync;
+  try {
+    writeFile(configDir, 'hooks/old-hook.js', 'managed hook\n');
+    writeManifest(configDir, {
+      'hooks/old-hook.js': sha256('managed hook\n'),
+    });
+
+    const plan = {
+      blocked: [],
+      actions: [
+        {
+          migrationId: '2026-05-11-remove-old-hook',
+          type: 'remove-managed',
+          relPath: 'hooks/old-hook.js',
+          reason: 'retired hook',
+          classification: 'managed-pristine',
+          originalHash: sha256('managed hook\n'),
+          currentHash: sha256('managed hook\n'),
+        },
+        {
+          migrationId: '2026-05-11-remove-old-hook',
+          type: 'unsupported-test-action',
+          relPath: 'hooks/other.js',
+          reason: 'force failure',
+          classification: 'managed-pristine',
+          originalHash: null,
+          currentHash: null,
+        },
+      ],
+    };
+
+    fs.copyFileSync = (src, dest) => {
+      if (String(src).includes('2026-05-11T00-00-04-000Z-rollback')) {
+        throw new Error('simulated rollback copy failure');
+      }
+      return originalCopyFileSync(src, dest);
+    };
+
+    assert.throws(
+      () => applyInstallerMigrationPlan({
+        configDir,
+        plan,
+        now: () => '2026-05-11T00:00:04.000Z',
+      }),
+      (error) => {
+        assert.match(error.message, /rollback incomplete/);
+        assert.equal(error.rollbackFailures.length, 1);
+        assert.equal(error.rollbackFailures[0].relPath, 'hooks/old-hook.js');
+        return true;
+      }
+    );
+  } finally {
+    fs.copyFileSync = originalCopyFileSync;
+    cleanup(configDir);
+  }
+});
+
+test('skips migration records already present in install state', () => {
+  const configDir = createTempInstall();
+  try {
+    writeManifest(configDir, {});
+    writeInstallState(configDir, {
+      schemaVersion: 1,
+      appliedMigrations: [
+        {
+          id: '2026-05-11-remove-old-hook',
+          appliedAt: '2026-05-11T00:00:00.000Z',
+          journal: 'gsd-migration-journal/prior.json',
+        },
+      ],
+    });
+
+    const plan = planInstallerMigrations({
+      configDir,
+      migrations: [
+        {
+          id: '2026-05-11-remove-old-hook',
+          description: 'Remove retired hook',
+          plan: () => {
+            throw new Error('already-applied migration planner must not run');
+          },
+        },
+      ],
+      now: () => '2026-05-11T00:00:03.000Z',
+    });
+
+    assert.deepEqual(plan.pendingMigrationIds, []);
+    assert.deepEqual(plan.actions, []);
+    assert.deepEqual(plan.blocked, []);
+  } finally {
+    cleanup(configDir);
+  }
+});
+
+test('discovers migration records from a directory in filename order', () => {
+  const configDir = createTempInstall();
+  try {
+    const migrationsDir = path.join(configDir, 'migrations');
+    fs.mkdirSync(migrationsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(migrationsDir, '002-second.cjs'),
+      "module.exports = { id: 'second', description: 'second', plan: () => [] };\n",
+      'utf8'
+    );
+    fs.writeFileSync(
+      path.join(migrationsDir, '001-first.cjs'),
+      "module.exports = { id: 'first', description: 'first', plan: () => [] };\n",
+      'utf8'
+    );
+
+    const migrations = discoverInstallerMigrations({ migrationsDir });
+
+    assert.deepEqual(migrations.map((migration) => migration.id), ['first', 'second']);
+  } finally {
+    cleanup(configDir);
+  }
+});
+
+test('rejects migration actions that escape the install root', () => {
+  const configDir = createTempInstall();
+  try {
+    writeManifest(configDir, {});
+
+    assert.throws(
+      () => planInstallerMigrations({
+        configDir,
+        migrations: [
+          {
+            id: '2026-05-11-bad-path',
+            description: 'Bad path',
+            plan: () => [
+              {
+                type: 'remove-managed',
+                relPath: 'hooks/../../outside.js',
+                reason: 'bad path',
+              },
+            ],
+          },
+        ],
+      }),
+      /relPath must stay inside configDir/
+    );
+  } finally {
+    cleanup(configDir);
+  }
+});
+
+test('runs discovered installer migrations against manifest-managed legacy orphan files', () => {
+  const configDir = createTempInstall();
+  try {
+    writeFile(configDir, 'hooks/statusline.js', 'legacy managed hook\n');
+    writeFile(configDir, 'hooks/custom.js', 'custom hook\n');
+    writeManifest(configDir, {
+      'hooks/statusline.js': sha256('legacy managed hook\n'),
+    });
+
+    const result = runInstallerMigrations({
+      configDir,
+      now: () => '2026-05-11T00:00:05.000Z',
+    });
+
+    assert.equal(fs.existsSync(path.join(configDir, 'hooks/statusline.js')), false);
+    assert.equal(fs.readFileSync(path.join(configDir, 'hooks/custom.js'), 'utf8'), 'custom hook\n');
+    assert.deepEqual(result.appliedMigrationIds, ['2026-05-11-legacy-orphan-files']);
+    assert.deepEqual(readInstallState(configDir).appliedMigrations.map((entry) => entry.id), ['2026-05-11-legacy-orphan-files']);
+  } finally {
+    cleanup(configDir);
+  }
+});

--- a/tests/installer-migrations.test.cjs
+++ b/tests/installer-migrations.test.cjs
@@ -8,6 +8,7 @@ const crypto = require('crypto');
 const {
   applyInstallerMigrationPlan,
   discoverInstallerMigrations,
+  INSTALL_STATE_NAME,
   planInstallerMigrations,
   readInstallState,
   runInstallerMigrations,
@@ -45,6 +46,28 @@ function writeManifest(root, files) {
   );
 }
 
+function legacyCodexHook(configDir) {
+  return {
+    hooks: [
+      {
+        type: 'command',
+        command: `node "${path.join(configDir, 'hooks', 'gsd-check-update.js')}"`,
+      },
+    ],
+  };
+}
+
+function userHook(command) {
+  return {
+    hooks: [
+      {
+        type: 'command',
+        command,
+      },
+    ],
+  };
+}
+
 test('plans a pending migration against an unchanged managed file', () => {
   const configDir = createTempInstall();
   try {
@@ -73,7 +96,17 @@ test('plans a pending migration against an unchanged managed file', () => {
 
     assert.deepEqual(plan.pendingMigrationIds, ['2026-05-11-remove-old-hook']);
     assert.equal(plan.blocked.length, 0);
-    assert.deepEqual(plan.actions, [
+    assert.equal(plan.actions.length, 1);
+    assert.deepEqual(
+      {
+        migrationId: plan.actions[0].migrationId,
+        type: plan.actions[0].type,
+        relPath: plan.actions[0].relPath,
+        reason: plan.actions[0].reason,
+        classification: plan.actions[0].classification,
+        originalHash: plan.actions[0].originalHash,
+        currentHash: plan.actions[0].currentHash,
+      },
       {
         migrationId: '2026-05-11-remove-old-hook',
         type: 'remove-managed',
@@ -82,8 +115,9 @@ test('plans a pending migration against an unchanged managed file', () => {
         classification: 'managed-pristine',
         originalHash: sha256('managed hook\n'),
         currentHash: sha256('managed hook\n'),
-      },
-    ]);
+      }
+    );
+    assert.match(plan.actions[0].migrationChecksum, /^sha256:/);
   } finally {
     cleanup(configDir);
   }
@@ -203,6 +237,7 @@ test('applies an unblocked plan with a journal and install-state update', () => 
 
     const state = readInstallState(configDir);
     assert.deepEqual(state.appliedMigrations.map((entry) => entry.id), ['2026-05-11-remove-old-hook']);
+    assert.match(state.appliedMigrations[0].checksum, /^sha256:/);
   } finally {
     cleanup(configDir);
   }
@@ -317,6 +352,70 @@ test('reports rollback restore failures instead of swallowing them', () => {
   }
 });
 
+test('rejects executable preserve-user actions because preservation blocks non-interactive apply', () => {
+  const configDir = createTempInstall();
+  try {
+    writeManifest(configDir, {});
+
+    assert.throws(
+      () => applyInstallerMigrationPlan({
+        configDir,
+        plan: {
+          blocked: [],
+          actions: [
+            {
+              migrationId: '2026-05-11-preserve-user',
+              type: 'preserve-user',
+              relPath: 'hooks/custom-user-hook.js',
+              reason: 'unknown user hook',
+              classification: 'unknown',
+              originalHash: null,
+              currentHash: sha256('user hook\n'),
+            },
+          ],
+        },
+      }),
+      /unsupported migration action type: preserve-user/
+    );
+  } finally {
+    cleanup(configDir);
+  }
+});
+
+test('keeps prior install state intact when a state write fails mid-write', () => {
+  const configDir = createTempInstall();
+  const originalWriteFileSync = fs.writeFileSync;
+  try {
+    writeInstallState(configDir, {
+      schemaVersion: 1,
+      appliedMigrations: [{ id: 'already-safe', appliedAt: '2026-05-11T00:00:00.000Z' }],
+    });
+
+    fs.writeFileSync = (filePath, content, ...rest) => {
+      if (path.basename(filePath).startsWith(`${INSTALL_STATE_NAME}.tmp-`)) {
+        throw new Error('simulated temp state write failure');
+      }
+      return originalWriteFileSync(filePath, content, ...rest);
+    };
+
+    assert.throws(
+      () => writeInstallState(configDir, {
+        schemaVersion: 1,
+        appliedMigrations: [{ id: 'new-migration', appliedAt: '2026-05-11T00:00:01.000Z' }],
+      }),
+      /simulated temp state write failure/
+    );
+  } finally {
+    fs.writeFileSync = originalWriteFileSync;
+  }
+
+  try {
+    assert.deepEqual(readInstallState(configDir).appliedMigrations.map((entry) => entry.id), ['already-safe']);
+  } finally {
+    cleanup(configDir);
+  }
+});
+
 test('skips migration records already present in install state', () => {
   const configDir = createTempInstall();
   try {
@@ -344,6 +443,83 @@ test('skips migration records already present in install state', () => {
         },
       ],
       now: () => '2026-05-11T00:00:03.000Z',
+    });
+
+    assert.deepEqual(plan.pendingMigrationIds, []);
+    assert.deepEqual(plan.actions, []);
+    assert.deepEqual(plan.blocked, []);
+  } finally {
+    cleanup(configDir);
+  }
+});
+
+test('refuses to plan an already-applied migration whose checksum changed', () => {
+  const configDir = createTempInstall();
+  try {
+    writeManifest(configDir, {});
+    writeInstallState(configDir, {
+      schemaVersion: 1,
+      appliedMigrations: [
+        {
+          id: '2026-05-11-remove-old-hook',
+          checksum: 'sha256:old-definition',
+          appliedAt: '2026-05-11T00:00:00.000Z',
+          journal: 'gsd-migration-journal/prior.json',
+        },
+      ],
+    });
+
+    assert.throws(
+      () => planInstallerMigrations({
+        configDir,
+        migrations: [
+          {
+            id: '2026-05-11-remove-old-hook',
+            checksum: 'sha256:new-definition',
+            description: 'Remove retired hook',
+            plan: () => [],
+          },
+        ],
+      }),
+      /applied migration checksum changed/
+    );
+  } finally {
+    cleanup(configDir);
+  }
+});
+
+test('ignores checksum drift for applied migrations outside the active runtime scope', () => {
+  const configDir = createTempInstall();
+  try {
+    writeManifest(configDir, {});
+    writeInstallState(configDir, {
+      schemaVersion: 1,
+      appliedMigrations: [
+        {
+          id: '2026-05-11-codex-only',
+          checksum: 'sha256:old-definition',
+          appliedAt: '2026-05-11T00:00:00.000Z',
+          journal: 'gsd-migration-journal/prior.json',
+        },
+      ],
+    });
+
+    const plan = planInstallerMigrations({
+      configDir,
+      runtime: 'claude',
+      scope: 'global',
+      migrations: [
+        {
+          id: '2026-05-11-codex-only',
+          checksum: 'sha256:new-definition',
+          runtimes: ['codex'],
+          scopes: ['global'],
+          description: 'Codex-only migration',
+          plan: () => {
+            throw new Error('out-of-scope migration planner must not run');
+          },
+        },
+      ],
     });
 
     assert.deepEqual(plan.pendingMigrationIds, []);
@@ -418,6 +594,7 @@ test('runs discovered installer migrations against manifest-managed legacy orpha
 
     const result = runInstallerMigrations({
       configDir,
+      scope: 'global',
       now: () => '2026-05-11T00:00:05.000Z',
     });
 
@@ -425,6 +602,69 @@ test('runs discovered installer migrations against manifest-managed legacy orpha
     assert.equal(fs.readFileSync(path.join(configDir, 'hooks/custom.js'), 'utf8'), 'custom hook\n');
     assert.deepEqual(result.appliedMigrationIds, ['2026-05-11-legacy-orphan-files']);
     assert.deepEqual(readInstallState(configDir).appliedMigrations.map((entry) => entry.id), ['2026-05-11-legacy-orphan-files']);
+  } finally {
+    cleanup(configDir);
+  }
+});
+
+test('runs a Codex legacy hooks.json cleanup migration without removing user hooks', () => {
+  const configDir = createTempInstall();
+  try {
+    writeFile(
+      configDir,
+      'hooks.json',
+      JSON.stringify({
+        SessionStart: [
+          legacyCodexHook(configDir),
+          userHook('node "/Users/example/bin/user-hook.js"'),
+          userHook('node "/Users/example/bin/gsd-check-update.js"'),
+        ],
+      }, null, 2)
+    );
+    writeManifest(configDir, {});
+
+    const result = runInstallerMigrations({
+      configDir,
+      runtime: 'codex',
+      scope: 'global',
+      now: () => '2026-05-11T00:00:06.000Z',
+    });
+
+    const hooksJson = JSON.parse(fs.readFileSync(path.join(configDir, 'hooks.json'), 'utf8'));
+    const commands = hooksJson.SessionStart.flatMap((entry) => entry.hooks).map((hook) => hook.command);
+
+    assert.deepEqual(commands, [
+      'node "/Users/example/bin/user-hook.js"',
+      'node "/Users/example/bin/gsd-check-update.js"',
+    ]);
+    assert.ok(result.appliedMigrationIds.includes('2026-05-11-codex-legacy-hooks-json'));
+  } finally {
+    cleanup(configDir);
+  }
+});
+
+test('skips runtime-specific migration records for other runtimes', () => {
+  const configDir = createTempInstall();
+  try {
+    writeFile(
+      configDir,
+      'hooks.json',
+      JSON.stringify({
+        SessionStart: [legacyCodexHook(configDir)],
+      }, null, 2)
+    );
+    writeManifest(configDir, {});
+
+    const result = runInstallerMigrations({
+      configDir,
+      runtime: 'claude',
+      scope: 'global',
+      now: () => '2026-05-11T00:00:07.000Z',
+    });
+
+    const hooksJson = JSON.parse(fs.readFileSync(path.join(configDir, 'hooks.json'), 'utf8'));
+    assert.equal(hooksJson.SessionStart[0].hooks[0].command, `node "${path.join(configDir, 'hooks', 'gsd-check-update.js')}"`);
+    assert.equal(result.appliedMigrationIds.includes('2026-05-11-codex-legacy-hooks-json'), false);
   } finally {
     cleanup(configDir);
   }

--- a/tests/installer-migrations.test.cjs
+++ b/tests/installer-migrations.test.cjs
@@ -14,6 +14,7 @@ const {
   runInstallerMigrations,
   writeInstallState,
 } = require('../get-shit-done/bin/lib/installer-migrations.cjs');
+const firstTimeBaselineMigration = require('../get-shit-done/bin/lib/installer-migrations/000-first-time-baseline.cjs');
 
 function createTempInstall() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-installer-migrations-'));
@@ -67,6 +68,134 @@ function userHook(command) {
     ],
   };
 }
+
+test('records a first-time baseline while preserving user-owned artifacts', () => {
+  const configDir = createTempInstall();
+  try {
+    writeFile(configDir, 'get-shit-done/workflows/plan.md', 'managed workflow\n');
+    writeFile(configDir, 'get-shit-done/USER-PROFILE.md', 'user profile\n');
+    writeManifest(configDir, {
+      'get-shit-done/workflows/plan.md': sha256('managed workflow\n'),
+    });
+
+    const result = runInstallerMigrations({
+      configDir,
+      runtime: 'claude',
+      scope: 'global',
+      migrations: [firstTimeBaselineMigration],
+      baselineScan: true,
+      now: () => '2026-05-11T00:00:00.000Z',
+    });
+
+    assert.deepEqual(result.appliedMigrationIds, ['2026-05-11-first-time-baseline-scan']);
+    assert.equal(fs.readFileSync(path.join(configDir, 'get-shit-done/workflows/plan.md'), 'utf8'), 'managed workflow\n');
+    assert.equal(fs.readFileSync(path.join(configDir, 'get-shit-done/USER-PROFILE.md'), 'utf8'), 'user profile\n');
+
+    assert.deepEqual(
+      result.plan.actions.map((action) => ({
+        type: action.type,
+        relPath: action.relPath,
+        classification: action.classification,
+      })),
+      [
+        {
+          type: 'record-baseline',
+          relPath: 'get-shit-done/workflows/plan.md',
+          classification: 'managed-pristine',
+        },
+        {
+          type: 'baseline-preserve-user',
+          relPath: 'get-shit-done/USER-PROFILE.md',
+          classification: 'user-owned',
+        },
+      ]
+    );
+    assert.deepEqual(readInstallState(configDir).appliedMigrations.map((entry) => entry.id), [
+      '2026-05-11-first-time-baseline-scan',
+    ]);
+  } finally {
+    cleanup(configDir);
+  }
+});
+
+test('preserves unknown files discovered in known install surfaces by default', () => {
+  const configDir = createTempInstall();
+  try {
+    writeFile(configDir, 'hooks/custom-user-hook.js', 'user hook\n');
+    writeManifest(configDir, {});
+
+    const result = runInstallerMigrations({
+      configDir,
+      runtime: 'claude',
+      scope: 'global',
+      migrations: [firstTimeBaselineMigration],
+      baselineScan: true,
+      now: () => '2026-05-11T00:00:01.000Z',
+    });
+
+    assert.deepEqual(result.blocked, undefined);
+    assert.deepEqual(
+      result.plan.actions.map((action) => ({
+        type: action.type,
+        relPath: action.relPath,
+        classification: action.classification,
+      })),
+      [
+        {
+          type: 'baseline-preserve-user',
+          relPath: 'hooks/custom-user-hook.js',
+          classification: 'unknown',
+        },
+      ]
+    );
+    assert.equal(fs.readFileSync(path.join(configDir, 'hooks/custom-user-hook.js'), 'utf8'), 'user hook\n');
+    assert.deepEqual(readInstallState(configDir).appliedMigrations.map((entry) => entry.id), [
+      '2026-05-11-first-time-baseline-scan',
+    ]);
+  } finally {
+    cleanup(configDir);
+  }
+});
+
+test('blocks stale GSD-looking baseline artifacts for explicit user choice', () => {
+  const configDir = createTempInstall();
+  try {
+    writeFile(configDir, 'hooks/gsd-retired-hook.js', 'old gsd hook\n');
+    writeManifest(configDir, {});
+
+    const result = runInstallerMigrations({
+      configDir,
+      runtime: 'claude',
+      scope: 'global',
+      migrations: [firstTimeBaselineMigration],
+      baselineScan: true,
+      now: () => '2026-05-11T00:00:02.000Z',
+    });
+
+    assert.deepEqual(result.appliedMigrationIds, []);
+    assert.equal(result.journalRelPath, null);
+    assert.equal(fs.existsSync(path.join(configDir, INSTALL_STATE_NAME)), false);
+    assert.equal(fs.readFileSync(path.join(configDir, 'hooks/gsd-retired-hook.js'), 'utf8'), 'old gsd hook\n');
+    assert.deepEqual(
+      result.blocked.map((action) => ({
+        type: action.type,
+        relPath: action.relPath,
+        classification: action.classification,
+        choices: action.choices,
+      })),
+      [
+        {
+          type: 'prompt-user',
+          relPath: 'hooks/gsd-retired-hook.js',
+          classification: 'stale-gsd-looking',
+          choices: ['keep', 'remove'],
+        },
+      ]
+    );
+  } finally {
+    cleanup(configDir);
+  }
+});
 
 test('plans a pending migration against an unchanged managed file', () => {
   const configDir = createTempInstall();


### PR DESCRIPTION
## Feature PR

## Linked Issue

Closes #3395

Linked issue labels: approved-feature, in-progress

## Approved Issue Description

## What to build

Build a first-class Installer Migration Module that replaces ad hoc install cleanup with a planned, journaled, reviewable migration system.

This should future-proof GSD updates when features move, rename, replace, or retire installed files. The migration tool must clean up stale GSD-owned artifacts, preserve user-owned data, back up locally modified managed files, support dry-run planning, and avoid leaving hybrid installs after failures.

Design references:
- `docs/installer-migrations.md`
- `docs/adr/0008-installer-migration-module.md`

## Phases

### Phase 1: Foundational migration runner

Create the core migration infrastructure in one coherent pass:
- install-state read/write next to `gsd-file-manifest.json`
- migration record discovery
- checksum tracking
- pending/applied migration detection
- dry-run planning
- shared action model
- managed/user-owned/unknown artifact classification
- journaled apply and rollback helpers

### Phase 2: Port existing cleanup behavior

Move one or more existing installer cleanup paths into the migration runner:
- orphaned hook/file cleanup
- stale runtime-generated artifacts
- config marker/section cleanup where ownership is provable

### Phase 3: First-time baseline scanner

Add a baseline migration for existing installs that predate migration tracking:
- scan known install surfaces
- classify files
- preserve unknowns by default
- report ambiguous artifacts
- offer user choices in interactive mode
- block or dry-run in non-interactive mode when destructive action is ambiguous

### Phase 4: Install/update integration

Wire the migration runner into normal install/update flow:
- run plan before package materialization
- apply safe migrations
- write install state after success
- report removed, backed up, preserved, skipped, and blocked actions
- keep existing install transforms working during migration adoption

### Phase 5: Authoring guardrails

Add contributor-facing guardrails:
- tests for migration records
- dry-run/apply regression tests
- user-owned preservation tests
- locally modified managed-file tests
- docs for when a feature retirement requires a migration

## Acceptance criteria

- [ ] Installer migrations are versioned and tracked in install state.
- [ ] The same planner powers dry-run and apply behavior.
- [ ] Managed, user-owned, and unknown artifacts are classified consistently.
- [ ] Unknown files are preserved by default.
- [ ] Locally modified managed files are backed up before removal or replacement.
- [ ] Migration apply writes a rollback journal and restores touched paths on failure where possible.
- [ ] At least one existing ad hoc cleanup path is ported into the migration runner.
- [ ] Existing installs can run a baseline scan without losing user data.
- [ ] Install/update output clearly reports what changed and what was preserved.
- [ ] Tests cover fresh install, reinstall, upgrade, modified managed files, user-owned files, unknown files, and failed apply rollback.

## Blocked by

None - can start immediately


## Standards Followed

- `CONTEXT.md`: contributor gate order, changeset PR-number rule, and domain vocabulary requirements.
- `CONTRIBUTING.md`: issue-first process, typed PR template, closing keyword, one-concern scope, changeset fragment, and test requirements.
- `docs/contributor-standards.md`: CONTEXT/ADR hierarchy, isolated worktree expectation, AI-assisted PR body requirements, and architecture-aware testing guidance.

- `docs/adr/0008-installer-migration-module.md`: Installer Migration Module decision and migration authoring contract.
- `docs/installer-migrations.md`: migration architecture, runtime configuration contract registry, ownership boundaries, and phase requirements.

## Feature Summary

This PR implements **Phase 3: First-time baseline scanner** of the approved first-class Installer Migration Module feature.

## What Changed

- Added the first-time baseline migration for installs that predate install-state tracking.
- Scans documented install surfaces and classifies managed, user-owned, unknown, and ambiguous artifacts.
- Preserves unknown files by default and blocks ambiguous destructive actions.
- Updated docs with runtime configuration contract registry, ownership boundaries, source snapshots, and source-limited warnings.

## Spec Compliance For This Phase

- [x] Existing installs can run a baseline scan without losing user data.
- [x] Unknown files are preserved by default.
- [x] Ambiguous destructive actions block or require user choice.
- [x] Runtime surfaces are derived from the documented runtime configuration contract registry.
- [ ] Normal install/update reporting across every runtime is Phase 4.

## Testing

- Baseline tests cover managed artifacts, modified managed artifacts, user-owned files, unknown files, source snapshots, and blocked ambiguity.
- Full test suite was run before the PR was opened.

### Platforms Tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux

### Runtimes Tested

- [x] Claude Code
- [x] Gemini CLI
- [x] OpenCode
- [x] Codex
- [x] Copilot
- [x] Other: Antigravity, Augment, Cline, CodeBuddy, Cursor, Hermes Agent, Kilo, Qwen Code, Trae, Windsurf are represented in the documented runtime surface registry.

## Scope Confirmation

- [x] The implementation matches the approved Phase 3 scope from #3395.
- [x] This PR is one concern: Installer Migration Module Phase 3.
- [x] No unrelated formatting, commands, workflows, or dependencies were added.

## Checklist

- [x] Issue linked above with `Closes #3395`.
- [x] Linked issue has the `approved-feature` label.
- [x] Feature PR body uses the repo-required feature template structure.
- [x] PR title uses required typed scope prefix: `Feat(installer):`.
- [x] Phase-specific `.changeset/` fragment added: `.changeset/steady-yaks-caper.md`.
- [x] Documentation updated where this phase changes architecture, behavior, or authoring rules.
- [x] Tests added or updated for this phase.
- [x] No unnecessary external dependencies added.
- [ ] Windows manually tested.
- [ ] Linux manually tested.

## Breaking Changes

None.

## Phase 3: First-time baseline scanner

This final section is intentionally appended after the approved issue description so reviewers can compare the whole approved feature request above against the concrete phase delivered by this PR.
