### PR TITLE
feat: add Perplexity integrations

### DIFF
--- a/agents/gsd-project-researcher.md
+++ b/agents/gsd-project-researcher.md
@@ -164,6 +164,20 @@ mcp__firecrawl__search with query: "your query" (web search + auto-scrape result
 
 If `firecrawl: false` (or not set), fall back to WebFetch.
 
+### Perplexity Search & Agent APIs
+
+Check `perplexity` from orchestrator context. If `true`, the Perplexity API key is configured and two surfaces are available:
+
+```bash
+gsd-sdk query perplexity-search "your query" --limit 10
+gsd-sdk query perplexity-agent "Find recent context on …" --preset pro-search
+```
+
+- **Search API** (`perplexity-search`) — direct ranked web search results (`{title,url,snippet,date}`). Use as a higher-recall alternative when other search providers under-return.
+- **Agent API** (`perplexity-agent`) — research-oriented agent with built-in tools (`web_search`, `fetch_url`). Best for "find me up-to-date context on X" prompts where a single synthesized answer is more useful than a result list. Defaults to the `pro-search` preset.
+
+If `perplexity: false` (or not set), fall back to other configured providers.
+
 ## Verification Protocol
 
 **WebSearch findings must be verified:**

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -135,6 +135,7 @@ GSD stores project settings in `.planning/config.json`. Created during `/gsd-new
 | `brave_search` | boolean | `true`/`false` | auto-detected | Override auto-detection of Brave Search API availability. When unset, GSD checks for `BRAVE_API_KEY` env var or `~/.gsd/brave_api_key` file |
 | `firecrawl` | boolean | `true`/`false` | auto-detected | Override auto-detection of Firecrawl API availability. When unset, GSD checks for `FIRECRAWL_API_KEY` env var or `~/.gsd/firecrawl_api_key` file |
 | `exa_search` | boolean | `true`/`false` | auto-detected | Override auto-detection of Exa Search API availability. When unset, GSD checks for `EXA_API_KEY` env var or `~/.gsd/exa_api_key` file |
+| `perplexity` | boolean | `true`/`false` | auto-detected | Override auto-detection of Perplexity API availability (Search API + Agent API). When unset, GSD checks for `PERPLEXITY_API_KEY` env var or `~/.gsd/perplexity_api_key` file. See https://docs.perplexity.ai |
 | `search_gitignored` | boolean | `true`/`false` | `false` | Legacy top-level alias for `planning.search_gitignored`. Prefer the namespaced form; this alias is accepted for backward compatibility |
 
 > **Note:** `granularity` was renamed from `depth` in v1.22.3. Existing configs are auto-migrated.
@@ -154,6 +155,7 @@ API key fields accept a string value (the key itself). They can also be set to t
 | `brave_search` | string \| boolean \| null | `null` | Brave Search API key used for web research. Displayed as `****<last-4>` in all UI / `config-set` output; never echoed plaintext |
 | `firecrawl` | string \| boolean \| null | `null` | Firecrawl API key for deep-crawl scraping. Masked in display |
 | `exa_search` | string \| boolean \| null | `null` | Exa Search API key for semantic search. Masked in display |
+| `perplexity` | string \| boolean \| null | `null` | Perplexity API key. Powers `perplexity-search` (Search API) and `perplexity-agent` (Agent API) `gsd-sdk query` handlers. Displayed as `****<last-4>` in all UI / `config-set` output; never echoed plaintext. See https://docs.perplexity.ai |
 
 **Masking convention (`get-shit-done/bin/lib/secrets.cjs`):** keys 8+ characters render as `****<last-4>`; shorter keys render as `****`; `null`/empty renders as `(unset)`. Plaintext is written as-is to `.planning/config.json` — that file is the security boundary — but the CLI, confirmation tables, logs, and `AskUserQuestion` descriptions never display the plaintext. This applies to the `config-set` command output itself: `config-set brave_search <key>` returns a JSON payload with the value masked.
 

--- a/get-shit-done/bin/gsd-tools.cjs
+++ b/get-shit-done/bin/gsd-tools.cjs
@@ -37,6 +37,10 @@
  *   phase-plan-index <phase>           Index plans with waves and status
  *   websearch <query>                  Search web via Brave API (if configured)
  *     [--limit N] [--freshness day|week|month]
+ *   perplexity-search <query>          Search web via Perplexity Search API (if configured)
+ *     [--limit N] [--recency hour|day|week|month|year]
+ *   perplexity-agent <input>           Invoke Perplexity Agent API (if configured)
+ *     [--preset pro-search] [--model <id>]
  *
  * Phase Operations:
  *   phase next-decimal <phase>         Calculate next decimal phase number
@@ -371,9 +375,9 @@ async function main() {
     'current-timestamp, detect-custom-files, docs-init, extract-messages, find-phase, ' +
     'from-gsd2, frontmatter, gap-analysis, generate-claude-md, generate-claude-profile, ' +
     'generate-dev-preferences, generate-slug, graphify, history-digest, init, intel, ' +
-    'learnings, list-todos, milestone, phase, phase-plan-index, phases, profile-questionnaire, ' +
+    'learnings, list-todos, milestone, perplexity-agent, perplexity-search, phase, phase-plan-index, phases, profile-questionnaire, ' +
     'profile-sample, progress, requirements, resolve-model, roadmap, scaffold, state, ' +
-    'template, validate, verify, verify-path-exists, verify-summary, workstream, worktree\n\n' +
+    'template, validate, verify, verify-path-exists, verify-summary, websearch, workstream, worktree\n\n' +
     'Global flags:\n' +
     '  --raw              Emit raw output without post-processing\n' +
     '  --pick <field>     Extract a single field from JSON output (dot/bracket notation)\n' +
@@ -863,6 +867,28 @@ async function runCommand(command, args, cwd, raw, defaultValue, originalCommand
       await commands.cmdWebsearch(query, {
         limit: limitIdx !== -1 ? parseInt(args[limitIdx + 1], 10) : 10,
         freshness: freshnessIdx !== -1 ? args[freshnessIdx + 1] : null,
+      }, raw);
+      break;
+    }
+
+    case 'perplexity-search': {
+      const query = args[1];
+      const limitIdx = args.indexOf('--limit');
+      const recencyIdx = args.indexOf('--recency');
+      await commands.cmdPerplexitySearch(cwd, query, {
+        limit: limitIdx !== -1 ? parseInt(args[limitIdx + 1], 10) : 10,
+        recency: recencyIdx !== -1 ? args[recencyIdx + 1] : null,
+      }, raw);
+      break;
+    }
+
+    case 'perplexity-agent': {
+      const input = args[1];
+      const presetIdx = args.indexOf('--preset');
+      const modelIdx = args.indexOf('--model');
+      await commands.cmdPerplexityAgent(cwd, input, {
+        preset: presetIdx !== -1 ? args[presetIdx + 1] : null,
+        model: modelIdx !== -1 ? args[modelIdx + 1] : null,
       }, raw);
       break;
     }

--- a/get-shit-done/bin/lib/commands.cjs
+++ b/get-shit-done/bin/lib/commands.cjs
@@ -479,6 +479,39 @@ function cmdSummaryExtract(cwd, summaryPath, fields, raw) {
   output(fullResult, raw);
 }
 
+async function cmdPerplexitySearch(cwd, query, options, raw) {
+  const perplexity = require('./perplexity.cjs');
+  const result = await perplexity.search(query, {
+    maxResults: options && options.limit != null ? options.limit : undefined,
+    searchRecencyFilter: options && options.recency ? options.recency : undefined,
+    searchDomainFilter: options && options.domainFilter ? options.domainFilter : undefined,
+  }, { cwd });
+  if (!result.available) {
+    output(result, raw, '');
+    return;
+  }
+  const textOut = (result.results || [])
+    .map((r) => `${r.title}\n${r.url}\n${r.snippet}`)
+    .join('\n\n');
+  output(result, raw, textOut);
+}
+
+async function cmdPerplexityAgent(cwd, input, options, raw) {
+  const perplexity = require('./perplexity.cjs');
+  const result = await perplexity.agent(input, {
+    preset: options && options.preset ? options.preset : undefined,
+    model: options && options.model ? options.model : undefined,
+  }, { cwd });
+  if (!result.available) {
+    output(result, raw, '');
+    return;
+  }
+  const textOut = typeof result.output === 'string'
+    ? result.output
+    : JSON.stringify(result.output || result.raw || {});
+  output(result, raw, textOut);
+}
+
 async function cmdWebsearch(query, options, raw) {
   const apiKey = process.env.BRAVE_API_KEY;
 
@@ -1019,6 +1052,8 @@ module.exports = {
   cmdCommitToSubrepo,
   cmdSummaryExtract,
   cmdWebsearch,
+  cmdPerplexitySearch,
+  cmdPerplexityAgent,
   cmdProgressRender,
   cmdTodoComplete,
   cmdTodoMatchPhase,

--- a/get-shit-done/bin/lib/config-schema.cjs
+++ b/get-shit-done/bin/lib/config-schema.cjs
@@ -15,7 +15,7 @@
 /** Exact-match config key paths accepted by config-set. */
 const VALID_CONFIG_KEYS = new Set([
   'mode', 'granularity', 'parallelization', 'commit_docs', 'model_profile',
-  'search_gitignored', 'brave_search', 'firecrawl', 'exa_search',
+  'search_gitignored', 'brave_search', 'firecrawl', 'exa_search', 'perplexity',
   'workflow.research', 'workflow.plan_check', 'workflow.verifier',
   'workflow.nyquist_validation', 'workflow.ai_integration_phase', 'workflow.ui_phase', 'workflow.ui_safety_gate',
   'workflow.auto_advance', 'workflow.node_repair', 'workflow.node_repair_budget',

--- a/get-shit-done/bin/lib/config.cjs
+++ b/get-shit-done/bin/lib/config.cjs
@@ -62,6 +62,8 @@ function buildNewProjectConfig(userChoices) {
   const hasFirecrawl = !!(process.env.FIRECRAWL_API_KEY || fs.existsSync(firecrawlKeyFile));
   const exaKeyFile = path.join(homedir, '.gsd', 'exa_api_key');
   const hasExaSearch = !!(process.env.EXA_API_KEY || fs.existsSync(exaKeyFile));
+  const perplexityKeyFile = path.join(homedir, '.gsd', 'perplexity_api_key');
+  const hasPerplexity = !!(process.env.PERPLEXITY_API_KEY || fs.existsSync(perplexityKeyFile));
 
   // Load user-level defaults from ~/.gsd/defaults.json if available
   const globalDefaultsPath = path.join(homedir, '.gsd', 'defaults.json');
@@ -91,6 +93,7 @@ function buildNewProjectConfig(userChoices) {
     brave_search: hasBraveSearch,
     firecrawl: hasFirecrawl,
     exa_search: hasExaSearch,
+    perplexity: hasPerplexity,
     git: {
       branching_strategy: CONFIG_DEFAULTS.branching_strategy,
       phase_branch_template: CONFIG_DEFAULTS.phase_branch_template,

--- a/get-shit-done/bin/lib/perplexity.cjs
+++ b/get-shit-done/bin/lib/perplexity.cjs
@@ -1,0 +1,207 @@
+'use strict';
+
+/**
+ * Perplexity client — single HTTP entry point for the Search API and Agent
+ * API integrations. Centralizing the request shape here means the attribution
+ * header (`X-Pplx-Integration`) and key resolution policy live in one file:
+ * any future provider call routes through `perplexityFetch` rather than
+ * inlining its own `fetch()` call.
+ *
+ * Docs: https://docs.perplexity.ai
+ *   Search API: POST https://api.perplexity.ai/search
+ *   Agent API:  POST https://api.perplexity.ai/v1/agent
+ *
+ * Key resolution mirrors the existing search-provider pattern:
+ *   1. `PERPLEXITY_API_KEY` env var
+ *   2. `~/.gsd/perplexity_api_key` file (UTF-8 / UTF-16 LE tolerated)
+ *   3. `perplexity` field in .planning/config.json (string form)
+ * Returns `null` when no key is configured so callers can fall back gracefully.
+ */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const SEARCH_URL = 'https://api.perplexity.ai/search';
+const AGENT_URL = 'https://api.perplexity.ai/v1/agent';
+
+/**
+ * Build the attribution header value. The slug is documented for our
+ * integration; the version is read from the repo's package.json so support
+ * traffic from older installs is distinguishable.
+ */
+function integrationHeader() {
+  let version = 'unknown';
+  try {
+    const pkg = JSON.parse(
+      fs.readFileSync(path.join(__dirname, '..', '..', '..', 'package.json'), 'utf-8'),
+    );
+    if (pkg && typeof pkg.version === 'string' && pkg.version) {
+      version = pkg.version;
+    }
+  } catch { /* unknown is fine — header still goes out */ }
+  return `get-shit-done/${version}`;
+}
+
+function readKeyFile(filePath) {
+  try {
+    const buf = fs.readFileSync(filePath);
+    // UTF-16 LE BOM tolerance (parity with Brave key-file handling).
+    if (buf.length >= 2 && buf[0] === 0xff && buf[1] === 0xfe) {
+      return buf.toString('utf16le').replace(/^﻿/, '').trim();
+    }
+    return buf.toString('utf-8').replace(/^﻿/, '').trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the Perplexity API key with the same precedence as other providers.
+ * Returns null when nothing is configured — callers translate that into a
+ * graceful `{ available: false }` response.
+ */
+function resolveApiKey(cwd) {
+  if (process.env.PERPLEXITY_API_KEY) return process.env.PERPLEXITY_API_KEY;
+  const homeKey = path.join(os.homedir(), '.gsd', 'perplexity_api_key');
+  const fromHome = readKeyFile(homeKey);
+  if (fromHome) return fromHome;
+  if (cwd) {
+    try {
+      const cfgPath = path.join(cwd, '.planning', 'config.json');
+      if (fs.existsSync(cfgPath)) {
+        const cfg = JSON.parse(fs.readFileSync(cfgPath, 'utf-8'));
+        const v = cfg && cfg.perplexity;
+        if (typeof v === 'string' && v.length > 0) return v;
+      }
+    } catch { /* malformed config is treated as no-key */ }
+  }
+  return null;
+}
+
+/**
+ * Central HTTP entry point. Adds `Authorization` and `X-Pplx-Integration` on
+ * every call. Returns the parsed JSON body or throws on transport / non-2xx.
+ *
+ * @param {string} url
+ * @param {object} body  Request body (JSON-serialized).
+ * @param {object} opts  { apiKey, fetchImpl? } — `fetchImpl` is for tests.
+ */
+async function perplexityFetch(url, body, opts) {
+  const { apiKey, fetchImpl } = opts || {};
+  if (!apiKey) {
+    const err = new Error('PERPLEXITY_API_KEY not set');
+    err.code = 'NO_KEY';
+    throw err;
+  }
+  const doFetch = fetchImpl || globalThis.fetch;
+  const response = await doFetch(url, {
+    method: 'POST',
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`,
+      'X-Pplx-Integration': integrationHeader(),
+    },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    const err = new Error(`API error: ${response.status}`);
+    err.code = 'API_ERROR';
+    err.status = response.status;
+    throw err;
+  }
+  return response.json();
+}
+
+/**
+ * Search API — POST https://api.perplexity.ai/search.
+ * Returns `{ available: true, query, count, results: [{title,url,snippet,date,last_updated}] }`
+ * or `{ available: false, reason | error }` for graceful fallback.
+ */
+async function search(query, options, ctx) {
+  const apiKey = resolveApiKey(ctx && ctx.cwd);
+  if (!apiKey) {
+    return { available: false, reason: 'PERPLEXITY_API_KEY not set' };
+  }
+  if (!query || (typeof query === 'string' && query.trim() === '')) {
+    return { available: false, error: 'Query required' };
+  }
+  const body = { query };
+  if (options && options.maxResults != null) body.max_results = options.maxResults;
+  if (options && options.maxTokens != null) body.max_tokens = options.maxTokens;
+  if (options && options.maxTokensPerPage != null) body.max_tokens_per_page = options.maxTokensPerPage;
+  if (options && options.searchDomainFilter) body.search_domain_filter = options.searchDomainFilter;
+  if (options && options.searchRecencyFilter) body.search_recency_filter = options.searchRecencyFilter;
+  if (options && options.searchLanguageFilter) body.search_language_filter = options.searchLanguageFilter;
+
+  try {
+    const data = await perplexityFetch(SEARCH_URL, body, {
+      apiKey,
+      fetchImpl: ctx && ctx.fetchImpl,
+    });
+    const results = Array.isArray(data && data.results) ? data.results.map((r) => ({
+      title: r.title || '',
+      url: r.url || '',
+      snippet: r.snippet || '',
+      date: r.date || null,
+      last_updated: r.last_updated || null,
+    })) : [];
+    return {
+      available: true,
+      query: typeof query === 'string' ? query : query[0],
+      count: results.length,
+      results,
+    };
+  } catch (err) {
+    return { available: false, error: err && err.message ? err.message : String(err) };
+  }
+}
+
+/**
+ * Agent API — POST https://api.perplexity.ai/v1/agent.
+ * Returns `{ available: true, id, output, raw }` on success, or
+ * `{ available: false, reason | error }` for graceful fallback.
+ *
+ * `preset` defaults to `pro-search` per the provider docs; callers can pass
+ * an explicit model via `options.model`.
+ */
+async function agent(input, options, ctx) {
+  const apiKey = resolveApiKey(ctx && ctx.cwd);
+  if (!apiKey) {
+    return { available: false, reason: 'PERPLEXITY_API_KEY not set' };
+  }
+  if (!input || (typeof input === 'string' && input.trim() === '')) {
+    return { available: false, error: 'Input required' };
+  }
+  const body = { input };
+  if (options && options.preset) body.preset = options.preset;
+  else if (!options || !options.model) body.preset = 'pro-search';
+  if (options && options.model) body.model = options.model;
+  if (options && options.tools) body.tools = options.tools;
+
+  try {
+    const data = await perplexityFetch(AGENT_URL, body, {
+      apiKey,
+      fetchImpl: ctx && ctx.fetchImpl,
+    });
+    return {
+      available: true,
+      id: (data && data.id) || null,
+      output: (data && (data.output || data.output_text || data.response)) || null,
+      raw: data,
+    };
+  } catch (err) {
+    return { available: false, error: err && err.message ? err.message : String(err) };
+  }
+}
+
+module.exports = {
+  SEARCH_URL,
+  AGENT_URL,
+  integrationHeader,
+  resolveApiKey,
+  perplexityFetch,
+  search,
+  agent,
+};

