### PR TITLE
feat(shell-projection): add shim wrapper drift guard

### DIFF
--- a/.changeset/quick-deer-squeak.md
+++ b/.changeset/quick-deer-squeak.md
@@ -1,0 +1,5 @@
+---
+type: Added
+pr: 3448
+---
+**Installer shim/wrapper drift guard now enforces projection seam ownership** — inline shim text builders in installer-owned serialized shell-command surfaces are rejected unless routed through the Shell Command Projection Module.

--- a/scripts/lint-shell-command-projection-drift.cjs
+++ b/scripts/lint-shell-command-projection-drift.cjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Focused drift guard for issue #3442:
+ * prevent installer-owned inline shim/wrapper text builders from bypassing the
+ * Shell Command Projection Module seam.
+ *
+ * Scope intentionally excludes subprocess execution helpers (spawnSync /
+ * execFileSync) because those are safe internal execution primitives, not
+ * serialized shell-command rendering.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const targetArg = process.argv[2] || path.join(ROOT, 'bin', 'install.js');
+const target = path.resolve(targetArg);
+const rel = path.relative(ROOT, target);
+
+let content;
+try {
+  content = fs.readFileSync(target, 'utf8');
+} catch (error) {
+  process.stderr.write(`lint-shell-command-projection-drift: failed to read ${target}: ${error.message}\n`);
+  process.exit(1);
+}
+
+const forbidden = [
+  {
+    label: 'inline cmd shim builder',
+    pattern: /@ECHO OFF\\r\\n@SETLOCAL\\r\\n@node /,
+  },
+  {
+    label: 'inline pwsh shim builder',
+    pattern: /#!\/usr\/bin\/env pwsh\\n& node /,
+  },
+  {
+    label: 'inline sh shim builder',
+    pattern: /#!\/usr\/bin\/env sh\\nexec node /,
+  },
+];
+
+const matches = forbidden.filter((rule) => rule.pattern.test(content));
+if (matches.length === 0) {
+  process.stdout.write(`ok shell-projection-drift: ${rel}\n`);
+  process.exit(0);
+}
+
+process.stderr.write(`ERROR shell-projection-drift: inline serialized shim builders found in ${rel}\n`);
+for (const match of matches) {
+  process.stderr.write(`  - ${match.label}\n`);
+}
+process.stderr.write('Route shim/wrapper rendering through get-shit-done/bin/lib/shell-command-projection.cjs\n');
+process.stderr.write('Safe subprocess execution via spawnSync/execFileSync is intentionally allowed.\n');
+process.exit(1);

