### PR TITLE
fix(state): padding-tolerant phase-ID matching across affected verbs (#3537)

### DIFF
--- a/.changeset/fix-3537-padding-tolerant-phase-id-matching.md
+++ b/.changeset/fix-3537-padding-tolerant-phase-id-matching.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3539
+---
+**Padded phase IDs no longer silently no-op on un-padded ROADMAP prose** — `phaseMarkdownRegexSource()` (added in 1.42.1) was wired into only 1 of 8 affected sites; the rest used raw `escapeRegex(phaseNum)` and silently failed when skills resolved a padded `phase_number` like `02.7` and passed it to state verbs against un-padded prose like `### Phase 2.7:`. The helper is now wired across `cmdRoadmapGetPhase`, `cmdRoadmapAnalyze`, `cmdRoadmapAnnotateDependencies`, `cmdPhaseComplete`, `cmdPhaseNextDecimal`, `cmdPhaseInsert`, and `getRoadmapPhaseInternal`; promoted from `roadmap.cjs` to `core.cjs` so the three lib files share one definition without a circular import. Closes #3537.

--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -726,6 +726,30 @@ function normalizePhaseName(phase) {
   return str;
 }
 
+/**
+ * Build a regex-source fragment that matches a phase number in ROADMAP.md /
+ * STATE.md prose regardless of zero-padding. ROADMAP text is human-authored and
+ * usually un-padded ("Phase 2.6"); phase dirs and SDK-normalized IDs are padded
+ * ("CK-02.6", "02.6"). Callers pass either form — this tolerates both:
+ *   "2.6" | "02.6" | "CK-02.6"  -> "0*2\.6"
+ *   "3"   | "03"                 -> "0*3"
+ *   "12A"                        -> "0*12A"   (case handled by /i at call sites)
+ *   "PROJ-42"                    -> "0*42"    (project-code prefix stripped, like normalizePhaseName)
+ *   non-numeric custom IDs       -> escaped passthrough
+ *
+ * Lives in core.cjs so phase.cjs / roadmap.cjs / core.cjs all share one helper.
+ */
+function phaseMarkdownRegexSource(phaseNum) {
+  const stripped = String(phaseNum).replace(/^[A-Z]{1,6}-(?=\d)/i, '');
+  const match = stripped.match(/^0*(\d+)([A-Z])?((?:\.\d+)*)$/i);
+  if (!match) return escapeRegex(phaseNum);
+
+  const integer = match[1].replace(/^0+/, '') || '0';
+  const letter = match[2] ? escapeRegex(match[2]) : '';
+  const decimal = match[3] ? escapeRegex(match[3]) : '';
+  return `0*${escapeRegex(integer)}${letter}${decimal}`;
+}
+
 function comparePhaseNum(a, b) {
   // Strip optional project_code prefix before comparing (e.g., 'CK-01-name' → '01-name')
   const sa = String(a).replace(/^[A-Z]{1,6}-/, '');
@@ -1071,19 +1095,15 @@ function getRoadmapPhaseInternal(cwd, phaseNum) {
     const roadmapRaw = platformReadSync(roadmapPath);
     if (roadmapRaw === null) throw new Error('missing');
     const content = extractCurrentMilestone(roadmapRaw, cwd);
-    // Strip leading zeros from purely numeric phase numbers so "03" matches "Phase 3:"
-    // in canonical ROADMAP headings. Non-numeric IDs (e.g. "PROJ-42") are kept as-is.
-    const normalized = /^\d+$/.test(String(phaseNum))
-      ? String(phaseNum).replace(/^0+(?=\d)/, '')
-      : String(phaseNum);
-    const escapedPhase = escapeRegex(normalized);
-    // Match both numeric and custom (Phase PROJ-42:) headers.
-    // For purely numeric phases allow optional leading zeros so both "Phase 1:" and
-    // "Phase 01:" are matched regardless of whether the ROADMAP uses padded numbers.
-    const isNumeric = /^\d+$/.test(String(phaseNum));
-    const phasePattern = isNumeric
-      ? new RegExp(`#{2,4}\\s*Phase\\s+0*${escapedPhase}:\\s*([^\\n]+)`, 'i')
-      : new RegExp(`#{2,4}\\s*Phase\\s+${escapedPhase}:\\s*([^\\n]+)`, 'i');
+    // Match Phase headers regardless of zero-padding — ROADMAP prose is usually
+    // un-padded ("Phase 2.6") while callers may pass padded ("02.6"). Decimal and
+    // letter-suffixed phases are handled too; custom IDs fall through to an exact
+    // escaped match. See phaseMarkdownRegexSource() — the old isNumeric branch here
+    // only padded integer phases, leaving decimals ("2.6") broken.
+    const phasePattern = new RegExp(
+      `#{2,4}\\s*Phase\\s+${phaseMarkdownRegexSource(phaseNum)}:\\s*([^\\n]+)`,
+      'i'
+    );
     const headerMatch = content.match(phasePattern);
     if (!headerMatch) return null;
 
@@ -1880,6 +1900,7 @@ module.exports = {
   isGitIgnored,
   escapeRegex,
   normalizePhaseName,
+  phaseMarkdownRegexSource,
   comparePhaseNum,
   searchPhaseInDir,
   extractPhaseToken,

--- a/get-shit-done/bin/lib/phase.cjs
+++ b/get-shit-done/bin/lib/phase.cjs
@@ -4,7 +4,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { escapeRegex, loadConfig, normalizePhaseName, comparePhaseNum, findPhaseInternal, getArchivedPhaseDirs, generateSlugInternal, getMilestonePhaseFilter, stripShippedMilestones, extractCurrentMilestone, replaceInCurrentMilestone, toPosixPath, output, error, readSubdirectories, phaseTokenMatches } = require('./core.cjs');
+const { escapeRegex, loadConfig, normalizePhaseName, phaseMarkdownRegexSource, comparePhaseNum, findPhaseInternal, getArchivedPhaseDirs, generateSlugInternal, getMilestonePhaseFilter, stripShippedMilestones, extractCurrentMilestone, replaceInCurrentMilestone, toPosixPath, output, error, readSubdirectories, phaseTokenMatches } = require('./core.cjs');
 const { platformWriteSync, platformReadSync, platformEnsureDir } = require('./shell-command-projection.cjs');
 const { planningDir, withPlanningLock } = require('./planning-workspace.cjs');
 const { extractFrontmatter } = require('./frontmatter.cjs');
@@ -170,8 +170,11 @@ function cmdPhaseNextDecimal(cwd, basePhase, raw) {
     if (fs.existsSync(roadmapPath)) {
       try {
         const roadmapContent = fs.readFileSync(roadmapPath, 'utf-8');
+        // phaseMarkdownRegexSource already prepends `0*` and tolerates un-padded
+        // ROADMAP prose vs the padded `normalized` value — the prior literal
+        // `0*${escaped}` only handled extra padding, not missing padding.
         const phasePattern = new RegExp(
-          `#{2,4}\\s*Phase\\s+0*${escapeRegex(normalized)}\\.(\\d+)\\s*:`, 'gi'
+          `#{2,4}\\s*Phase\\s+${phaseMarkdownRegexSource(normalized)}\\.(\\d+)\\s*:`, 'gi'
         );
         let pm;
         while ((pm = phasePattern.exec(roadmapContent)) !== null) {
@@ -719,9 +722,10 @@ function cmdPhaseInsert(cwd, afterPhase, description, raw) {
       }
     } catch { /* intentionally empty */ }
 
-    // Also scan ROADMAP.md content (already loaded) for decimal entries
+    // Also scan ROADMAP.md content (already loaded) for decimal entries.
+    // phaseMarkdownRegexSource already prepends `0*` and tolerates un-padded prose.
     const rmPhasePattern = new RegExp(
-      `#{2,4}\\s*Phase\\s+0*${escapeRegex(normalizedBase)}\\.(\\d+)\\s*:`, 'gi'
+      `#{2,4}\\s*Phase\\s+${phaseMarkdownRegexSource(normalizedBase)}\\.(\\d+)\\s*:`, 'gi'
     );
     let rmMatch;
     while ((rmMatch = rmPhasePattern.exec(rawContent)) !== null) {
@@ -1030,14 +1034,15 @@ function cmdPhaseComplete(cwd, phaseNum, raw) {
       let roadmapContent = fs.readFileSync(roadmapPath, 'utf-8');
 
       // Checkbox: - [ ] Phase N: → - [x] Phase N: (...completed DATE)
+      // phaseMarkdownRegexSource tolerates padded callers vs un-padded ROADMAP prose.
       const checkboxPattern = new RegExp(
-        `(-\\s*\\[)[ ](\\]\\s*.*Phase\\s+${escapeRegex(phaseNum)}[:\\s][^\\n]*)`,
+        `(-\\s*\\[)[ ](\\]\\s*.*Phase\\s+${phaseMarkdownRegexSource(phaseNum)}[:\\s][^\\n]*)`,
         'i'
       );
       roadmapContent = roadmapContent.replace(checkboxPattern, `$1x$2 (completed ${today})`);
 
       // Progress table: update Status to Complete, add date (handles 4 or 5 column tables)
-      const phaseEscaped = escapeRegex(phaseNum);
+      const phaseEscaped = phaseMarkdownRegexSource(phaseNum);
       const tableRowPattern = new RegExp(
         `^(\\|\\s*${phaseEscaped}\\.?\\s[^|]*(?:\\|[^\\n]*))$`,
         'im'
@@ -1094,7 +1099,7 @@ function cmdPhaseComplete(cwd, phaseNum, raw) {
       const reqPath = path.join(planningDir(cwd), 'REQUIREMENTS.md');
       if (fs.existsSync(reqPath)) {
         // Extract the current phase section from roadmap (scoped to avoid cross-phase matching)
-        const phaseEsc = escapeRegex(phaseNum);
+        const phaseEsc = phaseMarkdownRegexSource(phaseNum);
         const currentMilestoneRoadmap = extractCurrentMilestone(roadmapContent, cwd);
         const phaseSectionMatch = currentMilestoneRoadmap.match(
           new RegExp(`(#{2,4}\\s*Phase\\s+${phaseEsc}[:\\s][\\s\\S]*?)(?=#{2,4}\\s*Phase\\s+|$)`, 'i')

--- a/get-shit-done/bin/lib/roadmap.cjs
+++ b/get-shit-done/bin/lib/roadmap.cjs
@@ -4,7 +4,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { escapeRegex, normalizePhaseName, output, error, findPhaseInternal, stripShippedMilestones, extractCurrentMilestone, replaceInCurrentMilestone, phaseTokenMatches } = require('./core.cjs');
+const { escapeRegex, normalizePhaseName, phaseMarkdownRegexSource, output, error, findPhaseInternal, stripShippedMilestones, extractCurrentMilestone, replaceInCurrentMilestone, phaseTokenMatches } = require('./core.cjs');
 const { platformWriteSync } = require('./shell-command-projection.cjs');
 const { planningPaths, withPlanningLock } = require('./planning-workspace.cjs');
 const scanPhasePlans = require('./plan-scan.cjs');
@@ -50,17 +50,6 @@ function countPhasePlansAndSummaries(phaseDir) {
     hasContext: phaseFiles.some(f => f.endsWith('-CONTEXT.md') || f === 'CONTEXT.md'),
     hasResearch: phaseFiles.some(f => f.endsWith('-RESEARCH.md') || f === 'RESEARCH.md'),
   };
-}
-
-function phaseMarkdownRegexSource(phaseNum) {
-  const stripped = String(phaseNum).replace(/^[A-Z]{1,6}-(?=\d)/i, '');
-  const match = stripped.match(/^0*(\d+)([A-Z])?((?:\.\d+)*)$/i);
-  if (!match) return escapeRegex(phaseNum);
-
-  const integer = match[1].replace(/^0+/, '') || '0';
-  const letter = match[2] ? escapeRegex(match[2]) : '';
-  const decimal = match[3] ? escapeRegex(match[3]) : '';
-  return `0*${escapeRegex(integer)}${letter}${decimal}`;
 }
 
 /**
@@ -147,8 +136,9 @@ function cmdRoadmapGetPhase(cwd, phaseNum, raw) {
     const rawContent = fs.readFileSync(roadmapPath, 'utf-8');
     const milestoneContent = extractCurrentMilestone(rawContent, cwd);
 
-    // Escape special regex chars in phase number, handle decimal
-    const escapedPhase = escapeRegex(phaseNum);
+    // Padding-tolerant phase-number fragment — a padded caller ("02.6") still
+    // matches un-padded ROADMAP prose ("Phase 2.6"). See phaseMarkdownRegexSource().
+    const escapedPhase = phaseMarkdownRegexSource(phaseNum);
 
     // Search the current milestone slice first, then fall back to full roadmap.
     // A malformed_roadmap result (checklist-only) from the milestone should not
@@ -249,7 +239,7 @@ function cmdRoadmapAnalyze(cwd, raw) {
     } catch { /* intentionally empty */ }
 
     // Check ROADMAP checkbox status
-    const checkboxPattern = new RegExp(`-\\s*\\[(x| )\\]\\s*.*Phase\\s+${escapeRegex(phaseNum)}[:\\s]`, 'i');
+    const checkboxPattern = new RegExp(`-\\s*\\[(x| )\\]\\s*.*Phase\\s+${phaseMarkdownRegexSource(phaseNum)}[:\\s]`, 'i');
     const checkboxMatch = content.match(checkboxPattern);
     const roadmapComplete = checkboxMatch ? checkboxMatch[1] === 'x' : false;
 
@@ -511,8 +501,8 @@ function cmdRoadmapAnnotateDependencies(cwd, phaseNum, raw) {
   withPlanningLock(cwd, () => {
     let content = fs.readFileSync(roadmapPath, 'utf-8');
 
-    // Find the phase section
-    const phaseEscaped = escapeRegex(phaseNum);
+    // Find the phase section (padding-tolerant — see phaseMarkdownRegexSource)
+    const phaseEscaped = phaseMarkdownRegexSource(phaseNum);
     const phaseHeaderPattern = new RegExp(`(#{2,4}\\s*Phase\\s+${phaseEscaped}:[^\\n]*)`, 'i');
     const phaseMatch = content.match(phaseHeaderPattern);
     if (!phaseMatch) return;

--- a/tests/bug-3537-padded-id-against-unpadded-roadmap.test.cjs
+++ b/tests/bug-3537-padded-id-against-unpadded-roadmap.test.cjs
@@ -1,0 +1,307 @@
+/**
+ * Regression tests for bug #3537
+ *
+ * Phase-state verbs silently no-op on projects whose ROADMAP.md prose uses
+ * un-padded phase numbers (e.g. `### Phase 2.7:`) while callers pass the padded
+ * form (`02.7`). GSD 1.42.1 added `phaseMarkdownRegexSource()` as the canonical
+ * padding-tolerant helper but wired it into only 1 of 8 affected functions —
+ * the other 7 still used raw `escapeRegex(phaseNum)` (or partial
+ * `0*${escapeRegex(...)}` which tolerates extra padding but not missing) and
+ * never matched.
+ *
+ * These parity tests, one per affected verb, assert that padded (`02.7`) and
+ * un-padded (`2.7`) inputs produce identical results against ROADMAP fixtures
+ * with un-padded prose. Pre-fix, padded calls return `found: false` /
+ * "Phase ... not found" while un-padded succeed — the parity assertion fails.
+ * Post-fix, both succeed identically.
+ *
+ * Per maintainer's brief (gsd-build/get-shit-done#3537), these are behavioral:
+ * each test runs the CLI via `runGsdTools` and parses JSON output. For write
+ * verbs that may emit success-shaped JSON even when the underlying mutation
+ * was a no-op, the test additionally asserts byte-equality of the resulting
+ * ROADMAP.md across two parallel fixtures — that's structural equality, not
+ * substring grepping.
+ */
+
+'use strict';
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { runGsdTools, createTempGitProject, cleanup } = require('./helpers.cjs');
+
+// ROADMAP fixture with UN-padded phase prose. Includes one integer-numbered
+// parent (`Phase 2`) and one decimal child (`Phase 2.7`) so verbs that need a
+// numbering anchor (`phase next-decimal`, `phase insert`) have one, and the
+// bug surface (padded `02.7` caller vs un-padded `2.7` prose) is exercised.
+function writeRoadmap(tmpDir) {
+  fs.writeFileSync(
+    path.join(tmpDir, '.planning', 'ROADMAP.md'),
+    [
+      '# Roadmap v1.0',
+      '',
+      '## Phases',
+      '',
+      '- [ ] Phase 2: Parent phase',
+      '- [ ] Phase 2.7: Sample padding-test phase',
+      '',
+      '### Phase 2: Parent phase',
+      '**Goal:** Parent goal',
+      '**Plans:** 0/0 plans complete',
+      '',
+      '### Phase 2.7: Sample padding-test phase',
+      '**Goal:** Verify padding-tolerant phase-ID matching.',
+      '**Depends on:** 2',
+      '**Plans:** 1/2 plans complete',
+      '',
+      'Some description here.',
+      '',
+    ].join('\n')
+  );
+}
+
+// Phase 2.7 directory + minimal plan/summary fixture for verbs that scan disk
+// before mutating ROADMAP (`phase complete`, `phase next-decimal`).
+function writePhaseDir(tmpDir) {
+  const phaseDir = path.join(tmpDir, '.planning', 'phases', '02.7-sample-padding-test-phase');
+  fs.mkdirSync(phaseDir, { recursive: true });
+  fs.writeFileSync(path.join(phaseDir, '01-PLAN.md'), '# Plan 1\n');
+  fs.writeFileSync(path.join(phaseDir, '01-SUMMARY.md'), '# Summary 1\n');
+  fs.writeFileSync(path.join(phaseDir, '02-PLAN.md'), '# Plan 2\n');
+}
+
+describe('bug #3537 — phase-state verbs tolerate un-padded ROADMAP prose with padded callers', () => {
+
+  test('phaseMarkdownRegexSource is exported from core.cjs (helper relocation)', () => {
+    // The 1.42.1 helper lived in roadmap.cjs but is needed by
+    // getRoadmapPhaseInternal in core.cjs. Promoting to core.cjs lets all
+    // three lib files share one definition without a circular import.
+    const core = require('../get-shit-done/bin/lib/core.cjs');
+    assert.strictEqual(
+      typeof core.phaseMarkdownRegexSource, 'function',
+      'phaseMarkdownRegexSource must be exported from core.cjs (#3537)'
+    );
+  });
+
+  describe('parity — read verbs (shared fixture, two calls)', () => {
+    let tmpDir;
+    beforeEach(() => { tmpDir = createTempGitProject('bug-3537-read-'); writeRoadmap(tmpDir); });
+    afterEach(() => cleanup(tmpDir));
+
+    test('roadmap get-phase: padded "02.7" returns same JSON as unpadded "2.7"', () => {
+      const padded = runGsdTools('roadmap get-phase 02.7', tmpDir);
+      const unpadded = runGsdTools('roadmap get-phase 2.7', tmpDir);
+
+      assert.ok(padded.success && unpadded.success,
+        `padded.error=${padded.error}; unpadded.error=${unpadded.error}`);
+      // get-phase honestly echoes the caller's phase_number in the response.
+      // The bug is about whether the verb RESOLVES the same phase under both
+      // pad-states — strip the input-echo before comparing the resolved data.
+      const paddedJson = JSON.parse(padded.output);
+      const unpaddedJson = JSON.parse(unpadded.output);
+      delete paddedJson.phase_number;
+      delete unpaddedJson.phase_number;
+      assert.deepStrictEqual(
+        paddedJson, unpaddedJson,
+        'padded and unpadded phase IDs must resolve to the same phase data'
+      );
+    });
+
+    test('roadmap annotate-dependencies: padded "02.7" annotates ROADMAP identically to unpadded "2.7"', (t) => {
+      // annotate-dependencies only reaches the line-515 phase-header regex
+      // when there are real plans with `wave` + `must_haves.truths` frontmatter
+      // — without them, it short-circuits at precondition checks and both
+      // pad-states return the same no-op (false GREEN). The richer fixture
+      // below (two plans across two waves) ensures the line-515 regex is
+      // actually exercised: pre-fix the padded caller's regex misses the
+      // un-padded prose → `updated: false`, while unpadded succeeds →
+      // `updated: true, waves: 2`. Parity broken pre-fix, restored post-fix.
+      const PLAN = (wave, truth) => [
+        '---',
+        'phase: "2.7"',
+        `plan: "01-0${wave}"`,
+        'type: standard',
+        `wave: ${wave}`,
+        'depends_on: []',
+        'files_modified: []',
+        'autonomous: true',
+        'must_haves:',
+        '  truths:',
+        `    - ${truth}`,
+        '  artifacts: []',
+        '  key_links: []',
+        '---',
+        '',
+        `<objective>Plan ${wave} objective</objective>`,
+        '',
+      ].join('\n');
+
+      const setupAnnotateFixture = (prefix) => {
+        const dir = createTempGitProject(prefix);
+        fs.writeFileSync(
+          path.join(dir, '.planning', 'ROADMAP.md'),
+          [
+            '# Roadmap v1.0',
+            '',
+            '## Phases',
+            '',
+            '- [ ] Phase 2.7: Sample padding-test phase',
+            '',
+            '### Phase 2.7: Sample padding-test phase',
+            '**Goal:** Verify padding-tolerant phase-ID matching.',
+            '**Plans:** 2 plans',
+            '',
+            'Plans:',
+            '- [ ] 01-01-PLAN.md — DB setup',
+            '- [ ] 01-02-PLAN.md — API',
+            '',
+          ].join('\n')
+        );
+        const phaseDir = path.join(dir, '.planning', 'phases', '02.7-sample-padding-test-phase');
+        fs.mkdirSync(phaseDir, { recursive: true });
+        fs.writeFileSync(path.join(phaseDir, '01-01-PLAN.md'), PLAN(1, 'DB schema is correct'));
+        fs.writeFileSync(path.join(phaseDir, '01-02-PLAN.md'), PLAN(2, 'API returns 200'));
+        return dir;
+      };
+
+      const a = setupAnnotateFixture('bug-3537-annot-padded-');
+      const b = setupAnnotateFixture('bug-3537-annot-unpad-');
+      t.after(() => { cleanup(a); cleanup(b); });
+
+      const padded = runGsdTools('roadmap annotate-dependencies 02.7', a);
+      const unpadded = runGsdTools('roadmap annotate-dependencies 2.7', b);
+
+      assert.ok(padded.success && unpadded.success,
+        `padded.error=${padded.error}; unpadded.error=${unpadded.error}`);
+
+      const roadmapA = fs.readFileSync(path.join(a, '.planning', 'ROADMAP.md'), 'utf-8');
+      const roadmapB = fs.readFileSync(path.join(b, '.planning', 'ROADMAP.md'), 'utf-8');
+      assert.strictEqual(
+        roadmapA, roadmapB,
+        'post-annotate ROADMAPs must be identical regardless of caller padding'
+      );
+    });
+  });
+
+  test('roadmap analyze: detects [x] checkbox when prose is un-padded but checklist is padded', (t) => {
+    // The bug at cmdRoadmapAnalyze:252 is a different surface from caller-
+    // padding: the checkbox regex is built from prose-form phaseNum but must
+    // match the checklist, which the project may have authored in padded form.
+    // Pre-fix `escapeRegex("2.7")` → `Phase\s+2\.7[:\s]` does not match the
+    // checklist line `- [x] Phase 02.7:`. Post-fix `phaseMarkdownRegexSource`
+    // prepends `0*` and the same call now matches the padded checklist.
+    const tmp = createTempGitProject('bug-3537-analyze-mismatch-');
+    fs.writeFileSync(
+      path.join(tmp, '.planning', 'ROADMAP.md'),
+      [
+        '# Roadmap v1.0',
+        '',
+        '## Phases',
+        '',
+        '- [x] Phase 02.7: Sample padding-test phase',  // PADDED + CHECKED
+        '',
+        '### Phase 2.7: Sample padding-test phase',     // UN-PADDED prose
+        '**Goal:** Verify padding-tolerant checkbox detection.',
+        '',
+      ].join('\n')
+    );
+    t.after(() => cleanup(tmp));
+
+    const result = runGsdTools('roadmap analyze', tmp);
+    assert.ok(result.success, `analyze failed: ${result.error}`);
+    const json = JSON.parse(result.output);
+    const phase27 = json.phases.find(p => p.number === '2.7');
+    assert.ok(phase27, 'phase 2.7 should appear in analyze output');
+    assert.strictEqual(
+      phase27.roadmap_complete, true,
+      'analyze must detect padded checklist [x] for an un-padded prose phase header'
+    );
+  });
+
+  describe('parity — write verbs (separate fixture per pad-state, post-state compared)', () => {
+
+    test('roadmap update-plan-progress: padded "02.7" mutates ROADMAP identically to unpadded "2.7"', (t) => {
+      const a = createTempGitProject('bug-3537-upp-padded-');
+      const b = createTempGitProject('bug-3537-upp-unpad-');
+      writeRoadmap(a); writeRoadmap(b);
+      writePhaseDir(a); writePhaseDir(b);
+      t.after(() => { cleanup(a); cleanup(b); });
+
+      const padded = runGsdTools('roadmap update-plan-progress 02.7', a);
+      const unpadded = runGsdTools('roadmap update-plan-progress 2.7', b);
+
+      assert.ok(padded.success && unpadded.success,
+        `padded.error=${padded.error}; unpadded.error=${unpadded.error}`);
+      const roadmapA = fs.readFileSync(path.join(a, '.planning', 'ROADMAP.md'), 'utf-8');
+      const roadmapB = fs.readFileSync(path.join(b, '.planning', 'ROADMAP.md'), 'utf-8');
+      assert.strictEqual(roadmapA, roadmapB,
+        'post-update ROADMAPs must be identical regardless of caller padding');
+    });
+
+    test('phase complete: padded "02.7" mutates ROADMAP identically to unpadded "2.7"', (t) => {
+      const a = createTempGitProject('bug-3537-complete-padded-');
+      const b = createTempGitProject('bug-3537-complete-unpad-');
+      writeRoadmap(a); writeRoadmap(b);
+      writePhaseDir(a); writePhaseDir(b);
+      t.after(() => { cleanup(a); cleanup(b); });
+
+      const padded = runGsdTools('phase complete 02.7', a);
+      const unpadded = runGsdTools('phase complete 2.7', b);
+
+      assert.ok(padded.success && unpadded.success,
+        `padded.error=${padded.error}; unpadded.error=${unpadded.error}`);
+      const roadmapA = fs.readFileSync(path.join(a, '.planning', 'ROADMAP.md'), 'utf-8');
+      const roadmapB = fs.readFileSync(path.join(b, '.planning', 'ROADMAP.md'), 'utf-8');
+      assert.strictEqual(roadmapA, roadmapB,
+        'post-complete ROADMAPs must be identical regardless of caller padding');
+    });
+
+    test('phase next-decimal: padded "02" suggests the same next decimal as unpadded "2"', (t) => {
+      const a = createTempGitProject('bug-3537-next-padded-');
+      const b = createTempGitProject('bug-3537-next-unpad-');
+      writeRoadmap(a); writeRoadmap(b);
+      writePhaseDir(a); writePhaseDir(b);
+      t.after(() => { cleanup(a); cleanup(b); });
+
+      // next-decimal scans for `Phase 0*${base}\.\d` occurrences. With unpadded
+      // prose `Phase 2.7` and padded caller `02`, pre-fix the literal `0*${escaped}`
+      // is `0*0*2` (technically tolerant of padding!) — but Brandon's diff drops
+      // the redundant literal `0*` since the helper already prepends it.
+      const padded = runGsdTools('phase next-decimal 02', a);
+      const unpadded = runGsdTools('phase next-decimal 2', b);
+
+      assert.ok(padded.success && unpadded.success,
+        `padded.error=${padded.error}; unpadded.error=${unpadded.error}`);
+      assert.deepStrictEqual(
+        JSON.parse(padded.output), JSON.parse(unpadded.output),
+        'padded and unpadded base phase IDs must produce the same next-decimal suggestion'
+      );
+    });
+
+    test('phase insert: padded "02" inserts under same parent as unpadded "2"', (t) => {
+      // cmdPhaseInsert signature: `phase insert <after-phase> <description>`.
+      // Pass argv as an array so the description ("Inserted phase") isn't
+      // split on whitespace. Pre-fix the line-724 regex uses the literal
+      // `0*${escapeRegex(normalizedBase)}` which already tolerates padding
+      // for integer bases — this test passes both ways and serves as a
+      // regression guard against the helper-relocation breaking the existing
+      // behavior.
+      const a = createTempGitProject('bug-3537-insert-padded-');
+      const b = createTempGitProject('bug-3537-insert-unpad-');
+      writeRoadmap(a); writeRoadmap(b);
+      writePhaseDir(a); writePhaseDir(b);
+      t.after(() => { cleanup(a); cleanup(b); });
+
+      const padded = runGsdTools(['phase', 'insert', '02', 'Inserted phase'], a);
+      const unpadded = runGsdTools(['phase', 'insert', '2', 'Inserted phase'], b);
+
+      assert.ok(padded.success && unpadded.success,
+        `padded.error=${padded.error}; unpadded.error=${unpadded.error}`);
+      const phasesA = fs.readdirSync(path.join(a, '.planning', 'phases')).sort();
+      const phasesB = fs.readdirSync(path.join(b, '.planning', 'phases')).sort();
+      assert.deepStrictEqual(phasesA, phasesB,
+        'phase insert must create the same phase directory regardless of caller padding');
+    });
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3537

> The linked issue carries the `confirmed-bug` label (applied 2026-05-14).

## What was broken

Phase-state verbs — `roadmap get-phase`, `roadmap analyze`, `roadmap annotate-dependencies`, `phase complete`, `phase next-decimal`, `phase insert`, and the shared `getRoadmapPhaseInternal` helper in `core.cjs` — silently no-op'd on projects whose `ROADMAP.md` uses un-padded phase numbers (`### Phase 2.7:`) when callers passed the padded form (`02.7`). Skills that resolve a phase and pass its padded `phase_number` to state verbs would receive success-shaped JSON while the regex never matched.

## What this fix does

Wires `phaseMarkdownRegexSource()` — the padding-tolerant regex-source helper added in 1.42.1 (#3287) — across the remaining affected sites. Promotes the helper from `roadmap.cjs` to `core.cjs` so all three lib files share one definition without circular imports.

## Root cause

1.42.1 added `phaseMarkdownRegexSource()` in `roadmap.cjs` and wired it into `cmdRoadmapUpdatePlanProgress` only. The other sites still constructed phase-number regex sources with raw `escapeRegex(phaseNum)` (or `0*${escapeRegex(...)}` literals that tolerate extra padding but not missing). A padded caller `02.7` produced `Phase\s+02\.7:` and never matched un-padded ROADMAP prose `### Phase 2.7:`.

Wired sites in this PR:

- `core.cjs:1079` — `getRoadmapPhaseInternal` (replaces the `isNumeric`-branched literal that left decimal phases broken)
- `roadmap.cjs:151` — `cmdRoadmapGetPhase` (`escapedPhase` → `searchPhaseInContent`)
- `roadmap.cjs:252` — `cmdRoadmapAnalyze` per-phase checkbox detection
- `roadmap.cjs:515` — `cmdRoadmapAnnotateDependencies` phase-header lookup
- `phase.cjs:174` — `cmdPhaseNextDecimal` decimal scan (drops the now-redundant literal `0*` since the helper prepends it)
- `phase.cjs:724` — `cmdPhaseInsert` decimal scan (same drop)
- `phase.cjs:1034`, `:1040`, `:1097` — `cmdPhaseComplete` checkbox + table-row + REQUIREMENTS section

`cmdRoadmapUpdatePlanProgress` already used the helper at `roadmap.cjs:356` and is unchanged.

## Testing

### How I verified the fix

New regression test `tests/bug-3537-padded-id-against-unpadded-roadmap.test.cjs`:

- Helper-export sanity test (confirms `phaseMarkdownRegexSource` is reachable from `core.cjs`).
- Parity-style behavioral tests per affected verb via `runGsdTools` from `tests/helpers.cjs`, asserting padded and un-padded callers produce the same result against un-padded ROADMAP fixtures.
- One mismatch-fixture test for `cmdRoadmapAnalyze` (un-padded prose + padded checklist) — a different surface from caller-padding but covered by the same regex fix at `roadmap.cjs:252`.

**TDD verified empirically:** stashed the lib changes, ran the new test against unpatched main — confirmed **RED** on 5 of 8 tests (helper export, `get-phase`, `annotate-dependencies`, `analyze`, `phase complete`). Restored the fix, re-ran — all 8 GREEN. The 3 always-GREEN tests are regression guards for sites where the literal `0*` already tolerated padding (`cmdRoadmapUpdatePlanProgress`, `cmdPhaseNextDecimal`, `cmdPhaseInsert` with integer bases) but the helper-relocation could regress.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS (local `npm test`: **9213 passing / 0 failing**)
- [ ] Windows (not exercised locally — covered by CI matrix)
- [x] Linux (covered by CI matrix: Ubuntu × Node 22, 24)
- [ ] N/A

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] N/A — purely SDK-internal regex-source change

## Checklist

- [x] Issue linked above with `Fixes #3537`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes
- [x] Regression test added
- [x] All existing tests pass (`npm test` — 9213/9213)
- [x] `.changeset/` fragment added (`fix-3537-padding-tolerant-phase-id-matching.md`, type Fixed)
- [x] No unnecessary dependencies added

## Breaking changes

None. `phaseMarkdownRegexSource` was not previously exported from `roadmap.cjs`'s `module.exports`, so promoting the definition to `core.cjs` and importing it back doesn't change any external API surface.

---

**Maintainer flexibility:** if you'd prefer to keep `phaseMarkdownRegexSource` defined in `roadmap.cjs` rather than promote it to `core.cjs`, the alternative is to keep the def in `roadmap.cjs`, export it, and import it into `core.cjs` + `phase.cjs`. Both shapes are equivalent for correctness; happy to refactor on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed phase identification to consistently match padded phase identifiers (e.g., `02.7`) against unpadded phase references in roadmap documentation, ensuring all roadmap and phase-related commands work correctly regardless of zero-padding format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3539)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->