### PR TITLE
feat: route Codex hook commands through projection seam

### DIFF
--- a/.changeset/fair-hawks-play.md
+++ b/.changeset/fair-hawks-play.md
@@ -1,0 +1,6 @@
+---
+type: Added
+pr: 0
+---
+
+**Codex managed hook commands now project through the shared shell-command seam** — the installer reuses the same runtime-aware command rendering policy for `config.toml` hook blocks and Codex reinstall rewrites, reducing shell-format drift between runtime surfaces. Closes #3440.

--- a/.changeset/fair-hawks-play.md
+++ b/.changeset/fair-hawks-play.md
@@ -1,6 +1,6 @@
 ---
 type: Added
-pr: 0
+pr: 3444
 ---
 
 **Codex managed hook commands now project through the shared shell-command seam** — the installer reuses the same runtime-aware command rendering policy for `config.toml` hook blocks and Codex reinstall rewrites, reducing shell-format drift between runtime surfaces. Closes #3440.

--- a/bin/install.js
+++ b/bin/install.js
@@ -8,6 +8,7 @@ const crypto = require('crypto');
 const {
   formatHookCommandForRuntime: formatHookCommandForShell,
   formatManagedHookScriptToken,
+  projectCodexHookTomlCommand,
 } = require('../get-shit-done/bin/lib/shell-command-projection.cjs');
 
 // Colors
