### PR TITLE
fix: state mutations recurse when Current Position has dollar amounts

### DIFF
--- a/.changeset/nimble-sloths-zip.md
+++ b/.changeset/nimble-sloths-zip.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 9999
+---
+**State mutations now preserve literal dollar amounts** — begin-phase, advance-plan, and complete-phase no longer recurse Current Position content when values contain `$N` patterns.

--- a/.changeset/nimble-sloths-zip.md
+++ b/.changeset/nimble-sloths-zip.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 9999
+pr: 3463
 ---
 **State mutations now preserve literal dollar amounts** — begin-phase, advance-plan, and complete-phase no longer recurse Current Position content when values contain `$N` patterns.

--- a/get-shit-done/bin/lib/state.cjs
+++ b/get-shit-done/bin/lib/state.cjs
@@ -264,7 +264,7 @@ function updateCurrentPositionFields(content, fields) {
     posBody = posBody.replace(/^Plan:.*$/m, `Plan: ${fields.plan}`);
   }
 
-  return content.replace(posPattern, `${posMatch[1]}${posBody}`);
+  return content.replace(posPattern, () => `${posMatch[1]}${posBody}`);
 }
 
 function cmdStateAdvancePlan(cwd, raw) {
@@ -1171,7 +1171,7 @@ function cmdStateBeginPhase(cwd, phaseNumber, phaseName, planCount, raw) {
           posBody = posBody.replace(/^Last activity:.*$/im, newActivity);
         }
 
-        content = content.replace(positionPattern, `${header}${posBody}`);
+        content = content.replace(positionPattern, () => `${header}${posBody}`);
         updated.push('Current Position');
       }
     } else {
@@ -1185,7 +1185,7 @@ function cmdStateBeginPhase(cwd, phaseNumber, phaseName, planCount, raw) {
         const resumeActivity = `Last activity: ${today} -- Phase ${phaseNumber} execution resumed (wave continue)`;
         if (/^Last activity:/im.test(posBody)) {
           posBody = posBody.replace(/^Last activity:.*$/im, resumeActivity);
-          content = content.replace(positionPattern, `${header}${posBody}`);
+          content = content.replace(positionPattern, () => `${header}${posBody}`);
           updated.push('Last activity (resume)');
         }
       }
@@ -1278,7 +1278,7 @@ function updatePerformanceMetricsSection(content, cwd, phaseNum, planCount, summ
       tableBody = tableBody ? tableBody + '\n' + newRow : newRow;
     }
 
-    content = content.replace(byPhaseTablePattern, `$1${tableBody}\n`);
+    content = content.replace(byPhaseTablePattern, (_match, tableHeader) => `${tableHeader}${tableBody}\n`);
   }
 
   return content;
@@ -1852,7 +1852,7 @@ function cmdStateCompletePhase(cwd, raw, overridePhase) {
         posBody = posBody.replace(/^Last activity:.*$/im, newActivity);
       }
 
-      content = content.replace(positionPattern, `${header}${posBody}`);
+      content = content.replace(positionPattern, () => `${header}${posBody}`);
       updated.push('Current Position');
     }
 

--- a/sdk/src/query/state-mutation.test.ts
+++ b/sdk/src/query/state-mutation.test.ts
@@ -533,6 +533,21 @@ describe('stateBeginPhase', () => {
     const content = await readFile(join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
     expect(content).toContain('Plan: 1 of 3');
   });
+
+  it('preserves literal dollar amounts in Current Position body', async () => {
+    const { stateBeginPhase } = await import('./state-mutation.js');
+    const withBudget = MINIMAL_STATE.replace(
+      'Last activity: 2026-04-08 -- Phase 10 execution started',
+      'Last activity: 2026-04-08 -- Phase 10 execution started\nBudget: $2,500 max test',
+    );
+    await setupTestProject(tmpDir, withBudget);
+
+    await stateBeginPhase(['11', 'State Mutations', '3'], tmpDir);
+
+    const content = await readFile(join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    expect(content).toContain('Budget: $2,500 max test');
+    expect((content.match(/^Budget:/gm) || []).length).toBe(1);
+  });
 });
 
 // ─── stateAdvancePlan ───────────────────────────────────────────────────────
