### PR TITLE
fix(state,phase,roadmap): sync all phase-status display surfaces on complete-phase

### DIFF
--- a/.changeset/lively-geese-greet.md
+++ b/.changeset/lively-geese-greet.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3498
+---
+**`state complete-phase` now syncs all phase-status display surfaces** — previously only updated Status / Last activity scalars, leaving the milestone phase-queue table inside STATE.md, the `## Current Position` progress line + ASCII bar, and the `.planning/ROADMAP.md` Progress Table all stuck on "Not started" / "In Progress" forever. Same fix mirrored into `phase complete` for parity. Pre-existing checkbox-suffix duplication on repeated `roadmap update-plan-progress` calls also fixed (`(completed DATE)` no longer accumulates).

--- a/get-shit-done/bin/lib/phase.cjs
+++ b/get-shit-done/bin/lib/phase.cjs
@@ -8,7 +8,7 @@ const { escapeRegex, loadConfig, normalizePhaseName, comparePhaseNum, findPhaseI
 const { platformWriteSync, platformReadSync, platformEnsureDir } = require('./shell-command-projection.cjs');
 const { planningDir, withPlanningLock } = require('./planning-workspace.cjs');
 const { extractFrontmatter } = require('./frontmatter.cjs');
-const { writeStateMd, readModifyWriteStateMd, stateExtractField, stateReplaceField, stateReplaceFieldWithFallback, updatePerformanceMetricsSection } = require('./state.cjs');
+const { writeStateMd, readModifyWriteStateMd, stateExtractField, stateReplaceField, stateReplaceFieldWithFallback, updatePerformanceMetricsSection, markPhaseQueueRowComplete, updateCurrentPositionPhaseProgress, countMilestonePhasesOnDisk } = require('./state.cjs');
 
 // #2893 — strict canonical filter: `{padded_phase}-{NN}-PLAN.md` or `PLAN.md`.
 // Documented in agents/gsd-planner.md (write_phase_prompt step). The wider
@@ -1274,6 +1274,18 @@ function cmdPhaseComplete(cwd, phaseNum, raw) {
 
       // Gate 4: Update Performance Metrics section (#1627)
       stateContent = updatePerformanceMetricsSection(stateContent, cwd, phaseNum, planCount, summaryCount);
+
+      // Mark the just-completed phase row as Complete in any milestone phase-queue
+      // table inside STATE.md. Idempotent — already-complete rows keep their date.
+      stateContent = markPhaseQueueRowComplete(stateContent, phaseNum, today);
+
+      // Refresh "Progress: X/Y phases complete (P%)" + ASCII bar inside the
+      // ## Current Position section from disk truth so display surfaces stay
+      // in lockstep with the frontmatter progress block.
+      const { totalPhases: discPhases, completedPhases: discComplete } = countMilestonePhasesOnDisk(cwd);
+      if (discPhases > 0) {
+        stateContent = updateCurrentPositionPhaseProgress(stateContent, discComplete, discPhases);
+      }
 
       return stateContent;
     }, cwd);

