### PR TITLE
fix(install): rewrite /gsd: -> /gsd- in Claude skill body to match frontmatter name

### DIFF
--- a/.changeset/3583-claude-skill-body-slash-transform.md
+++ b/.changeset/3583-claude-skill-body-slash-transform.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+issue: 3583
+---
+Claude global-skill install now rewrites `/gsd:<cmd>` body references to `/gsd-<cmd>` so the installed SKILL.md body matches the hyphen-form `name:` Claude Code surfaces in its slash-command picker. Previously, `convertClaudeCommandToClaudeSkill` rebuilt the frontmatter but emitted the body unchanged, leaving routing hints like "Next step: /gsd:discuss-phase" that Claude Code rejected as "Unknown command" on global skill installs. Mirrors the body rewrite the Copilot adapter has applied since #2858. Source files keep canonical `/gsd:<cmd>` per the #3443 invariant.

--- a/bin/install.js
+++ b/bin/install.js
@@ -20,6 +20,10 @@ const {
   projectCodexHookTomlCommand,
 } = require('../get-shit-done/bin/lib/shell-command-projection.cjs');
 
+const {
+  transformColonToHyphen,
+} = require('../scripts/fix-slash-commands.cjs');
+
 // Colors
 const cyan = '\x1b[36m';
 const green = '\x1b[32m';