@@ -556,6 +571,23 @@ describe('stateAdvancePlan', () => {
     const data = result.data as Record<string, unknown>;
     expect(data.advanced).toBe(true);
     expect(data.current_plan).toBe(3);
+  });
+
+  it('keeps literal dollar amounts stable after multiple updates', async () => {
+    const { stateAdvancePlan } = await import('./state-mutation.js');
+    const withBudget = MINIMAL_STATE.replace(
+      'Last activity: 2026-04-08 -- Phase 10 execution started',
+      'Last activity: 2026-04-08 -- Phase 10 execution started\nBudget: $2,500 max test',
+    ).replace('Plan: 2 of 3', 'Plan: 1 of 20');
+    await setupTestProject(tmpDir, withBudget);
+
+    for (let i = 0; i < 8; i += 1) {
+      await stateAdvancePlan([], tmpDir);
+    }
+
+    const content = await readFile(join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    expect(content).toContain('Budget: $2,500 max test');
+    expect((content.match(/^Budget:/gm) || []).length).toBe(1);
   });
 });
 

--- a/sdk/src/query/state-mutation.ts
+++ b/sdk/src/query/state-mutation.ts
@@ -77,7 +77,7 @@ function updateCurrentPositionFields(content: string, fields: Record<string, str
     posBody = posBody.replace(/^Plan:.*$/m, `Plan: ${fields.plan}`);
   }
 
-  return content.replace(posPattern, `${posMatch[1]}${posBody}`);
+  return content.replace(posPattern, () => `${posMatch[1]}${posBody}`);
 }
 
 /** Port of `readTextArgOrFile` from `state.cjs` — inline text or file path under project root. */
@@ -508,7 +508,7 @@ export const stateBeginPhase: QueryHandler = async (args, projectDir, workstream
         posBody = posBody.replace(/^Last activity:.*$/im, newActivity);
       }
 
-      content = content.replace(positionPattern, `${header}${posBody}`);
+      content = content.replace(positionPattern, () => `${header}${posBody}`);
       updated.push('Current Position');
     }
 

--- a/tests/bug-3454-state-dollar-backreference-growth.test.cjs
+++ b/tests/bug-3454-state-dollar-backreference-growth.test.cjs
@@ -25,10 +25,45 @@ Last session: 2026-01-01
   fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), state, 'utf8');
 }
 
