### PR TITLE
fix: align planner plan contract with phase index

### DIFF
--- a/.changeset/silly-jaguars-sing.md
+++ b/.changeset/silly-jaguars-sing.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 1
+---
+**`/gsd-plan-phase` now documents phase-plan-index-compatible plan conventions** — planner guidance uses canonical `depends_on` and SUMMARY forms, and native phase indexing warns when it ignores noncanonical plan filenames.

--- a/.changeset/silly-jaguars-sing.md
+++ b/.changeset/silly-jaguars-sing.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 1
+pr: 3436
 ---
 **`/gsd-plan-phase` now documents phase-plan-index-compatible plan conventions** — planner guidance uses canonical `depends_on` and SUMMARY forms, and native phase indexing warns when it ignores noncanonical plan filenames.

--- a/agents/gsd-planner.md
+++ b/agents/gsd-planner.md
@@ -426,7 +426,7 @@ phase: XX-name
 plan: NN
 type: execute
 wave: N                     # Execution wave (1, 2, 3...)
-depends_on: []              # Plan IDs this plan requires
+depends_on: []              # Plan IDs this plan requires; canonical examples: `[01-01, 01-02]` or `[01-01-auth-hardening]`
 files_modified: []          # Files this plan touches
 autonomous: true            # false if plan has checkpoints
 requirements: []            # REQUIRED — Requirement IDs from ROADMAP this plan addresses. MUST NOT be empty.
@@ -496,7 +496,7 @@ Output: [Artifacts created]
 </success_criteria>
 
 <output>
-After completion, create `.planning/phases/XX-name/{phase}-{plan}-SUMMARY.md`
+After completion, create `.planning/phases/XX-name/{padded_phase}-{plan}-SUMMARY.md`
 </output>
 ```
 
@@ -508,7 +508,7 @@ After completion, create `.planning/phases/XX-name/{phase}-{plan}-SUMMARY.md`
 | `plan` | Yes | Plan number within phase |
 | `type` | Yes | `execute` or `tdd` |
 | `wave` | Yes | Execution wave number |
-| `depends_on` | Yes | Plan IDs this plan requires |
+| `depends_on` | Yes | Plan IDs this plan requires; use canonical in-phase IDs like `01-01` or `01-01-auth-hardening` |
 | `files_modified` | Yes | Files this plan touches |
 | `autonomous` | Yes | `true` if no checkpoints |
 | `requirements` | Yes | **MUST** list requirement IDs from ROADMAP. Every roadmap requirement ID MUST appear in at least one plan. |

--- a/agents/gsd-planner.md
+++ b/agents/gsd-planner.md
@@ -426,7 +426,7 @@ phase: XX-name
 plan: NN
 type: execute
 wave: N                     # Execution wave (1, 2, 3...)
-depends_on: []              # Plan IDs this plan requires; canonical examples: `[01-01, 01-02]` or `[01-01-auth-hardening]`
+depends_on: []              # Use `01-01`/`01-01-auth-hardening`
 files_modified: []          # Files this plan touches
 autonomous: true            # false if plan has checkpoints
 requirements: []            # REQUIRED — Requirement IDs from ROADMAP this plan addresses. MUST NOT be empty.
@@ -496,7 +496,7 @@ Output: [Artifacts created]
 </success_criteria>
 
 <output>
-After completion, create `.planning/phases/XX-name/{padded_phase}-{plan}-SUMMARY.md`
+Create `.planning/phases/XX-name/{padded_phase}-{plan}-SUMMARY.md` when done
 </output>
 ```
 
