### PR TITLE
fix: prevent archived phase dirs from triggering W007

### DIFF
--- a/.changeset/sturdy-wolves-glide.md
+++ b/.changeset/sturdy-wolves-glide.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3564
+---
+**validate.health no longer raises W007 for archived milestone phases** - archived `v*-phases` directories remain valid for historical W006 checks, but W007 now only reports unexpected active phase directories. Fixes #3560.

--- a/sdk/src/query/validate.test.ts
+++ b/sdk/src/query/validate.test.ts
@@ -643,6 +643,26 @@ describe('validateHealth', () => {
     expect(w006s.some(w => String(w.message).includes('Phase 7'))).toBe(false);
   });
 
+  it('does not emit W007 for archived milestone-only phase dirs (#3560)', async () => {
+    await createHealthyPlanning();
+    await writeFile(join(tmpDir, '.planning', 'ROADMAP.md'), [
+      '# Roadmap',
+      '',
+      '## v1.1: Current',
+      '',
+      '### Phase 21: Active',
+      '',
+    ].join('\n'));
+    await mkdir(join(tmpDir, '.planning', 'phases', '21-active'), { recursive: true });
+    await mkdir(join(tmpDir, '.planning', 'milestones', 'v1.0-phases', '02-old-shipped-phase'), { recursive: true });
+
+    const result = await validateHealth([], tmpDir);
+    const data = result.data as Record<string, unknown>;
+    const warnings = data.warnings as Array<Record<string, unknown>>;
+    const w007s = warnings.filter(w => w.code === 'W007');
+    expect(w007s.some(w => String(w.message).includes('Phase 02'))).toBe(false);
+  });
+
   it('does not emit W006 for unchecked future phases with no directory (#3559)', async () => {
     await createHealthyPlanning();
     await writeFile(join(tmpDir, '.planning', 'ROADMAP.md'), [

--- a/sdk/src/query/validate.ts
+++ b/sdk/src/query/validate.ts
@@ -621,12 +621,16 @@ export const validateHealth: QueryHandler = async (args, projectDir, workstream)
       }
 
       const diskPhases = new Set<string>();
+      const activeDiskPhases = new Set<string>();
       try {
         const entries = await readdir(phasesDir, { withFileTypes: true });
         for (const e of entries) {
           if (e.isDirectory()) {
             const dm = e.name.match(/^(\d+[A-Z]?(?:\.\d+)*)/i);
-            if (dm) diskPhases.add(dm[1]);
+            if (dm) {
+              diskPhases.add(dm[1]);
+              activeDiskPhases.add(dm[1]);
+            }
           }
         }
       } catch { /* intentionally empty */ }
@@ -655,7 +659,7 @@ export const validateHealth: QueryHandler = async (args, projectDir, workstream)
         }
       }
 
-      for (const p of diskPhases) {
+      for (const p of activeDiskPhases) {
         const variants = phaseVariants(p);
         if (![...variants].some((variant) => roadmapPhaseVariants.has(variant))) {
           addIssue('warning', 'W007', `Phase ${p} exists on disk but not in ROADMAP.md`, 'Add to roadmap or remove directory');


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #3560

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

`validate.health` emitted W007 for phase directories under archived milestone folders, treating historical archive entries as active rogue phases.

## What this fix does

Keeps archived milestone phases available for W006 historical coverage, but scopes W007 to active `.planning/phases` directories only.

## Root cause

A single combined on-disk phase set was reused for both W006 and W007, so archive entries intended for historical W006 compatibility also triggered W007 false positives.

## Testing

### How I verified the fix

- `cd sdk && CI=1 npm run test -- src/query/validate.test.ts --reporter=verbose`

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Health validation no longer reports false W007 warnings for archived milestone phase directories; W007 is now limited to unexpected active phase directories while archived phases remain valid for historical checks.
* **Tests**
  * Added a regression test to ensure archived milestone-only phase directories do not trigger W007.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3564)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->