-function readBudgetLine(tmpDir) {
+function parseStateFile(tmpDir) {
   const content = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf8');
-  const budgetLines = content.split('\n').filter((line) => line.startsWith('Budget:'));
-  return { content, budgetLines };
+  const sections = {};
+  const keyCountsBySection = {};
+  let currentSection = '__root__';
+  sections[currentSection] = {};
+  keyCountsBySection[currentSection] = {};
+
+  for (const rawLine of content.split(/\r?\n/u)) {
+    const headingMatch = /^##\s+(.+)$/u.exec(rawLine);
+    if (headingMatch) {
+      currentSection = headingMatch[1].trim();
+      sections[currentSection] = sections[currentSection] || {};
+      keyCountsBySection[currentSection] = keyCountsBySection[currentSection] || {};
+      continue;
+    }
+
+    const trimmed = rawLine.trim();
+    if (!trimmed) continue;
+
+    const boldFieldMatch = /^\*\*([^*]+)\*\*:\s*(.*)$/u.exec(trimmed);
+    if (boldFieldMatch) {
+      const key = boldFieldMatch[1].trim();
+      const value = boldFieldMatch[2].trim();
+      sections[currentSection][key] = value;
+      keyCountsBySection[currentSection][key] = (keyCountsBySection[currentSection][key] || 0) + 1;
+      continue;
+    }
+
+    const colonIndex = trimmed.indexOf(':');
+    if (colonIndex <= 0) continue;
+
+    const key = trimmed.slice(0, colonIndex).trim();
+    const value = trimmed.slice(colonIndex + 1).trim();
+    sections[currentSection][key] = value;
+    keyCountsBySection[currentSection][key] = (keyCountsBySection[currentSection][key] || 0) + 1;
+  }
+
+  return { content, sections, keyCountsBySection };
 }
 
 describe('bug #3454: state mutation must preserve literal $N amounts', () => {
@@ -47,9 +82,10 @@ describe('bug #3454: state mutation must preserve literal $N amounts', () => {
     const result = runGsdTools(['state', 'advance-plan'], tmpDir);
     assert.equal(result.success, true, `state advance-plan failed: ${result.error || result.output}`);
 
-    const { budgetLines } = readBudgetLine(tmpDir);
-    assert.equal(budgetLines.length, 1, `expected one Budget line, got ${budgetLines.length}`);
-    assert.equal(budgetLines[0], 'Budget: $2,500 max test');
+    const parsed = parseStateFile(tmpDir);
+    const currentPosition = parsed.sections['Current Position'] || {};
+    assert.equal(currentPosition.Budget, '$2,500 max test');
+    assert.equal((parsed.keyCountsBySection['Current Position'] || {}).Budget, 1);
   });
 
   test('state begin-phase keeps Current Position dollar amount literal', () => {
@@ -57,9 +93,10 @@ describe('bug #3454: state mutation must preserve literal $N amounts', () => {
     const result = runGsdTools(['state', 'begin-phase', '--phase', '1', '--name', 'setup', '--plans', '2'], tmpDir);
     assert.equal(result.success, true, `state begin-phase failed: ${result.error || result.output}`);
 
-    const { budgetLines } = readBudgetLine(tmpDir);
-    assert.equal(budgetLines.length, 1, `expected one Budget line, got ${budgetLines.length}`);
-    assert.equal(budgetLines[0], 'Budget: $2,500 max test');
+    const parsed = parseStateFile(tmpDir);
+    const currentPosition = parsed.sections['Current Position'] || {};
+    assert.equal(currentPosition.Budget, '$2,500 max test');
+    assert.equal((parsed.keyCountsBySection['Current Position'] || {}).Budget, 1);
   });
 
   test('state complete-phase keeps Current Position dollar amount literal', () => {
@@ -67,9 +104,10 @@ describe('bug #3454: state mutation must preserve literal $N amounts', () => {
     const result = runGsdTools(['state', 'complete-phase', '--phase', '1'], tmpDir);
     assert.equal(result.success, true, `state complete-phase failed: ${result.error || result.output}`);
 
-    const { budgetLines } = readBudgetLine(tmpDir);
-    assert.equal(budgetLines.length, 1, `expected one Budget line, got ${budgetLines.length}`);
-    assert.equal(budgetLines[0], 'Budget: $2,500 max test');
+    const parsed = parseStateFile(tmpDir);
+    const currentPosition = parsed.sections['Current Position'] || {};
+    assert.equal(currentPosition.Budget, '$2,500 max test');
+    assert.equal((parsed.keyCountsBySection['Current Position'] || {}).Budget, 1);
   });
 
   test('repeated state advance-plan stays size-bounded with dollar amounts', () => {

--- a/tests/bug-3454-state-dollar-backreference-growth.test.cjs
+++ b/tests/bug-3454-state-dollar-backreference-growth.test.cjs
@@ -1,0 +1,89 @@
+'use strict';
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { createTempProject, cleanup, runGsdTools } = require('./helpers.cjs');
+
+function seedState(tmpDir, planLine = '1 of 2') {
+  const state = `# Project State
+
+**Status:** executing
+**Current Phase:** 1
+
+## Current Position
+Phase: 1 of 1
+Plan: ${planLine}
+Status: Ready
+Last activity: 2026-01-01
+Budget: $2,500 max test
+
+## Session Continuity
+Last session: 2026-01-01
+`;
+  fs.writeFileSync(path.join(tmpDir, '.planning', 'STATE.md'), state, 'utf8');
+}
+
+function readBudgetLine(tmpDir) {
+  const content = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf8');
+  const budgetLines = content.split('\n').filter((line) => line.startsWith('Budget:'));
+  return { content, budgetLines };
+}
+
+describe('bug #3454: state mutation must preserve literal $N amounts', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject('bug-3454-');
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('state advance-plan keeps Current Position dollar amount literal', () => {
+    seedState(tmpDir, '1 of 20');
+    const result = runGsdTools(['state', 'advance-plan'], tmpDir);
+    assert.equal(result.success, true, `state advance-plan failed: ${result.error || result.output}`);
+
+    const { budgetLines } = readBudgetLine(tmpDir);
+    assert.equal(budgetLines.length, 1, `expected one Budget line, got ${budgetLines.length}`);
+    assert.equal(budgetLines[0], 'Budget: $2,500 max test');
+  });
+
+  test('state begin-phase keeps Current Position dollar amount literal', () => {
+    seedState(tmpDir);
+    const result = runGsdTools(['state', 'begin-phase', '--phase', '1', '--name', 'setup', '--plans', '2'], tmpDir);
+    assert.equal(result.success, true, `state begin-phase failed: ${result.error || result.output}`);
+
+    const { budgetLines } = readBudgetLine(tmpDir);
+    assert.equal(budgetLines.length, 1, `expected one Budget line, got ${budgetLines.length}`);
+    assert.equal(budgetLines[0], 'Budget: $2,500 max test');
+  });
+
+  test('state complete-phase keeps Current Position dollar amount literal', () => {
+    seedState(tmpDir);
+    const result = runGsdTools(['state', 'complete-phase', '--phase', '1'], tmpDir);
+    assert.equal(result.success, true, `state complete-phase failed: ${result.error || result.output}`);
+
+    const { budgetLines } = readBudgetLine(tmpDir);
+    assert.equal(budgetLines.length, 1, `expected one Budget line, got ${budgetLines.length}`);
+    assert.equal(budgetLines[0], 'Budget: $2,500 max test');
+  });
+
+  test('repeated state advance-plan stays size-bounded with dollar amounts', () => {
+    seedState(tmpDir, '1 of 20');
+    const statePath = path.join(tmpDir, '.planning', 'STATE.md');
+    let stabilizedSize = null;
+    for (let i = 0; i < 8; i += 1) {
+      const result = runGsdTools(['state', 'advance-plan'], tmpDir);
+      assert.equal(result.success, true, `iteration ${i + 1} failed: ${result.error || result.output}`);
+      if (i === 0) stabilizedSize = fs.statSync(statePath).size;
+    }
+
+    const endSize = fs.statSync(statePath).size;
+    const growth = endSize / stabilizedSize;
+    assert.ok(growth <= 1.5, `expected <=1.5x growth after first write, got ${growth.toFixed(2)}x (${stabilizedSize} -> ${endSize})`);
+  });
+});


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #3454

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

`state.begin-phase`, `state.advance-plan`, and `state.complete-phase` could corrupt and recursively expand `## Current Position` when text contained literal `$N` patterns (for example `$2,500`).

## What this fix does

Replaces vulnerable template-string replacement paths with function replacements in CJS and SDK state mutation code, and adds regression tests for literal-dollar preservation and bounded repeated-update growth.

## Root cause

`String.replace(regex, templateString)` interprets `$1/$2/...` as capture backreferences in replacement strings. Injecting section bodies containing `$N` caused capture substitution and recursive content duplication.

## Testing

### How I verified the fix

Ran:
- `node --test tests/bug-3454-state-dollar-backreference-growth.test.cjs`
- `node --test tests/state.test.cjs --test-name-pattern "state begin-phase preserves Current Position fields|state complete-phase: decorated Phase fallback"`
- `cd sdk && npm test -- src/query/state-mutation.test.ts`

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * State mutations now preserve literal dollar amounts (e.g., $2,500) in budget fields when running phase operations (advance-plan, begin-phase, complete-phase), preventing accidental corruption of Current Position content.

* **Tests**
  * Added regression and unit tests to ensure dollar-prefixed budget values remain unchanged and that state file growth stays bounded across repeated operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3463)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->