@@ -508,7 +508,7 @@ After completion, create `.planning/phases/XX-name/{padded_phase}-{plan}-SUMMARY
 | `plan` | Yes | Plan number within phase |
 | `type` | Yes | `execute` or `tdd` |
 | `wave` | Yes | Execution wave number |
-| `depends_on` | Yes | Plan IDs this plan requires; use canonical in-phase IDs like `01-01` or `01-01-auth-hardening` |
+| `depends_on` | Yes | Plan IDs this plan requires |
 | `files_modified` | Yes | Files this plan touches |
 | `autonomous` | Yes | `true` if no checkpoints |
 | `requirements` | Yes | **MUST** list requirement IDs from ROADMAP. Every roadmap requirement ID MUST appear in at least one plan. |

--- a/sdk/src/query/phase.test.ts
+++ b/sdk/src/query/phase.test.ts
@@ -505,4 +505,27 @@ describe('phasePlanIndex', () => {
     expect(planA!.depends_on).toEqual([]);
     expect(planB!.depends_on).toEqual(['15-01']);
   });
+
+  it('#3430: native phase-plan-index warns about noncanonical plan-shaped files it cannot index', async () => {
+    const phase16 = join(tmpDir, '.planning', 'phases', '16-warning');
+    await mkdir(phase16, { recursive: true });
+    await writeFile(join(phase16, '16-PLAN-01-eval-harness.md'), [
+      '---',
+      'phase: 16-warning',
+      'plan: 01',
+      'wave: 1',
+      'autonomous: true',
+      'depends_on: []',
+      '---',
+      '<objective>Noncanonical plan filename.</objective>',
+    ].join('\n'));
+
+    const result = await phasePlanIndex(['16'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+
+    expect(data.plans).toEqual([]);
+    expect(data.warnings).toEqual([
+      'Ignored noncanonical plan files: 16-PLAN-01-eval-harness.md',
+    ]);
+  });
 });

--- a/sdk/src/query/phase.ts
+++ b/sdk/src/query/phase.ts
@@ -278,6 +278,11 @@ export const phasePlanIndex: QueryHandler = async (args, projectDir, workstream)
   const phaseFiles = await readdir(phaseDir);
   const planFiles = phaseFiles.filter(f => f.endsWith('-PLAN.md') || f === 'PLAN.md').sort();
   const summaryFiles = phaseFiles.filter(f => f.endsWith('-SUMMARY.md') || f === 'SUMMARY.md');
+  const nonCanonicalPlanFiles = phaseFiles.filter((f) => (
+    f.toLowerCase().endsWith('.md')
+    && /(^|-)plan(-|\.)/i.test(f)
+    && !(f.endsWith('-PLAN.md') || f === 'PLAN.md')
+  )).sort();
 
   // Build set of plan IDs with summaries — match the planId derivation logic
   const completedPlanIds = new Set(
@@ -432,6 +437,10 @@ export const phasePlanIndex: QueryHandler = async (args, projectDir, workstream)
   const incomplete: string[] = [];
   let hasCheckpoints = false;
   const warnings: string[] = [];
+
+  if (nonCanonicalPlanFiles.length > 0) {
+    warnings.push(`Ignored noncanonical plan files: ${nonCanonicalPlanFiles.join(', ')}`);
+  }
 
   for (const raw of rawPlans) {
     if (!raw.autonomous) {

--- a/tests/bug-3430-planner-phase-contract.test.cjs
+++ b/tests/bug-3430-planner-phase-contract.test.cjs
@@ -1,0 +1,44 @@
+// allow-test-rule: source-text-is-the-product
+// Planner markdown is the deployed planning contract; these checks lock the
+// exact canonical forms that downstream phase-plan-index accepts.
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const PLANNER_PATH = path.join(__dirname, '..', 'agents', 'gsd-planner.md');
+
+function readPlanner() {
+  return fs.readFileSync(PLANNER_PATH, 'utf8');
+}
+
+test('#3430: planner SUMMARY instruction uses canonical padded phase/plan form', () => {
+  const content = readPlanner();
+  assert.match(
+    content,
+    /After completion, create `\.planning\/phases\/XX-name\/\{padded_phase\}-\{plan\}-SUMMARY\.md`/,
+    'planner must instruct executors to write SUMMARY files in canonical padded-phase form'
+  );
+  assert.doesNotMatch(
+    content,
+    /After completion, create `\.planning\/phases\/XX-name\/\{phase\}-\{plan\}-SUMMARY\.md`/,
+    'planner must not instruct the broken {phase}-{plan}-SUMMARY.md form'
+  );
+});
+
+test('#3430: planner depends_on docs show canonical in-phase plan ids', () => {
+  const content = readPlanner();
+  assert.match(
+    content,
+    /depends_on:[^\n]*canonical examples: `\[01-01, 01-02\]` or `\[01-01-auth-hardening\]`/,
+    'planner must document canonical depends_on examples that phase-plan-index resolves'
+  );
+  assert.doesNotMatch(
+    content,
+    /depends_on:[^\n]*01-trust\/01/,
+    'planner must not document phase-slug/plan-number depends_on examples as canonical'
+  );
+});

--- a/tests/bug-3430-planner-phase-contract.test.cjs
+++ b/tests/bug-3430-planner-phase-contract.test.cjs
@@ -19,7 +19,7 @@ test('#3430: planner SUMMARY instruction uses canonical padded phase/plan form',
   const content = readPlanner();
   assert.match(
     content,
-    /After completion, create `\.planning\/phases\/XX-name\/\{padded_phase\}-\{plan\}-SUMMARY\.md`/,
+    /Create `\.planning\/phases\/XX-name\/\{padded_phase\}-\{plan\}-SUMMARY\.md` when done/,
     'planner must instruct executors to write SUMMARY files in canonical padded-phase form'
   );
   assert.doesNotMatch(
@@ -33,7 +33,7 @@ test('#3430: planner depends_on docs show canonical in-phase plan ids', () => {
   const content = readPlanner();
   assert.match(
     content,
-    /depends_on:[^\n]*canonical examples: `\[01-01, 01-02\]` or `\[01-01-auth-hardening\]`/,
+    /depends_on:[^\n]*Use `01-01`\/`01-01-auth-hardening`/,
     'planner must document canonical depends_on examples that phase-plan-index resolves'
   );
   assert.doesNotMatch(


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #3430

---

## What was broken

`/gsd-plan-phase` guidance and the native `phase-plan-index` query had drifted apart: planner docs still showed a broken SUMMARY filename form, `depends_on` guidance was underspecified, and noncanonical plan files were silently ignored.

## What this fix does

Documents the canonical planner contract, adds regressions for the planner/query seam, and makes native `phase-plan-index` warn when it skips noncanonical plan files.

## Root cause

The planner prompt and the Phase Query seam evolved independently. Native phase indexing had no warning path for plan-shaped files that missed the canonical `*-PLAN.md` contract, so users saw silent empty results instead of a diagnostic.

## Testing

### How I verified the fix

- `node --test tests/bug-3430-planner-phase-contract.test.cjs`
- `cd sdk && npx vitest run src/query/phase.test.ts`
- `npm run lint:tests -- tests/bug-3430-planner-phase-contract.test.cjs`
- `npm run lint:changeset`
- `npm test`

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added detection and warnings for noncanonical plan filenames in phase directories to guide users toward proper naming conventions.

* **Documentation**
  * Clarified canonical phase-plan naming conventions and `depends_on` format requirements in planner guidance.
  * Refined output instructions for plan summary file creation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3436)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->