### PR TITLE
fix: deterministic changelog extraction for /gsd:update

### DIFF
--- a/bin/extract-changelog.cjs
+++ b/bin/extract-changelog.cjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Extract changelog entries between two versions.
+ *
+ * Usage:
+ *   node extract-changelog.cjs --from <installed> --to <latest> [changelog-file]
+ *   curl -sL <url> | node extract-changelog.cjs --from <installed> --to <latest> -
+ *
+ * Reads from file arg (default: stdin), parses Keep-a-Changelog format,
+ * and prints only sections between --from (exclusive) and --to (inclusive).
+ * Exit 0 with output, exit 1 on usage error, exit 2 if no matching range found.
+ */
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+function parseArgs(argv) {
+  const args = { from: null, to: null, file: null };
+  const rest = argv.slice(2);
+  for (let i = 0; i < rest.length; i++) {
+    if (rest[i] === '--from' && rest[i + 1]) { args.from = rest[++i]; continue; }
+    if (rest[i] === '--to' && rest[i + 1]) { args.to = rest[++i]; continue; }
+    if (rest[i] === '--json') { args.json = true; continue; }
+    if (rest[i] === '--help' || rest[i] === '-h') {
+      console.log('Usage: extract-changelog.cjs --from <version> --to <version> [file|-]');
+      console.log('  Reads changelog from file or stdin, extracts entries between versions.');
+      process.exit(0);
+    }
+    args.file = rest[i];
+  }
+  if (!args.from || !args.to) {
+    console.error('Error: --from and --to are required');
+    process.exit(1);
+  }
+  return args;
+}
+
+function parseVersion(tag) {
+  const v = tag.replace(/^v/, '');
+  return v.split('.').map(Number);
+}
+
+function versionGt(a, b) {
+  const pa = parseVersion(a);
+  const pb = parseVersion(b);
+  for (let i = 0; i < 3; i++) {
+    if ((pa[i] || 0) > (pb[i] || 0)) return true;
+    if ((pa[i] || 0) < (pb[i] || 0)) return false;
+  }
+  return false;
+}
+
+function versionEq(a, b) {
+  const pa = parseVersion(a);
+  const pb = parseVersion(b);
+  return pa[0] === pb[0] && pa[1] === pb[1] && pa[2] === pb[2];
+}
+
+function extractSections(text, fromVersion, toVersion) {
+  const versionHeaderRe = /^## \[(\d+\.\d+\.\d+)\]/gm;
+  const sections = [];
+  let match;
+
+  while ((match = versionHeaderRe.exec(text)) !== null) {
+    sections.push({
+      version: match[1],
+      start: match.index,
+    });
+  }
+
+  if (sections.length === 0) {
+    return null;
+  }
+
+  for (let i = 0; i < sections.length; i++) {
+    sections[i].end = i + 1 < sections.length ? sections[i + 1].start : text.length;
+  }
+
+  const collected = [];
+  for (const section of sections) {
+    if (versionGt(section.version, fromVersion) && !versionGt(section.version, toVersion)) {
+      collected.push({
+        version: section.version,
+        content: text.slice(section.start, section.end).trimEnd(),
+      });
+    }
+  }
+
+  return collected;
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  let text;
+
+  if (args.file && args.file !== '-') {
+    text = fs.readFileSync(path.resolve(args.file), 'utf8');
+  } else {
+    text = fs.readFileSync(0, 'utf8');
+  }
+
+  const sections = extractSections(text, args.from, args.to);
+
+  if (!sections || sections.length === 0) {
+    if (args.json) {
+      console.log(JSON.stringify({ ok: false, versions: [], count: 0 }));
+    } else {
+      console.error(`No changelog entries found between v${args.from} and v${args.to}`);
+    }
+    process.exit(2);
+  }
+
+  if (args.json) {
+    console.log(JSON.stringify({
+      ok: true,
+      from: args.from.replace(/^v/, ''),
+      to: args.to.replace(/^v/, ''),
+      count: sections.length,
+      versions: sections.map(s => s.version),
+    }));
+    return;
+  }
+
+  for (let i = 0; i < sections.length; i++) {
+    if (i > 0) console.log('');
+    console.log(sections[i].content);
+  }
+}
+
+main();

