### PR TITLE
fix(sdk): skip terminal-labeled phases in init.progress next_phase

### DIFF
--- a/.changeset/noble-mice-squeak.md
+++ b/.changeset/noble-mice-squeak.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3478
+---
+**`gsd-sdk query init.progress` now respects terminal phase labels in roadmap headings** — phases marked COMPLETE/SHIPPED/DEFERRED/SUPERSEDED/MERGED/FOLDED are counted complete and skipped as next pending phase.

--- a/sdk/src/query/init-complex.test.ts
+++ b/sdk/src/query/init-complex.test.ts
@@ -329,6 +329,12 @@ describe('initProgress', () => {
         '',
         '## Phase 4.23: New pending work',
         '',
+        '## Phase 4.24: Follow-up item (PROMOTED)',
+        '',
+        '## Phase 4.25: Another follow-up (REGISTERED)',
+        '',
+        '## Phase 4.26: Triage marker (INSERTED)',
+        '',
       ].join('\n'));
 
       const result = await initProgress([], tmp);
@@ -337,10 +343,16 @@ describe('initProgress', () => {
       const phase412 = phases.find(p => p.number === '4.12');
       const phase413 = phases.find(p => p.number === '4.13');
       const phase417 = phases.find(p => p.number === '4.17');
+      const phase424 = phases.find(p => p.number === '4.24');
+      const phase425 = phases.find(p => p.number === '4.25');
+      const phase426 = phases.find(p => p.number === '4.26');
 
       expect(phase412?.status).toBe('complete');
       expect(phase413?.status).toBe('complete');
       expect(phase417?.status).toBe('complete');
+      expect(phase424?.status).not.toBe('complete');
+      expect(phase425?.status).not.toBe('complete');
+      expect(phase426?.status).not.toBe('complete');
       expect(data.completed_count).toBe(3);
       expect((data.next_phase as Record<string, unknown>).number).toBe('4.23');
     } finally {

--- a/sdk/src/query/init-complex.test.ts
+++ b/sdk/src/query/init-complex.test.ts
@@ -295,6 +295,58 @@ describe('initProgress', () => {
       await rm(tmp, { recursive: true, force: true });
     }
   });
+
+  it('treats terminal heading labels as complete when selecting next_phase (#3472)', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'gsd-init-complex-3472-'));
+    try {
+      await mkdir(join(tmp, '.planning'), { recursive: true });
+      await writeFile(join(tmp, '.planning', 'config.json'), JSON.stringify({
+        model_profile: 'balanced',
+        commit_docs: false,
+        git: {
+          branching_strategy: 'none',
+          phase_branch_template: 'gsd/phase-{phase}-{slug}',
+          milestone_branch_template: 'gsd/{milestone}-{slug}',
+          quick_branch_template: null,
+        },
+        workflow: { research: true, plan_check: true, verifier: true, nyquist_validation: true },
+      }));
+      await writeFile(join(tmp, '.planning', 'STATE.md'), [
+        '---',
+        'milestone: v1.0',
+        '---',
+      ].join('\n'));
+      await writeFile(join(tmp, '.planning', 'ROADMAP.md'), [
+        '# Roadmap',
+        '',
+        '## v1.0: Current',
+        '',
+        '## Phase 4.12: Old Work (COMPLETE)',
+        '',
+        '## Phase 4.13: Another old one (SHIPPED 2026-05-12)',
+        '',
+        '## Phase 4.17: Human Auth (DEFERRED)',
+        '',
+        '## Phase 4.23: New pending work',
+        '',
+      ].join('\n'));
+
+      const result = await initProgress([], tmp);
+      const data = result.data as Record<string, unknown>;
+      const phases = data.phases as Record<string, unknown>[];
+      const phase412 = phases.find(p => p.number === '4.12');
+      const phase413 = phases.find(p => p.number === '4.13');
+      const phase417 = phases.find(p => p.number === '4.17');
+
+      expect(phase412?.status).toBe('complete');
+      expect(phase413?.status).toBe('complete');
+      expect(phase417?.status).toBe('complete');
+      expect(data.completed_count).toBe(3);
+      expect((data.next_phase as Record<string, unknown>).number).toBe('4.23');
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('initManager', () => {

--- a/sdk/src/query/init-complex.ts
+++ b/sdk/src/query/init-complex.ts
@@ -102,6 +102,25 @@ function extractCheckboxStates(content: string): Map<string, boolean> {
 }
 
 /**
+ * Extract terminal phase markers from ROADMAP phase headings, e.g.
+ * `(COMPLETE)`, `(SHIPPED ...)`, `(DEFERRED)`, `(SUPERSEDED ...)`.
+ * These labels mean the phase should not be selected as next pending work.
+ */
+function extractTerminalStatusLabels(content: string): Set<string> {
+  const terminal = new Set<string>();
+  const headingPattern = /#{2,4}\s*Phase\s+(\d+[A-Z]?(?:\.\d+)*)\s*:\s*([^\n]+)/gi;
+  const terminalRe = /(?:\(|\*\*)\s*(SHIPPED|COMPLETE|DEFERRED|SUPERSEDED|MERGED\s+INTO|FOLDED\s+INTO)\b/i;
+  let m: RegExpExecArray | null;
+  while ((m = headingPattern.exec(content)) !== null) {
+    if (terminalRe.test(m[2])) {
+      terminal.add(m[1]);
+      terminal.add(m[1].replace(/^0+/, '') || '0');
+    }
+  }
+  return terminal;
+}
+
+/**
  * Derive progress-level status from a ROADMAP checkbox when the phase has
  * no on-disk directory. Returns 'complete' for `[x]`, 'not_started' otherwise.
  * Disk status (when present) always wins — it's more recent truth for in-flight work.
@@ -291,6 +310,7 @@ export const initProgress: QueryHandler = async (_args, projectDir, workstream) 
   const roadmapPhaseNames = new Map<string, string>();
   const seenPhaseNums = new Set<string>();
   let checkboxStates = new Map<string, boolean>();
+  let terminalLabels = new Set<string>();
 
   try {
     const rawRoadmap = await readFile(paths.roadmap, 'utf-8');
@@ -303,6 +323,7 @@ export const initProgress: QueryHandler = async (_args, projectDir, workstream) 
       roadmapPhaseNames.set(pNum, pName);
     }
     checkboxStates = extractCheckboxStates(roadmapContent);
+    terminalLabels = extractTerminalStatusLabels(roadmapContent);
   } catch { /* intentionally empty */ }
 
   // Scan phase directories
@@ -345,6 +366,9 @@ export const initProgress: QueryHandler = async (_args, projectDir, workstream) 
       if (roadmapComplete && status !== 'complete') {
         status = 'complete';
       }
+      if (terminalLabels.has(phaseNumber) || terminalLabels.has(strippedNum)) {
+        status = 'complete';
+      }
 
       const phaseInfo: Record<string, unknown> = {
         number: phaseNumber,
@@ -373,17 +397,18 @@ export const initProgress: QueryHandler = async (_args, projectDir, workstream) 
     const stripped = num.replace(/^0+/, '') || '0';
     if (!seenPhaseNums.has(stripped)) {
       const status = deriveStatusFromCheckbox(num, checkboxStates);
+      const terminalComplete = terminalLabels.has(num) || terminalLabels.has(stripped);
       const phaseInfo: Record<string, unknown> = {
         number: num,
         name: name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, ''),
         directory: null,
-        status,
+        status: terminalComplete ? 'complete' : status,
         plan_count: 0,
         summary_count: 0,
         has_research: false,
       };
       phases.push(phaseInfo);
-      if (!nextPhase && !currentPhase && status !== 'complete') {
+      if (!nextPhase && !currentPhase && phaseInfo.status !== 'complete') {
         nextPhase = phaseInfo;
       }
     }


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #3472

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

`init.progress` ignored terminal phase labels in ROADMAP headings (`COMPLETE`, `SHIPPED`, `DEFERRED`, etc.), so completed phases were still treated as pending and could be selected as `next_phase`.

## What this fix does

This fix parses terminal heading labels as completion signals and ensures `next_phase` selection skips those terminal-labeled phases.

## Root cause

Completion logic only considered on-disk PLAN/SUMMARY parity and checkbox state; heading terminal status labels were not represented in status derivation.

## Testing

### How I verified the fix

- `npm --prefix sdk test -- src/query/init-complex.test.ts`
- Added regression test in `sdk/src/query/init-complex.test.ts` covering terminal-label handling and `next_phase` selection.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `query init.progress` to properly recognize phases marked with terminal status labels (COMPLETE, SHIPPED, DEFERRED, SUPERSEDED, MERGED, FOLDED) and skip them when determining the next pending phase.

* **Tests**
  * Added test coverage for terminal phase label detection in roadmap parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3478)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->