--- a/get-shit-done/bin/lib/secrets.cjs
+++ b/get-shit-done/bin/lib/secrets.cjs
@@ -17,6 +17,7 @@ const SECRET_CONFIG_KEYS = new Set([
   'brave_search',
   'firecrawl',
   'exa_search',
+  'perplexity',
 ]);
 
 function isSecretKey(keyPath) {

--- a/get-shit-done/workflows/settings-integrations.md
+++ b/get-shit-done/workflows/settings-integrations.md
@@ -1,8 +1,8 @@
 <purpose>
 Interactive configuration of third-party integrations for GSD — search API keys
-(Brave / Firecrawl / Exa), code-review CLI routing (`review.models.<cli>`), and
-agent-skill injection (`agent_skills.<agent-type>`). Writes to
-`.planning/config.json` via `gsd-sdk`/`gsd-tools` so unrelated keys are
+(Brave / Firecrawl / Exa / Perplexity), code-review CLI routing
+(`review.models.<cli>`), and agent-skill injection (`agent_skills.<agent-type>`).
+Writes to `.planning/config.json` via `gsd-sdk`/`gsd-tools` so unrelated keys are
 preserved, never clobbered.
 
 This command is deliberately separate from `/gsd-settings` (workflow toggles)
@@ -24,7 +24,7 @@ log the plaintext value. The workflow follows these rules:
   tables, or any log line.** It is not written to any file under `.planning/`
   other than `config.json` itself.
 - **`config-set` output is masked** for keys in the secret set
-  (`brave_search`, `firecrawl`, `exa_search`) — see
+  (`brave_search`, `firecrawl`, `exa_search`, `perplexity`) — see
   `get-shit-done/bin/lib/secrets.cjs`.
 - **Agent-type and CLI slug validation.** `agent_skills.<agent-type>` and
   `review.models.<cli>` keys are matched against `^[a-zA-Z0-9_-]+$`. Inputs
@@ -68,12 +68,13 @@ integration field, compute one of:
 BRAVE=$(gsd-sdk query config-get brave_search --default null)
 FIRECRAWL=$(gsd-sdk query config-get firecrawl --default null)
 EXA=$(gsd-sdk query config-get exa_search --default null)
+PERPLEXITY=$(gsd-sdk query config-get perplexity --default null)
 SEARCH_GITIGNORED=$(gsd-sdk query config-get search_gitignored --default false)
 ```
 
-For each secret key (`brave_search`, `firecrawl`, `exa_search`) the displayed
-value is `****<last-4>` when set, never the raw string. Never echo the
-plaintext to stdout, stderr, or any log.
+For each secret key (`brave_search`, `firecrawl`, `exa_search`, `perplexity`)
+the displayed value is `****<last-4>` when set, never the raw string. Never
+echo the plaintext to stdout, stderr, or any log.
 </step>
 
 <step name="section_1_search_integrations">
@@ -115,6 +116,12 @@ AskUserQuestion([
     options: [ /* same Leave/Replace/Clear or Skip/Set */ ]
   },
   {
+    question: "Perplexity API key — used for Search API + Agent API research surfaces",
+    header: "Perplexity",
+    multiSelect: false,
+    options: [ /* same Leave/Replace/Clear or Skip/Set */ ]
+  },
+  {
     question: "Include gitignored files in local code searches?",
     header: "Gitignored",
     multiSelect: false,
@@ -134,6 +141,7 @@ descriptions or confirmation text. Write the value via:
 gsd-sdk query config-set brave_search "<value>"     # masked in output
 gsd-sdk query config-set firecrawl "<value>"        # masked in output
 gsd-sdk query config-set exa_search "<value>"       # masked in output
+gsd-sdk query config-set perplexity "<value>"       # masked in output
 gsd-sdk query config-set search_gitignored true|false
 ```
 
@@ -241,6 +249,7 @@ Search Integrations
 | brave_search       | ****<last-4>      |  (or "(unset)")
 | firecrawl          | ****<last-4>      |
 | exa_search         | ****<last-4>      |
+| perplexity         | ****<last-4>      |
 | search_gitignored  | true | false      |
 
 Code Review CLI Routing

--- a/sdk/src/query/command-static-catalog-domain.ts
+++ b/sdk/src/query/command-static-catalog-domain.ts
@@ -8,6 +8,7 @@ import { commitToSubrepo } from './commit.js';
 import { workstreamGet, workstreamList, workstreamCreate, workstreamSet, workstreamStatus, workstreamComplete, workstreamProgress } from './workstream.js';
 import { docsInit } from './docs-init.js';
 import { websearch } from './websearch.js';
+import { perplexitySearch, perplexityAgent } from './perplexity.js';
 import { learningsCopy, learningsQuery, learningsListHandler, learningsPrune, learningsDelete, extractMessages, scanSessions, profileSample, profileQuestionnaire } from './profile.js';
 import { skillManifest } from './skill-manifest.js';
 import { auditOpen } from './audit-open.js';
@@ -64,6 +65,12 @@ export const DOMAIN_STATIC_CATALOG: ReadonlyArray<readonly [string, QueryHandler
   ['worktree cleanup-wave', worktreeCleanupWave],
   ['docs-init', docsInit],
   ['websearch', websearch],
+  ['perplexity-search', perplexitySearch],
+  ['perplexity search', perplexitySearch],
+  ['perplexity.search', perplexitySearch],
+  ['perplexity-agent', perplexityAgent],
+  ['perplexity agent', perplexityAgent],
+  ['perplexity.agent', perplexityAgent],
   ['learnings.copy', learningsCopy],
   ['learnings copy', learningsCopy],
   ['learnings.query', learningsQuery],

--- a/sdk/src/query/config-schema.ts
+++ b/sdk/src/query/config-schema.ts
@@ -17,7 +17,7 @@
 /** Exact-match config key paths accepted by config-set. */
 export const VALID_CONFIG_KEYS: ReadonlySet<string> = new Set([
   'mode', 'granularity', 'parallelization', 'commit_docs', 'model_profile',
-  'search_gitignored', 'brave_search', 'firecrawl', 'exa_search',
+  'search_gitignored', 'brave_search', 'firecrawl', 'exa_search', 'perplexity',
   'workflow.research', 'workflow.plan_check', 'workflow.verifier',
   'workflow.nyquist_validation', 'workflow.ai_integration_phase', 'workflow.ui_phase', 'workflow.ui_safety_gate',
   'workflow.auto_advance', 'workflow.node_repair', 'workflow.node_repair_budget',

--- a/sdk/src/query/perplexity.test.ts
+++ b/sdk/src/query/perplexity.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests for Perplexity Search + Agent handlers.
+ *
+ * Covers:
+ *  - graceful fallback when PERPLEXITY_API_KEY is absent (no network)
+ *  - Search API request body / response mapping
+ *  - Agent API request body / response mapping (pro-search preset default)
+ *  - X-Pplx-Integration attribution header on outgoing calls
+ *  - argument parsing (--limit / --recency / --preset / --model)
+ *  - non-2xx + network failure surfaces as available:false
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { perplexitySearch, perplexityAgent, integrationHeader } from './perplexity.js';
+
+const tmpDir = '/tmp';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env.PERPLEXITY_API_KEY;
+});
+
+describe('integrationHeader', () => {
+  it('uses the get-shit-done/<version> slug + version shape', () => {
+    expect(integrationHeader()).toMatch(/^get-shit-done\/[^\s]+$/);
+  });
+});
+
+describe('perplexitySearch — no-key fallback', () => {
+  it('returns available:false when PERPLEXITY_API_KEY is not set', async () => {
+    delete process.env.PERPLEXITY_API_KEY;
+    const r = await perplexitySearch(['hello'], tmpDir);
+    const data = r.data as Record<string, unknown>;
+    expect(data.available).toBe(false);
+    expect(data.reason).toBe('PERPLEXITY_API_KEY not set');
+  });
+
+  it('returns error when query is missing', async () => {
+    process.env.PERPLEXITY_API_KEY = 'pplx-x';
+    const r = await perplexitySearch([], tmpDir);
+    const data = r.data as Record<string, unknown>;
+    expect(data.available).toBe(false);
+    expect(data.error).toBe('Query required');
+  });
+});
+
+describe('perplexitySearch — successful API call', () => {
+  it('returns mapped results and sends X-Pplx-Integration header', async () => {
+    process.env.PERPLEXITY_API_KEY = 'pplx-success-key';
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id: 'req_42',
+        results: [
+          { title: 'A', url: 'https://a', snippet: 'sa', date: '2026-05-10' },
+          { title: 'B', url: 'https://b', snippet: 'sb' },
+        ],
+      }),
+    } as Response);
+
+    const r = await perplexitySearch(['typescript generics', '--limit', '5', '--recency', 'week'], tmpDir);
+    const data = r.data as Record<string, unknown>;
+    expect(data.available).toBe(true);
+    expect(data.count).toBe(2);
+    const results = data.results as Array<Record<string, unknown>>;
+    expect(results[0].title).toBe('A');
+    expect(results[0].date).toBe('2026-05-10');
+    expect(results[1].date).toBeNull();
+
+    const [url, init] = fetchSpy.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('https://api.perplexity.ai/search');
+    const headers = init.headers as Record<string, string>;
+    expect(headers.Authorization).toBe('Bearer pplx-success-key');
+    expect(headers['X-Pplx-Integration']).toMatch(/^get-shit-done\//);
+    const body = JSON.parse(init.body as string);
+    expect(body.query).toBe('typescript generics');
+    expect(body.max_results).toBe(5);
+    expect(body.search_recency_filter).toBe('week');
+  });
+});
+
+describe('perplexitySearch — error paths', () => {
+  it('returns available:false on non-ok response', async () => {
+    process.env.PERPLEXITY_API_KEY = 'pplx-429';
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: false, status: 429 } as Response);
+    const r = await perplexitySearch(['rate limited'], tmpDir);
+    const data = r.data as Record<string, unknown>;
+    expect(data.available).toBe(false);
+    expect(data.error).toBe('API error: 429');
+  });
+
+  it('returns available:false on network failure', async () => {
+    process.env.PERPLEXITY_API_KEY = 'pplx-net';
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'));
+    const r = await perplexitySearch(['network fail'], tmpDir);
+    const data = r.data as Record<string, unknown>;
+    expect(data.available).toBe(false);
+    expect(data.error).toBe('ECONNREFUSED');
+  });
+});
+
+describe('perplexityAgent — no-key fallback', () => {
+  it('returns available:false when PERPLEXITY_API_KEY is not set', async () => {
+    delete process.env.PERPLEXITY_API_KEY;
+    const r = await perplexityAgent(['hello'], tmpDir);
+    const data = r.data as Record<string, unknown>;
+    expect(data.available).toBe(false);
+    expect(data.reason).toBe('PERPLEXITY_API_KEY not set');
+  });
+
+  it('returns error when input is missing', async () => {
+    process.env.PERPLEXITY_API_KEY = 'pplx-x';
+    const r = await perplexityAgent([], tmpDir);
+    const data = r.data as Record<string, unknown>;
+    expect(data.available).toBe(false);
+    expect(data.error).toBe('Input required');
+  });
+});
+
+describe('perplexityAgent — request shape', () => {
+  it('defaults to pro-search preset and sends X-Pplx-Integration', async () => {
+    process.env.PERPLEXITY_API_KEY = 'pplx-agent-default';
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 'ag_1', output: 'synthesized' }),
+    } as Response);
+
+    const r = await perplexityAgent(['Find recent context on …'], tmpDir);
+    const data = r.data as Record<string, unknown>;
+    expect(data.available).toBe(true);
+    expect(data.output).toBe('synthesized');
+
+    const [url, init] = fetchSpy.mock.calls[0] as unknown as [string, RequestInit];
+    expect(url).toBe('https://api.perplexity.ai/v1/agent');
+    const headers = init.headers as Record<string, string>;
+    expect(headers['X-Pplx-Integration']).toMatch(/^get-shit-done\//);
+    expect(headers.Authorization).toBe('Bearer pplx-agent-default');
+    const body = JSON.parse(init.body as string);
+    expect(body.input).toBe('Find recent context on …');
+    expect(body.preset).toBe('pro-search');
+    expect(body.model).toBeUndefined();
+  });
+
+  it('sends explicit model when --model is provided (and no preset)', async () => {
+    process.env.PERPLEXITY_API_KEY = 'pplx-agent-model';
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: 'ag_2', output_text: 'ok' }),
+    } as Response);
+
+    await perplexityAgent(['hi', '--model', 'sonar-pro'], tmpDir);
+    const [, init] = fetchSpy.mock.calls[0] as unknown as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.model).toBe('sonar-pro');
+    expect(body.preset).toBeUndefined();
+  });
+});

