### PR TITLE
fix(sdk): state.prune current phase fallback handling

### DIFF
--- a/.changeset/steady-bears-purr.md
+++ b/.changeset/steady-bears-purr.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3477
+---
+**`gsd-sdk query state.prune` now derives current phase from frontmatter fallbacks** — the command no longer reports a false 'Only 0 phases' when STATE.md omits the body Current Phase field.

--- a/sdk/src/query/state-mutation.test.ts
+++ b/sdk/src/query/state-mutation.test.ts
@@ -1135,3 +1135,64 @@ Last activity: 2026-04-20 -- v1.0 shipped
     expect(data.error).toBeDefined();
   });
 });
+
+describe('statePrune current phase extraction (#3471)', () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'gsd-sdk-stateprune-'));
+  });
+
+  afterEach(async () => {
+    if (tmpDir) await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('uses frontmatter progress.completed_phases when body Current Phase field is absent', async () => {
+    const stateContent = `---
+gsd_state_version: 1.0
+milestone: v1.1
+status: executing
+progress:
+  total_phases: 21
+  completed_phases: 12
+  total_plans: 79
+  completed_plans: 75
+  percent: 95
+---
+
+# Session State
+
+## Current Position
+
+Phase 12 execution in progress.
+`;
+    await setupTestProject(tmpDir, stateContent);
+    const { statePrune } = await import('./state-mutation.js');
+    const result = await statePrune(['--keep-recent', '3', '--dry-run'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+
+    expect(data.pruned).toBe(false);
+    expect(data.dry_run).toBe(true);
+    expect(data.cutoff_phase).toBe(9);
+    expect(data.reason).toBeUndefined();
+  });
+
+  it('returns a targeted reason when no current phase source can be parsed', async () => {
+    const stateContent = `---
+gsd_state_version: 1.0
+milestone: v1.1
+status: executing
+---
+
+# Session State
+`;
+    await setupTestProject(tmpDir, stateContent);
+    const { statePrune } = await import('./state-mutation.js');
+    const result = await statePrune(['--keep-recent', '3', '--dry-run'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+
+    expect(data.pruned).toBe(false);
+    expect(typeof data.reason).toBe('string');
+    expect(String(data.reason)).toContain('Could not determine current phase');
+  });
+});

--- a/sdk/src/query/state-mutation.ts
+++ b/sdk/src/query/state-mutation.ts
@@ -1621,8 +1621,32 @@ export const statePrune: QueryHandler = async (args, projectDir, workstream) => 
   }
 
   const fullContent = await readFile(statePath, 'utf-8');
-  const currentPhaseRaw = stateExtractField(fullContent, 'Current Phase');
-  const currentPhase = parseInt(String(currentPhaseRaw ?? ''), 10) || 0;
+  const fm = extractFrontmatter(fullContent);
+  const fmProgress = (typeof fm.progress === 'object' && fm.progress !== null)
+    ? fm.progress as Record<string, unknown>
+    : null;
+  const phaseCandidates: unknown[] = [
+    fm.current_phase,
+    stateExtractField(fullContent, 'Current Phase'),
+    fmProgress?.completed_phases,
+    fmProgress?.total_phases,
+  ];
+  let currentPhase: number | null = null;
+  for (const candidate of phaseCandidates) {
+    const parsed = parseInt(String(candidate ?? '').trim(), 10);
+    if (Number.isInteger(parsed) && parsed > 0) {
+      currentPhase = parsed;
+      break;
+    }
+  }
+  if (currentPhase === null) {
+    return {
+      data: {
+        pruned: false,
+        reason: 'Could not determine current phase from STATE.md. Add **Current Phase:** N, frontmatter current_phase: N, or progress.completed_phases.',
+      },
+    };
+  }
   const cutoff = currentPhase - keepRecent;
 
   if (cutoff <= 0) {

--- a/sdk/src/query/state-mutation.ts
+++ b/sdk/src/query/state-mutation.ts
@@ -1643,7 +1643,7 @@ export const statePrune: QueryHandler = async (args, projectDir, workstream) => 
     return {
       data: {
         pruned: false,
-        reason: 'Could not determine current phase from STATE.md. Add **Current Phase:** N, frontmatter current_phase: N, or progress.completed_phases.',
+        reason: 'Could not determine current phase from STATE.md. Add **Current Phase:** N, frontmatter current_phase: N, progress.completed_phases, or progress.total_phases.',
       },
     };
   }


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #3471

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

`gsd-sdk query state.prune` fell through to `currentPhase = 0` when `STATE.md` omitted the body `**Current Phase:**` field, which produced a misleading `Only 0 phases` no-op.

## What this fix does

This fix derives current phase from supported fallbacks (`current_phase`, body field, `progress.completed_phases`, `progress.total_phases`) and returns a targeted reason when phase cannot be determined.

## Root cause

`statePrune` only read one legacy body field and coerced missing data through `parseInt(...) || 0`, conflating parse failure with a real phase count.

## Testing

### How I verified the fix

- `npm --prefix sdk test -- src/query/state-mutation.test.ts`
- Added/ran regression coverage in `sdk/src/query/state-mutation.test.ts` for frontmatter fallback extraction and missing-phase reason path.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None
