### PR TITLE
fix: gsd-debug-session-manager uses stale Task() dispatcher

### DIFF
--- a/.changeset/eager-lynx-munch.md
+++ b/.changeset/eager-lynx-munch.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 9999
+---
+**`/gsd-debug` session manager now dispatches via `Agent()`** — stale `Task()` invocation no longer collapses debugger work into inline execution.

--- a/.changeset/eager-lynx-munch.md
+++ b/.changeset/eager-lynx-munch.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 9999
+pr: 3462
 ---
 **`/gsd-debug` session manager now dispatches via `Agent()`** — stale `Task()` invocation no longer collapses debugger work into inline execution.

--- a/agents/gsd-debug-session-manager.md
+++ b/agents/gsd-debug-session-manager.md
@@ -83,7 +83,7 @@ goal: {goal}
 ```
 
 ```
-Task(
+Agent(
   prompt=filled_prompt,
   subagent_type="gsd-debugger",
   model="{debugger_model}",

--- a/tests/debug-session-management.test.cjs
+++ b/tests/debug-session-management.test.cjs
@@ -161,8 +161,13 @@ describe('debug skill dispatch and sub-orchestrator (#2148, #2151)', () => {
 
   test('gsd-debug-session-manager agent exists with correct tools', () => {
     const content = fs.readFileSync(path.join(process.cwd(), 'agents', 'gsd-debug-session-manager.md'), 'utf8');
-    assert.ok(content.includes('Task'), 'gsd-debug-session-manager missing Task tool');
+    assert.ok(content.includes('Agent'), 'gsd-debug-session-manager missing Agent tool');
     assert.ok(content.includes('AskUserQuestion'), 'gsd-debug-session-manager missing AskUserQuestion tool');
+  });
+
+  test('gsd-debug-session-manager spawns debugger with Agent() dispatcher', () => {
+    const content = fs.readFileSync(path.join(process.cwd(), 'agents', 'gsd-debug-session-manager.md'), 'utf8');
+    assert.ok(content.includes('\nAgent('), 'session manager must dispatch debugger with Agent(');
   });
 
   test('gsd-debug-session-manager uses DATA_START/DATA_END for checkpoint responses', () => {


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #3460

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

`/gsd-debug` session-manager declared `Agent` in tools, but its spawn block still invoked `Task(`, so delegated debugger execution could collapse into inline manager execution.

## What this fix does

Switches the dispatcher invocation in `agents/gsd-debug-session-manager.md` from `Task(` to `Agent(` and adds a regression assertion in `tests/debug-session-management.test.cjs` that enforces the `Agent(` spawn contract.

## Root cause

Task→Agent migration drift: frontmatter/tool naming was updated, but one live invocation token remained stale in the session-manager body.

## Testing

### How I verified the fix

Ran:
- `node --test tests/debug-session-management.test.cjs`

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None
