### PR TITLE
feat: transport resolved reasoning effort to agent launches

### DIFF
--- a/.changeset/agent-launch-reasoning-transport.md
+++ b/.changeset/agent-launch-reasoning-transport.md
@@ -1,0 +1,5 @@
+---
+type: Added
+pr: 3474
+---
+**Agent launch model resolution now transports reasoning effort** — `resolve-model` JSON output includes supported runtime `reasoning_effort`, and runtime adapter guidance passes it to child-agent launches only when supported.

--- a/bin/install.js
+++ b/bin/install.js
@@ -2360,6 +2360,10 @@ Direct mapping:
   GSD embeds the resolved per-agent model directly into each agent's \`.toml\`
   at install time so \`model_overrides\` from \`.planning/config.json\` and
   \`~/.gsd/defaults.json\` are honored automatically by Codex's agent router.
+- Resolved \`reasoning_effort="low|medium|high|xhigh"\` → pass \`reasoning_effort\`
+  to \`spawn_agent\` when the runtime/tool supports it. Omit missing, empty,
+  inherited, or unsupported values; do not invent one-off effort literals in
+  workflow prose.
 - \`fork_context: false\` by default — GSD agents load their own context via \`<files_to_read>\` blocks
 - \`Task(isolation="worktree")\` / \`Agent(isolation="worktree")\` → no direct Codex mapping.
   Codex \`spawn_agent\` does not create or bind a git worktree automatically.

--- a/docs/CLI-TOOLS.md
+++ b/docs/CLI-TOOLS.md
@@ -207,7 +207,9 @@ node gsd-tools.cjs config-set-model-profile <profile>
 ```bash
 # Get model for agent based on current profile
 node gsd-tools.cjs resolve-model <agent-name>