@@ -1664,6 +1668,13 @@ function skillFrontmatterName(skillDirName) {
  * preserve allowed-tools as YAML multiline list, preserve argument-hint.
  * Emits `name: gsd-<cmd>` (hyphen) so Skill(skill="gsd-<cmd>") calls and
  * tab autocomplete use the canonical command namespace.
+ *
+ * Body conversion (#3583): the installed skill is invoked through its
+ * hyphen-form `name:` (e.g. `/gsd-plan-phase` in the slash picker), so any
+ * `/gsd:<cmd>` references in the body would be unresolvable for the end
+ * user. Rewrite them to `/gsd-<cmd>` using the roster-checked transformer
+ * shared with the source-side guard. Mirrors the body rewrite the Copilot
+ * adapter applies via `convertClaudeToCopilotContent`.
  */
 function convertClaudeCommandToClaudeSkill(content, skillName, runtime = null) {
   const { frontmatter, body } = extractFrontmatterAndBody(content);
@@ -1694,7 +1705,8 @@ function convertClaudeCommandToClaudeSkill(content, skillName, runtime = null) {
   if (toolsBlock) fm += toolsBlock;
   fm += '---';
 
-  return `${fm}\n${body}`;
+  const transformedBody = transformColonToHyphen(body, Array.from(getGsdCommandRoster()));
+  return `${fm}\n${transformedBody}`;
 }
 
 /**

--- a/scripts/fix-slash-commands.cjs
+++ b/scripts/fix-slash-commands.cjs
@@ -57,6 +57,31 @@ function transformContent(src, cmdNames) {
   return src.replace(pattern, (_, cmd) => `/gsd:${cmd}`);
 }
 
+/**
+ * Mirror of `buildPattern` for the opposite direction. Matches canonical
+ * `/gsd:<cmd>` references so they can be rewritten to `/gsd-<cmd>` at
+ * install time for runtimes that surface skills under their hyphen-form
+ * `name:` (Claude global skills, Qwen, Hermes). Same word-boundary
+ * discipline and same empty-roster short-circuit as `buildPattern`.
+ */
+function buildColonPattern(cmdNames) {
+  if (!Array.isArray(cmdNames) || cmdNames.length === 0) return null;
+  const sorted = [...cmdNames].sort((a, b) => b.length - a.length);
+  return new RegExp(`/gsd:(${sorted.join('|')})(?=[^a-zA-Z0-9_-]|$)`, 'g');
+}
+
+/**
+ * Pure transform: rewrite canonical `/gsd:<cmd>` to `/gsd-<cmd>` for the
+ * given command names. Inverse of `transformContent`. Used by install-time
+ * adapters that emit SKILL.md bodies for runtimes whose slash-command
+ * surface is hyphen-formed (see #3583).
+ */
+function transformColonToHyphen(src, cmdNames) {
+  const pattern = buildColonPattern(cmdNames);
+  if (!pattern) return src;
+  return src.replace(pattern, (_, cmd) => `/gsd-${cmd}`);
+}
+
 function readCmdNames() {
   return fs.readdirSync(COMMANDS_DIR)
     .filter(f => f.endsWith('.md'))
@@ -103,4 +128,10 @@ if (require.main === module) {
   console.log('Done.');
 }
 
-module.exports = { transformContent, buildPattern, SKIP_DIRS };
+module.exports = {
+  transformContent,
+  buildPattern,
+  transformColonToHyphen,
+  buildColonPattern,
+  SKIP_DIRS,
+};

--- a/tests/bug-2543-gsd-slash-namespace.test.cjs
+++ b/tests/bug-2543-gsd-slash-namespace.test.cjs
@@ -147,6 +147,45 @@ describe('slash-command namespace invariant (#3443)', () => {
     });
   });
 
+  describe('transformColonToHyphen — install-time inverse (#3583)', () => {
+    const {
+      transformColonToHyphen,
+    } = require(path.join(ROOT, 'scripts', 'fix-slash-commands.cjs'));
+    const liveCmdNames = cmdNames;
+
+    test('rewrites /gsd:<cmd> to /gsd-<cmd>', () => {
+      const out = transformColonToHyphen('Run /gsd:plan-phase next.', liveCmdNames);
+      assert.ok(out.includes('/gsd-plan-phase'), `expected /gsd-plan-phase, got: ${out}`);
+      assert.ok(!out.includes('/gsd:plan-phase'), `colon form must not survive, got: ${out}`);
+    });
+
+    test('rewrites multiple occurrences in one pass', () => {
+      const out = transformColonToHyphen(
+        'First /gsd:discuss-phase 1 then /gsd:plan-phase 1.', liveCmdNames);
+      assert.ok(out.includes('/gsd-discuss-phase'));
+      assert.ok(out.includes('/gsd-plan-phase'));
+      assert.ok(!out.match(/\/gsd:[a-z]/), `no colon form may remain, got: ${out}`);
+    });
+
+    test('idempotent on already-hyphenated input', () => {
+      const input = 'Run /gsd-plan-phase next.';
+      assert.strictEqual(transformColonToHyphen(input, liveCmdNames), input,
+        'transformer must be a no-op when input is already hyphenated');
+    });
+
+    test('respects word boundary — does not rewrite /gsd:plan-phase-extra', () => {
+      const out = transformColonToHyphen('/gsd:plan-phase-extra', liveCmdNames);
+      assert.strictEqual(out, '/gsd:plan-phase-extra',
+        'word-boundary lookahead must prevent partial matches in colon direction');
+    });
+
+    test('no-ops on empty roster (guards against broad rewrite)', () => {
+      const input = 'Run /gsd:plan-phase next.';
+      assert.strictEqual(transformColonToHyphen(input, []), input,
+        'empty roster must short-circuit, never produce a stray /gsd-');
+    });
+  });
+
   test('transformer leaves non-command identifiers untouched', () => {
     const { transformContent } = require(path.join(ROOT, 'scripts', 'fix-slash-commands.cjs'));
     const sample = 'Use /gsd-sdk query and node bin/gsd-tools.cjs';

--- a/tests/bug-3583-claude-skill-body-transform.test.cjs
+++ b/tests/bug-3583-claude-skill-body-transform.test.cjs
@@ -1,0 +1,106 @@
+'use strict';
+
+/**
+ * Claude global-skill SKILL.md body must use hyphen-form `/gsd-<cmd>` (#3583).
+ *
+ * History:
+ *   #3443 re-established `/gsd:<cmd>` as canonical in source. Non-Claude
+ *   runtimes convert at install time. Claude global skill installs surface
+ *   commands under hyphen-form `name:` (see #2808), so body references must
+ *   agree with the slash-picker invocation form the end user sees.
+ *
+ * Asymmetry the fix closes:
+ *   The Copilot adapter rewrites `/gsd:` → `/gsd-` in body via
+ *   `convertClaudeToCopilotContent` at bin/install.js:1598. The Claude
+ *   skill adapter previously emitted body unchanged, leaving routing
+ *   hints like "Next step: /gsd:discuss-phase" that Claude Code rejects
+ *   as "Unknown command" on global skill installs.
+ */
+
+// MUST be set before requiring bin/install.js so the installer's top-level
+// code short-circuits instead of running a full install during test load.
+process.env.GSD_TEST_MODE = '1';
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  convertClaudeCommandToClaudeSkill,
+} = require('../bin/install.js');
+
+describe('convertClaudeCommandToClaudeSkill body rewrite (#3583)', () => {
+  test('rewrites /gsd:<cmd> to /gsd-<cmd> in body so it matches frontmatter name', () => {
+    const input = [
+      '---',
+      'name: should-be-overwritten',
+      'description: Test command',
+      '---',
+      '',
+      'Next step',
+      '',
+      '/gsd:discuss-phase 1     # discuss Phase 1',
+    ].join('\n');
+    const out = convertClaudeCommandToClaudeSkill(input, 'gsd-discuss-phase', null);
+    assert.ok(out.includes('name: gsd-discuss-phase'),
+      `frontmatter name must be hyphen form, got:\n${out}`);
+    assert.ok(out.includes('/gsd-discuss-phase'),
+      `body must use hyphen form, got:\n${out}`);
+    assert.ok(!out.includes('/gsd:discuss-phase'),
+      `colon form must not survive in body, got:\n${out}`);
+  });
+
+  test('rewrites multiple body occurrences in one conversion', () => {
+    const input = [
+      '---',
+      'name: x',
+      'description: Test',
+      '---',
+      '',
+      'First /gsd:discuss-phase 1 then /gsd:plan-phase 1 then /gsd:execute-phase 1.',
+    ].join('\n');
+    const out = convertClaudeCommandToClaudeSkill(input, 'gsd-x', null);
+    assert.ok(out.includes('/gsd-discuss-phase'));
+    assert.ok(out.includes('/gsd-plan-phase'));
+    assert.ok(out.includes('/gsd-execute-phase'));
+    assert.ok(!out.match(/\/gsd:[a-z]/), `no colon form may remain in body, got:\n${out}`);
+  });
+
+  test('leaves non-command identifiers in body alone (gsd-sdk, gsd-tools)', () => {
+    const input = [
+      '---',
+      'name: x',
+      'description: Test',
+      '---',
+      '',
+      'Use /gsd-sdk query and node bin/gsd-tools.cjs.',
+    ].join('\n');
+    const out = convertClaudeCommandToClaudeSkill(input, 'gsd-x', null);
+    assert.ok(out.includes('/gsd-sdk'), 'gsd-sdk must remain untouched');
+    assert.ok(out.includes('bin/gsd-tools.cjs'), 'gsd-tools must remain untouched');
+  });
+
+  test('idempotent on body that already uses hyphen form', () => {
+    const input = [
+      '---',
+      'name: x',
+      'description: Test',
+      '---',
+      '',
+      'Already-converted: /gsd-plan-phase 1.',
+    ].join('\n');
+    const out = convertClaudeCommandToClaudeSkill(input, 'gsd-x', null);
+    assert.ok(out.includes('/gsd-plan-phase'),
+      'hyphen form must survive a re-conversion');
+    assert.ok(!out.match(/\/gsd:[a-z]/),
+      'no colon form must be introduced');
+  });
+
+  test('passthrough when input has no frontmatter (no rewrite path)', () => {
+    const input = 'Plain text with /gsd:plan-phase reference.';
+    const out = convertClaudeCommandToClaudeSkill(input, 'gsd-x', null);
+    // Documented behavior at install.js: bail early if no frontmatter.
+    // This guards against accidentally rewriting bodies that lack the YAML
+    // header — those are not skill files and should pass through verbatim.
+    assert.strictEqual(out, input);
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3583

## What was broken

After installing GSD for Claude Code via `npm install`, the slash-command picker surfaces commands as `/gsd-help`, `/gsd-ship`, etc. (hyphen form), but workflow output emitted from installed SKILL.md bodies still recommends `/gsd:<cmd>` (colon form). Claude Code rejects those with `Unknown command: /gsd:discuss-phase. Did you mean /gsd-discuss-phase?`.

## What this fix does

`convertClaudeCommandToClaudeSkill` (`bin/install.js`) now applies a roster-checked `transformColonToHyphen` to the body before reassembly, so the installed SKILL.md body matches the hyphen-form `name:` Claude Code surfaces. Source files keep canonical `/gsd:<cmd>` per the #3443 invariant — only the install-time output changes.

## Root cause

The Claude skill adapter rebuilt frontmatter (with `name: gsd-<cmd>`) but emitted the body unchanged — an asymmetry with the Copilot adapter at `bin/install.js:1598`, which has applied `gsd:` → `gsd-` to bodies since #2858. The new transformer mirrors that behavior using the existing word-boundary + roster discipline `transformContent` already uses for the inverse direction.

## Testing

### How I verified the fix

- 5 unit tests on the new `transformColonToHyphen` transformer added to `tests/bug-2543-gsd-slash-namespace.test.cjs` (covers rewrite, multi-occurrence, idempotence, word boundary, empty roster).
- 5 end-to-end tests on `convertClaudeCommandToClaudeSkill` body rewrite in new `tests/bug-3583-claude-skill-body-transform.test.cjs`.
- Targeted regression run on 9 skill-related suites (`bug-1736`, `bug-2543`, `bug-2643`, `bug-2808`, `bug-2973`, `bug-3583`, `claude-skills-migration`, `qwen-skills-migration`, `hermes-skills-migration`): **80/80 pass**.
- `node scripts/lint-no-source-grep.cjs`: 0 violations.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code (global skill install path)
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

Note: implicitly covers **Qwen** and **Hermes** as well — both install paths funnel through `convertClaudeCommandToClaudeSkill` (`bin/install.js:5988`, with `runtime === 'qwen'` / `runtime === 'hermes'` branches earlier in the same function). Existing migration tests for both pass with the change.

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [ ] Linked issue has the `confirmed-bug` label *(pending maintainer triage — issue freshly opened alongside this PR)*
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (targeted run; awaiting full CI)
- [x] `.changeset/` fragment added (`.changeset/3583-claude-skill-body-slash-transform.md`)
- [x] No unnecessary dependencies added

## Breaking changes

None. The change only affects installed SKILL.md files on the Claude global / Qwen / Hermes install paths. Source files in `commands/gsd/` remain unchanged. The Claude **local** install path (which uses namespaced `commands/gsd/` and is invoked via `/gsd:<cmd>`) is unaffected — colon form there is correct and is preserved.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed global skill installation for Claude Code to correctly rewrite slash-command references in skill bodies, ensuring installed skills work with Claude Code's slash-command picker and command routing system.

* **Tests**
  * Added comprehensive tests validating slash-command reference transformations during skill installation, including edge cases and idempotency checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3586?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->