### PR TITLE
fix(3605): scrub retired slash commands from agents/*.md

### DIFF
--- a/.changeset/3605-stale-agent-command-refs.md
+++ b/.changeset/3605-stale-agent-command-refs.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+issue: 3605
+---
+**Agent contracts no longer reference retired `/gsd-research-phase` or `/gsd-insert-phase`** — six surviving references in `agents/gsd-executor.md`, `agents/gsd-phase-researcher.md`, `agents/gsd-planner.md`, `agents/gsd-research-synthesizer.md`, and `agents/gsd-roadmapper.md` are replaced with `/gsd:plan-phase --research-phase <N>` and `/gsd:phase insert`. Adds a regression guard (`tests/bug-3605-stale-research-insert-phase-agent-refs.test.cjs`) that fails when any retired command name reappears in `agents/*.md` — covers the gap that let #3029, #3044, and #3131 miss the `agents/` directory.

--- a/agents/gsd-executor.md
+++ b/agents/gsd-executor.md
@@ -192,7 +192,7 @@ This exclusion exists because a failed install may indicate a slopsquatted or ha
     `[package-name]` could not be installed. Before proceeding:
     1. Verify the package exists and is legitimate: https://npmjs.com/package/[package-name]
     2. Confirm the package name is spelled correctly in PLAN.md
-    3. If the package does not exist, re-run /gsd-plan-phase --research-phase &lt;N&gt; to find the correct package
+    3. If the package does not exist, re-run /gsd:plan-phase --research-phase <N> to find the correct package
   </how-to-verify>
   <resume-signal>Type "verified" with the correct package name, or "abort" to stop the phase</resume-signal>
 </task>

--- a/agents/gsd-executor.md
+++ b/agents/gsd-executor.md
@@ -192,7 +192,7 @@ This exclusion exists because a failed install may indicate a slopsquatted or ha
     `[package-name]` could not be installed. Before proceeding:
     1. Verify the package exists and is legitimate: https://npmjs.com/package/[package-name]
     2. Confirm the package name is spelled correctly in PLAN.md
-    3. If the package does not exist, return to /gsd-research-phase to find the correct package
+    3. If the package does not exist, re-run /gsd-plan-phase --research-phase &lt;N&gt; to find the correct package
   </how-to-verify>
   <resume-signal>Type "verified" with the correct package name, or "abort" to stop the phase</resume-signal>
 </task>

--- a/agents/gsd-phase-researcher.md
+++ b/agents/gsd-phase-researcher.md
@@ -14,7 +14,7 @@ color: cyan
 <role>
 You are a GSD phase researcher. You answer "What do I need to know to PLAN this phase well?" and produce a single RESEARCH.md that the planner consumes.
 
-Spawned by `/gsd:plan-phase` (integrated) or `/gsd-research-phase` (standalone).
+Spawned by `/gsd:plan-phase` (integrated) or `/gsd:plan-phase --research-phase <N>` (standalone).
 
 @~/.claude/get-shit-done/references/mandatory-initial-read.md
 

--- a/agents/gsd-planner.md
+++ b/agents/gsd-planner.md
@@ -183,7 +183,7 @@ Discovery is MANDATORY unless you can prove current context exists.
 - Level 2+: New library not in package.json, external API, "choose/select/evaluate" in description
 - Level 3: "architecture/design/system", multiple external services, data modeling, auth design
 
-For niche domains (3D, games, audio, shaders, ML), suggest `/gsd:plan-phase --research-phase <N>` before plan-phase.
+For niche domains (3D/games/audio/shaders/ML), suggest `/gsd:plan-phase --research-phase <N>` first.
 
 </discovery_levels>
 
@@ -988,7 +988,7 @@ Use `phase_dir` from init context (already loaded in load_project_state).
 
 ```bash
 cat "$phase_dir"/*-CONTEXT.md 2>/dev/null   # From /gsd:discuss-phase
-cat "$phase_dir"/*-RESEARCH.md 2>/dev/null   # From /gsd:plan-phase --research-phase
+cat "$phase_dir"/*-RESEARCH.md 2>/dev/null   # Research output
 cat "$phase_dir"/*-DISCOVERY.md 2>/dev/null  # From mandatory discovery
 ```
 

--- a/agents/gsd-planner.md
+++ b/agents/gsd-planner.md
@@ -183,7 +183,7 @@ Discovery is MANDATORY unless you can prove current context exists.
 - Level 2+: New library not in package.json, external API, "choose/select/evaluate" in description
 - Level 3: "architecture/design/system", multiple external services, data modeling, auth design
 
-For niche domains (3D, games, audio, shaders, ML), suggest `/gsd-research-phase` before plan-phase.
+For niche domains (3D, games, audio, shaders, ML), suggest `/gsd:plan-phase --research-phase <N>` before plan-phase.
 
 </discovery_levels>
 
@@ -988,7 +988,7 @@ Use `phase_dir` from init context (already loaded in load_project_state).
 
 ```bash
 cat "$phase_dir"/*-CONTEXT.md 2>/dev/null   # From /gsd:discuss-phase
-cat "$phase_dir"/*-RESEARCH.md 2>/dev/null   # From /gsd-research-phase
+cat "$phase_dir"/*-RESEARCH.md 2>/dev/null   # From /gsd:plan-phase --research-phase
 cat "$phase_dir"/*-DISCOVERY.md 2>/dev/null  # From mandatory discovery
 ```
 

--- a/agents/gsd-research-synthesizer.md
+++ b/agents/gsd-research-synthesizer.md
@@ -112,7 +112,7 @@ This is the most important section. Based on combined research:
 - Which pitfalls it must avoid
 
 **Add research flags:**
-- Which phases likely need `/gsd-research-phase` during planning?
+- Which phases likely need `/gsd:plan-phase --research-phase <N>` during planning?
 - Which phases have well-documented patterns (skip research)?
 
 ## Step 5: Assess Confidence

--- a/agents/gsd-roadmapper.md
+++ b/agents/gsd-roadmapper.md
@@ -202,7 +202,7 @@ Track coverage as you go.
 **Integer phases (1, 2, 3):** Planned milestone work.
 
 **Decimal phases (2.1, 2.2):** Urgent insertions after planning.
-- Created via `/gsd-insert-phase`
+- Created via `/gsd:phase insert`
 - Execute between integers: 1 → 1.1 → 1.2 → 2
 
 **Starting number:**

--- a/tests/bug-3605-stale-research-insert-phase-agent-refs.test.cjs
+++ b/tests/bug-3605-stale-research-insert-phase-agent-refs.test.cjs
@@ -1,0 +1,87 @@
+// allow-test-rule: source-text-is-the-product
+// agents/*.md text IS the deployed contract — Claude Code, Codex, etc. load these
+// files at runtime and surface their content to users. Testing for retired slash
+// commands in this text is testing what real users will see.
+
+/**
+ * Bug #3605: Stale slash command references in 5 agent files
+ *
+ * After #3042 deleted /gsd-research-phase (replaced by
+ * /gsd-plan-phase --research-phase <N>) and v1.40.0 consolidated /gsd-insert-phase
+ * into /gsd-phase insert, six occurrences survived in agents/*.md because none of
+ * the consolidation passes (#3029, #3044, #3131) included agents/ in their per-name
+ * scrub scope. scripts/fix-slash-commands.cjs lists agents/ in SEARCH_DIRS but only
+ * runs the /gsd- → /gsd: namespace transform, not retired-name replacement.
+ *
+ * This guard fails when any retired command name reappears in agents/*.md.
+ */
+
+'use strict';
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const AGENTS_DIR = path.join(__dirname, '..', 'agents');
+
+const RETIRED_COMMANDS = [
+  '/gsd-research-phase',
+  '/gsd-insert-phase',
+  '/gsd-add-phase',
+  '/gsd-remove-phase',
+  '/gsd-analyze-dependencies',
+];
+
+function listAgentFiles() {
+  return fs
+    .readdirSync(AGENTS_DIR)
+    .filter((name) => name.endsWith('.md'))
+    .map((name) => path.join(AGENTS_DIR, name));
+}
+
+function scanForRetired(filePath) {
+  const text = fs.readFileSync(filePath, 'utf-8');
+  const lines = text.split('\n');
+  const hits = [];
+  for (let i = 0; i < lines.length; i++) {
+    for (const cmd of RETIRED_COMMANDS) {
+      const idx = lines[i].indexOf(cmd);
+      if (idx === -1) continue;
+      const next = lines[i].charCodeAt(idx + cmd.length);
+      // Only count if the match is a real invocation, not a prefix of a longer name.
+      // The next char must be a non-name char (anything outside [A-Za-z0-9-_]).
+      const isWordBoundary =
+        Number.isNaN(next) ||
+        !((next >= 48 && next <= 57) || // 0-9
+          (next >= 65 && next <= 90) || // A-Z
+          (next >= 97 && next <= 122) || // a-z
+          next === 45 || // -
+          next === 95); // _
+      if (!isWordBoundary) continue;
+      hits.push({ line: i + 1, cmd, text: lines[i].trim() });
+    }
+  }
+  return hits;
+}
+
+describe('bug #3605: agent contracts must not reference retired slash commands', () => {
+  const agentFiles = listAgentFiles();
+
+  test('at least one agent file is scanned (smoke)', () => {
+    assert.ok(agentFiles.length > 0, 'expected agents/*.md to exist');
+  });
+
+  for (const file of agentFiles) {
+    const rel = path.relative(path.join(__dirname, '..'), file);
+    test(`${rel} contains no retired slash commands`, () => {
+      const hits = scanForRetired(file);
+      assert.deepEqual(
+        hits,
+        [],
+        `${rel} contains retired command references:\n` +
+          hits.map((h) => `  line ${h.line}: ${h.cmd} — ${h.text}`).join('\n'),
+      );
+    });
+  }
+});


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #3605

