### PR TITLE
fix: quote debug command argument-hint

### DIFF
--- a/.changeset/wise-koalas-climb.md
+++ b/.changeset/wise-koalas-climb.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 1
+---
+**`/gsd-debug` command metadata now parses as valid YAML** — external YAML tooling and command-contract validation no longer fail on the unquoted argument hint.

--- a/.changeset/wise-koalas-climb.md
+++ b/.changeset/wise-koalas-climb.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 1
+pr: 3435
 ---
 **`/gsd-debug` command metadata now parses as valid YAML** — external YAML tooling and command-contract validation no longer fail on the unquoted argument hint.

--- a/commands/gsd/debug.md
+++ b/commands/gsd/debug.md
@@ -1,7 +1,7 @@
 ---
 name: gsd:debug
 description: Systematic debugging with persistent state across context resets
-argument-hint: [list | status <slug> | continue <slug> | --diagnose] [issue description]
+argument-hint: "[list | status <slug> | continue <slug> | --diagnose] [issue description]"
 allowed-tools:
   - Read
   - Write

--- a/tests/bug-3431-debug-command-yaml.test.cjs
+++ b/tests/bug-3431-debug-command-yaml.test.cjs
@@ -1,0 +1,31 @@
+// allow-test-rule: source-text-is-the-product
+// Command markdown frontmatter is the deployed contract; this regression test
+// verifies the real YAML surface that external parsers consume.
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const YAML = require('yaml');
+
+const DEBUG_COMMAND_PATH = path.join(__dirname, '..', 'commands', 'gsd', 'debug.md');
+
+function readFrontmatter(filePath) {
+  const content = fs.readFileSync(filePath, 'utf8');
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  assert.ok(match, 'command must start with YAML frontmatter');
+  return YAML.parse(match[1]);
+}
+
+test('#3431: commands/gsd/debug.md frontmatter parses as YAML and preserves argument-hint', () => {
+  const frontmatter = readFrontmatter(DEBUG_COMMAND_PATH);
+
+  assert.equal(frontmatter.name, 'gsd:debug');
+  assert.equal(
+    frontmatter['argument-hint'],
+    '[list | status <slug> | continue <slug> | --diagnose] [issue description]',
+    'argument-hint should remain user-visible text after YAML parsing'
+  );
+});

--- a/tests/bug-3431-debug-command-yaml.test.cjs
+++ b/tests/bug-3431-debug-command-yaml.test.cjs
@@ -8,15 +8,12 @@ const { test } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
-const YAML = require('yaml');
+const { parseFrontmatter } = require('./helpers.cjs');
 
 const DEBUG_COMMAND_PATH = path.join(__dirname, '..', 'commands', 'gsd', 'debug.md');
 
 function readFrontmatter(filePath) {
-  const content = fs.readFileSync(filePath, 'utf8');
-  const match = content.match(/^---\n([\s\S]*?)\n---/);
-  assert.ok(match, 'command must start with YAML frontmatter');
-  return YAML.parse(match[1]);
+  return parseFrontmatter(fs.readFileSync(filePath, 'utf8'));
 }
 
 test('#3431: commands/gsd/debug.md frontmatter parses as YAML and preserves argument-hint', () => {


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #3431

---

## What was broken

`commands/gsd/debug.md` shipped an unquoted `argument-hint` frontmatter value, so standard YAML parsers rejected the command metadata.

## What this fix does

Quotes the `argument-hint` value and adds a regression test that parses the command frontmatter with a real YAML parser.

## Root cause

The command contract tests relied on a looser frontmatter reader, so invalid YAML syntax in the deployed command markdown was not exercised.

## Testing

### How I verified the fix

- `node --test tests/bug-3431-debug-command-yaml.test.cjs tests/command-contract.test.cjs`
- `npm run lint:tests -- tests/bug-3431-debug-command-yaml.test.cjs`
- `npm run lint:changeset`
- `npm test`

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed metadata formatting for the gsd:debug command so external YAML/validation tools parse it correctly.

* **Documentation**
  * Updated command metadata to explicitly quote the argument-hint string containing supported flags/subcommands and the [issue description] pattern.

* **Tests**
  * Added a regression test to assert the command metadata parses and contains the expected fields.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3435)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->