### PR TITLE
feat(sdk): refuse `gsd-sdk init` when subdirs contain .planning/ (#3046)

### DIFF
--- a/sdk/src/cli.test.ts
+++ b/sdk/src/cli.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { parseCliArgs, resolveInitInput, USAGE, type ParsedCliArgs } from './cli.js';
+import { parseCliArgs, resolveInitInput, USAGE, detectNestedPlanningDirs, type ParsedCliArgs } from './cli.js';
 import { mkdir, writeFile, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -422,5 +422,100 @@ describe('USAGE', () => {
   it('documents --init option', () => {
     expect(USAGE).toContain('--init');
     expect(USAGE).toContain('Bootstrap from a PRD');
+  });
+
+  it('documents --allow-nested-planning opt-out flag (#3046)', () => {
+    expect(USAGE).toContain('--allow-nested-planning');
+    expect(USAGE).toMatch(/nested-planning guard/i);
+  });
+});
+
+// ─── --allow-nested-planning flag parsing ────────────────────────────────────
+
+describe('parseCliArgs --allow-nested-planning', () => {
+  it('defaults to false when flag not present', () => {
+    const result = parseCliArgs(['init', 'build X']);
+    expect(result.allowNestedPlanning).toBe(false);
+  });
+
+  it('parses --allow-nested-planning on init command', () => {
+    const result = parseCliArgs(['init', 'build X', '--allow-nested-planning']);
+    expect(result.allowNestedPlanning).toBe(true);
+  });
+
+  it('parses --allow-nested-planning on run command (no-op but accepted)', () => {
+    const result = parseCliArgs(['run', 'build X', '--allow-nested-planning']);
+    expect(result.allowNestedPlanning).toBe(true);
+  });
+
+  it('parses --allow-nested-planning on query command via permissive parser', () => {
+    const result = parseCliArgs(['query', 'state.load', '--allow-nested-planning']);
+    expect(result.command).toBe('query');
+    expect(result.allowNestedPlanning).toBe(true);
+    // permissive parser should NOT forward the flag into queryArgv (it's an SDK flag)
+    expect(result.queryArgv).not.toContain('--allow-nested-planning');
+  });
+});
+
+// ─── detectNestedPlanningDirs ────────────────────────────────────────────────
+
+describe('detectNestedPlanningDirs', () => {
+  let rootDir: string;
+
+  beforeEach(async () => {
+    rootDir = join(tmpdir(), `gsd-nested-detect-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(rootDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(rootDir, { recursive: true, force: true });
+  });
+
+  it('returns empty list when no subdirectories exist', () => {
+    expect(detectNestedPlanningDirs(rootDir)).toEqual([]);
+  });
+
+  it('returns empty list when subdirectories exist but none have .planning/', async () => {
+    await mkdir(join(rootDir, 'project-a'));
+    await mkdir(join(rootDir, 'project-b'));
+    expect(detectNestedPlanningDirs(rootDir)).toEqual([]);
+  });
+
+  it('returns the subdirectory name when one subdir has a .planning/ directory', async () => {
+    await mkdir(join(rootDir, 'NAVIO_v3', '.planning'), { recursive: true });
+    expect(detectNestedPlanningDirs(rootDir)).toEqual(['NAVIO_v3']);
+  });
+
+  it('returns multiple names when multiple subdirs have .planning/', async () => {
+    await mkdir(join(rootDir, 'project-a', '.planning'), { recursive: true });
+    await mkdir(join(rootDir, 'project-b', '.planning'), { recursive: true });
+    await mkdir(join(rootDir, 'project-c'));
+    const result = detectNestedPlanningDirs(rootDir).sort();
+    expect(result).toEqual(['project-a', 'project-b']);
+  });
+
+  it('skips hidden directories (e.g. .git, .planning at root level)', async () => {
+    // .planning at the root is the existing-project case — NOT what this guard detects
+    await mkdir(join(rootDir, '.planning'), { recursive: true });
+    await mkdir(join(rootDir, '.git'), { recursive: true });
+    // also create a planning file inside .git so we don't accidentally match
+    await mkdir(join(rootDir, '.git', '.planning'), { recursive: true });
+    expect(detectNestedPlanningDirs(rootDir)).toEqual([]);
+  });
+
+  it('skips node_modules even when it contains nested .planning/', async () => {
+    await mkdir(join(rootDir, 'node_modules', 'some-pkg', '.planning'), { recursive: true });
+    expect(detectNestedPlanningDirs(rootDir)).toEqual([]);
+  });
+
+  it('treats a regular file named .planning as not a project (statSync.isDirectory() false)', async () => {
+    await mkdir(join(rootDir, 'fake-project'));
+    await writeFile(join(rootDir, 'fake-project', '.planning'), 'this is a file, not a dir');
+    expect(detectNestedPlanningDirs(rootDir)).toEqual([]);
+  });
+
+  it('returns empty list when projectDir is unreadable/missing', () => {
+    const missing = join(tmpdir(), `gsd-nonexistent-${Date.now()}`);
+    expect(detectNestedPlanningDirs(missing)).toEqual([]);
   });
 });

--- a/sdk/src/cli.ts
+++ b/sdk/src/cli.ts
@@ -8,6 +8,7 @@
 
 import { parseArgs } from 'node:util';
 import { readFile } from 'node:fs/promises';
+import { readdirSync, statSync } from 'node:fs';
 import { resolve, join, isAbsolute } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -38,6 +39,12 @@ export interface ParsedCliArgs {
   help: boolean;
   version: boolean;
   /**
+   * Opt-out for the nested-planning guard. When `true`, `gsd-sdk init` proceeds
+   * even if the resolved `projectDir` has immediate subdirectories that contain
+   * their own `.planning/` (i.e. nested GSD projects). See #3046 for context.
+   */
+  allowNestedPlanning?: boolean;
+  /**
    * When `command === 'query'`, tokens after `query` with only known SDK flags removed.
    * Extra flags are kept so handlers that share gsd-tools-style argv (e.g. `--pick`) still receive them.
    */
@@ -55,6 +62,7 @@ function parseCliArgsQueryPermissive(argv: string[]): ParsedCliArgs {
   let maxBudget: number | undefined;
   let help = false;
   let version = false;
+  let allowNestedPlanning = false;
   const queryArgv: string[] = [];
 
   let i = 1;
@@ -104,6 +112,11 @@ function parseCliArgsQueryPermissive(argv: string[]): ParsedCliArgs {
       i += 1;
       continue;
     }
+    if (a === '--allow-nested-planning') {
+      allowNestedPlanning = true;
+      i += 1;
+      continue;
+    }
     queryArgv.push(a);
     i += 1;
   }
@@ -128,6 +141,7 @@ function parseCliArgsQueryPermissive(argv: string[]): ParsedCliArgs {
     ws,
     help,
     version,
+    allowNestedPlanning,
     queryArgv,
   };
 }
@@ -150,6 +164,7 @@ export function parseCliArgs(argv: string[]): ParsedCliArgs {
       model: { type: 'string' },
       'max-budget': { type: 'string' },
       init: { type: 'string' },
+      'allow-nested-planning': { type: 'boolean', default: false },
       help: { type: 'boolean', short: 'h', default: false },
       version: { type: 'boolean', short: 'v', default: false },
     },
@@ -176,7 +191,46 @@ export function parseCliArgs(argv: string[]): ParsedCliArgs {
     ws: values.ws as string | undefined,
     help: values.help as boolean,
     version: values.version as boolean,
+    allowNestedPlanning: values['allow-nested-planning'] as boolean,
   };
+}
+
+// ─── Nested-planning guard helper ────────────────────────────────────────────
+
+/**
+ * Detect immediate subdirectories of `projectDir` that contain their own
+ * `.planning/` directory. Used by the init guard (#3046) to refuse accidental
+ * bootstrapping in a parent dir that already contains nested GSD projects.
+ *
+ * Returns the list of subdirectory names (relative to `projectDir`). Hidden
+ * dirs (`.git`, `.planning`, etc.) and `node_modules` are skipped. An
+ * unreadable `projectDir` returns an empty list rather than throwing — the
+ * guard is advisory; failing to read should never block init.
+ */
+export function detectNestedPlanningDirs(projectDir: string): string[] {
+  let entryNames: string[];
+  try {
+    entryNames = readdirSync(projectDir, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .filter((d) => !d.name.startsWith('.'))
+      .filter((d) => d.name !== 'node_modules')
+      .map((d) => d.name);
+  } catch {
+    return [];
+  }
+
+  const result: string[] = [];
+  for (const name of entryNames) {
+    const planningPath = join(projectDir, name, '.planning');
+    try {
+      if (statSync(planningPath).isDirectory()) {
+        result.push(name);
+      }
+    } catch {
+      // .planning/ missing in this subdir — not a GSD project, skip
+    }
+  }
+  return result;
 }
 
 // ─── Usage ───────────────────────────────────────────────────────────────────
@@ -203,6 +257,11 @@ Options:
   --ws-port <port>      Enable WebSocket transport on <port>
   --model <model>       Override LLM model
   --max-budget <n>      Max budget per step in USD
+  --allow-nested-planning
+                        (init only) Bypass the nested-planning guard. Allows
+                        init even when subdirectories contain their own
+                        .planning/. Default: refuse with a "did you mean to
+                        init from <subdir>?" message. See #3046.
   -h, --help            Show this help
   -v, --version         Show version
 `.trim();
@@ -355,6 +414,37 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<void
 
   // ─── Init command ─────────────────────────────────────────────────────────
   if (args.command === 'init') {
+    // #3046: nested-planning guard. Refuse to bootstrap when the resolved
+    // projectDir has immediate subdirectories with their own .planning/ — that
+    // pattern almost always means the user is in the wrong working directory
+    // (e.g. parent of NAVIO_v3/) and a successful init would write a parallel
+    // .planning/ + .git/ that collides with the nested project. The roadmapper
+    // step inside init has shown willingness to also walk into nested ROADMAP.md
+    // files during bootstrap, so refusing up-front is the only safe stance.
+    // Opt-out via --allow-nested-planning for legitimate workspace-root inits.
+    if (!args.allowNestedPlanning) {
+      const nested = detectNestedPlanningDirs(args.projectDir);
+      if (nested.length > 0) {
+        console.error(`Error: gsd-sdk init refused — found nested GSD project(s) in subdirectories of ${args.projectDir}:`);
+        for (const name of nested) {
+          console.error(`  - ${name}/.planning/`);
+        }
+        console.error('');
+        console.error('Did you mean to init from one of these subdirectories?');
+        const suggest = nested[0];
+        const inputHint = args.initInput ?? '[input]';
+        console.error(`  cd ${suggest} && gsd-sdk init ${inputHint}`);
+        console.error(`  # or, without changing directories:`);
+        console.error(`  gsd-sdk init ${inputHint} --project-dir ${join(args.projectDir, suggest)}`);
+        console.error('');
+        console.error('If you really intend to bootstrap a new project at the current level');
+        console.error('(creates a parallel .planning/ that may collide with nested projects),');
+        console.error('pass --allow-nested-planning.');
+        process.exitCode = 1;
+        return;
+      }
+    }
+
     let input: string;
     try {
       input = await resolveInitInput(args);


### PR DESCRIPTION
## Summary

Adds an SDK-level guard so `gsd-sdk init` refuses to bootstrap a project at a path whose immediate subdirectories contain their own `.planning/` directories — the dominant pattern that produces "init mutated my unrelated existing project" incidents.

Opt-out flag `--allow-nested-planning` preserves the existing behavior for legitimate workspace-root inits.

## Motivation — the contamination incident

A real-world failure on 2026-05-14 motivated this change. User invoked `gsd-sdk init "phase-op 29.3"` (a 13-character prompt) from `C:\workspace\` — the parent directory of `NAVIO_v3/`, where an active GSD project lived with hundreds of commits of `.planning/` history. Init proceeded for 21 minutes through 9 sub-sessions ($2.99) and mutated **both** locations before hitting max-turns:

| Location | Damage |
|---|---|
| `C:\workspace\.planning/` | Created from scratch (new PROJECT.md, REQUIREMENTS.md, research/) |
| `C:\workspace\.git/` | Created from scratch with 3 commits adding the above |
| `NAVIO_v3/.planning/PROJECT.md` | **145 lines deleted**, replaced with generic boilerplate (terminology from a different project schema — "32 reusable blocks", "User Profile" etc.) |
| `NAVIO_v3/.planning/ROADMAP.md` | Two fabricated `#### Phase N:` detail sections injected — invented features ("Momentum Pulse Block streak indicator") with invented requirement IDs (`LOOP-03`, `PROG-04`, `DATA-04`, `VALID-04`) |

The init agent logged its reasoning explicitly: *"The NAVIO_v3 edit was also valid"* — the decision to walk into a nested project's ROADMAP.md was a runtime judgment call. Combined with `defaultMode: bypassPermissions` in the user's Claude Code settings, nothing surfaced for confirmation. The user spotted it post-hoc when an unrelated session noticed the foreign vocabulary.

This is not a "user error" problem so much as a CLI design opportunity. The init flow already has enough information (the filesystem) to detect the wrong-CWD case and refuse before any mutation. Once init has started, the agent isn't well-positioned to decide whether a nested edit is legitimate.

## What changes

**`sdk/src/cli.ts`:**

- New exported helper `detectNestedPlanningDirs(projectDir): string[]`. Scans immediate subdirectories (depth 1) for `.planning/` directories. Skips dotdirs (`.git`, `.planning`) and `node_modules`. Returns `[]` rather than throwing on unreadable `projectDir` — the guard is advisory and should never harden into a different failure.
- New CLI flag `--allow-nested-planning` (default `false`). Parsed in both the strict `parseCliArgs` and the permissive `parseCliArgsQueryPermissive`. Threaded onto `ParsedCliArgs.allowNestedPlanning`.
- Guard call at the top of the `if (args.command === 'init')` branch — fires before `resolveInitInput`, so input resolution side effects don't run when the guard would have refused.
- `USAGE` updated to document the flag.

**Refusal output (example):**

```
$ gsd-sdk init "phase-op 29.3"
Error: gsd-sdk init refused — found nested GSD project(s) in subdirectories of C:\workspace:
  - NAVIO_v3/.planning/

Did you mean to init from one of these subdirectories?
  cd NAVIO_v3 && gsd-sdk init phase-op 29.3
  # or, without changing directories:
  gsd-sdk init phase-op 29.3 --project-dir C:\workspace\NAVIO_v3

If you really intend to bootstrap a new project at the current level
(creates a parallel .planning/ that may collide with nested projects),
pass --allow-nested-planning.
```

## Why a hard refuse rather than a warning

A warning would not have prevented the incident. The init flow runs in subprocess-spawned Claude Code sub-sessions with their own permissions context; the user is not interactively present per-step. Once the agent decides to proceed, it does. A refusal that requires an explicit `--allow-nested-planning` flag forces the operator to acknowledge the nested-project state and either re-CWD or sign off in writing.

## Why only immediate subdirectories (depth 1)

The vast majority of "wrong CWD" cases land you one level above the project root (workspace dir, home dir, etc.). Deeper scans (depth N) get expensive on large trees and produce noise (e.g., `node_modules/foo/.planning/` in vendored deps — already skipped here but the broader principle holds). The depth-1 check is a precise match for the common failure mode without false-positive risk.

## Why `node_modules` is skipped explicitly

Some dependencies (including this SDK's own consumers) ship `.planning/` directories as part of their `files` array. A user running `gsd-sdk init` inside their own project root with this SDK as a dep would otherwise be falsely refused.

## Test plan

- [x] 8 new unit tests for `detectNestedPlanningDirs` (empty/single/multiple/hidden-skip/node_modules-skip/regular-file-not-dir/unreadable-projectDir → [])
- [x] 4 new unit tests for `--allow-nested-planning` flag parsing (init / run / query / default-false)
- [x] 1 new USAGE assertion that the flag is documented
- [x] All 60 `cli.test.ts` tests pass (47 existing + 13 new)
- [x] `tsc --noEmit` clean
- [x] Manual verification on the contamination scenario: `cd C:\workspace && gsd-sdk init "test"` → refused with the message above; `gsd-sdk init "test" --allow-nested-planning` → proceeds past the guard
- [x] The 11 pre-existing unit failures in `query/skills`, `query/helpers`, `query/config-mutation`, `query/check-decision-coverage`, `query/phase-lifecycle`, `query/query-dispatch` were verified on a pristine checkout of `upstream/main` (`git checkout upstream/main -- sdk/src/cli.ts sdk/src/cli.test.ts` → same 11 fail). None are touched by this change.

## Followups (not in this PR — happy to do as separate PRs if accepted)

- Consider extending the same guard to `gsd-sdk auto` and `gsd-sdk auto --init` — same bootstrap surface, same risk.
- Consider a finer-grained variant that warns rather than refuses when the current `projectDir` itself already has a `.planning/` (suggests the user knows what they're doing) but a nested project also exists.
- Add a recovery hint to the existing `phase_found: false` error path pointing at the same root cause (CWD outside project root) — same incident class, just downstream.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--allow-nested-planning` CLI flag to override nested-directory checks during initialization.
  * CLI now detects and prevents initialization when nested `.planning/` directories are present in subdirectories.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3492)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->