### PR TITLE
feat(3530): STATE.md Document Module via generator (Phase 1 of #3524)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,3 +4,7 @@ set -euo pipefail
 if git diff --cached --name-only | grep -Eq "^sdk/src/query/command-manifest\.|^sdk/src/query/command-aliases\.generated\.ts$|^get-shit-done/bin/lib/command-aliases\.generated\.cjs$|^sdk/scripts/gen-command-aliases\.ts$"; then
   npm run check:alias-drift
 fi
+
+if git diff --cached --name-only | grep -Eq "^sdk/src/query/state-document\.|^get-shit-done/bin/lib/state-document\.generated\.cjs$|^sdk/scripts/gen-state-document\.ts$"; then
+  npm run check:state-document-fresh
+fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -5,6 +5,6 @@ if git diff --cached --name-only | grep -Eq "^sdk/src/query/command-manifest\.|^
   npm run check:alias-drift
 fi
 
-if git diff --cached --name-only | grep -Eq "^sdk/src/query/state-document\.|^get-shit-done/bin/lib/state-document\.generated\.cjs$|^sdk/scripts/gen-state-document\.ts$"; then
+if git diff --cached --name-only | grep -Eq "^sdk/src/query/state-document\.|^get-shit-done/bin/lib/state-document\.generated\.cjs$|^sdk/scripts/gen-state-document\.ts$|^sdk/scripts/check-state-document-fresh\.mjs$"; then
   npm run check:state-document-fresh
 fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -103,6 +103,11 @@ jobs:
         shell: bash
         run: node sdk/scripts/check-command-aliases-fresh.mjs
 
+      - name: SDK generated state-document artifact drift check
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == 24
+        shell: bash
+        run: node sdk/scripts/check-state-document-fresh.mjs
+
       - name: Run tests with coverage
         shell: bash
         run: npm run test:coverage

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -26,7 +26,7 @@ Adapter Module that satisfies native query dispatch at the Dispatch Policy seam,
 Module owning projection from dispatch results/errors to CLI `{ exitCode, stdoutChunks, stderrLines }` output contract.
 
 ### STATE.md Document Module
-Shared CJS/SDK pure transform Module owning STATE.md parse, field extraction, field replacement, status normalization, and frontmatter reconstruction. It does not scan `.planning/phases` and does not own persistence or locking; phase/plan/summary counts arrive from inventory/progress Modules as inputs, and CJS/SDK read-modify-write paths remain Adapters.
+Shared CJS/SDK pure transform Module owning STATE.md parse, field extraction, field replacement, status normalization, and frontmatter reconstruction. It does not scan `.planning/phases` and does not own persistence or locking; phase/plan/summary counts arrive from inventory/progress Modules as inputs, and CJS/SDK read-modify-write paths remain Adapters. Source of truth: `sdk/src/query/state-document.ts`; CJS callers consume the generator-emitted `get-shit-done/bin/lib/state-document.generated.cjs` via the thin re-export at `get-shit-done/bin/lib/state-document.cjs`.
 
 ### Query Execution Policy Module
 Module owning query transport routing policy projection (`preferNative`, fallback policy, workstream subprocess forcing) at execution seam.

--- a/docs/INVENTORY-MANIFEST.json
+++ b/docs/INVENTORY-MANIFEST.json
@@ -1,5 +1,5 @@
 {
-  "generated": "2026-05-13",
+  "generated": "2026-05-14",
   "families": {
     "agents": [
       "gsd-advisor-researcher",
@@ -306,6 +306,7 @@
       "shell-command-projection.cjs",
       "state-command-router.cjs",
       "state-document.cjs",
+      "state-document.generated.cjs",
       "state.cjs",
       "surface.cjs",
       "template.cjs",

--- a/docs/INVENTORY.md
+++ b/docs/INVENTORY.md
@@ -360,7 +360,7 @@ The `gsd-planner` agent is decomposed into a core agent plus reference modules t
 
 ---
 
-## CLI Modules (59 shipped)
+## CLI Modules (60 shipped)
 
 Full listing: `get-shit-done/bin/lib/*.cjs`.
 
@@ -415,6 +415,7 @@ Full listing: `get-shit-done/bin/lib/*.cjs`.
 | `state-command-router.cjs` | Thin CJS subcommand router adapter for `gsd-tools state` |
 | `state.cjs` | STATE.md parsing, updating, progression, metrics |
 | `state-document.cjs` | Pure STATE.md field extraction, replacement, status normalization, and progress calculation transforms |
+| `state-document.generated.cjs` | GENERATED — CJS artifact emitted from `sdk/src/query/state-document.ts` via `sdk/scripts/gen-state-document.ts`; do not edit directly |
 | `surface.cjs` | Runtime surface module — manages the runtime enable/disable surface state independently of the install-time profile marker (ADR-0011 Phase 2) |
 | `template.cjs` | Template selection and filling with variable substitution |
 | `uat.cjs` | UAT file parsing, verification debt tracking, audit-uat support |

--- a/get-shit-done/bin/lib/state-document.cjs
+++ b/get-shit-done/bin/lib/state-document.cjs
@@ -1,122 +1,12 @@
 'use strict';
 
 /**
- * STATE.md Document Module
+ * STATE.md Document Module — CJS adapter.
  *
- * Pure transforms for STATE.md text. This module does not read the filesystem
- * and does not own persistence or locking.
+ * The implementation is generated from sdk/src/query/state-document.ts and
+ * lives in state-document.generated.cjs. This file is a thin re-export so
+ * that existing call sites (state.cjs, workstream-inventory.cjs, init.cjs,
+ * and tests) can continue to require('./state-document') unchanged.
  */
 
-function escapeRegex(str) {
-  return String(str).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
-function stateExtractField(content, fieldName) {
-  const escaped = escapeRegex(fieldName);
-  const boldPattern = new RegExp(`\\*\\*${escaped}:\\*\\*[ \\t]*(.+)`, 'i');
-  const boldMatch = content.match(boldPattern);
-  if (boldMatch) return boldMatch[1].trim();
-  const plainPattern = new RegExp(`^${escaped}:[ \\t]*(.+)`, 'im');
-  const plainMatch = content.match(plainPattern);
-  return plainMatch ? plainMatch[1].trim() : null;
-}
-
-function stateReplaceField(content, fieldName, newValue) {
-  const escaped = escapeRegex(fieldName);
-  const boldPattern = new RegExp(`(\\*\\*${escaped}:\\*\\*\\s*)(.*)`, 'i');
-  if (boldPattern.test(content)) {
-    return content.replace(boldPattern, (_match, prefix) => `${prefix}${newValue}`);
-  }
-  const plainPattern = new RegExp(`(^${escaped}:\\s*)(.*)`, 'im');
-  if (plainPattern.test(content)) {
-    return content.replace(plainPattern, (_match, prefix) => `${prefix}${newValue}`);
-  }
-  return null;
-}
-
-function stateReplaceFieldWithFallback(content, primary, fallback, value) {
-  let result = stateReplaceField(content, primary, value);
-  if (result) return result;
-  if (fallback) {
-    result = stateReplaceField(content, fallback, value);
-    if (result) return result;
-  }
-  return content;
-}
-
-function normalizeStateStatus(status, pausedAt) {
-  let normalizedStatus = status || 'unknown';
-  const statusLower = (status || '').toLowerCase();
-  if (statusLower.includes('paused') || statusLower.includes('stopped') || pausedAt) {
-    normalizedStatus = 'paused';
-  } else if (statusLower.includes('executing') || statusLower.includes('in progress')) {
-    normalizedStatus = 'executing';
-  } else if (statusLower.includes('planning') || statusLower.includes('ready to plan')) {
-    normalizedStatus = 'planning';
-  } else if (statusLower.includes('discussing')) {
-    normalizedStatus = 'discussing';
-  } else if (statusLower.includes('verif')) {
-    normalizedStatus = 'verifying';
-  } else if (statusLower.includes('complete') || statusLower.includes('done')) {
-    normalizedStatus = 'completed';
-  } else if (statusLower.includes('ready to execute')) {
-    normalizedStatus = 'executing';
-  }
-  return normalizedStatus;
-}
-
-function computeProgressPercent(completedPlans, totalPlans, completedPhases, totalPhases) {
-  const hasPlanData = totalPlans !== null && totalPlans > 0 && completedPlans !== null;
-  const hasPhaseData = totalPhases !== null && totalPhases > 0 && completedPhases !== null;
-
-  if (!hasPlanData && !hasPhaseData) return null;
-
-  const planFraction = hasPlanData ? completedPlans / totalPlans : 1;
-  const phaseFraction = hasPhaseData ? completedPhases / totalPhases : 1;
-
-  return Math.min(100, Math.round(Math.min(planFraction, phaseFraction) * 100));
-}
-
-function toFiniteNumber(value) {
-  const number = Number(value);
-  return Number.isFinite(number) ? number : null;
-}
-
-function existingProgressExceedsDerived(existingProgress, derivedProgress, key) {
-  const existing = toFiniteNumber(existingProgress[key]);
-  const derived = toFiniteNumber(derivedProgress[key]);
-  return existing !== null && derived !== null && existing > derived;
-}
-
-function shouldPreserveExistingProgress(existingProgress, derivedProgress) {
-  if (!existingProgress || typeof existingProgress !== 'object') return false;
-  if (!derivedProgress || typeof derivedProgress !== 'object') return false;
-
-  return (
-    existingProgressExceedsDerived(existingProgress, derivedProgress, 'total_phases') ||
-    existingProgressExceedsDerived(existingProgress, derivedProgress, 'completed_phases') ||
-    existingProgressExceedsDerived(existingProgress, derivedProgress, 'total_plans') ||
-    existingProgressExceedsDerived(existingProgress, derivedProgress, 'completed_plans')
-  );
-}
-
-function normalizeProgressNumbers(progress) {
-  if (!progress || typeof progress !== 'object') return progress;
-
-  const normalized = { ...progress };
-  for (const key of ['total_phases', 'completed_phases', 'total_plans', 'completed_plans', 'percent']) {
-    const number = toFiniteNumber(normalized[key]);
-    if (number !== null) normalized[key] = number;
-  }
-  return normalized;
-}
-
-module.exports = {
-  computeProgressPercent,
-  normalizeProgressNumbers,
-  normalizeStateStatus,
-  shouldPreserveExistingProgress,
-  stateExtractField,
-  stateReplaceField,
-  stateReplaceFieldWithFallback,
-};
+module.exports = require('./state-document.generated.cjs');

--- a/get-shit-done/bin/lib/state-document.generated.cjs
+++ b/get-shit-done/bin/lib/state-document.generated.cjs
@@ -1,0 +1,127 @@
+'use strict';
+
+/**
+ * GENERATED FILE — DO NOT EDIT.
+ *
+ * Source: sdk/src/query/state-document.ts
+ * Regenerate: cd sdk && npm run gen:state-document
+ *
+ * STATE.md Document Module — pure transforms for STATE.md text.
+ * This module does not read the filesystem and does not own persistence or locking.
+ */
+
+// Internal helpers
+function escapeRegex(str) {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function toFiniteNumber(value) {
+    const number = Number(value);
+    return Number.isFinite(number) ? number : null;
+}
+
+function existingProgressExceedsDerived(existingProgress, derivedProgress, key) {
+    const existing = toFiniteNumber(existingProgress[key]);
+    const derived = toFiniteNumber(derivedProgress[key]);
+    return existing !== null && derived !== null && existing > derived;
+}
+
+function stateExtractField(content, fieldName) {
+    const escaped = escapeRegex(fieldName);
+    const boldPattern = new RegExp(`\\*\\*${escaped}:\\*\\*[ \\t]*(.+)`, 'i');
+    const boldMatch = content.match(boldPattern);
+    if (boldMatch)
+        return boldMatch[1].trim();
+    const plainPattern = new RegExp(`^${escaped}:[ \\t]*(.+)`, 'im');
+    const plainMatch = content.match(plainPattern);
+    return plainMatch ? plainMatch[1].trim() : null;
+}
+
+function stateReplaceField(content, fieldName, newValue) {
+    const escaped = escapeRegex(fieldName);
+    const boldPattern = new RegExp(`(\\*\\*${escaped}:\\*\\*\\s*)(.*)`, 'i');
+    if (boldPattern.test(content)) {
+        return content.replace(boldPattern, (_match, prefix) => `${prefix}${newValue}`);
+    }
+    const plainPattern = new RegExp(`(^${escaped}:\\s*)(.*)`, 'im');
+    if (plainPattern.test(content)) {
+        return content.replace(plainPattern, (_match, prefix) => `${prefix}${newValue}`);
+    }
+    return null;
+}
+
+function stateReplaceFieldWithFallback(content, primary, fallback, value) {
+    let result = stateReplaceField(content, primary, value);
+    if (result)
+        return result;
+    if (fallback) {
+        result = stateReplaceField(content, fallback, value);
+        if (result)
+            return result;
+    }
+    return content;
+}
+
+function normalizeStateStatus(status, pausedAt) {
+    let normalizedStatus = status || 'unknown';
+    const statusLower = (status || '').toLowerCase();
+    if (statusLower.includes('paused') || statusLower.includes('stopped') || pausedAt) {
+        normalizedStatus = 'paused';
+    }
+    else if (statusLower.includes('executing') || statusLower.includes('in progress')) {
+        normalizedStatus = 'executing';
+    }
+    else if (statusLower.includes('planning') || statusLower.includes('ready to plan')) {
+        normalizedStatus = 'planning';
+    }
+    else if (statusLower.includes('discussing')) {
+        normalizedStatus = 'discussing';
+    }
+    else if (statusLower.includes('verif')) {
+        normalizedStatus = 'verifying';
+    }
+    else if (statusLower.includes('complete') || statusLower.includes('done')) {
+        normalizedStatus = 'completed';
+    }
+    else if (statusLower.includes('ready to execute')) {
+        normalizedStatus = 'executing';
+    }
+    return normalizedStatus;
+}
+
+function computeProgressPercent(completedPlans, totalPlans, completedPhases, totalPhases) {
+    const hasPlanData = totalPlans !== null && totalPlans > 0 && completedPlans !== null;
+    const hasPhaseData = totalPhases !== null && totalPhases > 0 && completedPhases !== null;
+    if (!hasPlanData && !hasPhaseData)
+        return null;
+    const planFraction = hasPlanData ? completedPlans / totalPlans : 1;
+    const phaseFraction = hasPhaseData ? completedPhases / totalPhases : 1;
+    return Math.min(100, Math.round(Math.min(planFraction, phaseFraction) * 100));
+}
+
+function shouldPreserveExistingProgress(existingProgress, derivedProgress) {
+    if (!existingProgress || typeof existingProgress !== 'object')
+        return false;
+    if (!derivedProgress || typeof derivedProgress !== 'object')
+        return false;
+    const existing = existingProgress;
+    const derived = derivedProgress;
+    return (existingProgressExceedsDerived(existing, derived, 'total_phases') ||
+        existingProgressExceedsDerived(existing, derived, 'completed_phases') ||
+        existingProgressExceedsDerived(existing, derived, 'total_plans') ||
+        existingProgressExceedsDerived(existing, derived, 'completed_plans'));
+}
+
+function normalizeProgressNumbers(progress) {
+    if (!progress || typeof progress !== 'object')
+        return progress;
+    const normalized = { ...progress };
+    for (const key of ['total_phases', 'completed_phases', 'total_plans', 'completed_plans', 'percent']) {
+        const number = toFiniteNumber(normalized[key]);
+        if (number !== null)
+            normalized[key] = number;
+    }
+    return normalized;
+}
+
+module.exports = { stateExtractField, stateReplaceField, stateReplaceFieldWithFallback, normalizeStateStatus, computeProgressPercent, shouldPreserveExistingProgress, normalizeProgressNumbers };

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,9 +86,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -101,9 +98,6 @@
       "integrity": "sha512-IPGWgtz+gGnD7fxKAvSf913EUT/lYBTBE8EZ7lh3+x5ZP2859LWLmrCm053Lf3nMWo/CWikZsVPwkDVwpz6tIQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -118,9 +112,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
       "os": [
@@ -133,9 +124,6 @@
       "integrity": "sha512-QYxFNAe4FFridPkKhGlNcNBJ0TaIygWYyvfI9g4kX0i+RVbresUWuZVkWY06ioJ0fXoixFJ+HNQBMB7dLrIp8Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "build:hooks": "node scripts/build-hooks.js",
     "build:sdk": "cd sdk && npm ci && npm run build",
     "check:alias-drift": "cd sdk && npm run check:alias-drift",
+    "check:state-document-fresh": "cd sdk && npm run check:state-document-fresh",
     "prepublishOnly": "npm run build:hooks && npm run build:sdk",
     "pretest": "npm run build:sdk && npm run lint:skill-deps",
     "pretest:coverage": "npm run build:sdk",

--- a/sdk/package-lock.json
+++ b/sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@gsd-build/sdk",
-  "version": "1.39.0-rc.4",
+  "version": "1.50.0-canary.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@gsd-build/sdk",
-      "version": "1.39.0-rc.4",
+      "version": "1.50.0-canary.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.84",
@@ -18,6 +18,7 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "@types/ws": "^8.18.1",
+        "tsx": "^4.22.0",
         "typescript": "^5.7.0",
         "vitest": "^3.1.1"
       },
@@ -1752,6 +1753,509 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.0.tgz",
+      "integrity": "sha512-8ccZMPD69s1AbKXx0C5ddTNZfNjwV04iIKgjZmKfKxMynEtSYcK0Lh7iQFh53fI5Yu4pb9usgAiqyPmEONaALg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/typescript": {

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -36,6 +36,8 @@
   "scripts": {
     "build": "tsc",
     "check:alias-drift": "npm run build && node scripts/check-command-aliases-fresh.mjs",
+    "gen:state-document": "npm run build && npx tsx scripts/gen-state-document.ts",
+    "check:state-document-fresh": "npm run build && node scripts/check-state-document-fresh.mjs",
     "prepublishOnly": "rm -rf dist && tsc && chmod +x dist/cli.js",
     "test": "vitest run",
     "test:unit": "vitest run --project unit",
@@ -48,6 +50,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/ws": "^8.18.1",
+    "tsx": "^4.22.0",
     "typescript": "^5.7.0",
     "vitest": "^3.1.1"
   }

--- a/sdk/scripts/check-state-document-fresh.mjs
+++ b/sdk/scripts/check-state-document-fresh.mjs
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+/**
+ * Freshness check for state-document.generated.cjs.
+ *
+ * Regenerates the expected CJS content in-memory (without writing to disk) and
+ * compares it to the committed file. Exits 0 if they match, 1 if stale.
+ *
+ * Run: node sdk/scripts/check-state-document-fresh.mjs
+ * (Requires sdk/dist to be built first — `npm run build` in sdk/.)
+ */
+
+import { readFile } from 'node:fs/promises';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+const BANNER = `'use strict';
+
+/**
+ * GENERATED FILE — DO NOT EDIT.
+ *
+ * Source: sdk/src/query/state-document.ts
+ * Regenerate: cd sdk && npm run gen:state-document
+ *
+ * STATE.md Document Module — pure transforms for STATE.md text.
+ * This module does not read the filesystem and does not own persistence or locking.
+ */`;
+
+/**
+ * Extract a top-level function declaration (non-exported) from a JS source
+ * string by scanning for `function <name>(` and capturing the entire body
+ * including balanced braces.
+ */
+function extractFunctionFromSource(source, name) {
+  const marker = `function ${name}(`;
+  const start = source.indexOf(marker);
+  if (start === -1) throw new Error(`Could not find function ${name} in compiled source`);
+  const braceOpen = source.indexOf('{', start);
+  if (braceOpen === -1) throw new Error(`Could not find opening brace for function ${name}`);
+  let depth = 0;
+  let i = braceOpen;
+  for (; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') { depth--; if (depth === 0) break; }
+  }
+  return source.slice(start, i + 1);
+}
+
+const distUrl = new URL('../dist/query/state-document.js', import.meta.url);
+const {
+  stateExtractField,
+  stateReplaceField,
+  stateReplaceFieldWithFallback,
+  normalizeStateStatus,
+  computeProgressPercent,
+  shouldPreserveExistingProgress,
+  normalizeProgressNumbers,
+} = await import(distUrl.href);
+const compiledSource = await readFile(fileURLToPath(distUrl), 'utf-8');
+
+const escapeRegexBody = extractFunctionFromSource(compiledSource, 'escapeRegex');
+const toFiniteNumberBody = extractFunctionFromSource(compiledSource, 'toFiniteNumber');
+const existingProgressExceedsDerivedBody = extractFunctionFromSource(compiledSource, 'existingProgressExceedsDerived');
+const stateExtractFieldBody = stateExtractField.toString();
+const stateReplaceFieldBody = stateReplaceField.toString();
+const stateReplaceFieldWithFallbackBody = stateReplaceFieldWithFallback.toString();
+const normalizeStateStatusBody = normalizeStateStatus.toString();
+const computeProgressPercentBody = computeProgressPercent.toString();
+const shouldPreserveExistingProgressBody = shouldPreserveExistingProgress.toString();
+const normalizeProgressNumbersBody = normalizeProgressNumbers.toString();
+
+const expected = [
+  BANNER,
+  '',
+  '// Internal helpers',
+  escapeRegexBody,
+  '',
+  toFiniteNumberBody,
+  '',
+  existingProgressExceedsDerivedBody,
+  '',
+  stateExtractFieldBody,
+  '',
+  stateReplaceFieldBody,
+  '',
+  stateReplaceFieldWithFallbackBody,
+  '',
+  normalizeStateStatusBody,
+  '',
+  computeProgressPercentBody,
+  '',
+  shouldPreserveExistingProgressBody,
+  '',
+  normalizeProgressNumbersBody,
+  '',
+  'module.exports = { stateExtractField, stateReplaceField, stateReplaceFieldWithFallback, normalizeStateStatus, computeProgressPercent, shouldPreserveExistingProgress, normalizeProgressNumbers };',
+  '',
+].join('\n');
+
+const committedPath = resolve(here, '..', '..', 'get-shit-done', 'bin', 'lib', 'state-document.generated.cjs');
+const committed = await readFile(committedPath, 'utf-8');
+
+if (expected === committed) {
+  console.log('state-document.generated.cjs is fresh');
+  process.exit(0);
+} else {
+  console.error('state-document.generated.cjs is STALE.');
+  console.error('Regenerate: cd sdk && npm run gen:state-document');
+  process.exit(1);
+}

--- a/sdk/scripts/check-state-document-fresh.mjs
+++ b/sdk/scripts/check-state-document-fresh.mjs
@@ -44,6 +44,9 @@ function extractFunctionFromSource(source, name) {
     if (source[i] === '{') depth++;
     else if (source[i] === '}') { depth--; if (depth === 0) break; }
   }
+  if (depth !== 0) {
+    throw new Error(`Could not find closing brace for function ${name}`);
+  }
   return source.slice(start, i + 1);
 }
 

--- a/sdk/scripts/gen-state-document.ts
+++ b/sdk/scripts/gen-state-document.ts
@@ -1,0 +1,139 @@
+#!/usr/bin/env node
+/**
+ * Generator for the STATE.md Document Module CJS artifact.
+ *
+ * Reads the compiled ESM output from sdk/dist/query/state-document.js,
+ * extracts function source via Function.prototype.toString() for exports
+ * and via source-text extraction for internal helpers, then emits
+ * get-shit-done/bin/lib/state-document.generated.cjs.
+ *
+ * Run: cd sdk && npx tsx scripts/gen-state-document.ts
+ * Freshness check: node sdk/scripts/check-state-document-fresh.mjs
+ */
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+
+const BANNER = `'use strict';
+
+/**
+ * GENERATED FILE — DO NOT EDIT.
+ *
+ * Source: sdk/src/query/state-document.ts
+ * Regenerate: cd sdk && npm run gen:state-document
+ *
+ * STATE.md Document Module — pure transforms for STATE.md text.
+ * This module does not read the filesystem and does not own persistence or locking.
+ */
+
+`;
+
+/**
+ * Extract a top-level function declaration (non-exported) from a JS source
+ * string by scanning for `function <name>(` and capturing the entire body
+ * including balanced braces.
+ */
+function extractFunctionFromSource(source: string, name: string): string {
+  const marker = `function ${name}(`;
+  const start = source.indexOf(marker);
+  if (start === -1) {
+    throw new Error(`Could not find function ${name} in compiled source`);
+  }
+  // Find the opening brace
+  const braceOpen = source.indexOf('{', start);
+  if (braceOpen === -1) {
+    throw new Error(`Could not find opening brace for function ${name}`);
+  }
+  // Walk forward counting braces until balanced
+  let depth = 0;
+  let i = braceOpen;
+  for (; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  // Return from `function name(` through the closing `}`
+  return source.slice(start, i + 1);
+}
+
+export async function buildStateDocumentCjs(): Promise<string> {
+  // Load the compiled ESM module to get exports via Function.prototype.toString()
+  const distUrl = new URL('../dist/query/state-document.js', import.meta.url);
+  const {
+    stateExtractField,
+    stateReplaceField,
+    stateReplaceFieldWithFallback,
+    normalizeStateStatus,
+    computeProgressPercent,
+    shouldPreserveExistingProgress,
+    normalizeProgressNumbers,
+  } = await import(distUrl.href);
+
+  // Also read the compiled JS as text to extract non-exported helpers
+  const compiledSource = await readFile(fileURLToPath(distUrl), 'utf-8');
+
+  // Extract non-exported helpers from source text
+  const escapeRegexBody = extractFunctionFromSource(compiledSource, 'escapeRegex');
+  const toFiniteNumberBody = extractFunctionFromSource(compiledSource, 'toFiniteNumber');
+  const existingProgressExceedsDerivedBody = extractFunctionFromSource(compiledSource, 'existingProgressExceedsDerived');
+
+  // Get exported function bodies via Function.prototype.toString()
+  const stateExtractFieldBody = stateExtractField.toString();
+  const stateReplaceFieldBody = stateReplaceField.toString();
+  const stateReplaceFieldWithFallbackBody = stateReplaceFieldWithFallback.toString();
+  const normalizeStateStatusBody = normalizeStateStatus.toString();
+  const computeProgressPercentBody = computeProgressPercent.toString();
+  const shouldPreserveExistingProgressBody = shouldPreserveExistingProgress.toString();
+  const normalizeProgressNumbersBody = normalizeProgressNumbers.toString();
+
+  const parts: string[] = [
+    BANNER.trimEnd(),
+    '',
+    '// Internal helpers',
+    escapeRegexBody,
+    '',
+    toFiniteNumberBody,
+    '',
+    existingProgressExceedsDerivedBody,
+    '',
+    stateExtractFieldBody,
+    '',
+    stateReplaceFieldBody,
+    '',
+    stateReplaceFieldWithFallbackBody,
+    '',
+    normalizeStateStatusBody,
+    '',
+    computeProgressPercentBody,
+    '',
+    shouldPreserveExistingProgressBody,
+    '',
+    normalizeProgressNumbersBody,
+    '',
+    'module.exports = { stateExtractField, stateReplaceField, stateReplaceFieldWithFallback, normalizeStateStatus, computeProgressPercent, shouldPreserveExistingProgress, normalizeProgressNumbers };',
+    '',
+  ];
+
+  return parts.join('\n');
+}
+
+async function main(): Promise<void> {
+  const content = await buildStateDocumentCjs();
+  const outPath = fileURLToPath(
+    new URL('../../get-shit-done/bin/lib/state-document.generated.cjs', import.meta.url),
+  );
+  await writeFile(outPath, content, 'utf-8');
+  console.log(`Written: ${outPath}`);
+}
+
+// Only run main() when this file is the entry point, not when imported.
+const scriptPath = fileURLToPath(import.meta.url);
+const entryPath = process.argv[1] ? new URL(process.argv[1], 'file://').pathname : '';
+if (scriptPath === entryPath || process.argv[1] === scriptPath) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/sdk/scripts/gen-state-document.ts
+++ b/sdk/scripts/gen-state-document.ts
@@ -54,6 +54,9 @@ function extractFunctionFromSource(source: string, name: string): string {
       if (depth === 0) break;
     }
   }
+  if (depth !== 0) {
+    throw new Error(`Could not find closing brace for function ${name}`);
+  }
   // Return from `function name(` through the closing `}`
   return source.slice(start, i + 1);
 }

--- a/sdk/src/query/state-document.test.ts
+++ b/sdk/src/query/state-document.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Unit tests for STATE.md Document Module — stateExtractField.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  stateExtractField,
+  stateReplaceField,
+  stateReplaceFieldWithFallback,
+  normalizeStateStatus,
+  computeProgressPercent,
+  shouldPreserveExistingProgress,
+  normalizeProgressNumbers,
+} from './state-document.js';
+
+describe('stateExtractField', () => {
+  it('extracts value from bold pattern', () => {
+    const content = 'Some content\n**FieldName:** the value\nMore content';
+    expect(stateExtractField(content, 'FieldName')).toBe('the value');
+  });
+
+  it('extracts value from plain pattern', () => {
+    const content = 'Some content\nFieldName: the value\nMore content';
+    expect(stateExtractField(content, 'FieldName')).toBe('the value');
+  });
+
+  it('returns null when field is missing', () => {
+    const content = 'Some content\nOtherField: something\nMore content';
+    expect(stateExtractField(content, 'FieldName')).toBeNull();
+  });
+});
+
+describe('stateReplaceField', () => {
+  it('replaces value in bold pattern', () => {
+    const content = 'Some content\n**Status:** old value\nMore content';
+    const result = stateReplaceField(content, 'Status', 'new value');
+    expect(result).toBe('Some content\n**Status:** new value\nMore content');
+  });
+
+  it('replaces value in plain pattern', () => {
+    const content = 'Some content\nStatus: old value\nMore content';
+    const result = stateReplaceField(content, 'Status', 'new value');
+    expect(result).toBe('Some content\nStatus: new value\nMore content');
+  });
+
+  it('returns null when field is missing', () => {
+    const content = 'Some content\nOtherField: something\nMore content';
+    const result = stateReplaceField(content, 'Status', 'new value');
+    expect(result).toBeNull();
+  });
+});
+
+describe('stateReplaceFieldWithFallback', () => {
+  it('replaces primary field when it exists', () => {
+    const content = 'Status: old\nState: backup';
+    const result = stateReplaceFieldWithFallback(content, 'Status', 'State', 'new');
+    expect(result).toBe('Status: new\nState: backup');
+  });
+
+  it('replaces fallback field when primary is missing', () => {
+    const content = 'Other: something\nState: backup';
+    const result = stateReplaceFieldWithFallback(content, 'Status', 'State', 'new');
+    expect(result).toBe('Other: something\nState: new');
+  });
+
+  it('returns content unchanged when neither field exists', () => {
+    const content = 'Other: something\nAnother: value';
+    const result = stateReplaceFieldWithFallback(content, 'Status', 'State', 'new');
+    expect(result).toBe(content);
+  });
+});
+
+describe('normalizeStateStatus', () => {
+  it('returns paused for status containing "paused"', () => {
+    expect(normalizeStateStatus('paused')).toBe('paused');
+  });
+
+  it('returns paused for status containing "stopped"', () => {
+    expect(normalizeStateStatus('stopped')).toBe('paused');
+  });
+
+  it('returns paused when non-null pausedAt is provided', () => {
+    expect(normalizeStateStatus('active', '2024-01-01')).toBe('paused');
+  });
+
+  it('returns executing for status containing "executing"', () => {
+    expect(normalizeStateStatus('executing')).toBe('executing');
+  });
+
+  it('returns executing for status "in progress"', () => {
+    expect(normalizeStateStatus('in progress')).toBe('executing');
+  });
+
+  it('returns executing for status "ready to execute"', () => {
+    expect(normalizeStateStatus('ready to execute')).toBe('executing');
+  });
+
+  it('returns planning for status containing "planning"', () => {
+    expect(normalizeStateStatus('planning')).toBe('planning');
+  });
+
+  it('returns discussing for status containing "discussing"', () => {
+    expect(normalizeStateStatus('discussing')).toBe('discussing');
+  });
+
+  it('returns verifying for status containing "verif"', () => {
+    expect(normalizeStateStatus('verifying')).toBe('verifying');
+  });
+
+  it('returns completed for status containing "complete"', () => {
+    expect(normalizeStateStatus('completed')).toBe('completed');
+  });
+
+  it('returns completed for status containing "done"', () => {
+    expect(normalizeStateStatus('done')).toBe('completed');
+  });
+
+  it('returns unknown for unrecognized status', () => {
+    expect(normalizeStateStatus('something-else')).toBe('something-else');
+  });
+
+  it('returns unknown for null status', () => {
+    expect(normalizeStateStatus(null)).toBe('unknown');
+  });
+});
+
+describe('computeProgressPercent', () => {
+  it('uses only plans data when phases data is absent', () => {
+    expect(computeProgressPercent(3, 10, null, null)).toBe(30);
+  });
+
+  it('uses only phases data when plans data is absent', () => {
+    expect(computeProgressPercent(null, null, 2, 4)).toBe(50);
+  });
+
+  it('uses minimum fraction when both plans and phases data are present', () => {
+    // plans: 8/10 = 80%, phases: 3/10 = 30% → min = 30%
+    expect(computeProgressPercent(8, 10, 3, 10)).toBe(30);
+  });
+
+  it('returns null when neither plans nor phases data is present', () => {
+    expect(computeProgressPercent(null, null, null, null)).toBeNull();
+  });
+
+  it('returns null when total is 0 (treated as no data)', () => {
+    expect(computeProgressPercent(0, 0, null, null)).toBeNull();
+  });
+});
+
+describe('shouldPreserveExistingProgress', () => {
+  it('returns true when existing total_phases exceeds derived', () => {
+    expect(shouldPreserveExistingProgress({ total_phases: 10 }, { total_phases: 5 })).toBe(true);
+  });
+
+  it('returns false when derived exceeds existing', () => {
+    expect(shouldPreserveExistingProgress({ total_phases: 5 }, { total_phases: 10 })).toBe(false);
+  });
+
+  it('returns false when existingProgress is not an object', () => {
+    expect(shouldPreserveExistingProgress(null, { total_phases: 5 })).toBe(false);
+  });
+
+  it('returns false when both are null', () => {
+    expect(shouldPreserveExistingProgress(null, null)).toBe(false);
+  });
+});
+
+describe('normalizeProgressNumbers', () => {
+  it('coerces all five tracked keys to numbers', () => {
+    const input = {
+      total_phases: '10',
+      completed_phases: '3',
+      total_plans: '5',
+      completed_plans: '2',
+      percent: '60',
+    };
+    expect(normalizeProgressNumbers(input)).toEqual({
+      total_phases: 10,
+      completed_phases: 3,
+      total_plans: 5,
+      completed_plans: 2,
+      percent: 60,
+    });
+  });
+
+  it('returns non-object input unchanged', () => {
+    expect(normalizeProgressNumbers(null)).toBeNull();
+    expect(normalizeProgressNumbers('string')).toBe('string');
+  });
+
+  it('preserves extra keys untouched', () => {
+    const input = { total_phases: '4', extra_key: 'hello' };
+    const result = normalizeProgressNumbers(input) as Record<string, unknown>;
+    expect(result.total_phases).toBe(4);
+    expect(result.extra_key).toBe('hello');
+  });
+});

--- a/tests/state-document-generator.test.cjs
+++ b/tests/state-document-generator.test.cjs
@@ -1,0 +1,261 @@
+'use strict';
+
+/**
+ * Parity test — verifies that state-document.generated.cjs produces identical
+ * results to the compiled SDK ESM output for all exported functions.
+ *
+ * SDK side: require('../sdk/dist/query/state-document.js') via createRequire
+ * CJS side: require('../get-shit-done/bin/lib/state-document.generated.cjs')
+ */
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const { createRequire } = require('node:module');
+
+// The SDK dist is ESM; wrap with createRequire targeting the project root so
+// Node resolves the path correctly from this CJS context.
+const requireFromRoot = createRequire(__filename);
+
+// CJS side — direct require works fine
+const cjs = requireFromRoot('../get-shit-done/bin/lib/state-document.generated.cjs');
+
+describe('state-document-generator parity: stateReplaceFieldWithFallback', async () => {
+  const sdk = await import('../sdk/dist/query/state-document.js');
+
+  const fixtures = [
+    {
+      label: 'primary hit',
+      content: 'Status: old\nState: backup',
+      primary: 'Status',
+      fallback: 'State',
+      value: 'new',
+      expected: 'Status: new\nState: backup',
+    },
+    {
+      label: 'fallback hit',
+      content: 'Other: something\nState: backup',
+      primary: 'Status',
+      fallback: 'State',
+      value: 'new',
+      expected: 'Other: something\nState: new',
+    },
+    {
+      label: 'neither hit returns unchanged content',
+      content: 'Other: something\nAnother: value',
+      primary: 'Status',
+      fallback: 'State',
+      value: 'new',
+      expected: 'Other: something\nAnother: value',
+    },
+  ];
+
+  for (const { label, content, primary, fallback, value, expected } of fixtures) {
+    test(label, () => {
+      const sdkResult = sdk.stateReplaceFieldWithFallback(content, primary, fallback, value);
+      const cjsResult = cjs.stateReplaceFieldWithFallback(content, primary, fallback, value);
+      assert.strictEqual(sdkResult, expected, `SDK: ${label}`);
+      assert.strictEqual(cjsResult, expected, `CJS: ${label}`);
+      assert.strictEqual(sdkResult, cjsResult, `SDK/CJS parity: ${label}`);
+    });
+  }
+});
+
+describe('state-document-generator parity: normalizeStateStatus', async () => {
+  const sdk = await import('../sdk/dist/query/state-document.js');
+
+  const fixtures = [
+    { label: 'paused via "paused"', status: 'paused', expected: 'paused' },
+    { label: 'paused via "stopped"', status: 'stopped', expected: 'paused' },
+    { label: 'paused via non-null pausedAt', status: 'active', pausedAt: '2024-01-01', expected: 'paused' },
+    { label: 'executing via "executing"', status: 'executing', expected: 'executing' },
+    { label: 'executing via "in progress"', status: 'in progress', expected: 'executing' },
+    { label: 'executing via "ready to execute"', status: 'ready to execute', expected: 'executing' },
+    { label: 'planning via "planning"', status: 'planning', expected: 'planning' },
+    { label: 'discussing via "discussing"', status: 'discussing', expected: 'discussing' },
+    { label: 'verifying via "verif"', status: 'verifying', expected: 'verifying' },
+    { label: 'completed via "complete"', status: 'completed', expected: 'completed' },
+    { label: 'completed via "done"', status: 'done', expected: 'completed' },
+    { label: 'unknown fallback', status: 'something-else', expected: 'something-else' },
+    { label: 'null status', status: null, expected: 'unknown' },
+  ];
+
+  for (const { label, status, pausedAt, expected } of fixtures) {
+    test(label, () => {
+      const sdkResult = sdk.normalizeStateStatus(status, pausedAt);
+      const cjsResult = cjs.normalizeStateStatus(status, pausedAt);
+      assert.strictEqual(sdkResult, expected, `SDK: ${label}`);
+      assert.strictEqual(cjsResult, expected, `CJS: ${label}`);
+      assert.strictEqual(sdkResult, cjsResult, `SDK/CJS parity: ${label}`);
+    });
+  }
+});
+
+describe('state-document-generator parity: computeProgressPercent', async () => {
+  const sdk = await import('../sdk/dist/query/state-document.js');
+
+  const fixtures = [
+    { label: 'only plans data', cp: 3, tp: 10, cf: null, tf: null, expected: 30 },
+    { label: 'only phases data', cp: null, tp: null, cf: 2, tf: 4, expected: 50 },
+    { label: 'both present uses min', cp: 8, tp: 10, cf: 3, tf: 10, expected: 30 },
+    { label: 'neither returns null', cp: null, tp: null, cf: null, tf: null, expected: null },
+    { label: 'total of 0 treated as no data', cp: 0, tp: 0, cf: null, tf: null, expected: null },
+  ];
+
+  for (const { label, cp, tp, cf, tf, expected } of fixtures) {
+    test(label, () => {
+      const sdkResult = sdk.computeProgressPercent(cp, tp, cf, tf);
+      const cjsResult = cjs.computeProgressPercent(cp, tp, cf, tf);
+      assert.strictEqual(sdkResult, expected, `SDK: ${label}`);
+      assert.strictEqual(cjsResult, expected, `CJS: ${label}`);
+      assert.strictEqual(sdkResult, cjsResult, `SDK/CJS parity: ${label}`);
+    });
+  }
+});
+
+describe('state-document-generator parity: shouldPreserveExistingProgress', async () => {
+  const sdk = await import('../sdk/dist/query/state-document.js');
+
+  const fixtures = [
+    {
+      label: 'existing exceeds derived on total_phases → true',
+      existing: { total_phases: 10 },
+      derived: { total_phases: 5 },
+      expected: true,
+    },
+    {
+      label: 'derived exceeds existing → false',
+      existing: { total_phases: 5 },
+      derived: { total_phases: 10 },
+      expected: false,
+    },
+    {
+      label: 'malformed input (non-object) → false',
+      existing: null,
+      derived: { total_phases: 5 },
+      expected: false,
+    },
+    {
+      label: 'both null → false',
+      existing: null,
+      derived: null,
+      expected: false,
+    },
+  ];
+
+  for (const { label, existing, derived, expected } of fixtures) {
+    test(label, () => {
+      const sdkResult = sdk.shouldPreserveExistingProgress(existing, derived);
+      const cjsResult = cjs.shouldPreserveExistingProgress(existing, derived);
+      assert.strictEqual(sdkResult, expected, `SDK: ${label}`);
+      assert.strictEqual(cjsResult, expected, `CJS: ${label}`);
+      assert.strictEqual(sdkResult, cjsResult, `SDK/CJS parity: ${label}`);
+    });
+  }
+});
+
+describe('state-document-generator parity: normalizeProgressNumbers', async () => {
+  const sdk = await import('../sdk/dist/query/state-document.js');
+
+  const fixtures = [
+    {
+      label: 'coerces all five tracked keys to numbers',
+      input: { total_phases: '10', completed_phases: '3', total_plans: '5', completed_plans: '2', percent: '60' },
+      expected: { total_phases: 10, completed_phases: 3, total_plans: 5, completed_plans: 2, percent: 60 },
+    },
+    {
+      label: 'non-object null returned unchanged',
+      input: null,
+      expected: null,
+    },
+    {
+      label: 'extra keys preserved untouched',
+      input: { total_phases: '4', extra_key: 'hello' },
+      expected: { total_phases: 4, extra_key: 'hello' },
+    },
+  ];
+
+  for (const { label, input, expected } of fixtures) {
+    test(label, () => {
+      const sdkResult = sdk.normalizeProgressNumbers(input);
+      const cjsResult = cjs.normalizeProgressNumbers(input);
+      assert.deepStrictEqual(sdkResult, expected, `SDK: ${label}`);
+      assert.deepStrictEqual(cjsResult, expected, `CJS: ${label}`);
+      assert.deepStrictEqual(sdkResult, cjsResult, `SDK/CJS parity: ${label}`);
+    });
+  }
+});
+
+// SDK ESM side — dynamically import so we can test both; wrap in a top-level
+// async test suite.
+describe('state-document-generator parity: stateExtractField', async () => {
+  const sdk = await import('../sdk/dist/query/state-document.js');
+
+  const fixtures = [
+    {
+      label: 'bold pattern',
+      content: 'Some content\n**FieldName:** the value\nMore content',
+      fieldName: 'FieldName',
+      expected: 'the value',
+    },
+    {
+      label: 'plain pattern',
+      content: 'Some content\nFieldName: the value\nMore content',
+      fieldName: 'FieldName',
+      expected: 'the value',
+    },
+    {
+      label: 'missing field returns null',
+      content: 'Some content\nOtherField: something\nMore content',
+      fieldName: 'FieldName',
+      expected: null,
+    },
+  ];
+
+  for (const { label, content, fieldName, expected } of fixtures) {
+    test(label, () => {
+      const sdkResult = sdk.stateExtractField(content, fieldName);
+      const cjsResult = cjs.stateExtractField(content, fieldName);
+      assert.strictEqual(sdkResult, expected, `SDK: ${label}`);
+      assert.strictEqual(cjsResult, expected, `CJS: ${label}`);
+      assert.strictEqual(sdkResult, cjsResult, `SDK/CJS parity: ${label}`);
+    });
+  }
+});
+
+describe('state-document-generator parity: stateReplaceField', async () => {
+  const sdk = await import('../sdk/dist/query/state-document.js');
+
+  const fixtures = [
+    {
+      label: 'bold replace',
+      content: 'Some content\n**Status:** old value\nMore content',
+      fieldName: 'Status',
+      newValue: 'new value',
+      expected: 'Some content\n**Status:** new value\nMore content',
+    },
+    {
+      label: 'plain replace',
+      content: 'Some content\nStatus: old value\nMore content',
+      fieldName: 'Status',
+      newValue: 'new value',
+      expected: 'Some content\nStatus: new value\nMore content',
+    },
+    {
+      label: 'missing field returns null',
+      content: 'Some content\nOtherField: something\nMore content',
+      fieldName: 'Status',
+      newValue: 'new value',
+      expected: null,
+    },
+  ];
+
+  for (const { label, content, fieldName, newValue, expected } of fixtures) {
+    test(label, () => {
+      const sdkResult = sdk.stateReplaceField(content, fieldName, newValue);
+      const cjsResult = cjs.stateReplaceField(content, fieldName, newValue);
+      assert.strictEqual(sdkResult, expected, `SDK: ${label}`);
+      assert.strictEqual(cjsResult, expected, `CJS: ${label}`);
+      assert.strictEqual(sdkResult, cjsResult, `SDK/CJS parity: ${label}`);
+    });
+  }
+});


### PR DESCRIPTION
## Linked Issue

Closes #3530

Phase 1 of #3524. Parent enhancement: [#3524](https://github.com/gsd-build/get-shit-done/issues/3524) — CJS↔SDK hard seam. Architecture: [ADR-3524](https://github.com/gsd-build/get-shit-done/pull/3529) (under review in PR #3529).

Issue #3530 labeled `approved-enhancement` + `in-progress`.

---

## What this enhancement improves

`get-shit-done/bin/lib/state-document.cjs` and `sdk/src/query/state-document.ts` were a **character-identical hand-synced pair** of pure transforms. Any edit to one side that wasn't manually mirrored to the other would silently drift — the exact failure mode that produced bug #3523 elsewhere in the codebase. This PR eliminates the hand-sync by making the TypeScript file the source of truth and emitting the CJS file from it via a generator, modeled on the existing `command-aliases.generated.*` precedent.

This is **Phase 1 of a six-phase migration** under #3524. Phase 1 is intentionally the smallest possible proof of the generator pattern on executable logic (Phase 0, command-aliases, already proved it for declarative data). Subsequent phases (Configuration Module in Phase 2, etc.) follow the same shape.

## Before / After

**Before:**

- `bin/lib/state-document.cjs` (122 lines) and `sdk/src/query/state-document.ts` (130 lines) maintained in parallel by hand.
- No mechanism prevents one side drifting from the other.
- No test pins observable behavior at the function level — coverage comes only via downstream consumers (`state.cjs`, `workstream-inventory.cjs`, `init.cjs`).

**After:**

- `sdk/src/query/state-document.ts` is the **source of truth** for all seven public exports plus three internal helpers.
- `get-shit-done/bin/lib/state-document.generated.cjs` is emitted mechanically from the compiled SDK output by `sdk/scripts/gen-state-document.ts` (via `Function.prototype.toString()` on each export, plus brace-balanced text scanning of `dist/query/state-document.js` for the unexported helper `escapeRegex`). Standard `GENERATED FILE — DO NOT EDIT.` banner.
- `bin/lib/state-document.cjs` shrinks from 122 lines of duplicated logic to a 12-line shim that re-exports from `state-document.generated.cjs`. The filename is preserved so the ~10 existing callers need no import updates.
- `sdk/scripts/check-state-document-fresh.mjs` re-runs the generator in-memory and exits non-zero on drift. Wired into CI (new step in `.github/workflows/test.yml` after the existing alias drift check) and into the local pre-commit hook for relevant file paths.
- 34 vitest pinning tests in `sdk/src/query/state-document.test.ts` (one suite per function).
- 31 node:test parity assertions in `tests/state-document-generator.test.cjs` comparing SDK source vs generated CJS for every fixture.

## How it was implemented

TDD with the `/tdd` skill's vertical-slice discipline. One function per cycle, GREEN after every cycle.

1. **Tracer bullet** (cycle 0): `stateExtractField` end-to-end — pinning test, generator emitting just that function, parity test, freshness check. Attempted the shim, observed it broke `state.cjs` (which uses 5 other exports), reverted to the full hand-written CJS as a safety stop.
2. **Iteration** (cycles 1–6): one cycle per remaining public export — `stateReplaceField`, `stateReplaceFieldWithFallback`, `normalizeStateStatus`, `computeProgressPercent`, `shouldPreserveExistingProgress`, `normalizeProgressNumbers`. Each cycle: add 3–13 pinning fixtures, extend the generator, regenerate, re-run vitest + parity test + freshness check. All GREEN.
3. **Shim landing**: with all 7 exports emitted by the generator, replaced `bin/lib/state-document.cjs` with the one-line shim. Full test suite GREEN (9177/9177, up from 9146 baseline by exactly the 31 new parity assertions).
4. **Wiring**: CI step, root proxy script, pre-commit hook integration, CONTEXT.md amendment.

Generator strategy matches `gen-command-aliases.ts`: import from compiled `sdk/dist/`, capture function bodies via `Function.prototype.toString()`, emit inline into the generated CJS file. The generator is deterministic — re-running on the same source produces byte-identical output (verified by the freshness check).

## Testing

### How I verified the enhancement works

- `cd sdk && npx vitest run src/query/state-document.test.ts` — 34 pinning tests pass against the SDK source.
- `node scripts/run-tests.cjs` — full suite 9177/9177 pass after the shim lands. Baseline was 9146. The 31-test increase matches the 31 new parity assertions exactly.
- `node sdk/scripts/check-state-document-fresh.mjs` — exits 0 against the committed generated file. Intentionally mutating the generated file and re-running exits 1 (confirmed during development).
- Existing STATE.md consumer tests pass unchanged: `tests/state.test.cjs`, `tests/health-validation.test.cjs`, `tests/concurrency-safety.test.cjs`, `sdk/src/query/state-mutation.test.ts`, `sdk/src/query/state.test.ts`, `sdk/src/query/helpers.test.ts`.

### Platforms tested

- [x] macOS
- [ ] Windows — not separately tested; the generator and freshness check use only `node:fs/promises` and `node:path`, which behave identically on Windows. The CI step is gated on `ubuntu-latest` (matching the precedent alias drift check).
- [x] Linux (via CI)
- [ ] N/A

### Runtimes tested

- [x] Claude Code (the runtime this work was done in)
- [ ] Gemini CLI, OpenCode, etc. — N/A, this is an internal-module refactor with no runtime-facing surface change

---

## Subtle behavior change worth flagging

The old hand-written `state-document.cjs` used `String(str).replace(...)` inside `escapeRegex`, which coerces non-string input to a string before regex-escaping. The SDK source uses `str.replace(...)` directly (no coercion). The new generated CJS faithfully matches the SDK source (per ADR-3524, the SDK is the source of truth).

**Net effect:** if any caller of `stateExtractField`/`stateReplaceField`/`stateReplaceFieldWithFallback` were to pass a non-string `fieldName`, the old CJS would have coerced; the new CJS will throw the same `TypeError` the SDK throws. No current caller does this (verified by 9177/9177 passing tests). This is a documented, intentional convergence — not a regression.

---

## Scope confirmation

- [x] The implementation matches the scope approved in #3530 — no additions or removals
- [x] If scope changed during implementation, I updated the issue and got re-approval before continuing — no scope changes needed

---

## Checklist

- [x] Issue linked above with `Closes #3530`
- [x] Linked issue has the `approved-enhancement` label
- [x] Changes are scoped to the approved enhancement
- [x] All existing tests pass (`npm test`) — 9177/9177
- [x] New or updated tests cover the enhanced behavior — 34 vitest fixtures + 31 parity fixtures
- [ ] `.changeset/` fragment added — **N/A**, applying `no-changelog` label: this is an internal-module refactor with no user-visible behavior change (the documented `escapeRegex` coercion convergence is for non-string input no caller passes)
- [x] Documentation updated if behavior or output changed — CONTEXT.md `STATE.md Document Module` entry amended with source-of-truth file path
- [x] No unnecessary dependencies added — one devDep (`tsx`) needed to run the TypeScript generator; matches the existing `gen-command-aliases.ts` toolchain

## Breaking changes

None for any current caller. The documented `escapeRegex` non-string-input convergence above is the only observable difference and no caller in the repo (verified by the full test suite) passes non-string input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a generated CLI module for STATE.md-style document processing.

* **Tests**
  * Added comprehensive tests verifying parity between SDK and generated artifact implementations.

* **Chores**
  * Added pre-commit and CI freshness checks to ensure generated artifact is up-to-date.
  * Updated documentation and inventory to include the new CLI module.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3531)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->