### PR TITLE
fix: use Claude Code runtime markers in ultraplan gate

### DIFF
--- a/.changeset/silly-finches-travel.md
+++ b/.changeset/silly-finches-travel.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3563
+---
+**Ultraplan runtime gate now detects Claude Code correctly** - runtime gating no longer relies on `CLAUDE_CODE_VERSION`; it uses Claude Code marker env vars and preserves the minimum supported version floor. Fixes #3561.

--- a/get-shit-done/workflows/ultraplan-phase.md
+++ b/get-shit-done/workflows/ultraplan-phase.md
@@ -29,7 +29,16 @@ Use /gsd:plan-phase for stable local planning.
 Check that the session is running inside Claude Code:
 
 ```bash
-echo "$CLAUDE_CODE_VERSION"
+if [ "$CLAUDECODE" = "1" ] || [ -n "$CLAUDE_CODE_ENTRYPOINT" ]; then
+  CC_VERSION="$(claude --version 2>/dev/null | awk '{print $1}')"
+  if [ -n "$CC_VERSION" ] && [ "$(printf '%s\n' "2.1.91" "$CC_VERSION" | sort -V | head -n1)" != "2.1.91" ]; then
+    echo ""
+  else
+    echo "claude-code:${CC_VERSION:-unknown}"
+  fi
+else
+  echo ""
+fi
 ```
 
 If the output is empty or unset, display the following error and exit:

--- a/get-shit-done/workflows/ultraplan-phase.md
+++ b/get-shit-done/workflows/ultraplan-phase.md
@@ -30,11 +30,11 @@ Check that the session is running inside Claude Code:
 
 ```bash
 if [ "$CLAUDECODE" = "1" ] || [ -n "$CLAUDE_CODE_ENTRYPOINT" ]; then
-  CC_VERSION="$(claude --version 2>/dev/null | awk '{print $1}')"
-  if [ -n "$CC_VERSION" ] && [ "$(printf '%s\n' "2.1.91" "$CC_VERSION" | sort -V | head -n1)" != "2.1.91" ]; then
-    echo ""
+  CC_VERSION="$(claude --version 2>/dev/null | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)"
+  if [ -n "$CC_VERSION" ] && [ "$(printf '%s\n' "2.1.91" "$CC_VERSION" | sort -V | head -n1)" = "2.1.91" ]; then
+    echo "claude-code:${CC_VERSION}"
   else
-    echo "claude-code:${CC_VERSION:-unknown}"
+    echo ""
   fi
 else
   echo ""

--- a/tests/ultraplan-phase.test.cjs
+++ b/tests/ultraplan-phase.test.cjs
@@ -86,8 +86,11 @@ describe('ultraplan-phase workflow beta marker', () => {
 describe('ultraplan-phase workflow runtime gate', () => {
   const content = fs.readFileSync(WF_PATH, 'utf-8');
 
-  test('checks CLAUDE_CODE_VERSION to detect Claude Code runtime', () => {
-    assert.ok(content.includes('CLAUDE_CODE_VERSION'), 'workflow must gate on CLAUDE_CODE_VERSION env var');
+  test('checks Claude Code runtime markers instead of version env var', () => {
+    assert.ok(
+      content.includes('CLAUDECODE') || content.includes('CLAUDE_CODE_ENTRYPOINT'),
+      'workflow must gate on Claude Code runtime marker env vars'
+    );
   });
 
   test('error message references /gsd-plan-phase as local alternative', () => {

--- a/tests/ultraplan-phase.test.cjs
+++ b/tests/ultraplan-phase.test.cjs
@@ -91,6 +91,10 @@ describe('ultraplan-phase workflow runtime gate', () => {
       content.includes('CLAUDECODE') || content.includes('CLAUDE_CODE_ENTRYPOINT'),
       'workflow must gate on Claude Code runtime marker env vars'
     );
+    assert.ok(
+      !content.includes('CLAUDE_CODE_VERSION'),
+      'workflow must not gate on CLAUDE_CODE_VERSION'
+    );
   });
 
   test('error message references /gsd-plan-phase as local alternative', () => {


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #3561

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

`/gsd:ultraplan-phase` runtime-gated on `CLAUDE_CODE_VERSION`, which is not a reliable Claude Code runtime signal, so valid Claude Code sessions could fail the gate.

## What this fix does

Updates the runtime gate to detect Claude Code via `CLAUDECODE` or `CLAUDE_CODE_ENTRYPOINT` and keeps a minimum-version floor check using `claude --version`.

## Root cause

The workflow used a single non-canonical env var as a runtime presence check instead of the runtime marker env vars used elsewhere.

## Testing

### How I verified the fix

- `node --test tests/ultraplan-phase.test.cjs`

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Ultraplan runtime gating to detect Claude Code reliably while preserving minimum supported version checks.

* **Tests**
  * Updated runtime-gate tests to assert detection uses Claude Code runtime markers and no longer relies on the previous version variable.

* **Chores**
  * Added a changeset entry documenting the fix.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3563)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->