### PR TITLE
fix: preserve literal $ replacements in state + restore debug Agent dispatch

### DIFF
--- a/.changeset/3454-3460-state-dollar-agent-dispatch.md
+++ b/.changeset/3454-3460-state-dollar-agent-dispatch.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Fix two confirmed bug regressions in debug/session and STATE mutation flows** — the debug session manager now dispatches subagents with `Agent(...)` (not stale `Task(...)` syntax), restoring intended isolated delegation (`#3460`). STATE mutation paths now use function-form `String.replace` for Current Position and metrics table rewrites so literal dollar amounts like `$2,500` are treated as plain text rather than backreferences, preventing body corruption during `state advance-plan`, `state begin-phase`, and `state complete-phase` (`#3454`).

--- a/.changeset/3454-3460-state-dollar-agent-dispatch.md
+++ b/.changeset/3454-3460-state-dollar-agent-dispatch.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3461
 ---
 **Fix two confirmed bug regressions in debug/session and STATE mutation flows** — the debug session manager now dispatches subagents with `Agent(...)` (not stale `Task(...)` syntax), restoring intended isolated delegation (`#3460`). STATE mutation paths now use function-form `String.replace` for Current Position and metrics table rewrites so literal dollar amounts like `$2,500` are treated as plain text rather than backreferences, preventing body corruption during `state advance-plan`, `state begin-phase`, and `state complete-phase` (`#3454`).

--- a/agents/gsd-debug-session-manager.md
+++ b/agents/gsd-debug-session-manager.md
@@ -83,7 +83,7 @@ goal: {goal}
 ```
 
 ```
-Task(
+Agent(
   prompt=filled_prompt,
   subagent_type="gsd-debugger",
   model="{debugger_model}",

--- a/get-shit-done/bin/lib/state.cjs
+++ b/get-shit-done/bin/lib/state.cjs
@@ -264,7 +264,7 @@ function updateCurrentPositionFields(content, fields) {
     posBody = posBody.replace(/^Plan:.*$/m, `Plan: ${fields.plan}`);
   }
 
-  return content.replace(posPattern, `${posMatch[1]}${posBody}`);
+  return content.replace(posPattern, () => `${posMatch[1]}${posBody}`);
 }
 
 function cmdStateAdvancePlan(cwd, raw) {
@@ -1171,7 +1171,7 @@ function cmdStateBeginPhase(cwd, phaseNumber, phaseName, planCount, raw) {
           posBody = posBody.replace(/^Last activity:.*$/im, newActivity);
         }
 
-        content = content.replace(positionPattern, `${header}${posBody}`);
+        content = content.replace(positionPattern, () => `${header}${posBody}`);
         updated.push('Current Position');
       }
     } else {
@@ -1185,7 +1185,7 @@ function cmdStateBeginPhase(cwd, phaseNumber, phaseName, planCount, raw) {
         const resumeActivity = `Last activity: ${today} -- Phase ${phaseNumber} execution resumed (wave continue)`;
         if (/^Last activity:/im.test(posBody)) {
           posBody = posBody.replace(/^Last activity:.*$/im, resumeActivity);
-          content = content.replace(positionPattern, `${header}${posBody}`);
+          content = content.replace(positionPattern, () => `${header}${posBody}`);
           updated.push('Last activity (resume)');
         }
       }
@@ -1278,7 +1278,7 @@ function updatePerformanceMetricsSection(content, cwd, phaseNum, planCount, summ
       tableBody = tableBody ? tableBody + '\n' + newRow : newRow;
     }
 
-    content = content.replace(byPhaseTablePattern, `$1${tableBody}\n`);
+    content = content.replace(byPhaseTablePattern, (_match, tableHeader) => `${tableHeader}${tableBody}\n`);
   }
 
   return content;
@@ -1852,7 +1852,7 @@ function cmdStateCompletePhase(cwd, raw, overridePhase) {
         posBody = posBody.replace(/^Last activity:.*$/im, newActivity);
       }
 
-      content = content.replace(positionPattern, `${header}${posBody}`);
+      content = content.replace(positionPattern, () => `${header}${posBody}`);
       updated.push('Current Position');
     }
 