--- a/get-shit-done/bin/lib/roadmap.cjs
+++ b/get-shit-done/bin/lib/roadmap.cjs
@@ -387,13 +387,18 @@ function cmdRoadmapUpdatePlanProgress(cwd, phaseNum, raw) {
       : `${summaryCount}/${planCount} plans executed`;
     roadmapContent = replaceInCurrentMilestone(roadmapContent, planCountPattern, `$1${planCountText}`);
 
-    // If complete: check checkbox
+    // If complete: check checkbox. Strip any pre-existing "(completed DATE)"
+    // suffix before appending today's date so repeated runs stay idempotent
+    // and don't accumulate duplicate suffixes.
     if (isComplete) {
       const checkboxPattern = new RegExp(
-        `(-\\s*\\[)[ ](\\]\\s*.*Phase\\s+${phasePattern}[:\\s][^\\n]*)`,
+        `(-\\s*\\[)[ ](\\]\\s*.*Phase\\s+${phasePattern}[:\\s])([^\\n]*)`,
         'i'
       );
-      roadmapContent = replaceInCurrentMilestone(roadmapContent, checkboxPattern, `$1x$2 (completed ${today})`);
+      roadmapContent = replaceInCurrentMilestone(roadmapContent, checkboxPattern, (_m, p1, p2, tail) => {
+        const trimmedTail = tail.replace(/\s*\(completed\s+\d{4}-\d{2}-\d{2}\)\s*$/i, '');
+        return `${p1}x${p2}${trimmedTail} (completed ${today})`;
+      });
     }
 
     // Mark completed plan checkboxes (e.g. "- [ ] 50-01-PLAN.md", "- [ ] 50-01:", or "- [ ] **50-01**")

--- a/get-shit-done/bin/lib/state.cjs
+++ b/get-shit-done/bin/lib/state.cjs
@@ -4,7 +4,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { escapeRegex, loadConfig, getMilestoneInfo, getMilestonePhaseFilter, output, error } = require('./core.cjs');
+const { escapeRegex, loadConfig, getMilestoneInfo, getMilestonePhaseFilter, output, error, findPhaseInternal } = require('./core.cjs');
 const { platformWriteSync, platformReadSync, platformEnsureDir } = require('./shell-command-projection.cjs');
 const { planningDir, planningPaths } = require('./planning-workspace.cjs');
 const { extractFrontmatter, reconstructFrontmatter } = require('./frontmatter.cjs');
@@ -265,6 +265,129 @@ function updateCurrentPositionFields(content, fields) {
   }
 
   return content.replace(posPattern, () => `${posMatch[1]}${posBody}`);
+}
+
+/**
+ * Mark a phase row as Complete in any "phase queue" / status table inside STATE.md.
+ *
+ * Finds markdown-table rows whose first non-empty cell is exactly the phase number
+ * (with optional leading zeros and whitespace) and replaces the last cell with
+ * `Complete (YYYY-MM-DD)`. Idempotent: rows whose last cell already starts with
+ * "Complete" are left untouched so the original completion date is preserved.
+ * Header separator rows (e.g. `| --- |`) are skipped.
+ *
+ * Closes the gap where state complete-phase only updated the Status / Last
+ * activity scalars but left the human-facing phase queue table stuck on
+ * "Not started" — a recurring source of stale roadmap displays.
+ */
+function markPhaseQueueRowComplete(content, phaseNum, today) {
+  if (!phaseNum) return content;
+  const phaseEsc = escapeRegex(String(phaseNum));
+  const rowPattern = new RegExp(`^\\|\\s*0*${phaseEsc}\\s*\\|.*$`, 'gm');
+  return content.replace(rowPattern, (row) => {
+    const cells = row.split('|');
+    if (cells.length < 4) return row;
+    const realCells = cells.slice(1, -1);
+    if (realCells.every((c) => /^[\s:-]+$/.test(c))) return row;
+    const lastIdx = cells.length - 2;
+    const lastCell = cells[lastIdx].trim();
+    if (/^complete\b/i.test(lastCell)) return row;
+    cells[lastIdx] = ` Complete (${today}) `;
+    return cells.join('|');
+  });
+}
+
+/**
+ * Update the `Progress: X/Y phases complete (P%)` line and the adjacent fenced
+ * ASCII progress bar inside the `## Current Position` section of STATE.md so
+ * they reflect the disk-derived phase completion count.
+ *
+ * Bar width is preserved when an existing fenced bar is found; otherwise no bar
+ * is added. Returns the content unchanged when no Current Position section
+ * exists or when neither the progress line nor a bar are present.
+ */
+function updateCurrentPositionPhaseProgress(content, completedPhases, totalPhases) {
+  if (!Number.isFinite(totalPhases) || totalPhases <= 0) return content;
+  if (!Number.isFinite(completedPhases) || completedPhases < 0) return content;
+
+  const percent = Math.min(100, Math.round((completedPhases / totalPhases) * 100));
+
+  const posPattern = /(##\s*Current Position\s*\n)([\s\S]*?)(?=\n##|$)/i;
+  const posMatch = content.match(posPattern);
+  if (!posMatch) return content;
+
+  let posBody = posMatch[2];
+  let mutated = false;
+
+  // Progress: X/Y phases complete (P%)
+  const progressLinePattern = /^Progress:\s*\d+\s*\/\s*\d+\s+phases\s+complete\s*\(\s*\d+%\s*\)\s*$/im;
+  if (progressLinePattern.test(posBody)) {
+    posBody = posBody.replace(
+      progressLinePattern,
+      `Progress: ${completedPhases}/${totalPhases} phases complete (${percent}%)`
+    );
+    mutated = true;
+  }
+
+  // Fenced ASCII bar like:
+  //   ```
+  //   [████░░░░░░] 80%
+  //   ```
+  // Preserve existing width by counting current fill+empty chars.
+  const fencedBarPattern = /(```\s*\r?\n)\[([█░]+)\]\s+\d+%(\s*\r?\n```)/;
+  const fencedBarMatch = posBody.match(fencedBarPattern);
+  if (fencedBarMatch) {
+    const barWidth = fencedBarMatch[2].length || 20;
+    const filled = Math.round((percent / 100) * barWidth);
+    const bar = '█'.repeat(filled) + '░'.repeat(Math.max(0, barWidth - filled));
+    posBody = posBody.replace(
+      fencedBarPattern,
+      (_m, open, _oldBar, close) => `${open}[${bar}] ${percent}%${close}`
+    );
+    mutated = true;
+  }
+
+  if (!mutated) return content;
+  return content.replace(posPattern, () => `${posMatch[1]}${posBody}`);
+}
+
+/**
+ * Count completed phases in the current milestone from disk.
+ *
+ * Returns `{ totalPhases, completedPhases }`. A phase counts as complete when
+ * its directory has at least one PLAN file and the SUMMARY count is >= the
+ * PLAN count. Phases without any PLAN files (e.g. not-yet-planned future
+ * phases) are not counted as complete. `totalPhases` is the count declared by
+ * the milestone filter when available, otherwise the on-disk directory count.
+ *
+ * Falls back to `{ totalPhases: 0, completedPhases: 0 }` on any read error so
+ * callers can guard with `totalPhases > 0` before computing percentages.
+ */
+function countMilestonePhasesOnDisk(cwd) {
+  try {
+    const phasesDir = planningPaths(cwd).phases;
+    if (!fs.existsSync(phasesDir)) return { totalPhases: 0, completedPhases: 0 };
+
+    const isDirInMilestone = getMilestonePhaseFilter(cwd);
+    const phaseDirs = fs.readdirSync(phasesDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory()).map((e) => e.name)
+      .filter(isDirInMilestone);
+
+    let completedPhases = 0;
+    for (const dir of phaseDirs) {
+      const files = fs.readdirSync(path.join(phasesDir, dir));
+      const plans = files.filter((f) => /-PLAN\.md$/i.test(f)).length;
+      const summaries = files.filter((f) => /-SUMMARY\.md$/i.test(f)).length;
+      if (plans > 0 && summaries >= plans) completedPhases++;
+    }
+
+    const declared = isDirInMilestone && isDirInMilestone.phaseCount > 0
+      ? isDirInMilestone.phaseCount : 0;
+    const totalPhases = Math.max(phaseDirs.length, declared);
+    return { totalPhases, completedPhases };
+  } catch {
+    return { totalPhases: 0, completedPhases: 0 };
+  }
 }
 
 function cmdStateAdvancePlan(cwd, raw) {
@@ -1854,8 +1977,42 @@ function cmdStateCompletePhase(cwd, raw, overridePhase) {
       updated.push('Current Position');
     }
 
+    // Mark the phase row complete in any milestone phase-queue table.
+    // Idempotent — already-Complete rows preserve their original date.
+    const beforeQueue = content;
+    content = markPhaseQueueRowComplete(content, currentPhase, today);
+    if (content !== beforeQueue) updated.push('Phase Queue Row');
+
+    // Refresh Current Position "Progress: X/Y phases complete (P%)" + ASCII bar
+    // from disk truth. Invalidate the disk-scan cache first because the just-
+    // marked-complete phase may have had its final SUMMARY committed during
+    // this same process.
+    _diskScanCache.delete(cwd);
+    const { totalPhases, completedPhases } = countMilestonePhasesOnDisk(cwd);
+    if (totalPhases > 0) {
+      const beforeProgress = content;
+      content = updateCurrentPositionPhaseProgress(content, completedPhases, totalPhases);
+      if (content !== beforeProgress) updated.push('Current Position Progress');
+    }
+
     return content;
   }, cwd);