--- a/tests/bug-3442-shim-projection-drift-guard.test.cjs
+++ b/tests/bug-3442-shim-projection-drift-guard.test.cjs
@@ -1,0 +1,83 @@
+'use strict';
+
+process.env.GSD_TEST_MODE = '1';
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const ROOT = path.resolve(__dirname, '..');
+const INSTALL = require(path.join(ROOT, 'bin', 'install.js'));
+const PROJECTION = require(path.join(ROOT, 'get-shit-done', 'bin', 'lib', 'shell-command-projection.cjs'));
+const DRIFT_LINT = path.join(ROOT, 'scripts', 'lint-shell-command-projection-drift.cjs');
+
+function runLint(targetFile) {
+  return spawnSync(process.execPath, [DRIFT_LINT, targetFile], {
+    cwd: ROOT,
+    encoding: 'utf8',
+  });
+}
+
+describe('bug #3442: shim/wrapper projection seam', () => {
+  test('buildWindowsShimTriple matches shared projection output', () => {
+    const shimSrc = path.join(ROOT, 'bin', 'gsd-sdk.js');
+    const fromInstall = INSTALL.buildWindowsShimTriple(shimSrc);
+    const fromProjection = PROJECTION.buildWindowsShimTriple(shimSrc);
+    assert.deepEqual(fromInstall.invocation, fromProjection.invocation);
+    assert.deepEqual(fromInstall.eol, fromProjection.eol);
+    assert.deepEqual(fromInstall.fileNames, fromProjection.fileNames);
+    assert.equal(fromInstall.render.cmd(), fromProjection.render.cmd());
+    assert.equal(fromInstall.render.ps1(), fromProjection.render.ps1());
+    assert.equal(fromInstall.render.sh(), fromProjection.render.sh());
+  });
+});
+
+describe('bug #3442: shim/wrapper serialized-command drift guard', () => {
+  test('drift guard passes for current install.js', () => {
+    const result = runLint(path.join(ROOT, 'bin', 'install.js'));
+    assert.equal(result.status, 0, `expected lint pass, got:\n${result.stderr || result.stdout}`);
+  });
+
+  test('drift guard fails when install-owned inline shim text builder is present', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-3442-'));
+    try {
+      const fixture = path.join(tmp, 'install-inline-builder.js');
+      fs.writeFileSync(
+        fixture,
+        [
+          'function badBuilder() {',
+          "  return '@ECHO OFF\\r\\n@SETLOCAL\\r\\n@node \"C:/shim.js\" %*\\r\\n';",
+          '}',
+          '',
+        ].join('\n'),
+      );
+      const result = runLint(fixture);
+      assert.notEqual(result.status, 0, 'inline shim renderer should be rejected by the drift guard');
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  test('drift guard does not block safe subprocess execution patterns', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-3442-'));
+    try {
+      const fixture = path.join(tmp, 'install-subprocess-safe.js');
+      fs.writeFileSync(
+        fixture,
+        [
+          "const cp = require('node:child_process');",
+          "cp.spawnSync('cmd.exe', ['/c', 'echo ok']);",
+          "cp.execFileSync('bash', ['-lc', 'printf %s \"$PATH\"']);",
+          '',
+        ].join('\n'),
+      );
+      const result = runLint(fixture);
+      assert.equal(result.status, 0, `spawnSync/execFileSync should remain allowed:\n${result.stderr || result.stdout}`);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Feature PR

> **Using the wrong template?**
> — Bug fix: use [fix.md](?template=fix.md)
> — Enhancement to existing behavior: use [enhancement.md](?template=enhancement.md)

---

## Linked Issue

Closes #3442
Refs #3439

## Feature summary

This feature locks the remaining installer-owned shim/wrapper serialized shell-text surface behind the Shell Command Projection Module seam by adding a focused drift guard and regression coverage that protects shared projection ownership while preserving safe subprocess execution paths.

## What changed

### New files

| File | Purpose |
|------|---------|
| `scripts/lint-shell-command-projection-drift.cjs` | Focused drift guard to catch new installer-owned inline shim/wrapper serialized shell text builders that bypass the projection seam |
| `tests/bug-3442-shim-projection-drift-guard.test.cjs` | Regression coverage for shim projection parity, guard failure on inline builders, and guard allowance for safe subprocess execution |

### Modified files

| File | What changed |
|------|-------------|
| _None_ | Existing `buildWindowsShimTriple()` adapter and projection seam remained intact; this slice adds guardrails + regression signal |

## Implementation notes

- `buildWindowsShimTriple()` already projects through `get-shit-done/bin/lib/shell-command-projection.cjs`; this slice deepens testability and drift protection around that seam.
- Drift guard is intentionally narrow to shim/wrapper serialized text patterns and does not lint-block `spawnSync`/`execFileSync` subprocess primitives.

## Spec compliance

- [x] `buildWindowsShimTriple()` consumes the Shell Command Projection Module for shell-specific wrapper text.
- [x] Shim/wrapper tests assert on shared projection outputs for `cmd`, `pwsh`, and `sh` variants.
- [x] Existing Windows shim behavior remains covered (including PowerShell and cmd launcher semantics).
- [x] A focused regression test or lint guard catches new installer-owned serialized shell-command builders that bypass the Shell Command Projection Module.
- [x] The guard does not block safe internal subprocess execution via `spawnSync` / `execFileSync`.

## Testing

### Test coverage

- `tests/bug-3442-shim-projection-drift-guard.test.cjs`
- `tests/bug-2962-windows-sdk-shim.test.cjs`
- `tests/bug-3413-shell-command-projection.test.cjs`
- `tests/bug-3011-sdk-path-diagnostic.test.cjs`
- `scripts/lint-shell-command-projection-drift.cjs bin/install.js`

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Codex
- [ ] Copilot
- [ ] Other: ___
- [x] N/A — this slice is installer/projection/lint behavior and is runtime-agnostic

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue exactly
- [x] No additional features, commands, or behaviors were added beyond what was approved
- [x] If scope changed during implementation, I updated the issue spec and received re-approval

---

## Checklist

- [x] Issue linked above with `Closes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `approved-feature` label — **PR will be closed if missing**
- [x] All acceptance criteria from the issue are met (listed above)
- [x] Implementation scope matches the approved spec exactly
- [ ] All existing tests pass (`npm test`)
- [x] New tests cover the happy path, error cases, and edge cases
- [x] `.changeset/` fragment added with a user-facing description of the feature (`npm run changeset -- --type Added --pr <NNN> --body "..."`)
- [ ] Documentation updated — commands, workflows, references, README if applicable
- [x] No unnecessary external dependencies added
- [x] Works on Windows (backslash paths handled)

## Breaking changes

None



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced shell command generation validation to prevent inconsistencies.

* **Tests**
  * Added regression tests for shell command handling and consistency checks.

* **Chores**
  * Added linting utility to enforce shell command standards.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3448)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->