---

## What was broken

Six references to retired slash commands survived in five `agents/*.md` files: five `/gsd-research-phase` (deleted in #3042) and one `/gsd-insert-phase` (consolidated into `/gsd:phase insert` in v1.40.0). One of them — `agents/gsd-executor.md:195` — is user-facing: it surfaces during a package-install failure recovery checkpoint, so a real user hits `Unknown command` while trying to recover from a stalled phase.

## What this fix does

Replaces the six stale strings with the live invocation paths and adds a regression test that fails when any retired command name reappears in `agents/*.md`.

| File | Line | Stale ref | Replaced with |
|---|---:|---|---|
| `agents/gsd-executor.md` | 195 | `/gsd-research-phase` | `/gsd-plan-phase --research-phase <N>` |
| `agents/gsd-phase-researcher.md` | 17 | `/gsd-research-phase` | `/gsd:plan-phase --research-phase <N>` |
| `agents/gsd-planner.md` | 186 | `/gsd-research-phase` | `/gsd:plan-phase --research-phase <N>` |
| `agents/gsd-planner.md` | 991 | `/gsd-research-phase` | `/gsd:plan-phase --research-phase` |
| `agents/gsd-research-synthesizer.md` | 115 | `/gsd-research-phase` | `/gsd:plan-phase --research-phase <N>` |
| `agents/gsd-roadmapper.md` | 205 | `/gsd-insert-phase` | `/gsd:phase insert` |

## Root cause

Every prior scrub pass (#3029, #3044, #3131) limited its `SEARCH_DIRS` to `workflows/`, `references/`, `templates/`, `contexts/`, `commands/`, and `hooks/` — `agents/` was outside scope. `scripts/fix-slash-commands.cjs` lists `agents/` in `SEARCH_DIRS` but only runs the `/gsd-` → `/gsd:` namespace transform; it does not rename retired commands. The structural gap is the absence of a per-name retirement guard for `agents/`. This PR closes that gap.

## Testing

### How I verified the fix

- RED: new regression guard reports 6 violations on the pre-fix tree.
- GREEN: 34/34 pass after the six replacements (`node --test tests/bug-3605-stale-research-insert-phase-agent-refs.test.cjs`).
- Related suites: `tests/bug-2950-stale-command-refs.test.cjs`, `tests/agent-frontmatter.test.cjs`, `tests/agent-size-budget.test.cjs` — 303/303 pass.
- `npm run lint:tests` — clean.

### Regression test added?

- [x] Yes — `tests/bug-3605-stale-research-insert-phase-agent-refs.test.cjs` scans every `agents/*.md` for `/gsd-research-phase`, `/gsd-insert-phase`, `/gsd-add-phase`, `/gsd-remove-phase`, `/gsd-analyze-dependencies` with word-boundary matching. Annotated `// allow-test-rule: source-text-is-the-product` — agent contracts are deployed text, identical exemption to `tests/bug-2950-stale-command-refs.test.cjs` which covers the same anti-pattern for `workflows/`.

### Platforms tested

- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific — `agents/*.md` is the canonical source loaded by every runtime that installs GSD)

---

## Checklist

- [x] Issue linked above with `Fixes #3605`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass
- [x] `.changeset/` fragment added (`.changeset/3605-stale-agent-command-refs.md`)
- [x] No unnecessary dependencies added

## Breaking changes

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated agent documentation to use current command syntax instead of retired commands.

* **Tests**
  * Added regression prevention test to ensure deprecated commands are not reintroduced in agent documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3613?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->