+
+  // Also update .planning/ROADMAP.md so the human-facing Progress Table and
+  // phase checkbox stay in lockstep with STATE.md. Without this, the verify-work
+  // manual mark-complete path leaves the roadmap stuck on "In Progress" while
+  // STATE.md says complete. Skip silently when the phase has no on-disk
+  // directory (state-only test fixtures, parallel mid-restructure repos): the
+  // roadmap updater calls error() which would terminate the process otherwise.
+  if (findPhaseInternal(cwd, resolvedPhase)) {
+    try {
+      const { cmdRoadmapUpdatePlanProgress } = require('./roadmap.cjs');
+      cmdRoadmapUpdatePlanProgress(cwd, resolvedPhase, true);
+      updated.push('Roadmap Progress Table');
+    } catch (e) {
+      process.stderr.write(`[gsd-tools] WARNING: roadmap update skipped after complete-phase: ${e.message}\n`);
+    }
+  }
 
   output(
     { updated, phase: resolvedPhase },
@@ -1871,6 +2028,9 @@ module.exports = {
   writeStateMd,
   readModifyWriteStateMd,
   updatePerformanceMetricsSection,
+  markPhaseQueueRowComplete,
+  updateCurrentPositionPhaseProgress,
+  countMilestonePhasesOnDisk,
   cmdStateLoad,
   cmdStateGet,
   cmdStatePatch,

--- a/tests/state-complete-phase-syncs-display-surfaces.test.cjs
+++ b/tests/state-complete-phase-syncs-display-surfaces.test.cjs
@@ -1,0 +1,214 @@
+/**
+ * Regression: state complete-phase must keep STATE.md and ROADMAP.md display
+ * surfaces in lockstep with the frontmatter, not just update Status / Last
+ * activity scalars.
+ *
+ * Surfaces verified:
+ *   1. STATE.md milestone phase-queue table → row marked Complete (DATE)
+ *   2. STATE.md ## Current Position progress line → "Progress: X/Y phases
+ *      complete (P%)" recomputed from disk truth
+ *   3. STATE.md ## Current Position fenced ASCII bar → bar fill matches percent
+ *   4. .planning/ROADMAP.md Progress Table row → Plans column + Status +
+ *      Completed date all updated via cmdRoadmapUpdatePlanProgress
+ *   5. .planning/ROADMAP.md phase checkbox → `[x]` + single (completed DATE)
+ *      suffix even on repeated runs
+ *
+ * Pre-fix: state complete-phase only touched Status / Last activity. The
+ * phase-queue table, the Current Position progress + bar, and the
+ * .planning/ROADMAP.md Progress Table all stayed stale forever.
+ */
+
+'use strict';
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { execFileSync } = require('node:child_process');
+
+const gsdTools = path.resolve(__dirname, '..', 'get-shit-done', 'bin', 'gsd-tools.cjs');
+
+function runState(args, cwd) {
+  return execFileSync('node', [gsdTools, 'state', ...args], {
+    cwd,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+}
+
+function writePhase(planningDir, phaseDirName, planCount, summaryCount) {
+  const phaseDir = path.join(planningDir, 'phases', phaseDirName);
+  fs.mkdirSync(phaseDir, { recursive: true });
+  for (let i = 1; i <= planCount; i++) {
+    const num = String(i).padStart(2, '0');
+    fs.writeFileSync(
+      path.join(phaseDir, `${phaseDirName.split('-')[0]}-${num}-PLAN.md`),
+      `---\nphase: ${phaseDirName.split('-')[0]}\nplan: ${i}\n---\n# Plan ${i}\n`
+    );
+  }
+  for (let i = 1; i <= summaryCount; i++) {
+    const num = String(i).padStart(2, '0');
+    fs.writeFileSync(
+      path.join(phaseDir, `${phaseDirName.split('-')[0]}-${num}-SUMMARY.md`),
+      `---\nstatus: complete\n---\n# Summary ${i}\n`
+    );
+  }
+}
+
+describe('state complete-phase syncs display surfaces', () => {
+  let tmpDir;
+  let planningDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-complete-display-'));
+    planningDir = path.join(tmpDir, '.planning');
+    fs.mkdirSync(planningDir, { recursive: true });
+
+    fs.writeFileSync(
+      path.join(planningDir, 'config.json'),
+      JSON.stringify({ project_code: 'TEST' })
+    );
+
+    fs.writeFileSync(
+      path.join(planningDir, 'STATE.md'),
+      `---
+gsd_state_version: 1.0
+milestone: v1.0
+current_phase: 2
+status: executing
+progress:
+  total_phases: 3
+  completed_phases: 0
+  total_plans: 5
+  completed_plans: 0
+  percent: 0
+---
+
+# State
+
+## v1.0 phase queue
+
+| # | Phase | REQ-IDs | Status |
+|---|-------|---------|--------|
+| 1 | Foundation | FOUND-01 | Not started |
+| 2 | Auth | AUTH-01 | Not started |
+| 3 | Polish | POLISH-01 | Not started |
+
+## Current Position
+
+Phase: 2 — IN PROGRESS
+Plan: 1 of 2
+Status: Executing Phase 2
+Progress: 0/3 phases complete (0%)
+
+\`\`\`
+[░░░░░░░░░░░░░░░░░░░░] 0%
+\`\`\`
+
+Last activity: 2026-01-01 -- started Phase 2
+`
+    );
+
+    fs.writeFileSync(
+      path.join(planningDir, 'ROADMAP.md'),
+      `# Roadmap
+
+## v1.0
+
+- [ ] **Phase 1: Foundation** — base scaffold
+- [ ] **Phase 2: Auth** — login flow
+- [ ] **Phase 3: Polish** — final tidy
+
+### Phase 1: Foundation
+
+**Plans:** 0/1 plans planned
+
+### Phase 2: Auth
+
+**Plans:** 0/2 plans planned
+
+### Phase 3: Polish
+
+**Plans:** 0/2 plans planned
+
+## Progress Table
+
+| Phase | Plans | Status | Completed |
+|-------|-------|--------|-----------|
+| 1. Foundation | 0/1 | Planned     |            |
+| 2. Auth | 0/2 | Planned     |            |
+| 3. Polish | 0/2 | Planned     |            |
+`
+    );
+
+    writePhase(planningDir, '01-foundation', 1, 1);
+    writePhase(planningDir, '02-auth', 2, 2);
+    writePhase(planningDir, '03-polish', 2, 0);
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test('marks phase queue row Complete with date', () => {
+    runState(['complete-phase', '--phase', '2'], tmpDir);
+    const state = fs.readFileSync(path.join(planningDir, 'STATE.md'), 'utf-8');
+    const today = new Date().toISOString().split('T')[0];
+    assert.match(state, new RegExp(`\\| 2 \\| Auth \\| AUTH-01 \\| Complete \\(${today}\\) \\|`));
+    assert.match(state, /\| 1 \| Foundation \| FOUND-01 \| Not started \|/);
+  });
+
+  test('refreshes Current Position progress line and ASCII bar from disk truth', () => {
+    runState(['complete-phase', '--phase', '2'], tmpDir);
+    const state = fs.readFileSync(path.join(planningDir, 'STATE.md'), 'utf-8');
+    // 2 of 3 phases complete on disk (Phase 1 = 1/1, Phase 2 = 2/2; Phase 3 = 0/2 doesn't count) → 67%
+    assert.match(state, /Progress: 2\/3 phases complete \(67%\)/);
+    // Bar must reflect 67% across 20 chars → 13 filled
+    assert.match(state, /\[█{13}░{7}\] 67%/);
+  });
+
+  test('updates .planning/ROADMAP.md Progress Table + checkbox', () => {
+    runState(['complete-phase', '--phase', '2'], tmpDir);
+    const roadmap = fs.readFileSync(path.join(planningDir, 'ROADMAP.md'), 'utf-8');
+    const today = new Date().toISOString().split('T')[0];
+    assert.match(roadmap, new RegExp(`\\| 2\\. Auth \\| 2/2 \\| Complete\\s+\\| ${today} \\|`));
+    assert.match(roadmap, new RegExp(`- \\[x\\] \\*\\*Phase 2: Auth\\*\\* — login flow \\(completed ${today}\\)`));
+  });
+
+  test('repeated runs are idempotent (no duplicate completed-date suffix)', () => {
+    runState(['complete-phase', '--phase', '2'], tmpDir);
+    runState(['complete-phase', '--phase', '2'], tmpDir);
+    runState(['complete-phase', '--phase', '2'], tmpDir);
+    const roadmap = fs.readFileSync(path.join(planningDir, 'ROADMAP.md'), 'utf-8');
+    const today = new Date().toISOString().split('T')[0];
+    // Exactly one "(completed DATE)" — not three.
+    const matches = roadmap.match(new RegExp(`Phase 2: Auth\\*\\* — login flow \\(completed ${today}\\)`, 'g'));
+    assert.equal(matches.length, 1);
+    assert.doesNotMatch(roadmap, /\(completed \d{4}-\d{2}-\d{2}\) \(completed/);
+    // STATE.md queue row keeps the original date — second run must not bump it.
+    const state = fs.readFileSync(path.join(planningDir, 'STATE.md'), 'utf-8');
+    const stateMatches = state.match(new RegExp(`\\(${today}\\)`, 'g'));
+    assert.ok(stateMatches.length >= 1);
+  });
+
+  test('skips phases without PLAN files when computing progress', () => {
+    // Phase 3 has 0 plans on disk — must not be counted as complete despite
+    // satisfying summaries >= plans (0 >= 0).
+    runState(['complete-phase', '--phase', '2'], tmpDir);
+    const state = fs.readFileSync(path.join(planningDir, 'STATE.md'), 'utf-8');
+    assert.match(state, /Progress: 2\/3 phases complete \(67%\)/);
+    assert.doesNotMatch(state, /Progress: 3\/3/);
+  });
+
+  test('queue table left untouched when row already marked Complete', () => {
+    runState(['complete-phase', '--phase', '2'], tmpDir);
+    const firstRun = fs.readFileSync(path.join(planningDir, 'STATE.md'), 'utf-8');
+    const firstDateMatch = firstRun.match(/\| 2 \| Auth \| AUTH-01 \| Complete \((\d{4}-\d{2}-\d{2})\) \|/);
+    assert.ok(firstDateMatch, 'first run should set a date');
+
+    runState(['complete-phase', '--phase', '2'], tmpDir);
+    const secondRun = fs.readFileSync(path.join(planningDir, 'STATE.md'), 'utf-8');
+    assert.match(secondRun, new RegExp(`\\| 2 \\| Auth \\| AUTH-01 \\| Complete \\(${firstDateMatch[1]}\\) \\|`));
+  });
+});


### PR DESCRIPTION
## Problem

`state complete-phase` (called by the verify-work auto-transition path) and `phase complete` (called by the transition.md auto-advance path) updated only the Status / Last activity scalars and the `Phase:` line inside `## Current Position`. **Four other surfaces that all answer the same "is this phase done?" question were left silently stale forever:**

1. STATE.md milestone phase-queue table — rows like `| 14 | PII Encryption | … | Not started |` never flipped to Complete
2. STATE.md `## Current Position` `Progress: X/Y phases complete (P%)` line
3. STATE.md `## Current Position` fenced ASCII progress bar
4. `.planning/ROADMAP.md` Progress Table row + phase checkbox (only updated when `phase complete` ran, not when `state complete-phase` ran)

Result: STATE.md frontmatter says `status: completed, completed_phases: 3` while the queue table four lines below says the same phase is `Not started`. Every milestone accumulates this drift; humans manually patch it commit-by-commit.

This was reported as: "the root ROADMAP keeps going out of date — fix it so this doesn't keep happening." The structural fix is to close the gap at the chokepoint, not patch the data.

## Solution

Add three new exported helpers in `bin/lib/state.cjs`:

| Helper | Responsibility |
|--------|----------------|
| `markPhaseQueueRowComplete(content, phaseNum, today)` | Find any markdown-table row whose first cell is exactly the phase number and rewrite the last cell to \`Complete (DATE)\`. **Idempotent** — rows whose last cell already starts with "Complete" are preserved (original date kept). Header separator rows (\`\| --- \|\`) are skipped. |
| \`updateCurrentPositionPhaseProgress(content, completedPhases, totalPhases)\` | Rewrite the \`Progress: X/Y phases complete (P%)\` line and the fenced ASCII bar inside \`## Current Position\`. Bar width is preserved when an existing bar is found. |
| \`countMilestonePhasesOnDisk(cwd)\` | Returns \`{ totalPhases, completedPhases }\` by scanning phase dirs in the current milestone (via \`getMilestonePhaseFilter\`). A phase counts as complete when \`plans > 0 && summaries >= plans\`. |

Wire them into both \`cmdStateCompletePhase\` (state.cjs) **and** \`cmdPhaseComplete\` (phase.cjs) so both code paths keep all surfaces in sync. \`cmdStateCompletePhase\` also calls \`cmdRoadmapUpdatePlanProgress\` so \`.planning/ROADMAP.md\` updates via the verify-work path. The roadmap call is **guarded by \`findPhaseInternal()\`** because the roadmap updater calls \`error()\` (= \`process.exit(1)\`) when a phase has no on-disk directory — state-only test fixtures and parallel mid-restructure repos must not be killed by a state mutation.

### Bonus fix

Pre-existing idempotency bug in \`cmdRoadmapUpdatePlanProgress\`: the phase-checkbox replacement appended \`(completed DATE)\` even when the line already had the suffix, so repeated runs accumulated \`(completed 2026-05-14) (completed 2026-05-14) (completed 2026-05-14)\`. Now strips any trailing \`(completed YYYY-MM-DD)\` from the checkbox tail before appending today's date. This is exposed more often by the new state→roadmap call path, so worth fixing now.

## Tests

New regression suite at \`tests/state-complete-phase-syncs-display-surfaces.test.cjs\` (6 cases):

1. ✓ marks phase queue row Complete with date
2. ✓ refreshes Current Position progress line and ASCII bar from disk truth
3. ✓ updates .planning/ROADMAP.md Progress Table + checkbox
4. ✓ repeated runs are idempotent (no duplicate completed-date suffix)
5. ✓ skips phases without PLAN files when computing progress
6. ✓ queue table left untouched when row already marked Complete

\`\`\`
ℹ tests 9095
ℹ pass 9095
ℹ fail 0
\`\`\`

## Out of scope

- The \`progress.completed_phases\` / \`progress.percent\` frontmatter updater already worked via \`syncStateFrontmatter\` calling \`buildStateFrontmatter\`. Not changed.
- The root \`/ROADMAP.md\` (project-specific human-curated chronological feature log) is not auto-maintained; only \`.planning/ROADMAP.md\` is treated as a structured artefact.

## Backwards compatibility

- All new behaviour is additive. \`cmdStateCompletePhase\` returns the same JSON shape, just with extra entries in \`updated[]\` (\`Phase Queue Row\`, \`Current Position Progress\`, \`Roadmap Progress Table\`).
- The roadmap-update guard via \`findPhaseInternal\` preserves existing behaviour for state-only fixtures: when no phase dir exists on disk, the roadmap update is silently skipped (state still updates as before). All 124 pre-existing state/phase/roadmap tests pass.

## Changeset

\`.changeset/lively-geese-greet.md\` adds a Fixed-type fragment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * `state complete-phase` now synchronizes all progress displays consistently across phase queues, progress summaries, ASCII progress bars, roadmap checkboxes, and activity timestamps.
  * Fixed duplicate completion date suffixes accumulating on repeated roadmap update operations.

* **Tests**
  * Added regression test coverage to verify consistent synchronization across all completion-related displays.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3498)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->