--- a/tests/debug-session-management.test.cjs
+++ b/tests/debug-session-management.test.cjs
@@ -161,8 +161,10 @@ describe('debug skill dispatch and sub-orchestrator (#2148, #2151)', () => {
 
   test('gsd-debug-session-manager agent exists with correct tools', () => {
     const content = fs.readFileSync(path.join(process.cwd(), 'agents', 'gsd-debug-session-manager.md'), 'utf8');
-    assert.ok(content.includes('Task'), 'gsd-debug-session-manager missing Task tool');
+    assert.ok(content.includes('Agent'), 'gsd-debug-session-manager missing Agent tool');
     assert.ok(content.includes('AskUserQuestion'), 'gsd-debug-session-manager missing AskUserQuestion tool');
+    assert.ok(content.includes('Agent('), 'gsd-debug-session-manager must dispatch with Agent(');
+    assert.ok(!content.includes('\nTask('), 'gsd-debug-session-manager must not dispatch with Task(');
   });
 
   test('gsd-debug-session-manager uses DATA_START/DATA_END for checkpoint responses', () => {

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -2621,5 +2621,120 @@ describe('state complete-phase: decorated Phase fallback (#2761 nitpick)', () =>
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Bug #3454 — literal $N in Current Position body must not trigger backrefs
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('bug #3454: state Current Position replacement preserves literal dollar amounts', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  function currentPositionBody(content) {
+    const m = content.match(/## Current Position\s*\n([\s\S]*?)(?=\n##|$)/i);
+    assert.ok(m, 'Current Position section should exist');
+    return m[1];
+  }
+
+  function assertLiteralDollarLinePreserved(posBody) {
+    const matches = posBody.match(/Budget: \$2,500 max test/g) || [];
+    assert.strictEqual(matches.length, 1, `Budget line should appear exactly once:\n${posBody}`);
+    assert.ok(!posBody.includes('Budget: Phase:'), `Budget line must not embed the whole section:\n${posBody}`);
+    assert.ok(!posBody.includes('\n,500 max test'), `Backreference artifact must not appear:\n${posBody}`);
+  }
+
+  test('advance-plan preserves literal "$2,500" line in Current Position', () => {
+    const stateMd = [
+      '# Project State',
+      '',
+      '**Current Plan:** 1',
+      '**Total Plans in Phase:** 3',
+      '**Status:** Executing',
+      '**Last Activity:** 2024-01-10',
+      '',
+      '## Current Position',
+      'Phase: 1 of 5 (setup)',
+      'Plan: 1 of 3 in current phase',
+      'Status: Executing',
+      'Budget: $2,500 max test',
+      'Last activity: 2026-03-20 -- Something',
+      'Progress: [..........] 0%',
+      '',
+      '## Session Continuity',
+      '',
+      'Last session: 2026-03-20',
+    ].join('\n') + '\n';
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), stateMd);
+
+    const result = runGsdTools('state advance-plan', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const updated = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    assertLiteralDollarLinePreserved(currentPositionBody(updated));
+  });
+
+  test('begin-phase preserves literal "$2,500" line in Current Position', () => {
+    const stateMd = [
+      '# Project State',
+      '',
+      '**Current Phase:** 1',
+      '**Current Phase Name:** setup',
+      '**Total Phases:** 5',
+      '**Current Plan:** 0',
+      '**Total Plans in Phase:** 0',
+      '**Status:** Ready to plan',
+      '**Last Activity:** 2026-03-20',
+      '',
+      '## Current Position',
+      'Phase: 1 of 5 (setup)',
+      'Plan: 0 of ? in current phase',
+      'Status: Ready to plan',
+      'Budget: $2,500 max test',
+      'Last activity: 2026-03-20 -- Roadmap created',
+      'Progress: [..........] 0%',
+      '',
+    ].join('\n') + '\n';
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), stateMd);
+
+    const result = runGsdTools(['state', 'begin-phase', '--phase', '1', '--name', 'setup', '--plans', '4'], tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const updated = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    assertLiteralDollarLinePreserved(currentPositionBody(updated));
+  });
+
+  test('complete-phase preserves literal "$2,500" line in Current Position', () => {
+    const stateMd = [
+      '# State',
+      '',
+      '**Status:** Executing',
+      '**Current Phase:** 03',
+      '**Last Activity:** 2024-01-15',
+      '',
+      '## Current Position',
+      '',
+      'Phase: 03 — EXECUTING',
+      'Plan: 03-01',
+      'Status: Executing',
+      'Budget: $2,500 max test',
+      'Last activity: 2024-01-15 -- Running phase',
+      '',
+    ].join('\n');
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), stateMd);
+
+    const result = runGsdTools('state complete-phase', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const updated = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    assertLiteralDollarLinePreserved(currentPositionBody(updated));
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
 // summary-extract command
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- fix bug #3454 by switching vulnerable `String.replace(..., string)` call sites in state mutation paths to function replacements so literal `$N` text in Current Position and metrics table rows is preserved
- add regression coverage for `state advance-plan`, `state begin-phase`, and `state complete-phase` with a `$2,500` fixture line
- fix bug #3460 by replacing stale `Task(...)` invocation text with `Agent(...)` in `gsd-debug-session-manager` and align test expectations

## Verification
- `node --test tests/debug-session-management.test.cjs`
- `node --test tests/state.test.cjs`
- `node scripts/lint-no-source-grep.cjs`
- `node --test tests/bug-3168-task-to-agent-rename.test.cjs`

Closes #3454
Closes #3460

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved state command issues where literal dollar amounts were being corrupted during `advance-plan`, `begin-phase`, and `complete-phase` operations
  * Fixed debug session manager to properly dispatch subagents using the correct delegation method
  * Added regression tests to prevent recurrence of state corruption issues

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3461)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->