### PR TITLE
fix(reapply-patches): add gsd-update filter arm to git-enhanced two-way merge (#3516)

### DIFF
--- a/.changeset/serene-pandas-zip.md
+++ b/.changeset/serene-pandas-zip.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3516
+---
+**`/gsd-update --reapply` no longer treats installer-authored commits as user customizations** — the git-enhanced two-way merge filter in `get-shit-done/workflows/reapply-patches.md` was missing the `gsd-update` arm after the slash-command rename from `/gsd:update` to `/gsd-update`. Commits created by the current update flow now fall through the filter and are excluded from the diff, preventing spurious merge-conflict prompts. The legacy `gsd:update` arm is preserved for back-compat, and `GSD update` / `gsd-install` exclusions are unchanged. (#3516)

--- a/.changeset/serene-pandas-zip.md
+++ b/.changeset/serene-pandas-zip.md
@@ -2,4 +2,4 @@
 type: Fixed
 pr: 3516
 ---
-**`/gsd-update --reapply` no longer treats installer-authored commits as user customizations** — the git-enhanced two-way merge filter in `get-shit-done/workflows/reapply-patches.md` was missing the `gsd-update` arm after the slash-command rename from `/gsd:update` to `/gsd-update`. Commits created by the current update flow now fall through the filter and are excluded from the diff, preventing spurious merge-conflict prompts. The legacy `gsd:update` arm is preserved for back-compat, and `GSD update` / `gsd-install` exclusions are unchanged. (#3516)
+**`/gsd-update --reapply` no longer treats installer-authored commits as user customizations** — the git-enhanced two-way merge filter in `get-shit-done/workflows/reapply-patches.md` was missing the `gsd-update` arm after the slash-command rename from `/gsd:update` to `/gsd-update`. Commits created by the current update flow no longer fall through; they now match the exclusion filter and are excluded from the diff, preventing spurious merge-conflict prompts. The legacy `gsd:update` arm is preserved for back-compat, and `GSD update` / `gsd-install` exclusions are unchanged. (#3516)

--- a/get-shit-done/workflows/reapply-patches.md
+++ b/get-shit-done/workflows/reapply-patches.md
@@ -228,7 +228,7 @@ d. **If ALL differences appear to be mechanical drift → still flag as CONFLICT
 When the config directory is a git repo but the pristine install commit can't be found, use commit history to identify user changes:
 ```bash
 # Find non-update commits that touched this file
-git -C "$CONFIG_DIR" log --oneline --no-merges -- "{file_path}" | grep -v "gsd:update\|GSD update\|gsd-install"
+git -C "$CONFIG_DIR" log --oneline --no-merges -- "{file_path}" | grep -v "gsd:update\|gsd-update\|GSD update\|gsd-install"
 ```
 Each matching commit represents an intentional user modification. Use the commit messages and diffs to understand what was changed and why.
 

--- a/tests/bug-3516-reapply-patches-gsd-update-filter.test.cjs
+++ b/tests/bug-3516-reapply-patches-gsd-update-filter.test.cjs
@@ -1,0 +1,123 @@
+// allow-test-rule: source-text-is-the-product
+// get-shit-done/workflows/reapply-patches.md is the installed runtime workflow —
+// its text IS the deployed behavioral contract for the --reapply flag.
+
+'use strict';
+
+/**
+ * Bug #3516: reapply-patches.md git-enhanced two-way merge filter misses
+ * commits authored by the renamed `/gsd-update` flow.
+ *
+ * The `grep -v` alternation on line 231 only included the legacy `gsd:update`
+ * marker. After the slash-command rename `/gsd:update` → `/gsd-update`, commits
+ * authored by the current flow fall through the filter and are misclassified as
+ * user customizations, prompting spurious merge conflicts during `--reapply`.
+ *
+ * Fix: add `gsd-update` arm to the alternation so both the legacy and current
+ * commit-message prefixes are excluded. `GSD update` and `gsd-install`
+ * exclusions are preserved.
+ *
+ * Per the repo's source-text-is-the-product exception: the workflow file's text
+ * IS the deployed behavioral contract. Structural assertion against the parsed
+ * shell command string is the correct test form here.
+ */
+
+const { describe, test, before } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const WORKFLOW_PATH = path.join(
+  __dirname,
+  '..',
+  'get-shit-done',
+  'workflows',
+  'reapply-patches.md',
+);
+
+/**
+ * Extract the git log filter command from the workflow.
+ *
+ * Looks for the `grep -v "..."` shell snippet inside the Git-enhanced two-way
+ * merge section and returns the alternation string between the quotes.
+ * Returns null if the snippet is absent (signals a structural regression).
+ */
+function extractFilterAlternation(content) {
+  // Match the grep -v "..." line in the bash block
+  const match = content.match(/grep\s+-v\s+"([^"]+)"/);
+  if (!match) return null;
+  return match[1];
+}
+
+/**
+ * Parse the alternation string (pipe-delimited) into individual arms.
+ * Handles escaped pipes produced by shell regex syntax (`\|`).
+ */
+function parseAlternationArms(alternation) {
+  // Shell grep alternation uses \| (escaped pipe); split on that
+  return alternation.split(/\\\|/).map((arm) => arm.trim());
+}
+
+describe('Bug #3516: git-enhanced two-way merge filter includes gsd-update arm', () => {
+  let content;
+  let alternation;
+  let arms;
+
+  before(() => {
+    content = fs.readFileSync(WORKFLOW_PATH, 'utf8');
+    alternation = extractFilterAlternation(content);
+    arms = alternation ? parseAlternationArms(alternation) : [];
+  });
+
+  test('workflow file exists', () => {
+    assert.ok(
+      fs.existsSync(WORKFLOW_PATH),
+      'get-shit-done/workflows/reapply-patches.md must exist',
+    );
+  });
+
+  test('git-enhanced two-way merge section contains a grep -v filter', () => {
+    assert.ok(
+      alternation !== null,
+      'reapply-patches.md must contain a `grep -v "..."` filter in the git-enhanced two-way merge section',
+    );
+  });
+
+  test('filter excludes legacy gsd:update commits (back-compat)', () => {
+    assert.ok(
+      arms.some((arm) => arm === 'gsd:update'),
+      `filter must include 'gsd:update' arm for back-compat; got arms: ${JSON.stringify(arms)}`,
+    );
+  });
+
+  test('filter excludes renamed gsd-update commits (primary fix)', () => {
+    assert.ok(
+      arms.some((arm) => arm === 'gsd-update'),
+      `filter must include 'gsd-update' arm (renamed flow); got arms: ${JSON.stringify(arms)}`,
+    );
+  });
+
+  test('filter excludes GSD update commits (no regression)', () => {
+    assert.ok(
+      arms.some((arm) => arm === 'GSD update'),
+      `filter must include 'GSD update' arm; got arms: ${JSON.stringify(arms)}`,
+    );
+  });
+
+  test('filter excludes gsd-install commits (no regression)', () => {
+    assert.ok(
+      arms.some((arm) => arm === 'gsd-install'),
+      `filter must include 'gsd-install' arm; got arms: ${JSON.stringify(arms)}`,
+    );
+  });
+
+  test('all four expected exclusion patterns are present in the filter', () => {
+    const required = ['gsd:update', 'gsd-update', 'GSD update', 'gsd-install'];
+    const missing = required.filter((p) => !arms.some((arm) => arm === p));
+    assert.deepEqual(
+      missing,
+      [],
+      `filter is missing required exclusion patterns: ${JSON.stringify(missing)}; got arms: ${JSON.stringify(arms)}`,
+    );
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3516

> Linked issue has `confirmed-bug` label (verified before opening this PR).

## What was broken

The `grep -v` alternation in the git-enhanced two-way merge step of `get-shit-done/workflows/reapply-patches.md` (line 231) only contained three arms: `gsd:update`, `GSD update`, and `gsd-install`. After the slash-command rename from `/gsd:update` to `/gsd-update`, commits authored by the current update flow fell through the filter and were misclassified as user customizations, causing spurious merge-conflict prompts during `/gsd-update --reapply`.

## What this fix does

Adds `gsd-update` as a fourth arm between `gsd:update` and `GSD update`. The legacy `gsd:update` arm is preserved for back-compat; `GSD update` and `gsd-install` exclusions are unchanged.

Before:
```
grep -v "gsd:update\|GSD update\|gsd-install"
```

After:
```
grep -v "gsd:update\|gsd-update\|GSD update\|gsd-install"
```

## Root cause

The filter was not updated when the slash-command was renamed from `/gsd:update` to `/gsd-update`. All other `gsd:` references in the codebase confirmed intentional by the triage audit (CLI warning prefix in `core.cjs`, test fixtures that assert the sanitizer strips legacy patterns, TypeScript declarations).

## Testing

### How I verified the fix

TDD red-green: wrote `tests/bug-3516-reapply-patches-gsd-update-filter.test.cjs` (7 tests) first, confirmed 2 failures before the fix, all 7 pass after.

```
node --test tests/bug-3516-reapply-patches-gsd-update-filter.test.cjs
# 7 passed, 0 failed
```

Full reapply-patches related suite:

```
node --test tests/reapply-patches.test.cjs tests/reapply-verify-hunks.test.cjs tests/bug-2424-reapply-patches-baseline-detection.test.cjs tests/bug-2969-verify-reapply-patches.test.cjs tests/bug-2994-verify-reapply-patches-installed-path.test.cjs
# 41 passed, 0 failed
```

### Regression test added?

- [x] Yes — `tests/bug-3516-reapply-patches-gsd-update-filter.test.cjs` (7 tests) asserting all four exclusion patterns are present in the filter.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #3516` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (7 behavioral tests)
- [x] All existing tests pass
- [x] `.changeset/serene-pandas-zip.md` added (type: Fixed)
- [x] No unnecessary dependencies added

## Breaking changes

None — adds a new exclusion arm to the filter; cannot cause previously-excluded commits to appear.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reapply behavior so the update command no longer treats installer-authored commits as user customizations.

* **Documentation**
  * Clarified the two-way merge instructions to explicitly exclude update/install-related commit messages from user-change detection.

* **Tests**
  * Added tests that assert the merge-filter excludes the expected update/install commit-message patterns to prevent regressions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3525)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->