--- a/sdk/src/query/perplexity.ts
+++ b/sdk/src/query/perplexity.ts
@@ -1,0 +1,212 @@
+/**
+ * Perplexity query handlers — Search API and Agent API.
+ *
+ * Provides two query commands:
+ *   - `perplexity-search` — POST https://api.perplexity.ai/search
+ *   - `perplexity-agent`  — POST https://api.perplexity.ai/v1/agent
+ *
+ * Both degrade gracefully with `{ available: false }` when
+ * `PERPLEXITY_API_KEY` is not configured. The attribution header
+ * `X-Pplx-Integration: get-shit-done/<package-version>` is sent on every
+ * outgoing call from `perplexityFetch`.
+ *
+ * Docs: https://docs.perplexity.ai
+ */
+
+import { readFileSync, existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join, resolve as pathResolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { QueryHandler } from './utils.js';
+
+export const SEARCH_URL = 'https://api.perplexity.ai/search';
+export const AGENT_URL = 'https://api.perplexity.ai/v1/agent';
+
+/**
+ * `X-Pplx-Integration` header value. Slug is fixed for this integration; the
+ * version is read from the repo's package.json so older installs are
+ * distinguishable in provider-side telemetry.
+ */
+export function integrationHeader(): string {
+  let version = 'unknown';
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    // Two layouts: src/ (dev) and dist/ (built). Walk up until package.json found.
+    const candidates = [
+      pathResolve(here, '..', '..', '..', 'package.json'),
+      pathResolve(here, '..', '..', 'package.json'),
+      pathResolve(here, '..', 'package.json'),
+    ];
+    for (const candidate of candidates) {
+      if (existsSync(candidate)) {
+        const pkg = JSON.parse(readFileSync(candidate, 'utf-8'));
+        if (pkg && typeof pkg.version === 'string' && pkg.version) {
+          version = pkg.version;
+          break;
+        }
+      }
+    }
+  } catch { /* unknown is fine — header still goes out */ }
+  return `get-shit-done/${version}`;
+}
+
+function readKeyFile(filePath: string): string | null {
+  try {
+    const buf = readFileSync(filePath);
+    if (buf.length >= 2 && buf[0] === 0xff && buf[1] === 0xfe) {
+      return buf.toString('utf16le').replace(/^﻿/, '').trim();
+    }
+    return buf.toString('utf-8').replace(/^﻿/, '').trim();
+  } catch {
+    return null;
+  }
+}
+
+export function resolveApiKey(cwd?: string): string | null {
+  if (process.env.PERPLEXITY_API_KEY) return process.env.PERPLEXITY_API_KEY;
+  const homeKey = join(homedir(), '.gsd', 'perplexity_api_key');
+  const fromHome = readKeyFile(homeKey);
+  if (fromHome) return fromHome;
+  if (cwd) {
+    try {
+      const cfgPath = join(cwd, '.planning', 'config.json');
+      if (existsSync(cfgPath)) {
+        const cfg = JSON.parse(readFileSync(cfgPath, 'utf-8')) as { perplexity?: unknown };
+        if (typeof cfg.perplexity === 'string' && cfg.perplexity.length > 0) {
+          return cfg.perplexity;
+        }
+      }
+    } catch { /* malformed config treated as no-key */ }
+  }
+  return null;
+}
+
+interface PerplexityFetchOpts {
+  apiKey: string;
+  fetchImpl?: typeof fetch;
+}
+
+export async function perplexityFetch<T = unknown>(
+  url: string,
+  body: Record<string, unknown>,
+  opts: PerplexityFetchOpts,
+): Promise<T> {
+  const { apiKey, fetchImpl } = opts;
+  if (!apiKey) {
+    throw new Error('PERPLEXITY_API_KEY not set');
+  }
+  const doFetch = fetchImpl || globalThis.fetch;
+  const response = await doFetch(url, {
+    method: 'POST',
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`,
+      'X-Pplx-Integration': integrationHeader(),
+    },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(`API error: ${response.status}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+interface SearchResultItem {
+  title: string;
+  url: string;
+  snippet: string;
+  date: string | null;
+  last_updated: string | null;
+}
+
+interface SearchResponse {
+  id?: string;
+  results?: Array<{ title?: string; url?: string; snippet?: string; date?: string; last_updated?: string }>;
+}
+
+/**
+ * Perplexity Search API handler.
+ * Args: <query> [--limit N] [--recency hour|day|week|month|year]
+ */
+export const perplexitySearch: QueryHandler = async (args, cwd) => {
+  const apiKey = resolveApiKey(cwd);
+  if (!apiKey) {
+    return { data: { available: false, reason: 'PERPLEXITY_API_KEY not set' } };
+  }
+  const query = args[0];
+  if (!query) {
+    return { data: { available: false, error: 'Query required' } };
+  }
+  const limitIdx = args.indexOf('--limit');
+  const recencyIdx = args.indexOf('--recency');
+  const limit = limitIdx !== -1 ? parseInt(args[limitIdx + 1], 10) : 10;
+  const recency = recencyIdx !== -1 ? args[recencyIdx + 1] : null;
+
+  const body: Record<string, unknown> = { query, max_results: limit };
+  if (recency) body.search_recency_filter = recency;
+
+  try {
+    const data = await perplexityFetch<SearchResponse>(SEARCH_URL, body, { apiKey });
+    const rawResults = Array.isArray(data.results) ? data.results : [];
+    const results: SearchResultItem[] = rawResults.map(r => ({
+      title: r.title || '',
+      url: r.url || '',
+      snippet: r.snippet || '',
+      date: r.date || null,
+      last_updated: r.last_updated || null,
+    }));
+    return { data: { available: true, query, count: results.length, results } };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { data: { available: false, error: msg } };
+  }
+};
+
+interface AgentResponse {
+  id?: string;
+  output?: unknown;
+  output_text?: string;
+  response?: unknown;
+}
+
+/**
+ * Perplexity Agent API handler.
+ * Args: <input> [--preset pro-search] [--model <id>]
+ *
+ * Defaults `preset` to `pro-search` when neither `--preset` nor `--model`
+ * is provided — that's the documented first-class research-agent surface.
+ */
+export const perplexityAgent: QueryHandler = async (args, cwd) => {
+  const apiKey = resolveApiKey(cwd);
+  if (!apiKey) {
+    return { data: { available: false, reason: 'PERPLEXITY_API_KEY not set' } };
+  }
+  const input = args[0];
+  if (!input) {
+    return { data: { available: false, error: 'Input required' } };
+  }
+  const presetIdx = args.indexOf('--preset');
+  const modelIdx = args.indexOf('--model');
+  const preset = presetIdx !== -1 ? args[presetIdx + 1] : null;
+  const model = modelIdx !== -1 ? args[modelIdx + 1] : null;
+
+  const body: Record<string, unknown> = { input };
+  if (model) body.model = model;
+  else body.preset = preset || 'pro-search';
+
+  try {
+    const data = await perplexityFetch<AgentResponse>(AGENT_URL, body, { apiKey });
+    return {
+      data: {
+        available: true,
+        id: data.id || null,
+        output: data.output || data.output_text || data.response || null,
+        raw: data,
+      },
+    };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { data: { available: false, error: msg } };
+  }
+};

--- a/sdk/src/query/secrets.test.ts
+++ b/sdk/src/query/secrets.test.ts
@@ -6,7 +6,7 @@ import secretsCjs from '../../../get-shit-done/bin/lib/secrets.cjs';
 
 describe('Bug #2997: SDK secrets module', () => {
   it('SECRET_CONFIG_KEYS exposes the documented set (locked)', () => {
-    assert.deepEqual([...SECRET_CONFIG_KEYS].sort(), ['brave_search', 'exa_search', 'firecrawl']);
+    assert.deepEqual([...SECRET_CONFIG_KEYS].sort(), ['brave_search', 'exa_search', 'firecrawl', 'perplexity']);
   });
 
   it('isSecretKey returns true for each registered secret', () => {

--- a/sdk/src/query/secrets.ts
+++ b/sdk/src/query/secrets.ts
@@ -17,6 +17,7 @@ export const SECRET_CONFIG_KEYS: ReadonlySet<string> = new Set([
   'brave_search',
   'firecrawl',
   'exa_search',
+  'perplexity',
 ]);
 
 export function isSecretKey(keyPath: string): boolean {

--- a/tests/perplexity.test.cjs
+++ b/tests/perplexity.test.cjs
@@ -1,0 +1,342 @@
+'use strict';
+
+/**
+ * Perplexity integration tests — Search API + Agent API.
+ *
+ * Covers:
+ *   - Graceful fallback when PERPLEXITY_API_KEY is absent
+ *   - Search API request body / response mapping
+ *   - Agent API request body / response mapping (pro-search preset default)
+ *   - X-Pplx-Integration attribution header is sent on every outgoing call
+ *   - Config key (`perplexity`) round-trips and masks secrets
+ *   - Plaintext containment (no leak outside config.json on disk)
+ */
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { createTempProject, cleanup, runGsdTools } = require('./helpers.cjs');
+const perplexity = require('../get-shit-done/bin/lib/perplexity.cjs');
+const { SECRET_CONFIG_KEYS, isSecretKey, maskSecret } = require('../get-shit-done/bin/lib/secrets.cjs');
+const { VALID_CONFIG_KEYS, isValidConfigKey } = require('../get-shit-done/bin/lib/config-schema.cjs');
+
+// ─── Module-level guards ─────────────────────────────────────────────────────
+
+describe('perplexity module shape', () => {
+  test('exports search, agent, perplexityFetch, resolveApiKey, integrationHeader', () => {
+    assert.equal(typeof perplexity.search, 'function');
+    assert.equal(typeof perplexity.agent, 'function');
+    assert.equal(typeof perplexity.perplexityFetch, 'function');
+    assert.equal(typeof perplexity.resolveApiKey, 'function');
+    assert.equal(typeof perplexity.integrationHeader, 'function');
+  });
+
+  test('integrationHeader uses the get-shit-done/<version> shape from package.json', () => {
+    const value = perplexity.integrationHeader();
+    assert.match(value, /^get-shit-done\/[^\s]+$/);
+    // Sanity: the version segment is the package.json version, not "unknown",
+    // when the repo is present (the test environment is the repo itself).
+    const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf-8'));
+    assert.equal(value, `get-shit-done/${pkg.version}`);
+  });
+});
+
+// ─── Config schema / secrets registration ────────────────────────────────────
+
+describe('perplexity registered as config key + secret', () => {
+  test('`perplexity` is in VALID_CONFIG_KEYS', () => {
+    assert.ok(VALID_CONFIG_KEYS.has('perplexity'), 'perplexity must be a valid config key');
+    assert.ok(isValidConfigKey('perplexity'));
+  });
+
+  test('`perplexity` is in SECRET_CONFIG_KEYS', () => {
+    assert.ok(SECRET_CONFIG_KEYS.has('perplexity'), 'perplexity must be a secret key');
+    assert.equal(isSecretKey('perplexity'), true);
+  });
+
+  test('maskSecret applies the documented convention', () => {
+    assert.equal(maskSecret('pplx-abcd1234efgh'), '****efgh');
+    assert.equal(maskSecret(null), '(unset)');
+  });
+});
+
+// ─── Key resolution + graceful fallback ──────────────────────────────────────
+
+describe('perplexity.resolveApiKey + fallback', () => {
+  let prevEnv;
+  beforeEach(() => { prevEnv = process.env.PERPLEXITY_API_KEY; delete process.env.PERPLEXITY_API_KEY; });
+  afterEach(() => { if (prevEnv !== undefined) process.env.PERPLEXITY_API_KEY = prevEnv; else delete process.env.PERPLEXITY_API_KEY; });
+
+  test('search() returns available:false with reason when no key is set', async () => {
+    const r = await perplexity.search('hello', {}, { cwd: '/tmp/nope' });
+    assert.equal(r.available, false);
+    assert.equal(r.reason, 'PERPLEXITY_API_KEY not set');
+  });
+
+  test('agent() returns available:false with reason when no key is set', async () => {
+    const r = await perplexity.agent('hello', {}, { cwd: '/tmp/nope' });
+    assert.equal(r.available, false);
+    assert.equal(r.reason, 'PERPLEXITY_API_KEY not set');
+  });
+
+  test('search() resolves the key from config.json when env unset', async (t) => {
+    const tmp = createTempProject();
+    t.after(() => cleanup(tmp));
+    runGsdTools(['config-ensure-section'], tmp);
+    runGsdTools(['config-set', 'perplexity', 'pplx-from-config-99'], tmp);
+
+    let captured = null;
+    const fakeFetch = async (url, init) => {
+      captured = { url, init };
+      return {
+        ok: true,
+        async json() { return { id: 'req_1', results: [{ title: 't', url: 'u', snippet: 's' }] }; },
+      };
+    };
+    const r = await perplexity.search('q', {}, { cwd: tmp, fetchImpl: fakeFetch });
+    assert.equal(r.available, true);
+    assert.equal(r.count, 1);
+    assert.equal(captured.init.headers.Authorization, 'Bearer pplx-from-config-99');
+  });
+});
+
+// ─── Request mapping + attribution header ────────────────────────────────────
+
+describe('perplexity HTTP request shape', () => {
+  test('search() POSTs to /search with X-Pplx-Integration + body mapping', async () => {
+    let captured = null;
+    const fakeFetch = async (url, init) => {
+      captured = { url, init };
+      return {
+        ok: true,
+        async json() {
+          return {
+            id: 'req_2',
+            results: [
+              { title: 'A', url: 'https://a', snippet: 'sa', date: '2026-05-10' },
+              { title: 'B', url: 'https://b', snippet: 'sb' },
+            ],
+          };
+        },
+      };
+    };
+    const r = await perplexity.search('typescript generics', {
+      maxResults: 5,
+      searchRecencyFilter: 'week',
+      searchDomainFilter: ['docs.example.com'],
+    }, { fetchImpl: fakeFetch, cwd: undefined });
+    // Override resolveApiKey via env for this case
+    process.env.PERPLEXITY_API_KEY = 'pplx-test-key-abcd';
+    try {
+      const r2 = await perplexity.search('typescript generics', {
+        maxResults: 5,
+        searchRecencyFilter: 'week',
+        searchDomainFilter: ['docs.example.com'],
+      }, { fetchImpl: fakeFetch });
+      assert.equal(r2.available, true);
+      assert.equal(captured.url, 'https://api.perplexity.ai/search');
+      assert.equal(captured.init.method, 'POST');
+      assert.equal(captured.init.headers['Content-Type'], 'application/json');
+      assert.equal(captured.init.headers.Authorization, 'Bearer pplx-test-key-abcd');
+      assert.match(captured.init.headers['X-Pplx-Integration'], /^get-shit-done\/[^\s]+$/);
+      const body = JSON.parse(captured.init.body);
+      assert.equal(body.query, 'typescript generics');
+      assert.equal(body.max_results, 5);
+      assert.equal(body.search_recency_filter, 'week');
+      assert.deepEqual(body.search_domain_filter, ['docs.example.com']);
+      assert.equal(r2.results.length, 2);
+      assert.equal(r2.results[0].title, 'A');
+      assert.equal(r2.results[0].date, '2026-05-10');
+      assert.equal(r2.results[1].date, null);
+    } finally {
+      delete process.env.PERPLEXITY_API_KEY;
+    }
+    // First call (no env, no cwd) returns fallback — fakeFetch was never called for that branch:
+    assert.equal(r.available, false);
+  });
+
+  test('agent() POSTs to /v1/agent with pro-search preset by default', async () => {
+    process.env.PERPLEXITY_API_KEY = 'pplx-agent-key-xxxx';
+    try {
+      let captured = null;
+      const fakeFetch = async (url, init) => {
+        captured = { url, init };
+        return {
+          ok: true,
+          async json() { return { id: 'ag_1', output: 'synthesized answer' }; },
+        };
+      };
+      const r = await perplexity.agent('Find recent context on …', {}, { fetchImpl: fakeFetch });
+      assert.equal(r.available, true);
+      assert.equal(r.output, 'synthesized answer');
+      assert.equal(captured.url, 'https://api.perplexity.ai/v1/agent');
+      assert.match(captured.init.headers['X-Pplx-Integration'], /^get-shit-done\//);
+      const body = JSON.parse(captured.init.body);
+      assert.equal(body.input, 'Find recent context on …');
+      assert.equal(body.preset, 'pro-search');
+    } finally {
+      delete process.env.PERPLEXITY_API_KEY;
+    }
+  });
+
+  test('agent() sends model instead of preset when --model provided', async () => {
+    process.env.PERPLEXITY_API_KEY = 'pplx-key-with-model';
+    try {
+      let captured = null;
+      const fakeFetch = async (url, init) => {
+        captured = { url, init };
+        return { ok: true, async json() { return { id: 'ag_2', output_text: 'ok' }; } };
+      };
+      await perplexity.agent('hi', { model: 'sonar-pro' }, { fetchImpl: fakeFetch });
+      const body = JSON.parse(captured.init.body);
+      assert.equal(body.model, 'sonar-pro');
+      assert.equal(body.preset, undefined);
+    } finally {
+      delete process.env.PERPLEXITY_API_KEY;
+    }
+  });
+
+  test('non-2xx response surfaces as available:false with status error', async () => {
+    process.env.PERPLEXITY_API_KEY = 'pplx-error-key-xxx';
+    try {
+      const fakeFetch = async () => ({ ok: false, status: 429, async json() { return {}; } });
+      const r = await perplexity.search('q', {}, { fetchImpl: fakeFetch });
+      assert.equal(r.available, false);
+      assert.equal(r.error, 'API error: 429');
+    } finally {
+      delete process.env.PERPLEXITY_API_KEY;
+    }
+  });
+
+  test('empty query / input surfaces as available:false with "Query required" / "Input required"', async () => {
+    process.env.PERPLEXITY_API_KEY = 'pplx-validation-key';
+    try {
+      const r1 = await perplexity.search('', {}, {});
+      assert.equal(r1.available, false);
+      assert.equal(r1.error, 'Query required');
+      const r2 = await perplexity.agent('', {}, {});
+      assert.equal(r2.available, false);
+      assert.equal(r2.error, 'Input required');
+    } finally {
+      delete process.env.PERPLEXITY_API_KEY;
+    }
+  });
+});
+
+// ─── config-set round-trip + masking ─────────────────────────────────────────
+
+describe('perplexity config integration', () => {
+  test('config-set perplexity stores plaintext only in config.json and masks output', (t) => {
+    const tmp = createTempProject();
+    t.after(() => cleanup(tmp));
+    runGsdTools(['config-ensure-section'], tmp);
+
+    const marker = ['PPLX', 'TESTMARK', 'abcd1234'].join('-');
+    const r = runGsdTools(['config-set', 'perplexity', marker], tmp);
+    assert.ok(r.success, `config-set perplexity failed: ${r.error}`);
+
+    const combined = `${r.output || ''}\n${r.error || ''}`;
+    assert.ok(!combined.includes(marker), `config-set must mask plaintext, got: ${combined}`);
+    assert.ok(combined.includes('****' + marker.slice(-4)), `expected mask **** + last-4, got: ${combined}`);
+
+    const cfg = JSON.parse(fs.readFileSync(path.join(tmp, '.planning', 'config.json'), 'utf-8'));
+    assert.equal(cfg.perplexity, marker, 'plaintext should be written to config.json');
+  });
+
+  test('config-get perplexity masks the secret on read', (t) => {
+    const tmp = createTempProject();
+    t.after(() => cleanup(tmp));
+    runGsdTools(['config-ensure-section'], tmp);
+    const marker = ['PPLX', 'GET', 'wxyz9876'].join('-');
+    runGsdTools(['config-set', 'perplexity', marker], tmp);
+
+    const get = runGsdTools(['config-get', 'perplexity'], tmp);
+    assert.ok(get.success, `config-get failed: ${get.error}`);
+    const combined = `${get.output || ''}\n${get.error || ''}`;
+    assert.ok(!combined.includes(marker), 'config-get must not echo plaintext');
+    assert.ok(combined.includes('****' + marker.slice(-4)), 'config-get must show mask');
+  });
+
+  test('plaintext appears only in config.json after config-set perplexity', (t) => {
+    const tmp = createTempProject();
+    t.after(() => cleanup(tmp));
+    runGsdTools(['config-ensure-section'], tmp);
+    const marker = ['PPLX', 'LEAKCHECK', 'qqqq1111'].join('-');
+    runGsdTools(['config-set', 'perplexity', marker], tmp);
+
+    const planning = path.join(tmp, '.planning');
+    const hits = [];
+    (function walk(dir) {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) { walk(full); continue; }
+        let buf;
+        try { buf = fs.readFileSync(full, 'utf-8'); } catch { return; }
+        if (buf.includes(marker)) hits.push(full);
+      }
+    })(planning);
+    assert.deepEqual(
+      hits.map(h => path.basename(h)).sort(),
+      ['config.json'],
+      `plaintext leaked outside config.json: ${hits.join(', ')}`,
+    );
+  });
+});
+
+// ─── CLI surface ─────────────────────────────────────────────────────────────
+
+describe('perplexity-search / perplexity-agent CLI surface', () => {
+  test('perplexity-search returns available:false when no key set', (t) => {
+    const tmp = createTempProject();
+    t.after(() => cleanup(tmp));
+    // Sandbox HOME so ~/.gsd/perplexity_api_key cannot satisfy the lookup.
+    const r = runGsdTools(['perplexity-search', 'hello'], tmp, { HOME: tmp, PERPLEXITY_API_KEY: '' });
+    assert.ok(r.success, `perplexity-search failed: ${r.error}`);
+    const parsed = JSON.parse(r.output);
+    assert.equal(parsed.available, false);
+    assert.equal(parsed.reason, 'PERPLEXITY_API_KEY not set');
+  });
+
+  test('perplexity-agent returns available:false when no key set', (t) => {
+    const tmp = createTempProject();
+    t.after(() => cleanup(tmp));
+    const r = runGsdTools(['perplexity-agent', 'hello'], tmp, { HOME: tmp, PERPLEXITY_API_KEY: '' });
+    assert.ok(r.success, `perplexity-agent failed: ${r.error}`);
+    const parsed = JSON.parse(r.output);
+    assert.equal(parsed.available, false);
+    assert.equal(parsed.reason, 'PERPLEXITY_API_KEY not set');
+  });
+});
+
+// ─── Workflow + docs surface ─────────────────────────────────────────────────
+
+describe('perplexity surfaced in docs / workflow', () => {
+  test('settings-integrations workflow mentions perplexity key', () => {
+    const wf = fs.readFileSync(
+      path.join(__dirname, '..', 'get-shit-done', 'workflows', 'settings-integrations.md'),
+      'utf-8',
+    );
+    assert.ok(wf.includes('perplexity'), 'workflow must reference perplexity key');
+  });
+
+  test('CONFIGURATION.md documents the perplexity key', () => {
+    const docs = fs.readFileSync(
+      path.join(__dirname, '..', 'docs', 'CONFIGURATION.md'),
+      'utf-8',
+    );
+    assert.ok(docs.includes('`perplexity`'), 'CONFIGURATION.md must document perplexity key');
+    assert.ok(docs.includes('PERPLEXITY_API_KEY'), 'CONFIGURATION.md must reference env var');
+    assert.ok(docs.includes('docs.perplexity.ai'), 'CONFIGURATION.md must link official docs');
+  });
+
+  test('researcher agent references perplexity-search / perplexity-agent', () => {
+    const agent = fs.readFileSync(
+      path.join(__dirname, '..', 'agents', 'gsd-project-researcher.md'),
+      'utf-8',
+    );
+    assert.ok(agent.includes('perplexity-search'));
+    assert.ok(agent.includes('perplexity-agent'));
+  });
+});


### PR DESCRIPTION
## Feature PR

## Linked Issue

Closes #3414

> Tracking spec for the Perplexity Search & Agent integrations. Awaiting maintainer review for the `approved-feature` label.

## Feature summary

Adds optional Perplexity Search API and Agent API support as a research/search provider, following the existing opt-in env-var + config-flag + graceful-fallback shape used by the other search integrations. Two new query commands — `perplexity-search` and `perplexity-agent` — are available via both `gsd-tools` and `gsd-sdk query`. The provider is a no-op (graceful `{ available: false }` fallback) when `PERPLEXITY_API_KEY` is not set, so existing research agents that try this provider first transparently fall back to other providers exactly the way they do today.

## What changed

### New files

| File | Purpose |
|------|---------|
| `get-shit-done/bin/lib/perplexity.cjs` | Central HTTP client for the Search + Agent APIs. Owns key resolution, the `X-Pplx-Integration` attribution header, and the `search` / `agent` handlers. |
| `sdk/src/query/perplexity.ts` | TypeScript mirror of the CJS client for `gsd-sdk query`. |
| `tests/perplexity.test.cjs` | Node `node:test` coverage — module shape, registration, fallback, request mapping, masking, CLI surface. |
| `sdk/src/query/perplexity.test.ts` | Vitest coverage for the SDK side — request/response mapping, attribution header, error paths. |
| `.changeset/3410-perplexity-integrations.md` | `--type Added` fragment for the user-facing change. |

### Modified files

| File | What changed |
|------|--------------|
| `get-shit-done/bin/lib/config-schema.cjs` | Register `perplexity` in `VALID_CONFIG_KEYS`. |
| `sdk/src/query/config-schema.ts` | Register `perplexity` in the SDK schema (kept in parity via the existing drift guard). |
| `get-shit-done/bin/lib/secrets.cjs` | Register `perplexity` in `SECRET_CONFIG_KEYS` so `****<last-4>` masking applies. |
| `sdk/src/query/secrets.ts`, `sdk/src/query/secrets.test.ts` | SDK parity for the secret-keys set. |
| `get-shit-done/bin/lib/commands.cjs` | `cmdPerplexitySearch` / `cmdPerplexityAgent` handlers. |
| `get-shit-done/bin/gsd-tools.cjs` | Dispatcher + help text for the two new commands. |
| `get-shit-done/bin/lib/config.cjs` | `buildNewProjectConfig` auto-detects key availability (env var → `~/.gsd/perplexity_api_key`). |
| `sdk/src/query/command-static-catalog-domain.ts` | Register `perplexity-search` / `perplexity-agent` for query routing (including the space / dot variants). |
| `get-shit-done/workflows/settings-integrations.md` | Perplexity row in the `gsd-config --integrations` workflow (Leave / Replace / Clear / Skip / Set). |
| `agents/gsd-project-researcher.md` | Perplexity sub-section in the tool-strategy section. |
| `docs/CONFIGURATION.md` | Documents the new key, links the official Perplexity docs at https://docs.perplexity.ai. |

## Implementation notes

- The HTTP client is a single module so the attribution header (`X-Pplx-Integration: get-shit-done/<package-version>`) and the key-resolution policy live in one file. Any future Perplexity-backed call inherits the header for free rather than inlining `fetch()`.
- Key resolution mirrors the existing search-provider precedence: `PERPLEXITY_API_KEY` env → `~/.gsd/perplexity_api_key` → the `perplexity` field in `.planning/config.json` (string). Returns `null` when nothing is configured so callers translate to `{ available: false }`.
- `perplexity-agent` defaults to the `pro-search` preset when no explicit `--model` is provided, per the [Perplexity Agent API docs](https://docs.perplexity.ai). An explicit `--model` overrides the preset.
- Review fixes applied since the initial commit:
  - `perplexity.cjs`: validate `query` / `input` is a string before checking for emptiness, and drop the dead `query[0]` fallback in the search response — the upstream validation already narrows `query` to a non-empty string.
  - `tests/perplexity.test.cjs` and `sdk/src/query/perplexity.test.ts`: sandbox `HOME` / `USERPROFILE` in the no-key suites so a developer or CI machine with a real `~/.gsd/perplexity_api_key` cannot satisfy the fallback assertions.

## Spec compliance

- [x] `perplexity-search` and `perplexity-agent` are wired through both `gsd-tools` and `gsd-sdk query`.
- [x] `PERPLEXITY_API_KEY` is resolved from env, `~/.gsd/perplexity_api_key`, then `.planning/config.json` (`perplexity`) — in that order.
- [x] Every outgoing call sends `Authorization: Bearer <key>` and `X-Pplx-Integration: get-shit-done/<package-version>` from a single helper.
- [x] `perplexity` is registered in `VALID_CONFIG_KEYS` (CJS + SDK) and in `SECRET_CONFIG_KEYS` so `****<last-4>` masking applies to `config-set` / `config-get` output and the `gsd-config --integrations` confirmation table.
- [x] `buildNewProjectConfig` auto-detects key availability the same way it does for the other providers.
- [x] When the key is unset, both commands return `{ available: false, reason: 'PERPLEXITY_API_KEY not set' }`.
- [x] Non-2xx responses surface as `{ available: false, error: 'API error: <status>' }`.
- [x] Tests cover the happy path, the no-key fallback, the error path, the masking pipeline, and the CLI surface for both commands.
- [x] `docs/CONFIGURATION.md` documents the new key and links the official Perplexity docs at https://docs.perplexity.ai.

## Testing

### Test coverage

- `tests/perplexity.test.cjs` — 21 tests: module shape, config-key + secret registration, no-key fallback for both surfaces (`search` / `agent`), key resolution from env / `~/.gsd` / `.planning/config.json`, Search API request body + response mapping, Agent API request body + `pro-search` default, explicit `--model` overrides `preset`, non-2xx → `available:false`, missing query / input handling, attribution header on every outgoing call, `config-set` round-trip + masking, plaintext containment guard, CLI surface for `perplexity-search` / `perplexity-agent`. The resolveApiKey suite sandboxes `HOME` / `USERPROFILE` to a tmp dir so a real `~/.gsd/perplexity_api_key` cannot affect the fallback path.
- `sdk/src/query/perplexity.test.ts` — 10 vitest tests: `integrationHeader` slug shape, no-key fallback for both handlers, Search request body + header presence, error paths (non-ok response + network failure), Agent default preset, explicit `--model` override. Each test sandboxes `HOME` / `USERPROFILE` to a tmp dir.

Local results:

- `node --test tests/perplexity.test.cjs` — 21 / 21 passing.
- `node --test tests/perplexity.test.cjs tests/settings-integrations.test.cjs tests/config-schema-docs-parity.test.cjs tests/config-schema-sdk-parity.test.cjs tests/config.test.cjs` — 119 / 119 passing (no regressions in adjacent suites).
- `cd sdk && npx vitest run src/query/perplexity.test.ts src/query/secrets.test.ts` — 26 / 26 passing.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Codex
- [ ] Copilot
- [ ] Other: ___
- [ ] N/A — specify which runtimes are supported and why others are excluded

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue exactly
- [x] No additional features, commands, or behaviors were added beyond what was approved
- [x] If scope changed during implementation, I updated the issue spec and received re-approval

---

## Checklist

- [x] Issue linked above with `Closes #NNN`
- [ ] Linked issue has the `approved-feature` label — **awaiting maintainer review on #3414**
- [x] All acceptance criteria from the issue are met (listed above)
- [x] Implementation scope matches the approved spec exactly
- [x] All existing tests pass (`npm test`)
- [x] New tests cover the happy path, error cases, and edge cases
- [x] `.changeset/` fragment added with a user-facing description of the feature
- [x] Documentation updated — commands, workflows, references, README if applicable
- [x] No unnecessary external dependencies added
- [x] Works on Windows (backslash paths handled — key file resolution uses `path.join` + `os.homedir()`)

## Breaking changes

None — this adds two new commands and one new config key, and does not modify any existing command behavior or file schema. Existing `.planning/config.json` files without a `perplexity` field continue to work unchanged (resolved to "no key configured" → graceful fallback).