### PR TITLE
fix(tests): require trailing slash in path-replacement homedir check (#3503)

### DIFF
--- a/tests/path-replacement.test.cjs
+++ b/tests/path-replacement.test.cjs
@@ -30,6 +30,17 @@ function computePathPrefix(homedir, targetDir) {
   return resolvedTarget + '/';
 }
 
+// Detect whether `content` leaks a resolved absolute homedir path (e.g.
+// /home/alice or /root). A bare substring match false-positives when homedir
+// is short and happens to appear inside ordinary words or tags — for example
+// `</root_cause_analysis>` when os.homedir() === '/root' (Docker). Real path
+// leaks are followed by a path separator, so we require a trailing '/'.
+// See #3503.
+function containsResolvedHomedir(content, normalizedHomedir) {
+  if (!normalizedHomedir || normalizedHomedir === '$HOME') return false;
+  return content.includes(normalizedHomedir + '/');
+}
+
 describe('pathPrefix computation', () => {
   test('default Claude global install uses $HOME/', () => {
     const homedir = os.homedir();
@@ -160,10 +171,34 @@ describe('installed .md files contain no resolved absolute paths', () => {
       let content = fs.readFileSync(file, 'utf8');
       content = content.replace(claudeDirRegex, pathPrefix);
       content = content.replace(claudeHomeRegex, pathPrefix);
-      if (content.includes(normalizedHomedir) && normalizedHomedir !== '$HOME') {
+      if (containsResolvedHomedir(content, normalizedHomedir)) {
         failures.push(path.relative(repoRoot, file));
       }
     }
     assert.deepStrictEqual(failures, [], `Files with resolved absolute paths: ${failures.join(', ')}`);
+  });
+});
+
+describe('containsResolvedHomedir predicate (#3503)', () => {
+  test('flags a real homedir path leak with trailing slash', () => {
+    const content = 'see /home/alice/.claude/config for details';
+    assert.strictEqual(containsResolvedHomedir(content, '/home/alice'), true);
+  });
+
+  test('does NOT flag short homedir appearing as substring of an identifier (#3503)', () => {
+    // Regression: in Docker, os.homedir() === '/root'. Agent markdown contains
+    // `<root_cause_analysis>` / `</root_cause_analysis>` tags. The old naive
+    // substring check false-fired on these. The trailing-slash rule fixes it.
+    const content = '<root_cause_analysis>\nfoo\n</root_cause_analysis>';
+    assert.strictEqual(containsResolvedHomedir(content, '/root'), false);
+  });
+
+  test('still flags /root when followed by a real path separator', () => {
+    const content = 'cat /root/.claude/agents.md';
+    assert.strictEqual(containsResolvedHomedir(content, '/root'), true);
+  });
+
+  test('returns false for $HOME placeholder', () => {
+    assert.strictEqual(containsResolvedHomedir('$HOME/.claude/', '$HOME'), false);
   });
 });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3503

## What was broken

`tests/path-replacement.test.cjs:163` used a naive `content.includes(normalizedHomedir)` to detect resolved-homedir leaks in installed `.md` files. When `os.homedir()` is short — notably `/root` inside Docker — the substring false-matched inside ordinary tokens like `</root_cause_analysis>` in `agents/gsd-debug-session-manager.md`, failing the suite with no real path leak.

## What this fix does

Requires a trailing path separator on the match: the check now looks for `normalizedHomedir + '/'`. Real absolute-path leaks always have a `/` after the homedir; substring hits inside identifiers and HTML-like tags do not.

The inline check has been extracted into a testable `containsResolvedHomedir(content, normalizedHomedir)` helper so the regression is covered directly.

## Root cause

Substring containment is too loose for short absolute paths. `/root` is a legitimate Linux/Docker homedir but is also a common prefix of unrelated identifiers (`root_cause_analysis`, `rootDir`, etc.). Anchoring the match with the trailing path separator that any real path leak must carry eliminates the false-positive class.

## Testing

### How I verified the fix

- Added a regression test asserting `containsResolvedHomedir('<root_cause_analysis>...</root_cause_analysis>', '/root') === false`. The test FAILS on the pre-fix predicate and PASSES on the fixed predicate (strict TDD red → green).
- Added supporting tests: real `/home/alice/.claude/...` leak still flagged; `/root/.claude/agents.md` still flagged; `$HOME` placeholder short-circuits to `false`.
- `node --test tests/path-replacement.test.cjs` — 13/13 pass.
- `npm test` — path-replacement suite green. Unrelated pre-existing failures in `profile-pipeline.test.cjs`, `frontmatter-cli.test.cjs`, `dispatcher.test.cjs`, `commands.test.cjs` reproduce on `main` without these changes (worktree path contains a space; not caused by this PR).

### Regression test added?

- [x] Yes — added a test that would have caught this bug (4 tests in `containsResolvedHomedir predicate (#3503)` describe block).

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux (the `/root` Docker case is exactly what this targets)
- [ ] N/A

### Runtimes tested

- [x] N/A (test-only change)

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed` label (maintainer to apply `confirmed-bug` if the mapping isn't automatic)
- [x] Fix is scoped to the reported bug — only the line-163 check changed; the inline expression was extracted into a named predicate so it could be tested directly
- [x] Regression test added
- [x] All existing tests pass (`npm test` — pre-existing unrelated failures only)
- [x] `.changeset/` fragment — not required; `scripts/changeset/lint.cjs` only gates user-facing prefixes (`bin/`, `agents/`, `commands/`, `hooks/`, `sdk/...`), and this PR only touches `tests/`
- [x] No unnecessary dependencies added

## Breaking changes

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Tests
* Enhanced detection of unresolved file paths in markdown documentation to prevent exposing system-specific paths in generated files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3504)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->