### PR TITLE
fix: avoid W006 for not-started future phases

### DIFF
--- a/.changeset/zesty-eagles-fly.md
+++ b/.changeset/zesty-eagles-fly.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3565
+---
+**validate.health no longer warns W006 for not-started phases** - unchecked roadmap phase entries are treated as planned/future and no longer require on-disk phase directories until work has started. Fixes #3559.

--- a/sdk/src/query/validate.test.ts
+++ b/sdk/src/query/validate.test.ts
@@ -667,6 +667,29 @@ describe('validateHealth', () => {
     expect(w006s.some(w => String(w.message).includes('Phase 22'))).toBe(false);
   });
 
+  it('does not alias 22A to 22 when suppressing W006 (#3565)', async () => {
+    await createHealthyPlanning();
+    await writeFile(join(tmpDir, '.planning', 'ROADMAP.md'), [
+      '# Roadmap',
+      '',
+      '## v1.1: Current',
+      '',
+      '- [x] **Phase 22: Started phase**',
+      '- [ ] **Phase 22A: Future variant**',
+      '',
+      '### Phase 22: Started phase',
+      '',
+      '### Phase 22A: Future variant',
+      '',
+    ].join('\n'));
+
+    const result = await validateHealth([], tmpDir);
+    const data = result.data as Record<string, unknown>;
+    const warnings = data.warnings as Array<Record<string, unknown>>;
+    const w006s = warnings.filter(w => w.code === 'W006');
+    expect(w006s.some(w => String(w.message).includes('Phase 22 in ROADMAP.md'))).toBe(true);
+  });
+
   it('does not emit I001 when plan file has descriptor but summary uses canonical stem (#3473)', async () => {
     await createHealthyPlanning();
     await mkdir(join(tmpDir, '.planning', 'phases', '68-bug-surface'), { recursive: true });

--- a/sdk/src/query/validate.test.ts
+++ b/sdk/src/query/validate.test.ts
@@ -643,6 +643,30 @@ describe('validateHealth', () => {
     expect(w006s.some(w => String(w.message).includes('Phase 7'))).toBe(false);
   });
 
+  it('does not emit W006 for unchecked future phases with no directory (#3559)', async () => {
+    await createHealthyPlanning();
+    await writeFile(join(tmpDir, '.planning', 'ROADMAP.md'), [
+      '# Roadmap',
+      '',
+      '## v1.1: Current',
+      '',
+      '- [x] **Phase 21: Active**',
+      '- [ ] **Phase 22: Future planned**',
+      '',
+      '### Phase 21: Active',
+      '',
+      '### Phase 22: Future planned',
+      '',
+    ].join('\n'));
+    await mkdir(join(tmpDir, '.planning', 'phases', '21-active'), { recursive: true });
+
+    const result = await validateHealth([], tmpDir);
+    const data = result.data as Record<string, unknown>;
+    const warnings = data.warnings as Array<Record<string, unknown>>;
+    const w006s = warnings.filter(w => w.code === 'W006');
+    expect(w006s.some(w => String(w.message).includes('Phase 22'))).toBe(false);
+  });
+
   it('does not emit I001 when plan file has descriptor but summary uses canonical stem (#3473)', async () => {
     await createHealthyPlanning();
     await mkdir(join(tmpDir, '.planning', 'phases', '68-bug-surface'), { recursive: true });

--- a/sdk/src/query/validate.ts
+++ b/sdk/src/query/validate.ts
@@ -598,6 +598,13 @@ export const validateHealth: QueryHandler = async (args, projectDir, workstream)
       while ((m = phasePattern.exec(roadmapContent)) !== null) {
         roadmapPhases.add(m[1]);
       }
+      const notStartedPhases = new Set<string>();
+      const uncheckedPattern = /-\s*\[\s\]\s*\*{0,2}Phase\s+(\d+[A-Z]?(?:\.\d+)*)[:\s*]/gi;
+      let um: RegExpExecArray | null;
+      while ((um = uncheckedPattern.exec(roadmapContent)) !== null) {
+        notStartedPhases.add(um[1]);
+        notStartedPhases.add(String(parseInt(um[1], 10)).padStart(2, '0'));
+      }
 
       const diskPhases = new Set<string>();
       try {
@@ -627,6 +634,7 @@ export const validateHealth: QueryHandler = async (args, projectDir, workstream)
       for (const p of roadmapPhases) {
         const padded = String(parseInt(p, 10)).padStart(2, '0');
         if (!diskPhases.has(p) && !diskPhases.has(padded)) {
+          if (notStartedPhases.has(p) || notStartedPhases.has(padded)) continue;
           addIssue('warning', 'W006', `Phase ${p} in ROADMAP.md but no directory on disk`, 'Create phase directory or remove from roadmap');
         }
       }

--- a/sdk/src/query/validate.ts
+++ b/sdk/src/query/validate.ts
@@ -594,16 +594,30 @@ export const validateHealth: QueryHandler = async (args, projectDir, workstream)
       const roadmapContent = await readFile(roadmapPath, 'utf-8');
       const roadmapPhases = new Set<string>();
       const phasePattern = /#{2,4}\s*Phase\s+(\d+[A-Z]?(?:\.\d+)*)\s*:/gi;
+      const phaseVariants = (phase: string): Set<string> => {
+        const variants = new Set<string>([phase]);
+        const dotIdx = phase.indexOf('.');
+        const head = dotIdx === -1 ? phase : phase.slice(0, dotIdx);
+        const tail = dotIdx === -1 ? '' : phase.slice(dotIdx);
+        const headMatch = head.match(/^(\d+)([A-Z]?)$/i);
+        if (!headMatch) return variants;
+        const numericHead = headMatch[1];
+        const letterSuffix = headMatch[2] || '';
+        variants.add(`${String(parseInt(numericHead, 10))}${letterSuffix}${tail}`);
+        variants.add(`${numericHead.padStart(2, '0')}${letterSuffix}${tail}`);
+        return variants;
+      };
+      const roadmapPhaseVariants = new Set<string>();
       let m: RegExpExecArray | null;
       while ((m = phasePattern.exec(roadmapContent)) !== null) {
         roadmapPhases.add(m[1]);
+        for (const variant of phaseVariants(m[1])) roadmapPhaseVariants.add(variant);
       }
       const notStartedPhases = new Set<string>();
       const uncheckedPattern = /-\s*\[\s\]\s*\*{0,2}Phase\s+(\d+[A-Z]?(?:\.\d+)*)[:\s*]/gi;
       let um: RegExpExecArray | null;
       while ((um = uncheckedPattern.exec(roadmapContent)) !== null) {
-        notStartedPhases.add(um[1]);
-        notStartedPhases.add(String(parseInt(um[1], 10)).padStart(2, '0'));
+        for (const variant of phaseVariants(um[1])) notStartedPhases.add(variant);
       }
 
       const diskPhases = new Set<string>();
@@ -632,16 +646,18 @@ export const validateHealth: QueryHandler = async (args, projectDir, workstream)
       } catch { /* intentionally empty */ }
 
       for (const p of roadmapPhases) {
-        const padded = String(parseInt(p, 10)).padStart(2, '0');
-        if (!diskPhases.has(p) && !diskPhases.has(padded)) {
-          if (notStartedPhases.has(p) || notStartedPhases.has(padded)) continue;
+        const variants = phaseVariants(p);
+        const existsOnDisk = [...variants].some((variant) => diskPhases.has(variant));
+        const isNotStarted = [...variants].some((variant) => notStartedPhases.has(variant));
+        if (!existsOnDisk) {
+          if (isNotStarted) continue;
           addIssue('warning', 'W006', `Phase ${p} in ROADMAP.md but no directory on disk`, 'Create phase directory or remove from roadmap');
         }
       }
 
       for (const p of diskPhases) {
-        const unpadded = String(parseInt(p, 10));
-        if (!roadmapPhases.has(p) && !roadmapPhases.has(unpadded)) {
+        const variants = phaseVariants(p);
+        if (![...variants].some((variant) => roadmapPhaseVariants.has(variant))) {
           addIssue('warning', 'W007', `Phase ${p} exists on disk but not in ROADMAP.md`, 'Add to roadmap or remove directory');
         }
       }


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #3559

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

`validate.health` emitted W006 for future planned phases that were explicitly unchecked in ROADMAP and intentionally had no on-disk phase directory yet.

## What this fix does

Adds not-started phase detection from unchecked roadmap summary entries and skips W006 for those phases while preserving W006 for started/completed missing-directory inconsistencies.

## Root cause

W006 treated every roadmap phase heading as started and did not apply the unchecked-summary exemption that already exists in the legacy validator path.

## Testing

### How I verified the fix

- `cd sdk && CI=1 npm run test -- src/query/validate.test.ts --reporter=verbose`

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [ ] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation no longer reports missing-phase warnings for roadmap entries marked as planned or not-yet-started; future phases no longer require on-disk directories until work begins.
  * Fixed incorrect aliasing between similar phase names (numeric and suffixed variants), so validation accurately distinguishes phases like "22" vs "22A".

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3565)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->