### PR TITLE
fix(sdk): make state.complete-phase idempotent (#3489)

### DIFF
--- a/.changeset/3489-complete-phase-idempotent.md
+++ b/.changeset/3489-complete-phase-idempotent.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3489
+---
+**`state complete-phase` is now idempotent — re-invocation no longer rolls STATE.md back.** Previously, running `gsd-sdk query state.complete-phase --phase <N>` (or `gsd state complete-phase --phase <N>`) a second time on a phase that was already marked complete silently rewound STATE.md to that phase's moment-of-completion, clobbering `Status`, `Last Activity`, `Last Activity Description`, and the `## Current Position` body. Any downstream consumer trusting STATE.md (`/gsd-progress`, planner, the next phase's discuss-phase context loader) was routed back to the rolled-back phase. The handler now reads STATE.md before writing: if the canonical `Current Phase` field already names a phase distinct from the one being completed, the project has clearly advanced past it and the handler returns a no-op (`{ updated: [], phase: "<N>", idempotent: true, note: "phase already superseded; no-op" }`) without touching STATE.md. (#3489)

--- a/get-shit-done/bin/lib/state.cjs
+++ b/get-shit-done/bin/lib/state.cjs
@@ -1805,6 +1805,27 @@ function cmdStateCompletePhase(cwd, raw, overridePhase) {
     return;
   }
 
+  // Idempotency guard (#3489). If STATE.md's canonical `Current Phase` field
+  // already names a phase distinct from the one we are being asked to mark
+  // complete, the project has advanced past the requested phase (e.g. a
+  // follow-up phase was inserted, or the next phase began). Re-running
+  // `state complete-phase --phase <N>` in that situation previously rolled
+  // STATE.md back to <N>'s moment-of-completion — silently clobbering Status,
+  // Last Activity, Last Activity Description, and the Current Position body.
+  // The handler is now a no-op in that case so re-invocation from downstream
+  // workflows cannot regress the project state.
+  const existingCurrentPhaseRaw = stateExtractField(content, 'Current Phase') || '';
+  const existingCurrentPhaseMatch = String(existingCurrentPhaseRaw).match(/(\d+[A-Z]?(?:\.\d+)*)/i);
+  const existingCurrentPhase = existingCurrentPhaseMatch ? existingCurrentPhaseMatch[1] : null;
+  if (existingCurrentPhase && existingCurrentPhase !== resolvedPhase) {
+    output(
+      { updated: [], phase: resolvedPhase, idempotent: true, note: 'phase already superseded; no-op' },
+      raw,
+      'false',
+    );
+    return;
+  }
+
   const today = new Date().toISOString().split('T')[0];
   const updated = [];
 

--- a/tests/bug-3489-complete-phase-idempotent.test.cjs
+++ b/tests/bug-3489-complete-phase-idempotent.test.cjs
@@ -1,0 +1,124 @@
+'use strict';
+
+// allow-test-rule: source-text-is-the-product
+// State.md is the deployed artifact; asserting on its literal text content
+// tests the deployed contract.
+
+/**
+ * Regression test for #3489
+ *
+ *   `gsd state complete-phase --phase <N>` was non-idempotent. Re-invoking it
+ *   on a phase already marked complete in STATE.md silently rolled STATE.md
+ *   back to that phase's moment-of-completion — overwriting Status, Last
+ *   Activity, Current Position and the body Status/Phase with stale values
+ *   derived from the just-completed phase.
+ *
+ *   Expected: when the target phase is already marked complete (and STATE.md
+ *   has clearly advanced past it — e.g. a later phase is now in progress or
+ *   inserted), `complete-phase` must be a no-op. No STATE.md write at all.
+ */
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { createTempProject, cleanup, runGsdTools } = require('./helpers.cjs');
+
+describe('bug #3489: state complete-phase must be idempotent', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject('bug-3489-');
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('re-running complete-phase on an already-complete phase does not roll STATE.md back', () => {
+    // STATE.md as it would appear AFTER phase 02.2 was legitimately completed
+    // AND a follow-up Phase 02.2.1 has since been inserted as in-progress.
+    // Re-invoking `state complete-phase --phase 02.2` from a downstream tool
+    // (e.g. a re-run of /gsd-execute-phase) must NOT regress this content.
+    const stateMd = [
+      '---',
+      'milestone: v1.0',
+      '---',
+      '',
+      '# State',
+      '',
+      '**Status:** in-progress',
+      '**Current Phase:** 02.2.1',
+      '**Last Activity:** 2026-05-13',
+      '**Last Activity Description:** Phase 02.2.1 inserted (urgent — gates Phase 5)',
+      '',
+      '## Current Position',
+      '',
+      'Phase: 02.2.1 — Not planned yet',
+      'Status: Phase 02.2.1 inserted (urgent — gates Phase 5)',
+      'Last activity: 2026-05-13 -- Phase 02.2.1 inserted (urgent — gates Phase 5)',
+      '',
+    ].join('\n');
+
+    const statePath = path.join(tmpDir, '.planning', 'STATE.md');
+    fs.writeFileSync(statePath, stateMd, 'utf8');
+    const before = fs.readFileSync(statePath, 'utf8');
+
+    const result = runGsdTools(['state', 'complete-phase', '--phase', '02.2'], tmpDir);
+    assert.ok(result.success, `command should not error, got: ${result.error || result.output}`);
+
+    const after = fs.readFileSync(statePath, 'utf8');
+
+    // Hard assertion: file is byte-identical to its pre-call snapshot.
+    assert.equal(
+      after,
+      before,
+      `STATE.md must not be rewritten when phase is already complete.\n\n--- before ---\n${before}\n--- after ---\n${after}`,
+    );
+
+    // Output should advertise the no-op so downstream consumers can detect it.
+    let payload = null;
+    try { payload = JSON.parse(result.output); } catch (_) { /* ignore */ }
+    assert.ok(payload && typeof payload === 'object', `expected JSON payload, got: ${result.output}`);
+    assert.deepEqual(payload.updated, [], `expected empty updated list, got: ${JSON.stringify(payload.updated)}`);
+    assert.equal(payload.phase, '02.2');
+    assert.equal(payload.idempotent, true, `expected idempotent:true flag, got: ${JSON.stringify(payload)}`);
+  });
+
+  test('completing the currently in-progress phase still works normally (no false-positive idempotency)', () => {
+    // Sanity check: the guard must not fire on the legitimate first completion.
+    const stateMd = [
+      '---',
+      'milestone: v1.0',
+      '---',
+      '',
+      '# State',
+      '',
+      '**Status:** in-progress',
+      '**Current Phase:** 03',
+      '**Last Activity:** 2026-05-13',
+      '',
+      '## Current Position',
+      '',
+      'Phase: 03',
+      'Status: Phase 03 executing',
+      '',
+    ].join('\n');
+
+    const statePath = path.join(tmpDir, '.planning', 'STATE.md');
+    fs.writeFileSync(statePath, stateMd, 'utf8');
+
+    const result = runGsdTools(['state', 'complete-phase', '--phase', '03'], tmpDir);
+    assert.ok(result.success, `command failed: ${result.error || result.output}`);
+
+    const after = fs.readFileSync(statePath, 'utf8');
+    assert.ok(
+      after.includes('**Status:** Phase 03 complete'),
+      `expected Status updated to "Phase 03 complete", got:\n${after}`,
+    );
+
+    const payload = JSON.parse(result.output);
+    assert.notEqual(payload.idempotent, true, 'first completion must not be flagged idempotent');
+    assert.ok(Array.isArray(payload.updated) && payload.updated.length > 0, 'expected non-empty updated list');
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3489

> The linked issue currently has no `confirmed-bug` label. **Asking a maintainer to apply `confirmed-bug` on #3489 before this PR is merged.**

## What was broken

`gsd-sdk query state.complete-phase --phase <N>` (and the underlying `gsd state complete-phase` CLI) was non-idempotent: re-invoking it on a phase already marked complete in STATE.md silently rolled STATE.md back to that phase's moment-of-completion. `Status`, `Last Activity`, `Last Activity Description`, and the `## Current Position` body were all overwritten with stale values derived from the just-completed phase, and the handler reported success (`{"updated": ["Status", "Last Activity", "Current Position"]}`) so no caller could detect the damage. Any downstream consumer trusting STATE.md (`/gsd-progress`, planner, the next phase's discuss-phase context loader) was routed back to the rolled-back phase.

## What this fix does

Adds an idempotency guard at the top of `cmdStateCompletePhase` in `get-shit-done/bin/lib/state.cjs`. If STATE.md's canonical `Current Phase` field already names a phase distinct from the one being completed, the project has clearly advanced past it (e.g. a follow-up phase was inserted, or the next phase began). The handler now returns a no-op payload (`{ updated: [], phase: "<N>", idempotent: true, note: "phase already superseded; no-op" }`) without writing to STATE.md.

## Root cause

`cmdStateCompletePhase` wrote unconditionally — it never consulted STATE.md to detect that the requested phase had been superseded. The handler is a legacy-bridge fallback (not registered in the SDK's native handler registry), so the SDK CLI falls through to `gsd-tools.cjs`. The bug was a missing read-before-write check; the rest of the handler is unchanged.

## Testing

### How I verified the fix

- TDD: red test first (`tests/bug-3489-complete-phase-idempotent.test.cjs`) — reproduces the rollback exactly, including the bug report's body (`Current Phase: 02.2.1`, `Status: Phase 02.2.1 inserted ...`) being clobbered by `Phase 02.2 marked complete`.
- Applied the guard. Test goes green. STATE.md is byte-identical before and after the re-invocation; payload reports `idempotent: true`.
- Second test asserts the guard does NOT fire on a legitimate first-time completion (no false-positive idempotency).
- Ran `node --test tests/state.test.cjs` — all 104 tests pass, including the four existing `complete-phase` cases from #2761 and #3063.
- Ran `node --test tests/bug-3454-state-dollar-backreference-growth.test.cjs` — passes (no regression on the adjacent `$N` backreference bug).
- Ran `npm test` — full suite passes. One pre-existing dispatcher test (`--cwd= form overrides working directory`) fails only because this worktree's path contains a space (`Mini Me`); the failure reproduces on `main` without my changes and is unrelated.

### Regression test added?

- [x] Yes — added `tests/bug-3489-complete-phase-idempotent.test.cjs` that would have caught this bug

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (CLI handler — not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #3489`
- [ ] Linked issue has the `confirmed-bug` label — **maintainer action requested**
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/3489-complete-phase-idempotent.md` fragment added
- [x] No unnecessary dependencies added

## Scope notes

This PR addresses **only** the idempotency-rollback symptom (the primary failure mode in #3489). The issue's "suggested fix" section also calls out:

- Suggested fix `(2)` — `stopped_at` derivation by chronological commit timestamp instead of filename sort order — is independent and not addressed here.
- Suggested fix `(3)` — porting the handler to the native SDK registry — is a larger refactor and not addressed here.

Both are worth follow-up issues; this fix stops the silent-rollback data loss while keeping the change surface minimal.

## Breaking changes

None. The handler's success path is unchanged; only the previously-broken re-invocation case is now a no-op. Existing callers receive the same `{ updated, phase }` shape; new callers can detect the no-op via the additional `idempotent: true` flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `state complete-phase` command idempotency: re-running the command when a phase is already marked complete now safely returns a no-op response and preserves your data without modifications. Previously, re-invoking the command could inadvertently rewrite your state. The command can now be safely executed multiple times without unintended side effects.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3499)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
