### PR TITLE
feat(sdk): deepen package seam for legacy query compatibility

### DIFF
--- a/.changeset/crisp-seams-align.md
+++ b/.changeset/crisp-seams-align.md
@@ -1,0 +1,5 @@
+---
+type: Changed
+pr: 0
+---
+SDK query compatibility now routes `write-profile` default path and query CLI fallback/error imports through explicit package-seam adapters, reducing install-layout coupling outside `sdk-package-compatibility`.

--- a/.changeset/crisp-seams-align.md
+++ b/.changeset/crisp-seams-align.md
@@ -1,5 +1,5 @@
 ---
 type: Changed
-pr: 0
+pr: 3419
 ---
 SDK query compatibility now routes `write-profile` default path and query CLI fallback/error imports through explicit package-seam adapters, reducing install-layout coupling outside `sdk-package-compatibility`.

--- a/sdk/src/query/profile-output.ts
+++ b/sdk/src/query/profile-output.ts
@@ -19,7 +19,7 @@ import { GSDError, ErrorClassification } from '../errors.js';
 import { detectRuntime, resolveGlobalSkillMarkdownPath } from './helpers.js';
 import { CLAUDE_INSTRUCTIONS } from './profile-questionnaire-data.js';
 import type { QueryHandler } from './utils.js';
-import { resolveBundledTemplatesDir } from '../sdk-package-compatibility.js';
+import { resolveBundledTemplatesDir, resolveLegacyUserProfilePath } from '../sdk-package-compatibility.js';
 
 const TEMPLATE_DIR = resolveBundledTemplatesDir();
 