-# Returns: opus | sonnet | haiku | inherit
+# Raw output returns the selected model ID/tier.
+# JSON output also includes profile and, when the active runtime supports it,
+# reasoning_effort.
 ```
 
 Agent names: `gsd-planner`, `gsd-executor`, `gsd-phase-researcher`, `gsd-project-researcher`, `gsd-research-synthesizer`, `gsd-verifier`, `gsd-plan-checker`, `gsd-integration-checker`, `gsd-roadmapper`, `gsd-debugger`, `gsd-codebase-mapper`, `gsd-nyquist-auditor`

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -980,6 +980,8 @@ The intent is the same as the Claude profile tiers -- use a stronger model for p
 
 When `runtime` is set, profile tiers (`opus`/`sonnet`/`haiku`) resolve to runtime-native model IDs instead of Claude aliases. This lets a single shared `.planning/config.json` work cleanly across Claude and Codex.
 
+`resolve-model` JSON output includes `reasoning_effort` when it is defined by the same runtime tier that selected the model. Runtime adapters may pass that value to child-agent launch calls that support it; runtimes without explicit support omit it.
+
 **Built-in tier maps:**
 
 | Runtime | `opus` | `sonnet` | `haiku` | reasoning_effort |

--- a/get-shit-done/bin/lib/commands.cjs
+++ b/get-shit-done/bin/lib/commands.cjs
@@ -4,7 +4,7 @@
 const fs = require('fs');
 const path = require('path');
 const { execGit } = require('./shell-command-projection.cjs');
-const { safeReadFile, loadConfig, isGitIgnored, normalizePhaseName, comparePhaseNum, getArchivedPhaseDirs, generateSlugInternal, getMilestoneInfo, getMilestonePhaseFilter, resolveModelInternal, stripShippedMilestones, extractCurrentMilestone, toPosixPath, output, error, findPhaseInternal, extractOneLinerFromBody, getRoadmapPhaseInternal } = require('./core.cjs');
+const { safeReadFile, loadConfig, isGitIgnored, normalizePhaseName, comparePhaseNum, getArchivedPhaseDirs, generateSlugInternal, getMilestoneInfo, getMilestonePhaseFilter, resolveModelInternal, resolveReasoningEffortInternal, stripShippedMilestones, extractCurrentMilestone, toPosixPath, output, error, findPhaseInternal, extractOneLinerFromBody, getRoadmapPhaseInternal } = require('./core.cjs');
 const { planningDir, planningPaths } = require('./planning-workspace.cjs');
 const { extractFrontmatter } = require('./frontmatter.cjs');
 const { MODEL_PROFILES } = require('./model-profiles.cjs');
@@ -240,11 +240,13 @@ function cmdResolveModel(cwd, agentType, raw) {
   const config = loadConfig(cwd);
   const profile = config.model_profile || 'balanced';
   const model = resolveModelInternal(cwd, agentType);
+  const reasoningEffort = resolveReasoningEffortInternal(cwd, agentType);
 
   const agentModels = MODEL_PROFILES[agentType];
   const result = agentModels
     ? { model, profile }
     : { model, profile, unknown_agent: true };
+  if (reasoningEffort) result.reasoning_effort = reasoningEffort;
   output(result, raw, model);
 }
 

--- a/sdk/src/query/QUERY-HANDLERS.md
+++ b/sdk/src/query/QUERY-HANDLERS.md
@@ -155,7 +155,7 @@ From `read-only-parity.integration.test.ts` (full `toEqual` on this repo):
 
 | SDK dispatch (canonical) | Notes |
 | ------------------------ | ----- |
-| `resolve-model` | Args e.g. `gsd-planner`. |
+| `resolve-model` | Args e.g. `gsd-planner`; returns `reasoning_effort` when the selected runtime tier defines one. |
 | `phase-plan-index` | Phase number arg. |
 | `roadmap.get-phase` | Phase number arg. |
 | `list.todos` | No args. |

--- a/sdk/src/query/config-query.test.ts
+++ b/sdk/src/query/config-query.test.ts
@@ -208,8 +208,28 @@ describe('resolveModel', () => {
     const planner = (await resolveModel(['gsd-planner'], tmpDir)).data as Record<string, unknown>;
     const executor = (await resolveModel(['gsd-executor'], tmpDir)).data as Record<string, unknown>;
 
-    expect(planner).toMatchObject({ model: 'gpt-5.5', profile: 'balanced' });
-    expect(executor).toMatchObject({ model: 'gpt-5.3-codex', profile: 'balanced' });
+    expect(planner).toMatchObject({ model: 'gpt-5.5', profile: 'balanced', reasoning_effort: 'high' });
+    expect(executor).toMatchObject({ model: 'gpt-5.3-codex', profile: 'balanced', reasoning_effort: 'medium' });
+  });
+
+  it('returns runtime reasoning_effort from the same phase-tier source as model', async () => {
+    const { resolveModel } = await import('./config-query.js');
+    await writeFile(
+      join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({
+        model_profile: 'budget',
+        runtime: 'codex',
+        models: { execution: 'opus' },
+      }),
+    );
+
+    const executor = (await resolveModel(['gsd-executor'], tmpDir)).data as Record<string, unknown>;
+
+    expect(executor).toMatchObject({
+      model: 'gpt-5.4',
+      profile: 'budget',
+      reasoning_effort: 'xhigh',
+    });
   });
 
   it('resolveModel uses workstream config when --ws is specified', async () => {

--- a/sdk/src/query/config-query.ts
+++ b/sdk/src/query/config-query.ts
@@ -222,7 +222,11 @@ export const resolveModel: QueryHandler = async (args, projectDir, workstream) =
   const tier = typeof phaseTier === 'string' ? phaseTier : alias;
   const runtimeTier = resolveRuntimeTier(config as Record<string, unknown>, tier);
   if (runtimeTier?.model) {
-    return { data: { model: runtimeTier.model, profile } };
+    const result: Record<string, unknown> = { model: runtimeTier.model, profile };
+    if (runtimeTier.reasoning_effort) {
+      result.reasoning_effort = runtimeTier.reasoning_effort;
+    }
+    return { data: result };
   }
 
   if (resolveModelIds === 'omit') {

--- a/tests/codex-config.test.cjs
+++ b/tests/codex-config.test.cjs
@@ -133,6 +133,8 @@ describe('getCodexSkillAdapterHeader', () => {
     const result = getCodexSkillAdapterHeader('gsd-execute-phase');
     assert.ok(result.includes('spawn_agent'), 'maps to spawn_agent');
     assert.ok(result.includes('agent_type'), 'maps subagent_type to agent_type');
+    assert.ok(result.includes('reasoning_effort'), 'documents reasoning_effort transport');
+    assert.ok(result.includes('do not invent one-off effort literals'), 'keeps effort policy centralized');
     assert.ok(result.includes('fork_context'), 'documents fork_context default');
     assert.ok(result.includes('wait(ids)'), 'documents parallel wait pattern');
     assert.ok(result.includes('close_agent'), 'documents close_agent cleanup');

--- a/tests/commands.test.cjs
+++ b/tests/commands.test.cjs
@@ -1117,6 +1117,21 @@ describe('resolve-model command', () => {
     assert.ok(output.model, 'should resolve a model');
   });
 
+  test('includes reasoning_effort when selected runtime supports it', () => {
+    fs.writeFileSync(path.join(tmpDir, '.planning', 'config.json'), JSON.stringify({
+      model_profile: 'balanced',
+      runtime: 'codex',
+      models: { planning: 'opus' },
+    }));
+    const result = runGsdTools('resolve-model gsd-planner', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.model, 'gpt-5.4');
+    assert.strictEqual(output.profile, 'balanced');
+    assert.strictEqual(output.reasoning_effort, 'xhigh');
+  });
+
   test('fails when no agent-type provided', () => {
     const result = runGsdTools('resolve-model', tmpDir);
     assert.ok(!result.success, 'should fail without agent-type');


### PR DESCRIPTION
## Feature PR

> **Using the wrong template?**
> — Bug fix: use [fix.md](?template=fix.md)
> — Enhancement to existing behavior: use [enhancement.md](?template=enhancement.md)

---

## Linked Issue

Closes #3474

> ⛔ **No `approved-feature` label on the issue = immediate close.**
> Do not open this PR if a maintainer has not yet approved the feature spec.
> Do not open this PR if you wrote code before the issue was approved.

---

## Feature summary

Expose the `reasoning_effort` already resolved by GSD model policy through command/query output, and document the runtime adapter contract for passing that resolved effort into supported child-agent launch calls.

## What changed

### New files

| File | Purpose |
|------|---------|
| `.changeset/agent-launch-reasoning-transport.md` | User-facing changelog fragment for the reasoning-effort transport behavior. |

### Modified files

| File | What changed |
|------|-------------|
| `bin/install.js` | Documents Codex adapter behavior for passing resolved `reasoning_effort` to supported `spawn_agent` calls. |
| `get-shit-done/bin/lib/commands.cjs` | Adds `reasoning_effort` to `resolve-model` JSON output when the selected runtime tier supports it. |
| `sdk/src/query/config-query.ts` | Adds `reasoning_effort` to SDK `resolve-model` query output when returned by runtime tier resolution. |
| `sdk/src/query/config-query.test.ts` | Covers SDK query output for runtime and phase-tier reasoning effort. |
| `tests/commands.test.cjs` | Covers CJS `resolve-model` JSON output for supported runtime reasoning effort. |
| `tests/codex-config.test.cjs` | Locks the Codex adapter guidance for reasoning-effort transport. |
| `docs/CLI-TOOLS.md` | Documents `resolve-model` JSON output including runtime-supported `reasoning_effort`. |
| `docs/CONFIGURATION.md` | Documents the runtime-aware profile output and adapter transport behavior. |
| `sdk/src/query/QUERY-HANDLERS.md` | Updates SDK query handler notes for `resolve-model`. |

## Implementation notes

This keeps reasoning levels centralized in existing model policy: model profiles, phase-type maps, dynamic routing, and per-agent overrides still decide the tier/model/effort. Runtime launch guidance only transports the resolved value when a runtime/tool supports it.

The upstream shell-command projection refactor changed `commands.cjs` during rebase; this PR keeps the new `execGit` seam and only adds the `resolveReasoningEffortInternal` import/output field.

## Spec compliance

- [x] Preserve existing Codex `reasoning_effort` resolution and allowlist behavior.
- [x] Expose resolved `reasoning_effort` alongside resolved model IDs through command/query output.
- [x] Keep task-tailored reasoning levels in central model policy.
- [x] Pass resolved effort only through runtime adapter guidance for runtimes that support it.
- [x] Avoid broad model-selection redesign or a new generic `thinking` field.
- [x] Add regression tests that model and reasoning effort derive from the same tier source and are available to launch adapters.

## Testing

### Test coverage

- `node --test tests\commands.test.cjs tests\codex-config.test.cjs tests\issue-2517-runtime-aware-profiles.test.cjs tests\feat-3023-phase-type-models.test.cjs`
- `cd sdk && npm test -- src\query\config-query.test.ts`
- `npm run lint:tests`
- `npm run lint:changeset`

### Platforms tested

- [ ] macOS
- [x] Windows (including backslash path handling)
- [ ] Linux

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Codex
- [ ] Copilot
- [ ] Other: ___
- [ ] N/A — specify which runtimes are supported and why others are excluded

---

## Scope confirmation

- [x] The implementation matches the scope approved in the linked issue exactly
- [x] No additional features, commands, or behaviors were added beyond what was approved
- [x] If scope changed during implementation, I updated the issue spec and received re-approval

---

## Checklist

- [x] Issue linked above with `Closes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `approved-feature` label — **PR will be closed if missing**
- [x] All acceptance criteria from the issue are met (listed above)
- [x] Implementation scope matches the approved spec exactly
- [ ] All existing tests pass (`npm test`) — focused suites listed above pass; full matrix/CI pending.
- [x] New tests cover the happy path, error cases, and edge cases
- [x] `.changeset/` fragment added with a user-facing description of the feature (`npm run changeset -- --type Added --pr <NNN> --body "..."`)
- [x] Documentation updated — commands, workflows, references, README if applicable
- [x] No unnecessary external dependencies added
- [x] Works on Windows (backslash paths handled)

## Breaking changes

None

## Screenshots / recordings

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model resolution now returns reasoning effort configuration when supported by the runtime tier.
  * Agent launches can now pass reasoning effort to child agents when the runtime supports it.

* **Documentation**
  * Updated CLI tool documentation to clarify that resolve-model JSON output includes reasoning effort details.
  * Updated runtime profile documentation to explain reasoning effort handling across runtime adapters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3482)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->