@@ -750,19 +751,19 @@ function buildCodexHookBlock(targetDir, opts) {
   const absoluteRunner = opts && opts.absoluteRunner;
   if (!absoluteRunner) return null;
   const eol = (opts && opts.eol) || '\n';
-  const updateCheckScript = path.resolve(targetDir, 'hooks', 'gsd-check-update.js').replace(/\\/g, '/');
-  // toml requires escaped interior quotes (\"). The runner is already a
-  // JSON-stringified token (with literal " around the absolute path); we
-  // need to escape those quotes so the toml parser sees them as part of
-  // the string value, not as the closing quote of the command field.
-  const runnerEscaped = absoluteRunner.replace(/"/g, '\\"');
-  const hookPathEscaped = updateCheckScript.replace(/"/g, '\\"');
+  const platform = (opts && opts.platform) || process.platform;
+  const updateCheckScript = path.resolve(targetDir, 'hooks', 'gsd-check-update.js');
+  const commandValue = projectCodexHookTomlCommand({
+    absoluteRunner,
+    scriptPath: updateCheckScript,
+    platform,
+  });
   return `${eol}# GSD Hooks${eol}` +
     `[[hooks.SessionStart]]${eol}` +
     `${eol}` +
     `[[hooks.SessionStart.hooks]]${eol}` +
     `type = "command"${eol}` +
-    `command = "${runnerEscaped} \\"${hookPathEscaped}\\""${eol}`;
+    `command = "${commandValue}"${eol}`;
 }
 
 /**
@@ -778,8 +779,9 @@ function buildCodexHookBlock(targetDir, opts) {
  * @param {string|null} absoluteRunner - Result of resolveNodeRunner().
  * @returns {{ content: string, changed: boolean }}
  */
-function rewriteLegacyCodexHookBlock(content, absoluteRunner) {
+function rewriteLegacyCodexHookBlock(content, absoluteRunner, opts) {
   if (!content || !absoluteRunner) return { content, changed: false };
+  const platform = (opts && opts.platform) || process.platform;
   let changed = false;
   // Match `command = "node <scriptToken>"` lines where scriptToken is
   // either an unquoted path (no spaces) or a toml-escaped quoted path.
@@ -799,11 +801,15 @@ function rewriteLegacyCodexHookBlock(content, absoluteRunner) {
       const scriptPath = quoted ? quoted[1] : scriptToken;
       const base = scriptPath.split(/[\\/]/).pop() || '';
       if (!CODEX_MANAGED_HOOK_BASENAMES.has(base)) return full;
+      const desiredCommand = projectCodexHookTomlCommand({
+        absoluteRunner,
+        scriptPath,
+        platform,
+      });
+      const currentCommand = `${prefix}${scriptToken}${suffix}`.replace(/^(command\s*=\s*")|("\s*)$/g, '');
+      if (currentCommand === desiredCommand) return full;
       changed = true;
-      const runnerEscaped = absoluteRunner.replace(/"/g, '\\"');
-      // Always re-quote the path on output for consistency with the new
-      // builder's shape.
-      return `${prefix}${runnerEscaped} \\"${scriptPath}\\"${suffix}`;
+      return `${prefix}${desiredCommand}${suffix}`;
     },
   );
   return { content: updated, changed };

--- a/bin/install.js
+++ b/bin/install.js
@@ -796,9 +796,16 @@ function rewriteLegacyCodexHookBlock(content, absoluteRunner, opts) {
     /^(command\s*=\s*")node\s+((?:\\"[^"]+\\"|\S+))("\s*)$/gm,
     (full, prefix, scriptToken, suffix) => {
       // Extract the underlying script path from the captured token —
-      // either the bare token or the inner content of \"...\".
-      const quoted = scriptToken.match(/^\\"(.+)\\"$/);
-      const scriptPath = quoted ? quoted[1] : scriptToken;
+      // either the bare token or the decoded inner content of \"...\".
+      const quoted = scriptToken.match(/^\\"([\s\S]+)\\"$/);
+      let scriptPath = scriptToken;
+      if (quoted) {
+        try {
+          scriptPath = String(parseTomlValue(`"${quoted[1]}"`, 0).value);
+        } catch {
+          scriptPath = quoted[1];
+        }
+      }
       const base = scriptPath.split(/[\\/]/).pop() || '';
       if (!CODEX_MANAGED_HOOK_BASENAMES.has(base)) return full;
       const desiredCommand = projectCodexHookTomlCommand({

--- a/get-shit-done/bin/lib/shell-command-projection.cjs
+++ b/get-shit-done/bin/lib/shell-command-projection.cjs
@@ -45,8 +45,34 @@ function formatManagedHookScriptToken(scriptPath, opts = {}) {
   return JSON.stringify(scriptPath.replace(/\\/g, '/'));
 }
 
+function projectManagedHookCommand({ absoluteRunner, scriptPath, runtime = 'generic', platform = process.platform }) {
+  if (!absoluteRunner || !scriptPath) return null;
+  const normalizedScriptPath = platform === 'win32' ? scriptPath.replace(/\\/g, '/') : scriptPath;
+  return formatHookCommandForRuntime(`${absoluteRunner} ${JSON.stringify(normalizedScriptPath)}`, {
+    platform,
+    runtime,
+  });
+}
+
+function escapeTomlDoubleQuotedString(value) {
+  return String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+function projectCodexHookTomlCommand({ absoluteRunner, scriptPath, platform = process.platform }) {
+  const command = projectManagedHookCommand({
+    absoluteRunner,
+    scriptPath,
+    runtime: 'codex',
+    platform,
+  });
+  return command === null ? null : escapeTomlDoubleQuotedString(command);
+}
+
 module.exports = {
   hookCommandNeedsPowerShellCallOperator,
   formatHookCommandForRuntime,
   formatManagedHookScriptToken,
+  projectManagedHookCommand,
+  escapeTomlDoubleQuotedString,
+  projectCodexHookTomlCommand,
 };

--- a/tests/bug-3017-codex-hook-absolute-node.test.cjs
+++ b/tests/bug-3017-codex-hook-absolute-node.test.cjs
@@ -37,7 +37,9 @@ const assert = require('node:assert/strict');
 const path = require('node:path');
 
 const INSTALL = require(path.join(__dirname, '..', 'bin', 'install.js'));
+const projection = require(path.join(__dirname, '..', 'get-shit-done', 'bin', 'lib', 'shell-command-projection.cjs'));
 const { buildCodexHookBlock, rewriteLegacyCodexHookBlock, resolveNodeRunner } = INSTALL;
+const { projectCodexHookTomlCommand } = projection;
 
 /**
  * Parse the toml hook block into a typed record so tests can assert on
@@ -85,6 +87,20 @@ function unescapeRunner(token) {
   if (t.startsWith('"') && t.endsWith('"')) t = t.slice(1, -1);
   return t;
 }
+
+describe('Bug #3017 / #3440: Codex hook projection seam', () => {
+  test('projectCodexHookTomlCommand renders escaped command value from shared projection module', () => {
+    const commandValue = projectCodexHookTomlCommand({
+      absoluteRunner: '"/usr/local/bin/node"',
+      scriptPath: '/tmp/codex-test/.codex/hooks/gsd-check-update.js',
+      platform: 'linux',
+    });
+    assert.equal(
+      commandValue,
+      '\\"/usr/local/bin/node\\" \\"/tmp/codex-test/.codex/hooks/gsd-check-update.js\\"',
+    );
+  });
+});
 
 describe('Bug #3017: buildCodexHookBlock emits absolute node runner', () => {
   test('exported as a function', () => {

--- a/tests/bug-3017-codex-hook-absolute-node.test.cjs
+++ b/tests/bug-3017-codex-hook-absolute-node.test.cjs
@@ -198,15 +198,19 @@ describe('Bug #3017: rewriteLegacyCodexHookBlock migrates bare-node on reinstall
     const runner = '"/usr/local/bin/node"';
     const result = rewriteLegacyCodexHookBlock(before, runner, { platform: 'win32' });
     assert.equal(result.changed, true);
+    const parsed = parseCodexHookBlock(result.content);
+    assert.equal(parsed.ok, true, 'hook block must parse correctly');
     const expected = projectCodexHookTomlCommand({
       absoluteRunner: runner,
       scriptPath: 'C:\\Users\\x\\.codex\\hooks\\gsd-check-update.js',
       platform: 'win32',
     });
-    assert.ok(
-      result.content.includes(`command = "${expected}"`),
-      'rewritten command must project from decoded Windows path (not TOML-escaped token text)'
-    );
+    assert.equal(parsed.command, expected,
+      'rewritten command must project from decoded Windows path (not TOML-escaped token text)');
+    assert.equal(unescapeRunner(parsed.runner), '/usr/local/bin/node',
+      'runner must equal supplied absolute path');
+    assert.equal(parsed.hookPath, 'C:/Users/x/.codex/hooks/gsd-check-update.js',
+      'hook path must equal decoded Windows path after projection normalization');
   });
 
   test('does NOT touch a managed-hook entry that already uses an absolute runner', () => {

--- a/tests/bug-3017-codex-hook-absolute-node.test.cjs
+++ b/tests/bug-3017-codex-hook-absolute-node.test.cjs
@@ -185,6 +185,30 @@ describe('Bug #3017: rewriteLegacyCodexHookBlock migrates bare-node on reinstall
     assert.ok(result.content.includes('name = "o3"'));
   });
 
+  test('decodes TOML-escaped quoted script paths before projection', () => {
+    const before = [
+      '# GSD Hooks',
+      '[[hooks.SessionStart]]',
+      '',
+      '[[hooks.SessionStart.hooks]]',
+      'type = "command"',
+      'command = "node \\"C:\\\\Users\\\\x\\\\.codex\\\\hooks\\\\gsd-check-update.js\\""',
+      '',
+    ].join('\n');
+    const runner = '"/usr/local/bin/node"';
+    const result = rewriteLegacyCodexHookBlock(before, runner, { platform: 'win32' });
+    assert.equal(result.changed, true);
+    const expected = projectCodexHookTomlCommand({
+      absoluteRunner: runner,
+      scriptPath: 'C:\\Users\\x\\.codex\\hooks\\gsd-check-update.js',
+      platform: 'win32',
+    });
+    assert.ok(
+      result.content.includes(`command = "${expected}"`),
+      'rewritten command must project from decoded Windows path (not TOML-escaped token text)'
+    );
+  });
+
   test('does NOT touch a managed-hook entry that already uses an absolute runner', () => {
     const already = [
       '# GSD Hooks',


### PR DESCRIPTION
## Feature PR

---

## Linked Issue

Closes #3440

---

## Feature summary

This slice moves Codex managed hook command rendering onto the shared Shell Command Projection Module so `config.toml` hook blocks and Codex reinstall rewrites reuse the same serialized command policy as other managed hook surfaces.

## What changed

### New files

| File | Purpose |
|------|---------|
| `.changeset/fair-hawks-play.md` | User-facing release fragment for the Codex hook projection slice. |

### Modified files

| File | What changed |
|------|-------------|
| `get-shit-done/bin/lib/shell-command-projection.cjs` | Added shared Codex hook command projection helpers for managed hook command text and TOML escaping. |
| `bin/install.js` | Routed `buildCodexHookBlock()` and `rewriteLegacyCodexHookBlock()` through the shared shell-command projection seam. |
| `tests/bug-3017-codex-hook-absolute-node.test.cjs` | Added direct coverage for the shared Codex hook projection helper and kept Codex reinstall regression coverage green. |

## Implementation notes

- This PR stays within the approved `#3440` slice only: Codex hook block generation and Codex reinstall rewrites.
- Internal subprocess execution remains unchanged and still does **not** route through shell-string projection.
- TOML output continues to preserve the absolute-node behavior from `#3017`; only ownership of the rendered command text moved.

## Spec compliance

- [x] `buildCodexHookBlock()` consumes the Shell Command Projection Module instead of hand-building the `command = "..."` string itself.
- [x] `rewriteLegacyCodexHookBlock()` reprojects managed Codex hook commands through the same shared projection seam.
- [x] Codex hook rendering preserves the existing absolute-node behavior from `#3017`.
- [x] Regression tests cover Codex managed-hook projection through typed/structured assertions rather than source-grep of installer string builders.
- [x] No user-authored Codex hook commands are rewritten.

## Testing

### Test coverage

Verified the Codex projection slice plus adjacent hook-projection regressions with:

```bash
node --test tests/bug-3017-codex-hook-absolute-node.test.cjs tests/bug-3413-shell-command-projection.test.cjs tests/bug-2979-hook-absolute-node.test.cjs
```

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux

### Runtimes tested

- [x] Claude Code
- [x] Gemini CLI
- [ ] OpenCode
- [x] Codex
- [ ] Copilot
- [ ] Other: ___
- [ ] N/A — specify which runtimes are supported and why others are excluded

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue exactly
- [x] No additional features, commands, or behaviors were added beyond what was approved
- [x] If scope changed during implementation, I updated the issue spec and received re-approval

---

## Checklist

- [x] Issue linked above with `Closes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `approved-feature` label — **PR will be closed if missing**
- [x] All acceptance criteria from the issue are met (listed above)
- [x] Implementation scope matches the approved spec exactly
- [ ] All existing tests pass (`npm test`)
- [x] New tests cover the happy path, error cases, and edge cases
- [x] `.changeset/` fragment added with a user-facing description of the feature (`npm run changeset -- --type Added --pr <NNN> --body "..."`)
- [ ] Documentation updated — commands, workflows, references, README if applicable
- [x] No unnecessary external dependencies added
- [ ] Works on Windows (backslash paths handled)

## Breaking changes

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer now generates platform-aware, TOML-safe hook commands for config files.

* **Bug Fixes**
  * Reduced shell-format drift across runtimes by rewriting hook command blocks only when necessary.

* **Tests**
  * Added tests validating hook command projection, platform normalization, and TOML escaping.

* **Chores**
  * Added a changeset documenting the update.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3444)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->