@@ -482,7 +482,7 @@ function cmdWriteProfileLogic(
 
   let outputPath = options.output;
   if (!outputPath) {
-    outputPath = join(homedir(), '.claude', 'get-shit-done', 'USER-PROFILE.md');
+    outputPath = resolveLegacyUserProfilePath();
   } else if (!isAbsolute(outputPath)) {
     outputPath = join(cwd, outputPath);
   }

--- a/sdk/src/query/query-cli-adapter.test.ts
+++ b/sdk/src/query/query-cli-adapter.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const dispatchSpy = vi.hoisted(() => vi.fn());
 const runQueryDispatchSpy = vi.hoisted(() => vi.fn());
+const resolveGsdToolsPathSeamSpy = vi.hoisted(() => vi.fn(() => '/mock/gsd-tools.cjs'));
 
 vi.mock('./helpers.js', () => ({
   findProjectRoot: (projectDir: string) => projectDir,
@@ -15,12 +16,18 @@ vi.mock('./query-dispatch.js', () => ({
   runQueryDispatch: (...args: unknown[]) => runQueryDispatchSpy(...args),
 }));
 
+vi.mock('../query-gsd-tools-path.js', () => ({
+  resolveGsdToolsPath: (...args: unknown[]) => resolveGsdToolsPathSeamSpy(...args),
+}));
+
 import { runQueryCliCommand } from './query-cli-adapter.js';
 
 describe('query-cli-adapter', () => {
   beforeEach(() => {
     dispatchSpy.mockReset();
     runQueryDispatchSpy.mockReset();
+    resolveGsdToolsPathSeamSpy.mockReset();
+    resolveGsdToolsPathSeamSpy.mockReturnValue('/mock/gsd-tools.cjs');
   });
 
   it('returns validation failure for missing query command', async () => {
@@ -52,6 +59,19 @@ describe('query-cli-adapter', () => {
     await runQueryCliCommand({
       projectDir: process.cwd(),
       ws: 'alpha',
+      queryArgv: ['state', 'show'],
+    });
+  });
+
+  it('wires resolveGsdToolsPath from the query seam module', async () => {
+    runQueryDispatchSpy.mockImplementationOnce(async (input: any) => {
+      expect(input.resolveGsdToolsPath).toBe(resolveGsdToolsPathSeamSpy);
+      expect(input.resolveGsdToolsPath('/tmp/project')).toBe('/mock/gsd-tools.cjs');
+      return { ok: true, exit_code: 0, stdout: '', stderr: [] };
+    });
+
+    await runQueryCliCommand({
+      projectDir: process.cwd(),
       queryArgv: ['state', 'show'],
     });
   });

--- a/sdk/src/query/query-cli-adapter.test.ts
+++ b/sdk/src/query/query-cli-adapter.test.ts
@@ -65,8 +65,9 @@ describe('query-cli-adapter', () => {
 
   it('wires resolveGsdToolsPath from the query seam module', async () => {
     runQueryDispatchSpy.mockImplementationOnce(async (input: any) => {
-      expect(input.resolveGsdToolsPath).toBe(resolveGsdToolsPathSeamSpy);
+      expect(typeof input.resolveGsdToolsPath).toBe('function');
       expect(input.resolveGsdToolsPath('/tmp/project')).toBe('/mock/gsd-tools.cjs');
+      expect(resolveGsdToolsPathSeamSpy).toHaveBeenCalledWith('/tmp/project');
       return { ok: true, exit_code: 0, stdout: '', stderr: [] };
     });
 

--- a/sdk/src/query/query-cli-adapter.ts
+++ b/sdk/src/query/query-cli-adapter.ts
@@ -1,6 +1,6 @@
 import { createRegistry } from './index.js';
 import { runQueryDispatch } from './query-dispatch.js';
-import { resolveGsdToolsPath } from '../gsd-tools.js';
+import { resolveGsdToolsPath } from '../query-gsd-tools-path.js';
 import { resolveQueryRuntimeContext } from './query-runtime-context.js';
 import { createCommandTopology } from './command-topology.js';
 import { buildQueryCliOutputFromDispatch, buildQueryCliOutputFromError, type QueryCliAdapterOutput } from './query-cli-output.js';

--- a/sdk/src/query/query-cli-output.test.ts
+++ b/sdk/src/query/query-cli-output.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { GSDToolsError } from '../gsd-tools.js';
+import { GSDToolsError } from '../gsd-tools-error.js';
 import { buildQueryCliOutputFromError } from './query-cli-output.js';
 
 describe('query-cli-output', () => {

--- a/sdk/src/query/query-cli-output.ts
+++ b/sdk/src/query/query-cli-output.ts
@@ -1,5 +1,5 @@
 import { GSDError, exitCodeFor } from '../errors.js';
-import { GSDToolsError } from '../gsd-tools.js';
+import { GSDToolsError } from '../gsd-tools-error.js';
 import type { QueryDispatchResult } from './query-dispatch-contract.js';
 
 export interface QueryCliAdapterOutput {

--- a/sdk/src/sdk-package-compatibility.test.ts
+++ b/sdk/src/sdk-package-compatibility.test.ts
@@ -12,6 +12,7 @@ import {
   resolveBundledTemplatesDir,
   resolveGsdToolsPath,
   resolveLegacyInstallDir,
+  resolveLegacyUserProfilePath,
   resolveLegacyTemplatesDir,
   resolveLegacyWorkflowsDir,
 } from './sdk-package-compatibility.js';
@@ -25,6 +26,7 @@ describe('SDK Package Seam Module', () => {
     expect(resolveLegacyInstallDir(homeDir)).toBe(join(homeDir, '.claude', 'get-shit-done'));
     expect(resolveLegacyTemplatesDir(homeDir)).toBe(join(homeDir, '.claude', 'get-shit-done', 'templates'));
     expect(resolveLegacyWorkflowsDir(homeDir)).toBe(join(homeDir, '.claude', 'get-shit-done', 'workflows'));
+    expect(resolveLegacyUserProfilePath(homeDir)).toBe(join(homeDir, '.claude', 'get-shit-done', 'USER-PROFILE.md'));
     expect(resolveBundledTemplatesDir()).toBe(BUNDLED_GSD_TEMPLATES_DIR);
     expect(resolveBundledAgentsDir()).toBe(BUNDLED_GSD_AGENTS_DIR);
   });

--- a/sdk/src/sdk-package-compatibility.ts
+++ b/sdk/src/sdk-package-compatibility.ts
@@ -58,6 +58,10 @@ export function resolveLegacyWorkflowsDir(homeDir: string = homedir()): string {
   return join(resolveLegacyInstallDir(homeDir), 'workflows');
 }
 
+export function resolveLegacyUserProfilePath(homeDir: string = homedir()): string {
+  return join(resolveLegacyInstallDir(homeDir), 'USER-PROFILE.md');
+}
+
 export function resolveLegacySkillsDir(homeDir: string = homedir()): string {
   return join(resolveLegacyInstallDir(homeDir), 'skills');
 }


### PR DESCRIPTION
## Enhancement PR

> **Using the wrong template?**
> — Bug fix: use [fix.md](?template=fix.md)
> — New feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.
> The linked issue **must** have the `approved-enhancement` label. If it does not, this PR will be closed without review.

Closes #3234

> ⛔ **No `approved-enhancement` label on the issue = immediate close.**
> Do not open this PR if a maintainer has not yet approved the enhancement proposal.

---

## What this enhancement improves

Consolidates remaining SDK query compatibility edges behind the SDK Package Seam Module so install-layout knowledge is less scattered.

## Before / After

**Before:**
- `write-profile` default output path was assembled inline with direct `homedir()+'.claude/get-shit-done'` knowledge.
- Query CLI adapter/output imported fallback/error types through broader SDK surfaces (`gsd-tools.js`), widening coupling at the seam.

**After:**
- `write-profile` now uses a seam-owned helper (`resolveLegacyUserProfilePath`) in `sdk-package-compatibility`.
- Query CLI adapter uses `query-gsd-tools-path` directly.
- Query CLI output uses `gsd-tools-error` directly.
- Added seam-focused tests for the new helper and query adapter wiring.

## How it was implemented

- Added `resolveLegacyUserProfilePath()` to `sdk/src/sdk-package-compatibility.ts`.
- Migrated `writeProfile` default path resolution in `sdk/src/query/profile-output.ts`.
- Tightened query CLI seam imports in:
  - `sdk/src/query/query-cli-adapter.ts`
  - `sdk/src/query/query-cli-output.ts`
- Added/updated tests in:
  - `sdk/src/sdk-package-compatibility.test.ts`
  - `sdk/src/query/query-cli-adapter.test.ts`
  - `sdk/src/query/query-cli-output.test.ts`

## Testing

### How I verified the enhancement works

- `TMPDIR=/private/tmp npm run test -- src/sdk-package-compatibility.test.ts src/query/query-cli-adapter.test.ts src/query/query-cli-output.test.ts src/query/profile.test.ts` (in `sdk/`)
- `npm run build` (in `sdk/`)

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing

---

## Checklist

- [x] Issue linked above with `Closes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `approved-enhancement` label — **PR will be closed if missing**
- [x] Changes are scoped to the approved enhancement — nothing extra included
- [ ] All existing tests pass (`npm test`)
- [x] New or updated tests cover the enhanced behavior
- [x] `.changeset/` fragment added (`npm run changeset -- --type Changed --pr <NNN> --body "..."`) — or `no-changelog` label applied if not user-facing
- [ ] Documentation updated if behavior or output changed
- [x] No unnecessary dependencies added

## Breaking changes

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query CLI error handling and tool-path resolution to make CLI fallbacks more reliable.
  * Profile output now defaults to the legacy user-profile location when no output is specified.

* **Refactor**
  * Rewired internal compatibility adapters and imports to reduce coupling and simplify runtime wiring.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3419)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->