### PR TITLE
chore(ci): add 5-day auto-close for awaiting-retest / needs-reproduction (#3506)

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -30,5 +30,29 @@ jobs:
             with updated reproduction steps on the latest GSD version.
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'
-          exempt-issue-labels: 'fix-pending,priority: critical,pinned,confirmed-bug,confirmed'
+          exempt-issue-labels: 'fix-pending,priority: critical,pinned,confirmed-bug,confirmed,awaiting-retest,needs-reproduction'
           exempt-pr-labels: 'fix-pending,priority: critical,pinned,DO NOT MERGE'
+
+  stale-retest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
+        with:
+          only-issue-labels: 'awaiting-retest,needs-reproduction'
+          days-before-issue-stale: 5
+          days-before-issue-close: 0
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          remove-stale-when-updated: true
+          stale-issue-message: >
+            Closing — we asked for a retest / reproduction more than 5 days ago and
+            haven't heard back. If this is still happening on the latest GSD version
+            you are welcome to open a new issue with the requested information.
+            We expect follow-up to maintainer requests within a reasonable window or
+            we close to keep the tracker actionable.
+          close-issue-message: >
+            Closed (not planned) — reporter did not respond within 5 days of our
+            retest / reproduction request. Re-open with the requested information,
+            or file a new issue if it still affects you on the latest GSD version.
+          exempt-issue-labels: 'pinned,priority: critical,fix-pending'


### PR DESCRIPTION
> *No typed PR template applies — this is a CI / tooling-only change with no user-facing behavior. Per the default template's "Not sure which type applies?" guidance, CI/tooling changes use this default with an explanatory note.*

Closes #3506

## Summary

Adds a second `stale` job to `.github/workflows/stale.yml` scoped via `only-issue-labels: 'awaiting-retest,needs-reproduction'` with a 5-day window and immediate close (`days-before-issue-close: 0`). The existing 28+14 broad job is unchanged in behavior except that `awaiting-retest` and `needs-reproduction` are now exempt from it — those issues are owned exclusively by the new tight job, so the two jobs do not race or double-close.

Trigger: the 2026-05-14 manual triage sweep surfaced five issues sitting in awaiting-retest / needs-reproduction for 2–3 days each (#3406, #3407, #3426, #3427, #3433). None hit 5 days yet, but the policy should be enforced automatically going forward.

## Behavior

- Issues with `awaiting-retest` or `needs-reproduction`, last updated > 5 days ago → stale comment + close (not planned) in the same workflow run.
- Issues touched by the reporter within the window → `remove-stale-when-updated: true` keeps them open and clears any stale label.
- PR side disabled in the new job via `days-before-pr-stale: -1` / `days-before-pr-close: -1`.
- Exempt overrides: `pinned`, `priority: critical`, `fix-pending`.

## Why a single workflow file, not a new one

`actions/stale` jobs are independent and the second job uses `only-issue-labels` for tight scoping; running them side-by-side in the same workflow keeps schedule + permissions in one place. The broad job's `exempt-issue-labels` is the only edit to its behavior — adding the two retest labels so it cannot accidentally hit them.

## Testing

CI-only change; the workflow is `workflow_dispatch`-able so maintainers can dry-run it against current open issues (`gh workflow run "Stale Cleanup"`) before the next cron tick. The action publishes a summary of what it would close, which is the safest way to validate before letting cron fire.

## Checklist

- [x] Linked issue: `Closes #3506`
- [x] Issue category: chore (CI/CD)
- [x] No user-facing behavior change → no \`.changeset/\` fragment needed (lint gates: `bin/`, `get-shit-done/`, `agents/`, `commands/`, `hooks/`, `sdk/src/`, `sdk/prompts/`, `CHANGELOG.md`; this PR touches only `.github/workflows/`).
- [x] Action SHA-pinned (`actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f`) per security policy.
- [x] No untrusted input flows into `run:` commands; only static `with:` config.

## Breaking changes

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced stale issue cleanup workflow with expanded label exemptions
  * Added new retest job with distinct stale/close thresholds and custom messaging for improved issue management automation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3507)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->