### PR TITLE
fix(pr-template-policy): stop false warning on valid enhancement template

### DIFF
--- a/scripts/pr-template-policy.cjs
+++ b/scripts/pr-template-policy.cjs
@@ -112,19 +112,21 @@ function evaluatePrTemplate(body, authorAssociation) {
   if (!normalizedBody) {
     valid = false;
     reason = 'PR body is empty; a typed pull request template is required.';
-  } else if (includesDefaultTemplate(normalizedBody)) {
-    valid = false;
-    reason = 'PR body still contains the default wrong-template guidance.';
   } else {
     const match = matchingTemplate(normalizedBody);
     template = match.template;
     missingHeadings = match.missingHeadings;
-    if (!template) {
-      valid = false;
-      reason = 'PR body does not match the fix, enhancement, or feature template.';
-    } else if (missingHeadings.length > 0) {
+    if (template && missingHeadings.length === 0) {
+      valid = true;
+    } else if (template && missingHeadings.length > 0) {
       valid = false;
       reason = `PR body appears to use the ${template} template but is missing required headings.`;
+    } else if (includesDefaultTemplate(normalizedBody)) {
+      valid = false;
+      reason = 'PR body still contains the default wrong-template guidance.';
+    } else {
+      valid = false;
+      reason = 'PR body does not match the fix, enhancement, or feature template.';
     }
   }
 

--- a/tests/pr-template-policy.test.cjs
+++ b/tests/pr-template-policy.test.cjs
@@ -99,6 +99,24 @@ describe('pr-template-policy', () => {
     assert.equal(result.template, 'enhancement');
   });
 
+  test('does not flag default-template marker phrase inside a valid enhancement template', () => {
+    const body = enhancementBody.replace(
+      '## Linked Issue',
+      [
+        '> **Using the wrong template?**',
+        '> - Bug fix: use [fix.md](?template=fix.md)',
+        '> - New feature: use [feature.md](?template=feature.md)',
+        '',
+        '## Linked Issue',
+      ].join('\n'),
+    );
+    const result = evaluatePrTemplate(body, 'COLLABORATOR');
+
+    assert.equal(result.valid, true);
+    assert.equal(result.action, 'pass');
+    assert.equal(result.template, 'enhancement');
+  });
+
   test('passes PR bodies that use the feature template', () => {
     const result = evaluatePrTemplate(featureBody, 'FIRST_TIME_CONTRIBUTOR');
 


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> - Enhancement: use [enhancement.md](?template=enhancement.md)
> - Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

Fixes #3422

## What was broken

`PR Template Format` could warn on a correctly formatted enhancement PR because the policy matched the phrase `Wrong template` before validating typed template structure.

## What this fix does

Reorders `scripts/pr-template-policy.cjs` evaluation so a fully valid typed template passes first, and default-template marker detection only applies when no valid typed template is detected.

## Root cause

The marker check (`includesDefaultTemplate`) ran before `matchingTemplate`, and the enhancement template itself contains `Using the wrong template?`, which matched the marker list and produced a false positive warning.

## Testing

### How I verified the fix

- Added regression test in `tests/pr-template-policy.test.cjs`:
  - `does not flag default-template marker phrase inside a valid enhancement template`
- Ran:
  - `node --test tests/pr-template-policy.test.cjs`
  - `node scripts/lint-no-source-grep.cjs`
  - `npm run lint:changeset`

### Regression test added?

- [x] Yes - added a test that would have caught this bug
- [ ] No - explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` - PR will be auto-closed if missing
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug - no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) - or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PR template validation to properly sequence the evaluation of template matching, detection of required headings, and related checks for more accurate validation results.
  * Fixed an edge case where guidance text about using different PR templates could incorrectly cause valid pull requests to fail template validation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3423)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->