### PR TITLE
fix(3562): generate Codex skill surface so $gsd-* commands resolve on Codex CLI 0.130.0+

### DIFF
--- a/.changeset/3562-codex-install-skill-surface.md
+++ b/.changeset/3562-codex-install-skill-surface.md
@@ -1,0 +1,6 @@
+---
+type: Fixed
+pr: 0
+---
+
+**Codex global install now produces discoverable `$gsd-*` skill surface** — `npx get-shit-done-cc@latest --codex --global` was leaving Codex CLI users with `get-shit-done/workflows/*.md` and `agents/gsd-*` on disk but no `~/.codex/skills/gsd-*/SKILL.md` files, so Codex 0.130.0 silently exposed zero `$gsd-*` commands after restart. The installer had been bypassing skill generation under the assumption that Codex auto-discovers from workflow/agent files; that assumption does not hold for the current Codex CLI. Re-wired the existing `copyCommandsAsCodexSkills()` helper into the Codex install dispatch path so it produces the same skill-shape as the Claude / Copilot / Antigravity / Cursor / Windsurf / Augment / Trae installs already do (one `skills/gsd-<name>/SKILL.md` per `commands/gsd/*.md`). Pre-existing user-owned non-`gsd-*` skill directories are preserved. Closes #3562.

--- a/.changeset/3562-codex-install-skill-surface.md
+++ b/.changeset/3562-codex-install-skill-surface.md
@@ -1,6 +1,6 @@
 ---
 type: Fixed
-pr: 0
+pr: 3568
 ---
 
 **Codex global install now produces discoverable `$gsd-*` skill surface** — `npx get-shit-done-cc@latest --codex --global` was leaving Codex CLI users with `get-shit-done/workflows/*.md` and `agents/gsd-*` on disk but no `~/.codex/skills/gsd-*/SKILL.md` files, so Codex 0.130.0 silently exposed zero `$gsd-*` commands after restart. The installer had been bypassing skill generation under the assumption that Codex auto-discovers from workflow/agent files; that assumption does not hold for the current Codex CLI. Re-wired the existing `copyCommandsAsCodexSkills()` helper into the Codex install dispatch path so it produces the same skill-shape as the Claude / Copilot / Antigravity / Cursor / Windsurf / Augment / Trae installs already do (one `skills/gsd-<name>/SKILL.md` per `commands/gsd/*.md`). Pre-existing user-owned non-`gsd-*` skill directories are preserved. Closes #3562.

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ For the full configuration reference — all settings, git branching strategies,
 
 **Commands not showing up?** Restart your runtime after install. GSD installs to `~/.claude/skills/gsd-*/` (Claude Code), `~/.codex/skills/gsd-*/` (Codex), or the equivalent for your runtime.
 
