### PR TITLE
fix(sdk): preserve same-milestone archived phase handling

### DIFF
--- a/.changeset/tidy-herons-dance.md
+++ b/.changeset/tidy-herons-dance.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3480
+---
+**SDK phase init/index queries now preserve same-milestone archived phase directories** — init and phase-plan-index no longer drop valid `milestones/vX-phases/*` matches as missing.

--- a/sdk/src/query/init.test.ts
+++ b/sdk/src/query/init.test.ts
@@ -358,6 +358,55 @@ describe('initExecutePhase', () => {
     expect(data.branching_strategy).toBe('phase');
     expect(typeof data.branch_name).toBe('string');
   });
+
+  it('keeps same-milestone archived phase directory instead of nulling it (#3469)', async () => {
+    const tmp = await mkdtemp(join(tmpdir(), 'gsd-init-3469-'));
+    try {
+      await mkdir(join(tmp, '.planning', 'milestones', 'v2.0-phases', '02-auth'), { recursive: true });
+      await writeFile(join(tmp, '.planning', 'PROJECT.md'), '# Project\n\n## What This Is\n\nA project.\n\n## Core Value\n\nValue here.\n\n## Requirements\n\n- Req 1\n');
+      await writeFile(join(tmp, '.planning', 'ROADMAP.md'), [
+        '# Roadmap',
+        '',
+        '## v2.0: Current',
+        '',
+        '### Phase 2: Auth',
+        '',
+        '**Goal:** Implement auth',
+        '',
+      ].join('\n'));
+      await writeFile(join(tmp, '.planning', 'STATE.md'), [
+        '---',
+        'milestone: v2.0',
+        'status: executing',
+        '---',
+        '',
+        '# Session State',
+      ].join('\n'));
+      await writeFile(join(tmp, '.planning', 'config.json'), JSON.stringify({
+        model_profile: 'balanced',
+        commit_docs: false,
+        git: {
+          branching_strategy: 'none',
+          phase_branch_template: 'gsd/phase-{phase}-{slug}',
+          milestone_branch_template: 'gsd/{milestone}-{slug}',
+          quick_branch_template: null,
+        },
+        workflow: { research: true, plan_check: true, verifier: true, nyquist_validation: true },
+      }));
+      await writeFile(
+        join(tmp, '.planning', 'milestones', 'v2.0-phases', '02-auth', '02-01-PLAN.md'),
+        '# Plan\n',
+      );
+
+      const result = await initExecutePhase(['2'], tmp);
+      const data = result.data as Record<string, unknown>;
+      expect(data.phase_found).toBe(true);
+      expect(data.phase_dir).toBe('.planning/milestones/v2.0-phases/02-auth');
+      expect(data.plan_count).toBe(1);
+    } finally {
+      await rm(tmp, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('initPlanPhase', () => {

--- a/sdk/src/query/init.ts
+++ b/sdk/src/query/init.ts
@@ -105,7 +105,7 @@ async function shouldDropArchivedPhaseMatch(
   projectDir: string,
   workstream?: string,
 ): Promise<boolean> {
-  if (!phaseInfo?.archived || !roadmapPhase?.found) return false;
+  if (!phaseInfo?.archived || !roadmapPhase || !roadmapPhase.found) return false;
   const archivedTag = String(phaseInfo.archived ?? '');
   const milestone = await getMilestoneInfo(projectDir, workstream);
   if (milestone?.version && archivedTag === milestone.version) return false;

--- a/sdk/src/query/init.ts
+++ b/sdk/src/query/init.ts
@@ -99,6 +99,19 @@ function computeExpectedPhaseDirName(
   return `${prefix}${paddedNum}-${slug}`;
 }
 
+async function shouldDropArchivedPhaseMatch(
+  phaseInfo: Record<string, unknown> | null,
+  roadmapPhase: Record<string, unknown> | null,
+  projectDir: string,
+  workstream?: string,
+): Promise<boolean> {
+  if (!phaseInfo?.archived || !roadmapPhase?.found) return false;
+  const archivedTag = String(phaseInfo.archived ?? '');
+  const milestone = await getMilestoneInfo(projectDir, workstream);
+  if (milestone?.version && archivedTag === milestone.version) return false;
+  return true;
+}
+
 /**
  * Get the latest completed milestone from MILESTONES.md.
  * Port of getLatestCompletedMilestone from init.cjs lines 10-25.
@@ -169,7 +182,7 @@ async function getPhaseInfoWithFallback(
   const roadmapPhase = roadmapResult.data as Record<string, unknown> | null;
 
   // Match init.cjs: drop archived disk match when the phase is listed in the current ROADMAP
-  if (phaseInfo?.archived && roadmapPhase?.found) {
+  if (await shouldDropArchivedPhaseMatch(phaseInfo, roadmapPhase, projectDir, workstream)) {
     phaseInfo = null;
   }
 
@@ -212,7 +225,7 @@ async function getPhaseInfoForVerifyWork(
   const roadmapResult = await roadmapGetPhase([phase], projectDir, workstream);
   const roadmapPhase = roadmapResult.data as Record<string, unknown> | null;
 
-  if (phaseInfo?.archived && roadmapPhase?.found) {
+  if (await shouldDropArchivedPhaseMatch(phaseInfo, roadmapPhase, projectDir, workstream)) {
     phaseInfo = null;
   }
 
@@ -694,7 +707,7 @@ export const initPhaseOp: QueryHandler = async (args, projectDir, workstream) =>
   const roadmapPhase = roadmapResult.data as Record<string, unknown> | null;
 
   // If the only match comes from an archived milestone, prefer current ROADMAP
-  if (phaseInfo?.archived && roadmapPhase?.found) {
+  if (await shouldDropArchivedPhaseMatch(phaseInfo, roadmapPhase, projectDir, workstream)) {
     const phaseName = roadmapPhase.phase_name as string;
     phaseInfo = {
       found: true,

--- a/sdk/src/query/init.ts
+++ b/sdk/src/query/init.ts
@@ -707,7 +707,7 @@ export const initPhaseOp: QueryHandler = async (args, projectDir, workstream) =>
   const roadmapPhase = roadmapResult.data as Record<string, unknown> | null;
 
   // If the only match comes from an archived milestone, prefer current ROADMAP
-  if (await shouldDropArchivedPhaseMatch(phaseInfo, roadmapPhase, projectDir, workstream)) {
+  if (roadmapPhase?.found && await shouldDropArchivedPhaseMatch(phaseInfo, roadmapPhase, projectDir, workstream)) {
     const phaseName = roadmapPhase.phase_name as string;
     phaseInfo = {
       found: true,

--- a/sdk/src/query/phase.test.ts
+++ b/sdk/src/query/phase.test.ts
@@ -307,6 +307,36 @@ describe('phasePlanIndex', () => {
     expect(data.plans).toEqual([]);
   });
 
+  it('falls back to archived milestone directory when root phases dir has no match (#3469)', async () => {
+    const archiveDir = join(tmpDir, '.planning', 'milestones', 'v2.0-phases', '02-auth');
+    await mkdir(archiveDir, { recursive: true });
+    await writeFile(join(archiveDir, '02-01-PLAN.md'), [
+      '---',
+      'phase: 02',
+      'plan: 01',
+      'wave: 1',
+      'autonomous: true',
+      '---',
+      '<objective>',
+      'Archived milestone plan.',
+      '</objective>',
+      '<tasks>',
+      '<task type=\"auto\">',
+      '  <name>Task 1</name>',
+      '</task>',
+      '</tasks>',
+    ].join('\n'));
+    await writeFile(join(archiveDir, '02-01-SUMMARY.md'), '# Summary\n');
+
+    const result = await phasePlanIndex(['2'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+    const plans = data.plans as Array<Record<string, unknown>>;
+
+    expect(data.error).toBeUndefined();
+    expect(plans.length).toBe(1);
+    expect(plans[0].id).toBe('02-01');
+  });
+
   // ── #3266 regression tests ─────────────────────────────────────────────
 
   it('#3266: wave 0 round-trip — plan with wave: 0 lands in waves["0"] with PlanInfo.wave === 0', async () => {

--- a/sdk/src/query/phase.ts
+++ b/sdk/src/query/phase.ts
@@ -262,6 +262,15 @@ export const phasePlanIndex: QueryHandler = async (args, projectDir, workstream)
   } catch { /* phases dir doesn't exist */ }
 
   if (!phaseDir) {
+    const found = await findPhase([phase], projectDir, workstream);
+    const foundData = found.data as Record<string, unknown> | null;
+    const relDir = foundData?.directory;
+    if (foundData?.found && typeof relDir === 'string' && relDir.trim() !== '') {
+      phaseDir = join(projectDir, relDir);
+    }
+  }
+
+  if (!phaseDir) {
     return {
       data: {
         phase: normalized,


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #3469

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

Same-milestone phases stored under `.planning/milestones/v<current>-phases/` were treated as stale archived matches and dropped from init/phase indexing paths, causing missing phase_dir/plan resolution.

## What this fix does

This fix makes archived-match dropping milestone-aware (only drop when archive tag differs from active milestone) and adds `phase-plan-index` fallback through `findPhase` so archived milestone dirs can be indexed.

## Root cause

Archived handling introduced for #2805 treated any archived hit as invalid whenever roadmap listed the phase, without checking whether archive tag matched the active milestone.

## Testing

### How I verified the fix

- `npm run build:sdk`
- `npm --prefix sdk test -- src/query/init.test.ts src/query/phase.test.ts`
- Added regression tests in:
  - `sdk/src/query/init.test.ts`
  - `sdk/src/query/phase.test.ts`

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None
