### PR TITLE
Docs: align v1.42.1 release notes format

### DIFF
--- a/docs/RELEASE-v1.42.1.md
+++ b/docs/RELEASE-v1.42.1.md
@@ -10,37 +10,156 @@ npx get-shit-done-cc@latest
 
 ## What's in this release
 
-1.42.1 is a safety, documentation, and control-surface release. The headline additions are the package legitimacy gate, skill-surface budgeting, installer migrations, configurable ship PR sections, reviewer defaults, and optional fallow structural review. It also includes execution and state hardening across quota handling, milestone tags, `project_code` phase directories, phase completion, nested git detection, Codex install migration, and SDK readiness.
+1.42.1 is a safety and control-surface release. The headline additions are the
+**package legitimacy gate**, **skill-surface budgeting**, and the **installer migration
+framework** — three changes that make GSD safer to install, safer to update, and easier
+to run in constrained contexts. The release also ships configurable `/gsd-ship` PR body
+sections, `/gsd-review` reviewer defaults, optional fallow structural review, and
+quota-aware execution recovery. Underneath that, 30+ correctness fixes cover
+`project_code` phase directories, phase completion, nested git detection, Codex
+install migration, SDK readiness, and decimal-phase dependencies.
 
-## Added
+### Added
 
-- **Package legitimacy gate against slopsquatting** — researchers audit external packages with `slopcheck`, planners add human verification for unverified packages, and executors stop on package install failures instead of trying similarly named alternatives.
-- **Skill surface budgeting** — install with `--profile=core`, `--profile=standard`, or the default `full`; profiles persist in `.gsd-profile`. Use `/gsd:surface` to list, enable, disable, or switch skill clusters without reinstalling.
-- **Installer migrations** — install now has an explicit migration framework for baseline scanning, legacy cleanup, user-owned file preservation, rollback, and ambiguous stale-file guardrails.
-- **Configurable `/gsd-ship` PR body sections** — `ship.pr_body_sections` appends project-specific PRD-style sections while preserving required review sections.
-- **`review.default_reviewers`** — no-flag `/gsd-review` can default to a configured reviewer subset; explicit flags and `--all` still take precedence.
-- **Optional fallow structural review** — `code_quality.fallow.*` runs a structural pre-pass for `/gsd-code-review`, writes `FALLOW.json`, and embeds findings in `REVIEW.md`.
-- **Statusline context meter placement** — `statusline.context_position: "front"` keeps the context meter visible on narrow terminals.
-- **Structured CLI errors** — `--json-errors` returns machine-readable error envelopes for `gsd-tools` callers.
+- **Package legitimacy gate against slopsquatting** — researchers audit external
+  packages with `slopcheck`, planners add human verification for unverified packages,
+  and executors stop on package install failures instead of trying similarly named
+  alternatives. This closes the path where AI-hallucinated package names could flow
+  from research into `npm install` / `pip install` / `cargo add`.
+  ([#3215](https://github.com/gsd-build/get-shit-done/pull/3215))
 
-## Changed
+- **Skill surface budgeting** — install with `--profile=core`, `--profile=standard`,
+  or the default `full`; profiles persist in `.gsd-profile`. Use `/gsd:surface` to
+  list, enable, disable, reset, or switch skill clusters without reinstalling.
+  `--minimal` and `--core-only` remain aliases for `--profile=core`.
+  ([#3408](https://github.com/gsd-build/get-shit-done/pull/3456))
 
-- **Human verification defaults to end-of-phase** — `workflow.human_verify_mode: "end-of-phase"` keeps human checks in verification blocks instead of scattering mid-flight checkpoint tasks. Set `"mid-flight"` to restore the older behavior.
-- **Quota and rate-limit failures get a distinct recovery path** — execute-phase classifies provider quota failures and guides wait-and-resume rather than retry-now.
-- **Milestone tags can be disabled** — `git.create_tag: false` prevents automatic tags for projects with their own release process.
-- **Reasoning effort is transported with resolved model IDs** — runtime-aware model resolution now carries `reasoning_effort` where supported, including Codex config output and SDK query paths.
-- **Shell command projection and SDK architecture seams were deepened** — hook commands, path actions, subprocess execution, platform file I/O, and SDK compatibility policy now flow through narrower typed modules.
+- **Installer migration framework** — install now has explicit migration records,
+  baseline scanning, legacy cleanup, user-owned artifact preservation, dry-run
+  reporting, rollback protection, and ambiguous stale-file guardrails.
+  ([#3398](https://github.com/gsd-build/get-shit-done/pull/3398),
+  [#3399](https://github.com/gsd-build/get-shit-done/pull/3399),
+  [#3400](https://github.com/gsd-build/get-shit-done/pull/3400),
+  [#3402](https://github.com/gsd-build/get-shit-done/pull/3402),
+  [#3404](https://github.com/gsd-build/get-shit-done/pull/3404))
 
-## Fixed
+- **Configurable `/gsd-ship` PR body sections** — `ship.pr_body_sections` appends
+  project-specific PRD-style sections while preserving the required `Summary`,
+  `Changes`, `Requirements Addressed`, `Verification`, and `Key Decisions` sections.
+  ([#3391](https://github.com/gsd-build/get-shit-done/pull/3391))
 
-- `project_code` phase directory prefixes now apply consistently across discuss, plan, import, gap-planning, and backlog creation paths.
-- Phase completion is idempotent and refreshes stale `STATE.md` progress and focus fields.
-- `/gsd-new-project` and ingest flows detect nested git worktrees and avoid creating nested `.git` directories.
-- Codex install migration preserves user hooks, removes duplicate legacy hook entries, and emits correct event-name keys.
-- SDK install readiness now requires durable shims before printing "GSD SDK ready", including Windows PATH repair.
-- User custom skills are detected during update preservation scans.
-- Decimal-phase short-form `depends_on` references resolve correctly.
-- `gsd-sdk query commit --files --respect-staged` preserves interactive staging.
+- **`review.default_reviewers`** — no-flag `/gsd-review` can default to a configured
+  reviewer subset. Explicit reviewer flags and `--all` still take precedence.
+  ([#3464](https://github.com/gsd-build/get-shit-done/pull/3464))
+
+- **Optional fallow structural review pre-pass** — `code_quality.fallow.*` runs a
+  structural pass before `/gsd-code-review`, writes `FALLOW.json`, and embeds
+  structural findings in `REVIEW.md`.
+  ([#3424](https://github.com/gsd-build/get-shit-done/pull/3486))
+
+- **Structured CLI error mode** — `gsd-tools --json-errors` returns machine-readable
+  error envelopes for automation and SDK callers while preserving human-readable output
+  by default.
+  ([#3255](https://github.com/gsd-build/get-shit-done/pull/3304))
+
+### Changed
+
+- **Human verification defaults to end-of-phase** — `workflow.human_verify_mode:
+  "end-of-phase"` keeps human checks in verification blocks instead of scattering
+  mid-flight checkpoint tasks. Set `"mid-flight"` to restore the previous blocking
+  checkpoint behavior.
+  ([#3309](https://github.com/gsd-build/get-shit-done/pull/3325))
+
+- **Quota and rate-limit failures get a distinct recovery path** — execute-phase
+  classifies provider quota failures (`429`, `rate limit`, `usage limit`,
+  `RESOURCE_EXHAUSTED`, etc.) and guides wait-and-resume instead of retry-now.
+  ([#3095](https://github.com/gsd-build/get-shit-done/pull/3490))
+
+- **Milestone tags can be disabled** — `git.create_tag: false` lets projects with
+  external release automation complete milestones without creating local tags.
+  Existing tag collisions now fail clearly instead of overwriting tags.
+  ([#3086](https://github.com/gsd-build/get-shit-done/pull/3508))
+
+- **Statusline context meter can move to the front** — `statusline.context_position:
+  "front"` renders the context meter after the model name so it stays visible in narrow
+  terminals.
+  ([#2937](https://github.com/gsd-build/get-shit-done/pull/3515))
+
+- **Reasoning effort is transported with resolved model IDs** — runtime-aware model
+  resolution now carries `reasoning_effort` where supported, including Codex config
+  output and SDK query paths.
+  ([#3474](https://github.com/gsd-build/get-shit-done/pull/3483))
+
+- **Shell command projection and SDK architecture seams deepened** — hook commands,
+  path actions, subprocess execution, platform file I/O, SDK compatibility policy, and
+  runtime skill policy now flow through narrower typed modules.
+  ([#3238](https://github.com/gsd-build/get-shit-done/pull/3238),
+  [#3316](https://github.com/gsd-build/get-shit-done/pull/3316),
+  [#3470](https://github.com/gsd-build/get-shit-done/pull/3470),
+  [#3476](https://github.com/gsd-build/get-shit-done/pull/3476),
+  [#3481](https://github.com/gsd-build/get-shit-done/pull/3481),
+  [#3484](https://github.com/gsd-build/get-shit-done/pull/3484))
+
+### Fixed
+
+- **`project_code` phase directory prefixes apply consistently** — first-touch
+  `/gsd-discuss-phase`, `/gsd-plan-phase`, import, gap-planning, and backlog creation
+  paths now create prefixed phase directories consistently.
+  ([#3287](https://github.com/gsd-build/get-shit-done/pull/3292),
+  [#3298](https://github.com/gsd-build/get-shit-done/pull/3306))
+
+- **Phase completion is idempotent and refreshes state** — `state complete-phase` and
+  `phase.complete` no longer leave stale `STATE.md` progress, focus, or body
+  frontmatter fields behind.
+  ([#3489](https://github.com/gsd-build/get-shit-done/pull/3499),
+  [#3517](https://github.com/gsd-build/get-shit-done/pull/3520))
+
+- **Nested git worktrees are detected** — `/gsd-new-project` and ingest flows avoid
+  creating nested `.git` directories when run inside an existing repository or
+  worktree.
+  ([#3491](https://github.com/gsd-build/get-shit-done/pull/3502))
+
+- **Codex install and hook migration are safer** — AoT hooks use event-name leaf keys,
+  duplicate legacy `hooks.json` entries are removed, user hooks are preserved, and
+  unsupported execute-phase worktrees are blocked.
+  ([#3346](https://github.com/gsd-build/get-shit-done/pull/3505),
+  [#3357](https://github.com/gsd-build/get-shit-done/pull/3380),
+  [#3360](https://github.com/gsd-build/get-shit-done/pull/3380))
+
+- **SDK install readiness is durable** — `--sdk` now forces SDK deployment, stale shims
+  are detected, Windows PATH probing is hardened, and "GSD SDK ready" only prints when
+  the shim is reachable.
+  ([#3033](https://github.com/gsd-build/get-shit-done/issues/3033),
+  [#3211](https://github.com/gsd-build/get-shit-done/pull/3282),
+  [#3231](https://github.com/gsd-build/get-shit-done/pull/3249),
+  [#3359](https://github.com/gsd-build/get-shit-done/pull/3380))
+
+- **User custom skills are preserved during update detection** — `detect-custom-files`
+  now scans `skills/`, preventing user-added skill files from being missed during
+  patch preservation.
+  ([#3317](https://github.com/gsd-build/get-shit-done/pull/3318))
+
+- **Decimal-phase `depends_on` references resolve correctly** — SDK phase indexing now
+  expands same-phase short forms such as `depends_on: [01]` and warns on unresolved
+  references.
+  ([#3488](https://github.com/gsd-build/get-shit-done/pull/3501))
+
+- **`gsd-sdk query commit --files --respect-staged` preserves interactive staging** —
+  respect-staged mode now avoids restaging pathspecs and commits only the already
+  staged hunks within the requested file scope.
+  ([#3522](https://github.com/gsd-build/get-shit-done/pull/3528))
+
+---
+
+## What was in 1.41.0
+
+[`RELEASE-v1.41.0.md`](RELEASE-v1.41.0.md) — per-phase-type model selection,
+dynamic routing with failure-tier escalation, the optional update banner,
+issue-driven orchestration, MVP mode SDK query verbs, graphify commit-based
+staleness, and 25+ correctness fixes across Homebrew node paths, milestone archives,
+secure-phase audits, cross-runtime installs, and statusline parsing.
+
+---
 
 ## Installing
 
@@ -55,4 +174,5 @@ npx get-shit-done-cc@latest
 npm install -g get-shit-done-cc@1.42.1
 ```
 
-The installer is idempotent. Re-running it updates in place while preserving `.planning/` and local patches.
+The installer is idempotent — re-running on an existing install updates in-place,
+preserving your `.planning/` directory and local patches.


### PR DESCRIPTION
Closes #3534

## Summary

- Reshape docs/RELEASE-v1.42.1.md to match previous stable release notes.
- Convert dense Added/Changed/Fixed sections to the prior ### section hierarchy with wrapped bullets and issue/PR references.
- Add the standard previous-release summary section for v1.41.0.

## Verification

- git diff --check
- node --test tests/docs-parity-live-registry.test.cjs tests/config-schema-docs-parity.test.cjs tests/config-field-docs.test.cjs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced v1.42.1 release notes with improved structure and expanded content
  * Added clearer headlines and reorganized feature descriptions in Added, Changed, and Fixed sections
  * Included link to previous release notes for additional context
  * Updated installer documentation to clarify update and preservation behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3535)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->