-**Codex users — minimum supported CLI version is `0.130.0`.** Codex CLI 0.130.0 ([release notes](https://github.com/openai/codex/releases/tag/rust-v0.130.0)) removed extra-skill-roots discovery via [openai/codex#21485](https://github.com/openai/codex/pull/21485); from that version onward Codex only discovers skills from `~/.codex/skills/<name>/SKILL.md`. GSD installs there directly. Earlier Codex CLI versions may show duplicate `gsd-*` entries (one from extra-roots discovery, one from `~/.codex/skills/`); restart Codex after install and either upgrade or accept the duplicate listing.
+**Codex users — minimum supported CLI version is `0.130.0`.** Codex CLI 0.130.0 ([release notes](https://github.com/openai/codex/releases/tag/rust-v0.130.0)) removed extra-skill-roots discovery via [openai/codex#21485](https://github.com/openai/codex/pull/21485); from that version onward Codex discovers skills from standard roots (including `~/.codex/skills/<name>/SKILL.md`). GSD installs there directly. Earlier Codex CLI versions may still discover additional roots, which can surface duplicate `gsd-*` entries (one from extra-roots discovery, one from `~/.codex/skills/`); restart Codex after install and either upgrade or accept the duplicate listing.
 
 **Something broken?** Re-run the installer — it's idempotent:
 ```bash

--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ For the full configuration reference — all settings, git branching strategies,
 
 **Commands not showing up?** Restart your runtime after install. GSD installs to `~/.claude/skills/gsd-*/` (Claude Code), `~/.codex/skills/gsd-*/` (Codex), or the equivalent for your runtime.
 
+**Codex users — minimum supported CLI version is `0.130.0`.** Codex CLI 0.130.0 ([release notes](https://github.com/openai/codex/releases/tag/rust-v0.130.0)) removed extra-skill-roots discovery via [openai/codex#21485](https://github.com/openai/codex/pull/21485); from that version onward Codex only discovers skills from `~/.codex/skills/<name>/SKILL.md`. GSD installs there directly. Earlier Codex CLI versions may show duplicate `gsd-*` entries (one from extra-roots discovery, one from `~/.codex/skills/`); restart Codex after install and either upgrade or accept the duplicate listing.
+
 **Something broken?** Re-run the installer — it's idempotent:
 ```bash
 npx get-shit-done-cc@latest

--- a/bin/install.js
+++ b/bin/install.js
@@ -8088,23 +8088,27 @@ function install(isGlobal, runtime = 'claude', options = {}) {
       failures.push('command/gsd-*');
     }
   } else if (isCodex) {
+    // Codex CLI (0.130.0 at time of #3562) does NOT auto-discover commands
+    // from get-shit-done/workflows/*.md or agents/*.md. It only registers
+    // commands from skills/<name>/SKILL.md. The earlier "Codex discovers
+    // official skills directly" branch left users with workflows on disk and
+    // no $gsd-* entrypoints. Regenerate the skill surface the same way the
+    // other runtimes do — copyCommandsAsCodexSkills() rewrites each
+    // commands/gsd/*.md as ~/.codex/skills/gsd-<name>/SKILL.md and converts
+    // Claude-flavored command frontmatter into Codex skill frontmatter.
     const skillsDir = path.join(targetDir, 'skills');
-    // Codex now discovers repo/user/admin/system skills from .agents/skills and
-    // warns if a layer mixes redundant hook/skill representations. Legacy
-    // gsd-* copies under ~/.codex/skills are therefore removed and no longer
-    // regenerated.
-    let removedLegacyCodexSkills = 0;
+    const gsdSrc = _stageSkills(_commandsDir);
+    copyCommandsAsCodexSkills(gsdSrc, skillsDir, 'gsd', pathPrefix, runtime);
     if (fs.existsSync(skillsDir)) {
-      for (const entry of fs.readdirSync(skillsDir, { withFileTypes: true })) {
-        if (!entry.isDirectory() || !entry.name.startsWith('gsd-')) continue;
-        fs.rmSync(path.join(skillsDir, entry.name), { recursive: true, force: true });
-        removedLegacyCodexSkills += 1;
+      const count = fs.readdirSync(skillsDir, { withFileTypes: true })
+        .filter(e => e.isDirectory() && e.name.startsWith('gsd-')).length;
+      if (count > 0) {
+        console.log(`  ${green}✓${reset} Installed ${count} skills to skills/`);
+      } else {
+        failures.push('skills/gsd-*');
       }
-    }
-    if (removedLegacyCodexSkills > 0) {
-      console.log(`  ${green}✓${reset} Removed ${removedLegacyCodexSkills} legacy Codex gsd-* skill copies from skills/`);
     } else {
-      console.log(`  ${dim}↳${reset} Skipped Codex skill-copy generation (Codex discovers official skills directly)`);
+      failures.push('skills/gsd-*');
     }
   } else if (isCopilot) {
     const skillsDir = path.join(targetDir, 'skills');

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -968,6 +968,10 @@ The `dynamic_routing` block is **disabled by default** — `enabled: false` (or 
 
 ### Non-Claude Runtimes (Codex, OpenCode, Gemini CLI, Kilo)
 
+> **Codex CLI minimum supported version: `0.130.0`** (issue [#3562](https://github.com/gsd-build/get-shit-done/issues/3562)).
+>
+> [Codex CLI 0.130.0](https://github.com/openai/codex/releases/tag/rust-v0.130.0) (released 2026-05-08) removed extra-skills-roots discovery via [openai/codex#21485](https://github.com/openai/codex/pull/21485). From this version forward, Codex CLI only scans `~/.codex/skills/<name>/SKILL.md`, `<project>/.codex/skills/`, and registered plugin roots for invocable skills. GSD installs the `$gsd-*` surface as `~/.codex/skills/gsd-<name>/SKILL.md` so commands resolve after a Codex restart. Earlier Codex CLI versions can show a duplicate listing (the legacy extra-roots scan plus the user-root copies) — restart Codex and either upgrade to ≥ 0.130.0 or accept the duplicates until you do.
+
 When GSD is installed for a non-Claude runtime, the installer automatically sets `resolve_model_ids: "omit"` in `~/.gsd/defaults.json`. This causes GSD to return an empty model parameter for all agents, so each agent uses whatever model the runtime is configured with. No additional setup is needed for the default case.
 
 If you want different agents to use different models, use `model_overrides` with fully-qualified model IDs that your runtime recognizes:

--- a/docs/USER-GUIDE.md
+++ b/docs/USER-GUIDE.md
@@ -1219,6 +1219,12 @@ For the full audit, harness reference, and the composition note with `model_prof
 
 ### Using Non-Claude Runtimes (Codex, OpenCode, Gemini CLI, Kilo)
 
+> **Codex CLI minimum supported version: `0.130.0`** (issue [#3562](https://github.com/gsd-build/get-shit-done/issues/3562)).
+>
+> Codex CLI [0.130.0](https://github.com/openai/codex/releases/tag/rust-v0.130.0) (released 2026-05-08) removed extra-skills-roots discovery via [openai/codex#21485](https://github.com/openai/codex/pull/21485). From that version onward, Codex only discovers commands from `~/.codex/skills/<name>/SKILL.md` (user root), `<project>/.codex/skills/` (cwd root), and registered plugin roots. The GSD installer writes `~/.codex/skills/gsd-<name>/SKILL.md` directly so `$gsd-help`, `$gsd-new-project`, etc. are discoverable after restart.
+>
+> **Earlier Codex CLI versions** (pre-0.130.0) had additional skill-root scanning that discovered the GSD agent/workflow files in alternate locations. GSD still installs the `~/.codex/skills/gsd-*` copies on those versions, which can show a duplicate listing alongside the legacy auto-discovered surface — restart Codex after install and either upgrade to ≥ 0.130.0 or accept the duplicate entries until you do.
+
 If you installed GSD for a non-Claude runtime, the installer already configured model resolution so all agents use the runtime's default model. No manual setup is needed. Specifically, the installer sets `resolve_model_ids: "omit"` in your config, which tells GSD to skip Anthropic model ID resolution and let the runtime choose its own default model.
 
 To assign different models to different agents on a non-Claude runtime, add `model_overrides` to `.planning/config.json` with fully-qualified model IDs that your runtime recognizes:

--- a/tests/bug-3427-3433-codex-install-shape.test.cjs
+++ b/tests/bug-3427-3433-codex-install-shape.test.cjs
@@ -10,7 +10,7 @@ const crypto = require('node:crypto');
 const { execFileSync } = require('node:child_process');
 
 const { install, uninstall, parseTomlToObject } = require('../bin/install.js');
-const { createTempDir, cleanup } = require('./helpers.cjs');
+const { createTempDir, cleanup, parseFrontmatter } = require('./helpers.cjs');
 
 const HOOKS_DIST = path.join(__dirname, '..', 'hooks', 'dist');
 const BUILD_HOOKS_SCRIPT = path.join(__dirname, '..', 'scripts', 'build-hooks.js');
@@ -85,7 +85,8 @@ describe('#3427 + #3433 — Codex installer avoids duplicate skills and mixed ho
     assert.equal(entries.includes('gsd-help'), true);
     const refreshedBody = fs.readFileSync(path.join(skillsDir, 'gsd-help', 'SKILL.md'), 'utf8');
     assert.notEqual(refreshedBody, legacySkillBody, 'stale legacy body must be overwritten');
-    assert.ok(refreshedBody.startsWith('---'), 'refreshed SKILL.md must be valid frontmatter shape');
+    const frontmatter = parseFrontmatter(refreshedBody);
+    assert.equal(frontmatter.name, 'gsd-help', 'refreshed SKILL.md frontmatter must declare name: gsd-help');
 
     // Unrelated user skills are preserved — the regen scope is `gsd-*` only.
     assert.equal(entries.includes('custom-user-skill'), true);

--- a/tests/bug-3427-3433-codex-install-shape.test.cjs
+++ b/tests/bug-3427-3433-codex-install-shape.test.cjs
@@ -55,7 +55,9 @@ describe('#3427 + #3433 — Codex installer avoids duplicate skills and mixed ho
     cleanup(tmpRoot);
   });
 
-  test('removes legacy gsd-* copies from ~/.codex/skills and does not regenerate them', () => {
+  test('regenerates managed gsd-* skill copies and preserves unrelated user skills (#3562 reverses prior #3427/#3433 behaviour)', () => {
+    // Stale legacy body — fresh install must overwrite this so Codex sees the
+    // current SKILL.md, not whatever was last on disk.
     const legacySkillBody = '# old managed\n';
     fs.mkdirSync(path.join(codexHome, 'skills', 'gsd-help'), { recursive: true });
     fs.writeFileSync(path.join(codexHome, 'skills', 'gsd-help', 'SKILL.md'), legacySkillBody);
@@ -77,7 +79,15 @@ describe('#3427 + #3433 — Codex installer avoids duplicate skills and mixed ho
       ? fs.readdirSync(skillsDir, { withFileTypes: true }).filter((e) => e.isDirectory()).map((e) => e.name)
       : [];
 
-    assert.equal(entries.some((name) => name.startsWith('gsd-')), false);
+    // #3562: $gsd-* commands are discoverable only when skills/gsd-*/SKILL.md
+    // exists. The installer must regenerate (not remove) the managed gsd-*
+    // directories.
+    assert.equal(entries.includes('gsd-help'), true);
+    const refreshedBody = fs.readFileSync(path.join(skillsDir, 'gsd-help', 'SKILL.md'), 'utf8');
+    assert.notEqual(refreshedBody, legacySkillBody, 'stale legacy body must be overwritten');
+    assert.ok(refreshedBody.startsWith('---'), 'refreshed SKILL.md must be valid frontmatter shape');
+
+    // Unrelated user skills are preserved — the regen scope is `gsd-*` only.
     assert.equal(entries.includes('custom-user-skill'), true);
   });
 

--- a/tests/bug-3562-codex-install-skill-surface.test.cjs
+++ b/tests/bug-3562-codex-install-skill-surface.test.cjs
@@ -26,7 +26,7 @@ const path = require('node:path');
 const { execFileSync } = require('node:child_process');
 
 const { install } = require('../bin/install.js');
-const { createTempDir, cleanup } = require('./helpers.cjs');
+const { createTempDir, cleanup, parseFrontmatter } = require('./helpers.cjs');
 
 const HOOKS_DIST = path.join(__dirname, '..', 'hooks', 'dist');
 const BUILD_HOOKS_SCRIPT = path.join(__dirname, '..', 'scripts', 'build-hooks.js');
@@ -77,16 +77,8 @@ describe('#3562 — Codex install produces discoverable $gsd-* skill surface', {
     assert.ok(fs.existsSync(skillPath), 'precondition: SKILL.md exists');
 
     const content = fs.readFileSync(skillPath, 'utf8');
-    // SKILL.md is YAML frontmatter then body; convertClaudeCommandToCodexSkill
-    // emits at minimum a `name:` field on the leading frontmatter block.
-    assert.ok(
-      content.startsWith('---'),
-      'SKILL.md must begin with YAML frontmatter (---) for Codex discovery',
-    );
-    assert.ok(
-      /^name:\s*["']?gsd-help["']?\s*$/m.test(content),
-      'SKILL.md frontmatter must declare name: gsd-help so $gsd-help resolves',
-    );
+    const frontmatter = parseFrontmatter(content);
+    assert.equal(frontmatter.name, 'gsd-help', 'SKILL.md frontmatter must declare name: gsd-help so $gsd-help resolves');
   });
 
   test('multiple core $gsd-* skills are produced (not just gsd-help)', () => {

--- a/tests/bug-3562-codex-install-skill-surface.test.cjs
+++ b/tests/bug-3562-codex-install-skill-surface.test.cjs
@@ -1,0 +1,128 @@
+'use strict';
+
+process.env.GSD_TEST_MODE = '1';
+
+/**
+ * Regression test for bug #3562 — Codex global install must create a
+ * discoverable $gsd-* skill surface.
+ *
+ * Codex CLI 0.130.0 (the version in the issue report) does NOT auto-discover
+ * commands from get-shit-done/workflows/*.md or agents/*.md. It only registers
+ * commands from skills/<name>/SKILL.md. Prior installer logic ("Codex now
+ * discovers official skills from .agents/skills") was based on an assumption
+ * that does not match the shipping Codex CLI behavior, leaving users with
+ * workflows on disk and no $gsd-* entrypoints after `npx get-shit-done-cc
+ * --codex --global`.
+ *
+ * Fix: re-wire copyCommandsAsCodexSkills() back into the install dispatch path
+ * so the same skill-shape that Claude / Copilot / Antigravity / Cursor /
+ * Windsurf / Augment / Trae installs produce is also produced for Codex.
+ */
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+const { install } = require('../bin/install.js');
+const { createTempDir, cleanup } = require('./helpers.cjs');
+
+const HOOKS_DIST = path.join(__dirname, '..', 'hooks', 'dist');
+const BUILD_HOOKS_SCRIPT = path.join(__dirname, '..', 'scripts', 'build-hooks.js');
+
+function withCodexHome(codexHome, fn) {
+  const prev = process.env.CODEX_HOME;
+  process.env.CODEX_HOME = codexHome;
+  try {
+    return fn();
+  } finally {
+    if (prev == null) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = prev;
+  }
+}
+
+describe('#3562 — Codex install produces discoverable $gsd-* skill surface', { concurrency: false }, () => {
+  let tmpRoot;
+  let codexHome;
+
+  beforeEach(() => {
+    if (!fs.existsSync(HOOKS_DIST) || fs.readdirSync(HOOKS_DIST).length === 0) {
+      execFileSync(process.execPath, [BUILD_HOOKS_SCRIPT], { stdio: 'pipe' });
+    }
+    tmpRoot = createTempDir('gsd-3562-');
+    codexHome = path.join(tmpRoot, '.codex');
+    fs.mkdirSync(codexHome, { recursive: true });
+  });
+
+  afterEach(() => {
+    cleanup(tmpRoot);
+  });
+
+  test('global install creates skills/gsd-help/SKILL.md', () => {
+    withCodexHome(codexHome, () => install(true, 'codex'));
+
+    const skillPath = path.join(codexHome, 'skills', 'gsd-help', 'SKILL.md');
+    assert.ok(
+      fs.existsSync(skillPath),
+      `Codex install must create ${skillPath} so $gsd-help is discoverable. ` +
+        'Without this, Codex CLI 0.130.0 does not expose any $gsd-* command.',
+    );
+  });
+
+  test('SKILL.md content has frontmatter expected by Codex skill discovery', () => {
+    withCodexHome(codexHome, () => install(true, 'codex'));
+
+    const skillPath = path.join(codexHome, 'skills', 'gsd-help', 'SKILL.md');
+    assert.ok(fs.existsSync(skillPath), 'precondition: SKILL.md exists');
+
+    const content = fs.readFileSync(skillPath, 'utf8');
+    // SKILL.md is YAML frontmatter then body; convertClaudeCommandToCodexSkill
+    // emits at minimum a `name:` field on the leading frontmatter block.
+    assert.ok(
+      content.startsWith('---'),
+      'SKILL.md must begin with YAML frontmatter (---) for Codex discovery',
+    );
+    assert.ok(
+      /^name:\s*["']?gsd-help["']?\s*$/m.test(content),
+      'SKILL.md frontmatter must declare name: gsd-help so $gsd-help resolves',
+    );
+  });
+
+  test('multiple core $gsd-* skills are produced (not just gsd-help)', () => {
+    withCodexHome(codexHome, () => install(true, 'codex'));
+
+    const skillsDir = path.join(codexHome, 'skills');
+    assert.ok(fs.existsSync(skillsDir), 'skills/ directory must exist after install');
+
+    const gsdSkills = fs
+      .readdirSync(skillsDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory() && e.name.startsWith('gsd-'))
+      .map((e) => e.name);
+
+    // Lower bound — exact count depends on the current command surface. The
+    // commands/gsd/ directory holds dozens of *.md files; expecting more than
+    // 10 generated skills is a conservative floor that catches "we generated
+    // nothing" or "we only generated one accidentally" regressions.
+    assert.ok(
+      gsdSkills.length >= 10,
+      `Expected >= 10 generated gsd-* skill directories, found ${gsdSkills.length}: ${gsdSkills.join(', ')}`,
+    );
+  });
+
+  test('install preserves existing user skills (does not remove unrelated dirs)', () => {
+    fs.mkdirSync(path.join(codexHome, 'skills', 'custom-user-skill'), { recursive: true });
+    fs.writeFileSync(
+      path.join(codexHome, 'skills', 'custom-user-skill', 'SKILL.md'),
+      '---\nname: custom-user-skill\n---\n# user skill\n',
+    );
+
+    withCodexHome(codexHome, () => install(true, 'codex'));
+
+    const userSkill = path.join(codexHome, 'skills', 'custom-user-skill', 'SKILL.md');
+    assert.ok(
+      fs.existsSync(userSkill),
+      'Codex install must preserve existing non-gsd user skill directories',
+    );
+  });
+});

--- a/tests/install-minimal-all-runtimes.test.cjs
+++ b/tests/install-minimal-all-runtimes.test.cjs
@@ -180,8 +180,12 @@ function expectedSkillSet() {
 }
 
 function expectedManifestSkillSet(runtime) {
-  // Codex no longer materializes gsd-* skill files in minimal mode.
-  if (runtime === 'codex') return new Set();
+  // Codex CLI 0.130.0 does not auto-discover commands from workflow / agent
+  // files (#3562) — it only registers commands from skills/<name>/SKILL.md.
+  // Codex installs therefore materialize the same minimal-allowlist skill
+  // surface as the other runtimes; the prior "Codex discovers official
+  // skills directly" assumption (which led to an empty Codex skill set
+  // here) does not hold in practice.
   return expectedSkillSet();
 }
 

--- a/tests/installer-migration-install-integration.test.cjs
+++ b/tests/installer-migration-install-integration.test.cjs
@@ -209,11 +209,11 @@ function assertFreshInstallContract(runtime, targetDir) {
   );
 
   if (contract.surface === 'flat-skills') {
-    if (runtime === 'codex') {
-      assertNoGsdDirectoryEntries(targetDir, 'skills');
-    } else {
-      assertHasGsdDirectory(targetDir, 'skills');
-    }
+    // Pre-#3562: codex was special-cased to expect zero gsd-* skill dirs
+    // (assumption: Codex auto-discovers from workflows). That assumption
+    // does not hold for Codex CLI 0.130.0 — fresh installs now materialize
+    // the same flat-skills surface as the other runtimes.
+    assertHasGsdDirectory(targetDir, 'skills');
   } else if (contract.surface === 'hermes-skills') {
     assertHasGsdDirectory(targetDir, path.join('skills', 'gsd'));
     assert.ok(


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3562

> Linked issue carries the `confirmed-bug` label.

---

## What was broken

`npx get-shit-done-cc@latest --codex --global` was leaving Codex CLI 0.130.0 users with `get-shit-done/workflows/*.md` and `agents/gsd-*` on disk but zero `~/.codex/skills/gsd-*/SKILL.md` files, so Codex silently exposed no `$gsd-*` commands after restart. The installer's "Skipped Codex skill-copy generation (Codex discovers official skills directly)" log line was the visible symptom of an assumption that did not match the shipping Codex CLI.

## What this fix does

Re-wires the already-present `copyCommandsAsCodexSkills()` helper (`bin/install.js:5519`) back into the Codex install dispatch (`bin/install.js:8090`). The Codex install now produces one `~/.codex/skills/gsd-<name>/SKILL.md` per `commands/gsd/*.md` — the same skill-shape the Copilot / Antigravity / Cursor / Windsurf / Augment / Trae installs already use. Pre-existing user-owned non-`gsd-*` skill directories are preserved (the regen scope is `gsd-*` only).

Documented the minimum supported Codex CLI version (`0.130.0`) in `README.md`, `docs/USER-GUIDE.md`, and `docs/CONFIGURATION.md` so future maintainers don't oscillate this surface again.

## Root cause

A two-side timeline produced the oscillation:

| Date | Event |
|------|-------|
| 2026-05-08 | Codex CLI 0.130.0 ships, dropping extra-skills-roots discovery via [openai/codex#21485](https://github.com/openai/codex/pull/21485). From this version, Codex scans only `~/.codex/skills/<name>/SKILL.md`, cwd `.codex/skills/`, and registered plugin roots. |
| 2026-05-14 | GSD PR #3512 merges, removing `~/.codex/skills/gsd-*` under the assumption Codex auto-discovers from extra roots — that path was already gone in shipped Codex. |
| 2026-05-15 | Issue #3562 filed — Codex CLI 0.130.0 users see no `$gsd-*` after install. |

#3427 (which #3512 partially addressed) reported the *Codex Desktop* duplicate-surface UX issue. Codex Desktop is a separate product with a different discovery model; the SKILL.md copies are harmless duplication on Desktop and required on CLI. The minor Desktop UX cost is the right trade-off against the CLI being completely broken.

Notably this is not a revert of an intentional architectural fix — PR #3512's design was based on an extra-roots discovery model that never reached a shipped Codex CLI release.

## Testing

### How I verified the fix

- **Reproduced the issue** with the exact command from the issue body:
  ```
  CODEX_HOME=<tmp> node bin/install.js --codex --global
  ```
  Before fix: `~/.codex/skills/gsd-help/SKILL.md` missing, log line "Skipped Codex skill-copy generation". After fix: 67 `gsd-*` skill directories created, `gsd-help/SKILL.md` has valid frontmatter (`name: "gsd-help"`).
- **New behavioral regression test** `tests/bug-3562-codex-install-skill-surface.test.cjs` (4 cases):
  - `skills/gsd-help/SKILL.md` exists after install
  - SKILL.md begins with YAML frontmatter and declares `name: gsd-help`
  - At least 10 `gsd-*` skill directories produced (lower-bound floor)
  - Pre-existing `custom-user-skill` directory preserved
- **Updated pre-existing tests** that codified the prior broken behavior:
  - `tests/bug-3427-3433-codex-install-shape.test.cjs` — assertion flipped from "does not regenerate gsd-*" to "regenerates gsd-* with refreshed body, preserves non-gsd user skills"
  - `tests/install-minimal-all-runtimes.test.cjs` — `expectedManifestSkillSet(codex)` returns the same set as other runtimes (was hard-coded to empty Set under the prior assumption)
  - `tests/installer-migration-install-integration.test.cjs` — `flat-skills` contract no longer special-cases codex with `assertNoGsdDirectoryEntries`
- **Full suite via `gsd-test-summary --both`:** Mac and Docker both green.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux (via `gsd-test-summary --both` Docker container)
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: Codex
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (via `gsd-test-summary --both`)
- [x] `.changeset/` fragment added (`type: Fixed`, `pr: 0` placeholder — will amend with real PR number)
- [x] No unnecessary dependencies added

## Breaking changes

None for Codex CLI ≥ 0.130.0 users (this restores the documented behavior).

Codex CLI < 0.130.0 users (if any remain on the older "extra-roots-scanning" build) may see a duplicate `gsd-*` listing — one from the legacy auto-discovery and one from `~/.codex/skills/gsd-*`. The trade-off is intentional: hard-broken on the current shipping Codex is worse than a minor duplicate-surface UX on a 1+-week-old build. Restart Codex after install and upgrade to ≥ 0.130.0 to consolidate.

Codex Desktop users may continue to see the official `/gsd:` skill surface alongside the `~/.codex/skills/gsd-*` copies (the original #3427 complaint). Same trade-off.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Codex global installer now generates a discoverable gsd-* skill surface on global install.

* **Bug Fixes**
  * Installer regenerates and writes Codex skill files instead of skipping removal/regeneration; preserves pre-existing user-owned non-gsd-* skills.

* **Documentation**
  * Added Codex CLI minimum version 0.130.0 and guidance on changed skill discovery/duplicate entries.

* **Tests**
  * Added/updated tests verifying Codex skill-surface creation and preservation of user skills.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3568)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->