### PR TITLE
fix: stabilize /gsd-progress flag routing parse contract

### DIFF
--- a/.changeset/graceful-sloths-wake.md
+++ b/.changeset/graceful-sloths-wake.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3418
+---
+**`/gsd-progress --next` no longer falls through to the default route** — the command now surfaces raw arguments on a dedicated line before flag parsing so `--next`, `--do`, and `--forensic` routing instructions remain stable for the model.

--- a/.changeset/graceful-sloths-wake.md
+++ b/.changeset/graceful-sloths-wake.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 3418
+pr: 3420
 ---
 **`/gsd-progress --next` no longer falls through to the default route** — the command now surfaces raw arguments on a dedicated line before flag parsing so `--next`, `--do`, and `--forensic` routing instructions remain stable for the model.

--- a/commands/gsd/progress.md
+++ b/commands/gsd/progress.md
@@ -35,7 +35,8 @@ Three modes:
 </execution_context>
 
 <process>
-Parse the first token of $ARGUMENTS:
+Arguments provided: "$ARGUMENTS"
+Parse the first token from the provided arguments:
 - If it is `--next`: strip the flag, execute the next workflow (passing remaining args e.g. --force).
 - If it is `--do`: strip the flag, pass remainder as freeform intent to the do workflow.
 - Otherwise: execute the progress workflow end-to-end (pass --forensic through if present).

--- a/tests/bug-3418-progress-flag-routing.test.cjs
+++ b/tests/bug-3418-progress-flag-routing.test.cjs
@@ -1,0 +1,33 @@
+// allow-test-rule: source-text-is-the-product
+// The command markdown is loaded directly by runtime prompt assembly.
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+describe('#3418: /gsd-progress flag routing prompt contract', () => {
+  test('progress command surfaces raw arguments on a dedicated line before routing parse', () => {
+    const command = fs.readFileSync(
+      path.join(__dirname, '..', 'commands', 'gsd', 'progress.md'),
+      'utf8'
+    );
+
+    assert.ok(
+      command.includes('Arguments provided: "$ARGUMENTS"'),
+      'progress.md must surface $ARGUMENTS on a dedicated line for stable flag parsing'
+    );
+  });
+
+  test('progress command must not inline-substitute $ARGUMENTS into parse instruction text', () => {
+    const command = fs.readFileSync(
+      path.join(__dirname, '..', 'commands', 'gsd', 'progress.md'),
+      'utf8'
+    );
+
+    assert.ok(
+      !command.includes('Parse the first token of $ARGUMENTS:'),
+      'progress.md must keep parse instructions independent from argument interpolation'
+    );
+  });
+});


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #3418

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

`/gsd-progress --next` could fall through to the default routing path because `$ARGUMENTS` was interpolated inline into the parse instruction text (`Parse the first token of $ARGUMENTS:`), which made the routing directive less stable for model parsing.

## What this fix does

The command now prints `Arguments provided: "$ARGUMENTS"` on its own line and parses from a neutral instruction (`Parse the first token from the provided arguments:`), so flag routing instructions for `--next`, `--do`, and `--forensic` remain explicit.

## Root cause

The prompt contract coupled runtime argument interpolation with instructional prose in a single sentence, creating ambiguity in the rendered model input for flag-first routes.

## Testing

### How I verified the fix

- `node --test tests/bug-3418-progress-flag-routing.test.cjs tests/progress-forensic.test.cjs tests/next-safety-gates.test.cjs`
- `TMPDIR=/private/tmp npm test`
- `node scripts/lint-no-source-grep.cjs`
- `node scripts/lint-command-contract.cjs`
- `node scripts/changeset/lint.cjs`
- `TMPDIR=/private/tmp npx vitest run src/query/command-seam-coverage.test.ts` (in `sdk/`)
- `node sdk/scripts/check-command-aliases-fresh.mjs`

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why: <!-- e.g., environment-specific, non-deterministic -->

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: Codex CLI/local runner
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `/gsd-progress --next` command to correctly handle flag routing and prevent fallthrough to default behavior. Ensures stable routing for `--next`, `--do`, and `--forensic` flags.

* **Tests**
  * Added test coverage to verify proper flag routing behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3420)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->