--- a/get-shit-done/workflows/update.md
+++ b/get-shit-done/workflows/update.md
@@ -366,9 +366,26 @@ Exit.
 <step name="show_changes_and_confirm">
 **If update available**, fetch and show what's new BEFORE updating:
 
-1. Fetch changelog from GitHub raw URL
-2. Extract entries between installed and latest versions
-3. Display preview and ask for confirmation:
+Use the bundled `extract-changelog.cjs` script for deterministic changelog parsing.
+Do NOT attempt to parse the changelog text yourself — the script handles
+Keep-a-Changelog format with exact version-boundary matching.
+
+```bash
+CHANGELOG_URL="https://raw.githubusercontent.com/gsd-build/get-shit-done/main/CHANGELOG.md"
+CHANGELOG=$(curl -sL "$CHANGELOG_URL")
+EXTRACT_SCRIPT="$GSD_DIR/get-shit-done/bin/extract-changelog.cjs"
+
+if [ -f "$EXTRACT_SCRIPT" ]; then
+  CHANGES=$(echo "$CHANGELOG" | node "$EXTRACT_SCRIPT" --from "$INSTALLED_VERSION" --to "$LATEST_VERSION")
+  if [ $? -ne 0 ]; then
+    CHANGES="(Could not extract changelog — [View full changelog]($CHANGELOG_URL))"
+  fi
+else
+  CHANGES="(extract-changelog.cjs not found — [View full changelog]($CHANGELOG_URL))"
+fi
+```
+
+Display the extracted changes and ask for confirmation:
 
 ```
 ## GSD Update Available

--- a/tests/extract-changelog.test.cjs
+++ b/tests/extract-changelog.test.cjs
@@ -1,0 +1,132 @@
+'use strict';
+process.env.GSD_TEST_MODE = '1';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const cp = require('node:child_process');
+
+const ROOT = path.join(__dirname, '..');
+const SCRIPT = path.join(ROOT, 'bin', 'extract-changelog.cjs');
+
+function run(args, stdin = '') {
+  const result = cp.spawnSync('node', [SCRIPT, ...args], {
+    input: stdin,
+    timeout: 5000,
+    encoding: 'utf8',
+  });
+  return {
+    exitCode: result.status,
+    stdout: (result.stdout || '').trim(),
+    stderr: (result.stderr || '').trim(),
+  };
+}
+
+const SAMPLE_CHANGELOG = `# Changelog
+
+## [1.41.0] - 2026-01-10
+
+### Added
+- Feature A
+- Feature B
+
+### Fixed
+- Bug fix X
+
+## [1.39.1] - 2025-12-20
+
+### Fixed
+- Bug fix Y
+
+## [1.38.5] - 2025-12-15
+
+### Added
+- Feature C
+
+## [1.38.4] - 2025-12-10
+
+### Fixed
+- Bug fix Z
+
+## [1.38.2] - 2025-12-01
+
+### Added
+- Feature D
+
+## [1.37.1] - 2025-11-20
+
+### Fixed
+- Bug fix W
+`;
+
+describe('extract-changelog.cjs', () => {
+  test('extracts all versions in range (from exclusive, to inclusive)', () => {
+    const r = run(['--from', '1.37.1', '--to', '1.41.0'], SAMPLE_CHANGELOG);
+    assert.equal(r.exitCode, 0);
+    assert.ok(r.stdout.includes('[1.41.0]'), 'includes 1.41.0');
+    assert.ok(r.stdout.includes('[1.39.1]'), 'includes 1.39.1');
+    assert.ok(r.stdout.includes('[1.38.5]'), 'includes 1.38.5');
+    assert.ok(r.stdout.includes('[1.38.4]'), 'includes 1.38.4');
+    assert.ok(r.stdout.includes('[1.38.2]'), 'includes 1.38.2');
+    assert.ok(!r.stdout.includes('[1.37.1]'), 'excludes fromVersion');
+  });
+
+  test('single version range returns just that version', () => {
+    const r = run(['--from', '1.39.1', '--to', '1.41.0'], SAMPLE_CHANGELOG);
+    assert.equal(r.exitCode, 0);
+    assert.ok(r.stdout.includes('[1.41.0]'));
+    assert.ok(!r.stdout.includes('[1.39.1]'));
+    assert.ok(!r.stdout.includes('[1.38.5]'));
+  });
+
+  test('exit 2 when no versions match the range', () => {
+    const r = run(['--from', '2.0.0', '--to', '3.0.0'], SAMPLE_CHANGELOG);
+    assert.equal(r.exitCode, 2);
+  });
+
+  test('--json returns structured output', () => {
+    const r = run(['--from', '1.37.1', '--to', '1.41.0', '--json'], SAMPLE_CHANGELOG);
+    assert.equal(r.exitCode, 0);
+    const parsed = JSON.parse(r.stdout);
+    assert.equal(parsed.ok, true);
+    assert.equal(parsed.from, '1.37.1');
+    assert.equal(parsed.to, '1.41.0');
+    assert.equal(parsed.count, 5);
+    assert.deepEqual(parsed.versions, ['1.41.0', '1.39.1', '1.38.5', '1.38.4', '1.38.2']);
+  });
+
+  test('--json returns ok:false when no match', () => {
+    const r = run(['--from', '2.0.0', '--to', '3.0.0', '--json'], SAMPLE_CHANGELOG);
+    assert.equal(r.exitCode, 2);
+    const parsed = JSON.parse(r.stdout);
+    assert.equal(parsed.ok, false);
+    assert.equal(parsed.count, 0);
+  });
+
+  test('exit 1 when --from or --to missing', () => {
+    const r1 = run(['--to', '1.41.0'], SAMPLE_CHANGELOG);
+    assert.equal(r1.exitCode, 1);
+
+    const r2 = run(['--from', '1.37.1'], SAMPLE_CHANGELOG);
+    assert.equal(r2.exitCode, 1);
+  });
+
+  test('equal from and to returns nothing (from is exclusive)', () => {
+    const r = run(['--from', '1.41.0', '--to', '1.41.0'], SAMPLE_CHANGELOG);
+    assert.equal(r.exitCode, 2);
+  });
+
+  test('strips leading v from version arguments', () => {
+    const r = run(['--from', 'v1.37.1', '--to', 'v1.39.1'], SAMPLE_CHANGELOG);
+    assert.equal(r.exitCode, 0);
+    assert.ok(r.stdout.includes('[1.38.2]'));
+    assert.ok(r.stdout.includes('[1.38.4]'));
+    assert.ok(r.stdout.includes('[1.38.5]'));
+  });
+
+  test('--help prints usage and exits 0', () => {
+    const r = run(['--help']);
+    assert.equal(r.exitCode, 0);
+    assert.ok(r.stdout.includes('Usage:'));
+  });
+});


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #3496

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

`/gsd:update` changelog extraction on the current line was not deterministic and could miss intermediate release sections between the installed version and the target/latest version.

## What this fix does

Adds a dedicated range-aware helper and routes `/gsd:update` through it so changelog extraction consistently returns every matching section from `(from, to]`.

## Root cause

The update workflow relied on vague/manual changelog parsing instead of a deterministic version-range extractor with explicit boundary semantics.

## Testing

### How I verified the fix

- Added a regression test first in `tests/extract-changelog.test.cjs`
- Confirmed it failed before implementation because the helper did not exist
- Implemented `bin/extract-changelog.cjs`
- Re-ran `node --test tests/extract-changelog.test.cjs` and it passed
- Manually verified helper behavior against the repo `CHANGELOG.md` for:
  - normal extraction range
  - `--json` mode
  - `v`-prefixed version args
  - no-match behavior returning exit code `2`
- Ran `npm test -- --grep extract-changelog`; the suite still hits unrelated pre-existing failures in `tests/code-review.test.cjs` and `tests/skill-manifest.test.cjs`

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: Node.js helper + workflow path on macOS
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [ ] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None
