### PR TITLE
fix(sdk): reduce validate.health false positives

### DIFF
--- a/.changeset/graceful-geese-tumble.md
+++ b/.changeset/graceful-geese-tumble.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3479
+---
+**`gsd-sdk query validate.health` now avoids three false-positive classes** — it accepts 999.X backlog phase dirs, recognizes milestone-archive phase directories for roadmap presence checks, and canonicalizes descriptor PLAN/SUMMARY filename pairing.

--- a/sdk/src/query/validate.test.ts
+++ b/sdk/src/query/validate.test.ts
@@ -603,6 +603,71 @@ describe('validateHealth', () => {
     expect(warnings.some(w => w.code === 'W005')).toBe(true);
   });
 
+  it('does not emit W005 for 999.X backlog phase directory naming (#3473)', async () => {
+    await createHealthyPlanning();
+    await mkdir(join(tmpDir, '.planning', 'phases', '999.1-backlog-sweep'), { recursive: true });
+
+    const result = await validateHealth([], tmpDir);
+    const data = result.data as Record<string, unknown>;
+    const warnings = data.warnings as Array<Record<string, unknown>>;
+    const w005ForBacklog = warnings.find(
+      w => w.code === 'W005' && String(w.message).includes('999.1-backlog-sweep'),
+    );
+    expect(w005ForBacklog).toBeUndefined();
+  });
+
+  it('does not emit W006 when roadmap phase exists in milestones archive dir (#3473)', async () => {
+    await createHealthyPlanning();
+    await writeFile(join(tmpDir, '.planning', 'ROADMAP.md'), [
+      '# Roadmap',
+      '',
+      '## v1.0: Shipped ✅ SHIPPED',
+      '',
+      '### Phase 7: Old shipped phase',
+      '',
+      '## v1.1: Current',
+      '',
+      '### Phase 1: Foundation',
+      '',
+    ].join('\n'));
+    await mkdir(join(tmpDir, '.planning', 'milestones', 'v1.0-phases', '07-old-shipped-phase'), { recursive: true });
+    await writeFile(
+      join(tmpDir, '.planning', 'milestones', 'v1.0-phases', '07-old-shipped-phase', '07-01-PLAN.md'),
+      '# Plan\n',
+    );
+
+    const result = await validateHealth([], tmpDir);
+    const data = result.data as Record<string, unknown>;
+    const warnings = data.warnings as Array<Record<string, unknown>>;
+    const w006s = warnings.filter(w => w.code === 'W006');
+    expect(w006s.some(w => String(w.message).includes('Phase 7'))).toBe(false);
+  });
+
+  it('does not emit I001 when plan file has descriptor but summary uses canonical stem (#3473)', async () => {
+    await createHealthyPlanning();
+    await mkdir(join(tmpDir, '.planning', 'phases', '68-bug-surface'), { recursive: true });
+    await writeFile(join(tmpDir, '.planning', 'phases', '68-bug-surface', '68-01-scaffolding-PLAN.md'), [
+      '---',
+      'phase: 68',
+      'plan: 01',
+      'wave: 1',
+      'depends_on: []',
+      'files_modified: []',
+      'autonomous: true',
+      '---',
+      '# Plan',
+    ].join('\n'));
+    await writeFile(join(tmpDir, '.planning', 'phases', '68-bug-surface', '68-01-SUMMARY.md'), '# Summary\n');
+
+    const result = await validateHealth([], tmpDir);
+    const data = result.data as Record<string, unknown>;
+    const info = data.info as Array<Record<string, unknown>>;
+    const i001ForPhase = info.find(
+      i => i.code === 'I001' && String(i.message).includes('68-bug-surface/68-01-scaffolding-PLAN.md'),
+    );
+    expect(i001ForPhase).toBeUndefined();
+  });
+
   it('returns early with E010 when CWD equals home directory', async () => {
     const result = await validateHealth([], homedir());
     const data = result.data as Record<string, unknown>;

--- a/sdk/src/query/validate.ts
+++ b/sdk/src/query/validate.ts
@@ -30,6 +30,15 @@ import { resolveBundledAgentsDir } from '../sdk-package-compatibility.js';
 const MAX_KEY_LINK_PATTERN_LEN = 512;
 
 /**
+ * Canonical plan stem used for PLAN/SUMMARY matching.
+ * Example: `68-01-scaffolding` -> `68-01`.
+ */
+function canonicalPlanStem(stem: string): string {
+  const m = stem.match(/^(\d+[A-Z]?(?:\.\d+)*-\d+)/i);
+  return m ? m[1] : stem;
+}
+
+/**
  * Build a RegExp for must_haves key_links pattern matching.
  * Long or nested-quantifier patterns fall back to a literal match via escapeRegex.
  */
@@ -526,7 +535,7 @@ export const validateHealth: QueryHandler = async (args, projectDir, workstream)
   try {
     const entries = await readdir(phasesDir, { withFileTypes: true });
     for (const e of entries) {
-      if (e.isDirectory() && !e.name.match(/^\d{2}(?:\.\d+)*-[\w-]+$/)) {
+      if (e.isDirectory() && !e.name.match(/^\d{2,}(?:\.\d+)*-[\w-]+$/)) {
         addIssue('warning', 'W005', `Phase directory "${e.name}" doesn't follow NN-name format`, 'Rename to match pattern (e.g., 01-setup)');
       }
     }
@@ -540,11 +549,17 @@ export const validateHealth: QueryHandler = async (args, projectDir, workstream)
       const phaseFiles = await readdir(join(phasesDir, e.name));
       const plans = phaseFiles.filter(f => f.endsWith('-PLAN.md') || f === 'PLAN.md');
       const summaries = phaseFiles.filter(f => f.endsWith('-SUMMARY.md') || f === 'SUMMARY.md');
-      const summaryBases = new Set(summaries.map(s => s.replace('-SUMMARY.md', '').replace('SUMMARY.md', '')));
+      const summaryBases = new Set<string>();
+      for (const summary of summaries) {
+        const summaryBase = summary.replace('-SUMMARY.md', '').replace('SUMMARY.md', '');
+        summaryBases.add(summaryBase);
+        summaryBases.add(canonicalPlanStem(summaryBase));
+      }
 
       for (const plan of plans) {
         const planBase2 = plan.replace('-PLAN.md', '').replace('PLAN.md', '');
-        if (!summaryBases.has(planBase2)) {
+        const canonicalBase = canonicalPlanStem(planBase2);
+        if (!summaryBases.has(planBase2) && !summaryBases.has(canonicalBase)) {
           addIssue('info', 'I001', `${e.name}/${plan} has no SUMMARY.md`, 'May be in progress');
         }
       }
@@ -590,6 +605,20 @@ export const validateHealth: QueryHandler = async (args, projectDir, workstream)
         for (const e of entries) {
           if (e.isDirectory()) {
             const dm = e.name.match(/^(\d+[A-Z]?(?:\.\d+)*)/i);
+            if (dm) diskPhases.add(dm[1]);
+          }
+        }
+      } catch { /* intentionally empty */ }
+      // Include archived milestone phase directories as valid on-disk locations
+      // for historical ROADMAP phases.
+      try {
+        const milestoneEntries = await readdir(join(planBase, 'milestones'), { withFileTypes: true });
+        for (const milestoneEntry of milestoneEntries) {
+          if (!milestoneEntry.isDirectory() || !/-phases$/i.test(milestoneEntry.name)) continue;
+          const archivedPhaseEntries = await readdir(join(planBase, 'milestones', milestoneEntry.name), { withFileTypes: true });
+          for (const archivedPhase of archivedPhaseEntries) {
+            if (!archivedPhase.isDirectory()) continue;
+            const dm = archivedPhase.name.match(/^(\d+[A-Z]?(?:\.\d+)*)/i);
             if (dm) diskPhases.add(dm[1]);
           }
         }


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #3473

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

`validate.health` produced three false-positive classes: W005 for `999.X` backlog naming, W006 for roadmap phases that exist under milestone archives, and I001 for descriptor PLAN names paired with canonical SUMMARY names.

## What this fix does

This fix widens W005 naming acceptance for multi-digit phase prefixes, includes archived milestone phase directories in W006 presence checks, and canonicalizes PLAN/SUMMARY stem matching for I001.

## Root cause

The validator assumed only `.planning/phases` as authoritative phase location and relied on strict exact stem matching without canonical plan-id normalization.

## Testing

### How I verified the fix

- `npm --prefix sdk test -- src/query/validate.test.ts`
- Added targeted regression coverage in `sdk/src/query/validate.test.ts` for the three reported false-positive classes.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None
