### PR TITLE
fix(commands): quote debug.md argument-hint to repair YAML frontmatter

### DIFF
--- a/.changeset/plucky-geese-caper.md
+++ b/.changeset/plucky-geese-caper.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3429
+---
+**`/gsd:debug` frontmatter parses correctly** — `argument-hint` value is now double-quoted so YAML doesn't interpret the bracketed flag list as a malformed flow sequence. Previously the command's frontmatter loaded with empty metadata silently.

--- a/commands/gsd/debug.md
+++ b/commands/gsd/debug.md
@@ -1,7 +1,7 @@
 ---
 name: gsd:debug
 description: Systematic debugging with persistent state across context resets
-argument-hint: [list | status <slug> | continue <slug> | --diagnose] [issue description]
+argument-hint: "[list | status <slug> | continue <slug> | --diagnose] [issue description]"
 allowed-tools:
   - Read
   - Write


### PR DESCRIPTION
## Fix PR

## Linked Issue

**No linked issue — contributor exemption requested for a one-line typo-class fix.** Filing a `confirmed-bug` issue first for a YAML quoting typo is disproportionate process. Happy to file one if maintainer prefers — flag and I'll do it.

---

## What was broken

`commands/gsd/debug.md` had an unquoted `argument-hint`:

```yaml
argument-hint: [list | status <slug> | continue <slug> | --diagnose] [issue description]
```

YAML reads `[...]` as a flow sequence; `|` and `<...>` tokens inside break the parse. The entire frontmatter loads with empty metadata at runtime — `name`, `description`, `allowed-tools` are silently dropped.

## What this fix does

Double-quotes the value. Matches the convention every other `commands/gsd/*.md` file already uses (15+ files).

## Root cause

Authored without quotes; never caught because the empty frontmatter degraded silently rather than erroring. Surfaced by `claude plugin validate` during work on #3428.

## Testing

- [x] No regression test in this PR
- Justification: a useful regression test would parse YAML frontmatter for every command and assert all parse — `architectural-invariant`-style check, larger scope than a one-line quoting fix. **Happy to open a follow-up issue and add that test** if maintainer wants it.
- Verified manually: `claude plugin validate` fails on `main`, passes on this branch.

### Platforms / Runtimes

- [x] Windows / Claude Code

---

## Checklist

- [ ] Linked issue — see note at top
- [x] Scoped to the bug
- [x] Existing tests pass
- [x] Changeset fragment added (`.changeset/plucky-geese-caper.md`)
- [x] No dependencies added

## Breaking changes

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect metadata parsing that was silently loading empty or invalid configuration data.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3429)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->