### PR TITLE
feat(shell-projection): route PATH guidance through typed action projection

### DIFF
--- a/.changeset/plucky-lemurs-dance.md
+++ b/.changeset/plucky-lemurs-dance.md
@@ -1,0 +1,5 @@
+---
+type: Added
+pr: 3447
+---
+**Installer PATH guidance now routes through the Shell Command Projection Module** — PATH repair/setup commands are projected from typed shell action IR (PowerShell/cmd/Git Bash/POSIX) to keep escaping and path-style policy consistent from one seam.

--- a/bin/install.js
+++ b/bin/install.js
@@ -12,6 +12,7 @@ const {
   projectLocalHookPrefix,
   projectLegacySettingsHookCommand,
   projectManagedHookCommand,
+  projectPathActionProjection,
   projectPortableHookBaseDir,
   projectShellCommandText,
   projectCodexHookTomlCommand,
@@ -9785,8 +9786,15 @@ function maybeSuggestPathExport(globalBin, homeDir) {
   console.log('');
   console.log(`  ${yellow}⚠${reset} ${bold}${globalBin}${reset} is not on your PATH.`);
   console.log(`    Add it with one of:`);
-  console.log(`      ${cyan}echo 'export PATH="${globalBin}:$PATH"' >> ~/.zshrc${reset}`);
-  console.log(`      ${cyan}echo 'export PATH="${globalBin}:$PATH"' >> ~/.bashrc${reset}`);
+  const projected = projectPathActionProjection({
+    mode: 'persist',
+    targetDir: globalBin,
+    platform: process.platform,
+  });
+  for (const action of projected.shellActions) {
+    const label = action.label ? `${action.label}: ` : '';
+    console.log(`      ${cyan}${label}${action.command}${reset}`);
+  }
   console.log('');
 }
 

--- a/get-shit-done/bin/lib/shell-command-projection.cjs
+++ b/get-shit-done/bin/lib/shell-command-projection.cjs
@@ -151,6 +151,86 @@ function projectCodexHookTomlCommand({ absoluteRunner, scriptPath, platform = pr
   return command === null ? null : escapeTomlDoubleQuotedString(command);
 }
 
+function escapePowerShellSingleQuoted(value) {
+  return String(value).replace(/'/g, "''");
+}
+
+function escapePosixDoubleQuoted(value) {
+  return String(value).replace(/[\\$"`]/g, '\\$&');
+}
+
+function escapeSingleQuotedShellLiteral(value) {
+  return String(value).replace(/'/g, "'\\''");
+}
+
+function renderShellActionLines(shellActions = []) {
+  return shellActions.map((action) => {
+    if (!action || !action.command) return '';
+    return action.label ? `${action.label}: ${action.command}` : action.command;
+  }).filter(Boolean);
+}
+
+function projectPathActionProjection({
+  mode = 'repair',
+  targetDir,
+  platform = process.platform,
+}) {
+  if (!targetDir) return { shellActions: [], actionLines: [] };
+
+  const isWin32 = platform === 'win32';
+
+  let shellActions;
+  if (isWin32) {
+    const psTargetDir = escapePowerShellSingleQuoted(targetDir);
+    const bashTargetDir = escapeSingleQuotedShellLiteral(String(targetDir).replace(/\\/g, '/'));
+    shellActions = [
+      {
+        label: 'PowerShell',
+        shell: 'powershell',
+        command: `[Environment]::SetEnvironmentVariable('PATH', '${psTargetDir};' + [Environment]::GetEnvironmentVariable('PATH', 'User'), 'User')`,
+      },
+      {
+        label: 'cmd.exe',
+        shell: 'cmd',
+        command: `powershell -Command "[Environment]::SetEnvironmentVariable('PATH', '${psTargetDir};' + [Environment]::GetEnvironmentVariable('PATH', 'User'), 'User')"`,
+      },
+      {
+        label: 'Git Bash',
+        shell: 'bash',
+        command: `echo 'export PATH="${bashTargetDir}:$PATH"' >> ~/.bashrc`,
+      },
+    ];
+  } else if (mode === 'persist') {
+    const bashTargetDir = escapeSingleQuotedShellLiteral(String(targetDir));
+    shellActions = [
+      {
+        label: 'zsh',
+        shell: 'zsh',
+        command: `echo 'export PATH="${bashTargetDir}:$PATH"' >> ~/.zshrc`,
+      },
+      {
+        label: 'bash',
+        shell: 'bash',
+        command: `echo 'export PATH="${bashTargetDir}:$PATH"' >> ~/.bashrc`,
+      },
+    ];
+  } else {
+    const posixTargetDir = escapePosixDoubleQuoted(targetDir);
+    shellActions = [
+      {
+        label: null,
+        shell: 'posix',
+        command: `export PATH="${posixTargetDir}:$PATH"`,
+      },
+    ];
+  }
+
+  return {
+    shellActions,
+    actionLines: renderShellActionLines(shellActions),
+  };
+}
+
 function buildWindowsShimTriple(shimSrc) {
   const path = require('path');
   const shimAbs = path.resolve(shimSrc);
@@ -179,18 +259,16 @@ function formatSdkPathDiagnostic({ shimDir, platform, runDir }) {
     (runDir.includes('/_npx/') || runDir.includes('\\_npx\\'));
   const shimLocationLine = shimDir ? `Shim written to: ${shimDir}` : '';
   const actionLines = [];
+  let shellActions = [];
   if (shimDir) {
-    const psShimDir = shimDir.replace(/'/g, "''");
-    const bashShimDir = shimDir.replace(/\\/g, '/').replace(/'/g, "'\\''");
-    const posixShimDir = shimDir.replace(/[\\$"`]/g, '\\$&');
+    const projected = projectPathActionProjection({
+      mode: 'repair',
+      targetDir: shimDir,
+      platform,
+    });
+    shellActions = projected.shellActions;
     actionLines.push('Add that directory to your PATH and restart your shell.');
-    if (isWin32) {
-      actionLines.push(`PowerShell: [Environment]::SetEnvironmentVariable('PATH', '${psShimDir};' + [Environment]::GetEnvironmentVariable('PATH', 'User'), 'User')`);
-      actionLines.push(`cmd.exe   : powershell -Command "[Environment]::SetEnvironmentVariable('PATH', '${psShimDir};' + [Environment]::GetEnvironmentVariable('PATH', 'User'), 'User')"`);
-      actionLines.push(`Git Bash  : echo 'export PATH="${bashShimDir}:$PATH"' >> ~/.bashrc`);
-    } else {
-      actionLines.push(`export PATH="${posixShimDir}:$PATH"`);
-    }
+    actionLines.push(...projected.actionLines);
   } else {
     actionLines.push('Could not locate a writable PATH directory to install the shim.');
     actionLines.push('Install globally to materialize the bin symlink:');
@@ -202,7 +280,7 @@ function formatSdkPathDiagnostic({ shimDir, platform, runDir }) {
         'install globally instead: npm install -g get-shit-done-cc',
       ]
     : [];
-  return { shimLocationLine, actionLines, npxNoteLines, isNpx, isWin32 };
+  return { shimLocationLine, actionLines, shellActions, npxNoteLines, isNpx, isWin32 };
 }
 
 module.exports = {
@@ -217,6 +295,8 @@ module.exports = {
   projectLegacySettingsHookCommand,
   escapeTomlDoubleQuotedString,
   projectCodexHookTomlCommand,
+  projectPathActionProjection,
+  renderShellActionLines,
   buildWindowsShimTriple,
   formatSdkPathDiagnostic,
 };

--- a/tests/bug-3441-path-action-projection.test.cjs
+++ b/tests/bug-3441-path-action-projection.test.cjs
@@ -1,0 +1,126 @@
+'use strict';
+
+process.env.GSD_TEST_MODE = '1';
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const fs = require('node:fs');
+const os = require('node:os');
+
+const projection = require(path.join(
+  __dirname,
+  '..',
+  'get-shit-done',
+  'bin',
+  'lib',
+  'shell-command-projection.cjs',
+));
+const install = require(path.join(__dirname, '..', 'bin', 'install.js'));
+
+function createTempHome() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-home-3441-'));
+}
+
+function cleanup(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+describe('bug #3441: PATH guidance is projected from typed shell action IR', () => {
+  test('projection module exports PATH action projection helper', () => {
+    assert.equal(typeof projection.projectPathActionProjection, 'function');
+  });
+
+  test('formatSdkPathDiagnostic exposes structured shellActions alongside rendered actionLines', () => {
+    const ir = install.formatSdkPathDiagnostic({
+      shimDir: 'C:\\Users\\me\\AppData\\Roaming\\npm',
+      platform: 'win32',
+      runDir: 'C:\\some\\path',
+    });
+
+    assert.ok(Array.isArray(ir.shellActions), 'shellActions must be an array');
+    assert.ok(ir.shellActions.length >= 3, `expected 3+ shell actions, got ${ir.shellActions.length}`);
+    assert.equal(ir.shellActions[0].label, 'PowerShell');
+    assert.equal(typeof ir.shellActions[0].command, 'string');
+    assert.equal(
+      ir.actionLines.some((line) => line.startsWith('PowerShell:')),
+      true,
+      `rendered action lines should include shell labels: ${JSON.stringify(ir.actionLines)}`,
+    );
+  });
+
+  test('persistent PATH export guidance is projected via the same seam', () => {
+    const posix = projection.projectPathActionProjection({
+      mode: 'persist',
+      targetDir: '/tmp/with quote',
+      platform: 'linux',
+    });
+    assert.ok(Array.isArray(posix.shellActions));
+    assert.equal(posix.shellActions.length, 2);
+    assert.equal(posix.shellActions[0].label, 'zsh');
+    assert.equal(posix.shellActions[1].label, 'bash');
+    assert.ok(posix.shellActions[0].command.includes('~/.zshrc'));
+    assert.ok(posix.shellActions[1].command.includes('~/.bashrc'));
+  });
+
+  test('POSIX repair mode escapes double-quoted shell metacharacters', () => {
+    const projected = projection.projectPathActionProjection({
+      mode: 'repair',
+      targetDir: '/tmp/qa\\"$HOME`tick',
+      platform: 'linux',
+    });
+    assert.equal(projected.shellActions.length, 1);
+    assert.equal(
+      projected.shellActions[0].command,
+      'export PATH="/tmp/qa\\\\\\"\\$HOME\\`tick:$PATH"',
+    );
+  });
+
+  test('POSIX persist mode escapes single quotes for rc-file echo commands', () => {
+    const projected = projection.projectPathActionProjection({
+      mode: 'persist',
+      targetDir: "/tmp/O'Neil/bin",
+      platform: 'linux',
+    });
+    assert.equal(projected.shellActions[0].command.includes("/tmp/O'\\''Neil/bin"), true);
+    assert.equal(projected.shellActions[1].command.includes("/tmp/O'\\''Neil/bin"), true);
+  });
+
+  test('maybeSuggestPathExport renders commands projected by path-action seam', () => {
+    const home = createTempHome();
+    const originalPath = process.env.PATH;
+    try {
+      const globalBin = path.join(home, '.npm-global', 'bin');
+      fs.mkdirSync(globalBin, { recursive: true });
+      fs.writeFileSync(path.join(home, '.zshrc'), 'export PATH="$HOME/.cargo/bin:$PATH"\n');
+      process.env.PATH = '';
+
+      const expected = projection.projectPathActionProjection({
+        mode: 'persist',
+        targetDir: globalBin,
+        platform: process.platform,
+      });
+
+      const logs = [];
+      const originalLog = console.log;
+      console.log = (...args) => logs.push(args.join(' '));
+      try {
+        install.maybeSuggestPathExport(globalBin, home);
+      } finally {
+        console.log = originalLog;
+      }
+
+      const joined = logs.join('\n');
+      for (const action of expected.shellActions) {
+        assert.ok(
+          joined.includes(action.command),
+          `expected installer output to include projected command: ${action.command}\nOutput:\n${joined}`,
+        );
+      }
+    } finally {
+      if (originalPath == null) delete process.env.PATH;
+      else process.env.PATH = originalPath;
+      cleanup(home);
+    }
+  });
+});


### PR DESCRIPTION
## Feature PR

> **Using the wrong template?**
> — Bug fix: use [fix.md](?template=fix.md)
> — Enhancement to existing behavior: use [enhancement.md](?template=enhancement.md)

---

## Linked Issue

Closes #3441
Refs #3439

## Feature summary

This adds typed PATH guidance projection to the Shell Command Projection Module and routes installer PATH diagnostics/setup messaging through that shared seam, so Windows and POSIX shell guidance is rendered from one owner with consistent escaping and path-style policy.

## What changed

### New files

| File | Purpose |
|------|---------|
| `tests/bug-3441-path-action-projection.test.cjs` | Regression tests for typed PATH action projection, installer seam usage, and shell escaping behavior |

### Modified files

| File | What changed |
|------|-------------|
| `get-shit-done/bin/lib/shell-command-projection.cjs` | Added typed PATH action projection (`projectPathActionProjection`) + shared action-line rendering; `formatSdkPathDiagnostic()` now emits structured `shellActions` and renders from projection output |
| `bin/install.js` | Removed installer-local PATH echo string construction in `maybeSuggestPathExport()` and routed output through projection seam |

## Implementation notes

- Kept subprocess execution behavior unchanged; this slice is projection-only.
- Preserved existing Windows/POSIX diagnostic behavior while moving command text ownership behind typed action IR.
- Added explicit escaping coverage for POSIX repair and persist output forms.

## Spec compliance

- [x] `formatSdkPathDiagnostic()` becomes a thin adapter over Shell Command Projection Module action IR.
- [x] Legacy direct PATH hint strings in the installer are removed or routed through the same projection seam.
- [x] Windows PowerShell / cmd.exe / Git Bash action lines remain covered by regression tests from `#3011`.
- [x] POSIX export-line guidance remains covered and shell-safe for quote / backslash cases.
- [x] Tests assert on typed action IR / structured shell lines, not broad source-grep of installer strings.

## Testing

### Test coverage

- `tests/bug-3441-path-action-projection.test.cjs`
- `tests/bug-3413-shell-command-projection.test.cjs`
- `tests/bug-3011-sdk-path-diagnostic.test.cjs`
- `tests/install-path-detection.test.cjs`

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Codex
- [ ] Copilot
- [ ] Other: ___
- [x] N/A — this change is installer/projection logic and runtime-agnostic; runtime-specific assertions are covered in existing projection tests

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue exactly
- [x] No additional features, commands, or behaviors were added beyond what was approved
- [x] If scope changed during implementation, I updated the issue spec and received re-approval

---

## Checklist

- [x] Issue linked above with `Closes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `approved-feature` label — **PR will be closed if missing**
- [x] All acceptance criteria from the issue are met (listed above)
- [x] Implementation scope matches the approved spec exactly
- [ ] All existing tests pass (`npm test`)
- [x] New tests cover the happy path, error cases, and edge cases
- [x] `.changeset/` fragment added with a user-facing description of the feature (`npm run changeset -- --type Added --pr <NNN> --body "..."`)
- [ ] Documentation updated — commands, workflows, references, README if applicable
- [x] No unnecessary external dependencies added
- [x] Works on Windows (backslash paths handled)

## Breaking changes

None



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PATH setup guidance during installation to work consistently across all shells (PowerShell, cmd, Git Bash, bash, zsh).
  * Fixed escaping and path-style handling to function correctly on all platforms.

* **Tests**
  * Added comprehensive test suite for PATH guidance consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3447)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->