### PR TITLE
fix(3599): preserve project-code prefix when looking up roadmap phases

### DIFF
--- a/.changeset/3599-roadmap-get-phase-project-code-prefix.md
+++ b/.changeset/3599-roadmap-get-phase-project-code-prefix.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+issue: 3599
+---
+**`roadmap get-phase PROJ-42` now matches `### Phase PROJ-42:` instead of returning `found: false`** — `cmdRoadmapGetPhase` now does a two-pass search when the caller passes a project-code-prefixed ID. The exact-escaped form (`### Phase PROJ-42:`) is tried first, and only falls back to the #3537 padding-tolerant numeric form (`### Phase 42:`) when the exact heading is not present. New helper `phaseMarkdownRegexSourceExact()` is added alongside the existing `phaseMarkdownRegexSource()` so callers that need the prefix-preserving path can opt in.

--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -687,6 +687,25 @@ function phaseMarkdownRegexSource(phaseNum) {
   return `0*${escapeRegex(integer)}${letter}${decimal}`;
 }
 
+/**
+ * #3599: when the caller passed a project-code-prefixed ID like `PROJ-42`,
+ * return the exact-escaped form so the caller can search the ROADMAP for
+ * `### Phase PROJ-42:` BEFORE falling back to the padding-tolerant numeric
+ * form. Returns null when the input has no project-code prefix — in that
+ * case the numeric form (`phaseMarkdownRegexSource`) is the only thing the
+ * caller needs.
+ *
+ * Two-pass at the call site preserves the #3537 contract (`CK-01` directory
+ * names mapping to `Phase 1:` prose) while letting `PROJ-42` resolve to its
+ * own prefixed heading without cross-matching a bare `### Phase 42:` that
+ * happens to share the trailing integer.
+ */
+function phaseMarkdownRegexSourceExact(phaseNum) {
+  const raw = String(phaseNum);
+  if (!/^[A-Z]{1,6}-(?=\d)/i.test(raw)) return null;
+  return escapeRegex(raw);
+}
+
 function comparePhaseNum(a, b) {
   // Strip optional project_code prefix before comparing (e.g., 'CK-01-name' → '01-name')
   const sa = String(a).replace(/^[A-Z]{1,6}-/, '');
@@ -1836,6 +1855,7 @@ module.exports = {
   escapeRegex,
   normalizePhaseName,
   phaseMarkdownRegexSource,
+  phaseMarkdownRegexSourceExact,
   comparePhaseNum,
   searchPhaseInDir,
   extractPhaseToken,

--- a/get-shit-done/bin/lib/roadmap.cjs
+++ b/get-shit-done/bin/lib/roadmap.cjs
@@ -4,7 +4,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { escapeRegex, normalizePhaseName, phaseMarkdownRegexSource, output, error, findPhaseInternal, stripShippedMilestones, extractCurrentMilestone, replaceInCurrentMilestone, phaseTokenMatches } = require('./core.cjs');
+const { escapeRegex, normalizePhaseName, phaseMarkdownRegexSource, phaseMarkdownRegexSourceExact, output, error, findPhaseInternal, stripShippedMilestones, extractCurrentMilestone, replaceInCurrentMilestone, phaseTokenMatches } = require('./core.cjs');
 const { platformWriteSync } = require('./shell-command-projection.cjs');
 const { planningPaths, withPlanningLock } = require('./planning-workspace.cjs');
 const scanPhasePlans = require('./plan-scan.cjs');
@@ -139,6 +139,29 @@ function cmdRoadmapGetPhase(cwd, phaseNum, raw) {
     const rawContent = fs.readFileSync(roadmapPath, 'utf-8');
     const milestoneContent = extractCurrentMilestone(rawContent, cwd);
 
+    // #3599 two-pass: when the caller passes a project-code-prefixed ID like
+    // `PROJ-42`, try the exact-prefixed heading first (`### Phase PROJ-42:`).
+    // If no match, fall back to the #3537 padding-tolerant numeric form so
+    // a `CK-01` query still resolves to `### Phase 1:`. Doing this at the
+    // call site (instead of inside phaseMarkdownRegexSource) avoids the
+    // alternation-order ambiguity where a bare `### Phase 42:` heading in
+    // the same document would intercept the match for a `PROJ-42` query.
+    const fullContent = stripShippedMilestones(rawContent);
+
+    const exactSource = phaseMarkdownRegexSourceExact(phaseNum);
+    if (exactSource) {
+      const exactMilestone = searchPhaseInContent(milestoneContent, exactSource, phaseNum);
+      if (exactMilestone && !exactMilestone.error) {
+        output(exactMilestone, raw, exactMilestone.section);
+        return;
+      }
+      const exactFull = searchPhaseInContent(fullContent, exactSource, phaseNum);
+      if (exactFull && !exactFull.error) {
+        output(exactFull, raw, exactFull.section);
+        return;
+      }
+    }
+
     // #3537: padding-tolerant fragment so callers passing `02.7` still match
     // un-padded ROADMAP prose (`### Phase 2.7:`).
     const escapedPhase = phaseMarkdownRegexSource(phaseNum);
@@ -146,7 +169,6 @@ function cmdRoadmapGetPhase(cwd, phaseNum, raw) {
     // Search the current milestone slice first, then fall back to full roadmap.
     // A malformed_roadmap result (checklist-only) from the milestone should not
     // block finding a full header match in the wider roadmap content.
-    const fullContent = stripShippedMilestones(rawContent);
     const milestoneResult = searchPhaseInContent(milestoneContent, escapedPhase, phaseNum);
     const result = (milestoneResult && !milestoneResult.error)
       ? milestoneResult

--- a/get-shit-done/bin/lib/roadmap.cjs
+++ b/get-shit-done/bin/lib/roadmap.cjs
@@ -94,7 +94,7 @@ function searchPhaseInContent(content, escapedPhase, phaseNum) {
 
   // Find the end of this section (next ## or ### phase header, or end of file)
   const restOfContent = content.slice(headerIndex);
-  const nextHeaderMatch = restOfContent.match(/\n#{2,4}\s+Phase\s+\d/i);
+  const nextHeaderMatch = restOfContent.match(/\n#{2,4}\s+Phase\s+[\w][\w.-]*/i);
   const sectionEnd = nextHeaderMatch
     ? headerIndex + nextHeaderMatch.index
     : content.length;

--- a/tests/bug-3599-roadmap-get-phase-project-code-prefix.test.cjs
+++ b/tests/bug-3599-roadmap-get-phase-project-code-prefix.test.cjs
@@ -1,0 +1,167 @@
+/**
+ * Bug #3599: roadmap.get-phase no longer matches custom phase IDs with
+ * project-code prefixes like `PROJ-42`.
+ *
+ * `phaseMarkdownRegexSource(phaseNum)` in get-shit-done/bin/lib/core.cjs
+ * (and its SDK twin in sdk/src/query/roadmap-update-plan-progress.ts) strips
+ * the `PROJ-` prefix before building the padding-tolerant numeric regex.
+ * Result: `roadmap get-phase PROJ-42` produces a regex of `0*42`, which
+ * matches `### Phase 42:` instead of (or in addition to) the intended
+ * `### Phase PROJ-42:`. The function's own docstring promises a fallback to
+ * `escapeRegex(phaseNum)` for non-numeric custom IDs, but that branch is
+ * unreachable for project-code-prefixed numeric IDs.
+ *
+ * Fix: the emitted regex must match BOTH the stripped numeric form (so
+ * `CK-01-name` directory inputs still resolve to `Phase 1:` in prose, the
+ * #3537 contract) AND the full prefixed form (so `PROJ-42` resolves to
+ * `Phase PROJ-42:`).
+ */
+
+'use strict';
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { runGsdTools, createTempProject, cleanup } = require('./helpers.cjs');
+
+function writeRoadmap(tmpDir, body) {
+  fs.writeFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), body);
+}
+
+function writeState(tmpDir, version) {
+  fs.writeFileSync(
+    path.join(tmpDir, '.planning', 'STATE.md'),
+    `---\nmilestone: ${version}\n---\n`,
+  );
+}
+
+describe('bug #3599: roadmap get-phase preserves project-code prefix in lookup', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject('bug-3599-');
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('finds ### Phase PROJ-42: when queried as PROJ-42', () => {
+    writeState(tmpDir, 'v1.0.0');
+    writeRoadmap(
+      tmpDir,
+      [
+        '# Roadmap',
+        '',
+        '## Current Milestone: v1.0.0 - Test',
+        '',
+        '### Phase PROJ-42: Custom phase',
+        '**Goal:** Verify project-code-prefixed lookup',
+        '',
+      ].join('\n'),
+    );
+
+    const result = runGsdTools('roadmap get-phase PROJ-42 --json', tmpDir);
+    assert.ok(result.success, `command failed: ${result.error || result.output}`);
+
+    const payload = JSON.parse(result.output);
+    assert.strictEqual(payload.found, true, `expected found=true, got: ${result.output}`);
+    assert.strictEqual(payload.phase_name, 'Custom phase');
+    assert.strictEqual(payload.goal, 'Verify project-code-prefixed lookup');
+  });
+
+  test('does NOT cross-match: querying 42 must not match ### Phase PROJ-42:', () => {
+    // Counter-test: if the regex erroneously matches both forms in both
+    // directions, this catches it. `42` must only match `Phase 42:` — not
+    // `Phase PROJ-42:` — otherwise integer phase lookups silently steal
+    // matches from prefixed siblings.
+    writeState(tmpDir, 'v1.0.0');
+    writeRoadmap(
+      tmpDir,
+      [
+        '# Roadmap',
+        '',
+        '## Current Milestone: v1.0.0 - Test',
+        '',
+        '### Phase PROJ-42: Should not be returned for `42`',
+        '**Goal:** Counter-test',
+        '',
+      ].join('\n'),
+    );
+
+    const result = runGsdTools('roadmap get-phase 42 --json', tmpDir);
+    assert.ok(result.success);
+    const payload = JSON.parse(result.output);
+    assert.strictEqual(
+      payload.found,
+      false,
+      `bare numeric '42' must not match 'Phase PROJ-42:'; got ${result.output}`,
+    );
+  });
+
+  test('preserves #3537 contract: CK-01 directory form resolves to Phase 1 prose', () => {
+    // Existing contract: phase directory names like `CK-01-name` carry the
+    // project_code prefix and a zero-padded number, but ROADMAP prose is
+    // typically un-padded (`### Phase 1:`). The padding-tolerant lookup must
+    // still bridge those two surfaces.
+    writeState(tmpDir, 'v1.0.0');
+    writeRoadmap(
+      tmpDir,
+      [
+        '# Roadmap',
+        '',
+        '## Current Milestone: v1.0.0 - Test',
+        '',
+        '### Phase 1: Numeric prose',
+        '**Goal:** #3537 contract — CK-01 dir → Phase 1 prose',
+        '',
+      ].join('\n'),
+    );
+
+    const result = runGsdTools('roadmap get-phase CK-01 --json', tmpDir);
+    assert.ok(result.success);
+    const payload = JSON.parse(result.output);
+    assert.strictEqual(
+      payload.found,
+      true,
+      `CK-01 must still resolve to 'Phase 1:' prose (#3537 contract); got ${result.output}`,
+    );
+    assert.strictEqual(payload.phase_name, 'Numeric prose');
+  });
+
+  test('finds the right phase when both prefixed and bare forms coexist', () => {
+    // Disambiguation test: a roadmap that contains BOTH `### Phase 42:` and
+    // `### Phase PROJ-42:` must resolve each query to its specific match.
+    writeState(tmpDir, 'v1.0.0');
+    writeRoadmap(
+      tmpDir,
+      [
+        '# Roadmap',
+        '',
+        '## Current Milestone: v1.0.0 - Test',
+        '',
+        '### Phase 42: Bare numeric',
+        '**Goal:** Bare',
+        '',
+        '### Phase PROJ-42: Prefixed',
+        '**Goal:** Prefixed',
+        '',
+      ].join('\n'),
+    );
+
+    const r42 = runGsdTools('roadmap get-phase 42 --json', tmpDir);
+    const rProj = runGsdTools('roadmap get-phase PROJ-42 --json', tmpDir);
+
+    const p42 = JSON.parse(r42.output);
+    const pProj = JSON.parse(rProj.output);
+
+    assert.strictEqual(p42.found, true);
+    assert.strictEqual(p42.phase_name, 'Bare numeric');
+    assert.strictEqual(p42.goal, 'Bare');
+
+    assert.strictEqual(pProj.found, true);
+    assert.strictEqual(pProj.phase_name, 'Prefixed');
+    assert.strictEqual(pProj.goal, 'Prefixed');
+  });
+});


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #3599

---

## What was broken

`roadmap get-phase PROJ-42` returned `{found: false}` for a ROADMAP that contained `### Phase PROJ-42: Custom phase`. Verified with a temp-project repro.

## What this fix does

Adds a two-pass search to `cmdRoadmapGetPhase` in `get-shit-done/bin/lib/roadmap.cjs`. When the caller passes a project-code-prefixed ID like `PROJ-42`, the exact-escaped regex (`### Phase PROJ-42:`) is tried first. Only if the exact heading is not present does the lookup fall back to the existing #3537 padding-tolerant numeric form (`### Phase 42:`).

A new helper `phaseMarkdownRegexSourceExact(phaseNum)` is added in `core.cjs` (returns the exact-escaped source for project-code-prefixed inputs, or `null` for un-prefixed inputs).

## Root cause

`phaseMarkdownRegexSource(phaseNum)` in `core.cjs:679` unconditionally strips the `^[A-Z]{1,6}-(?=\d)` prefix before matching. For `PROJ-42` this builds the regex `0*42`, which matches `### Phase 42:` but never `### Phase PROJ-42:`. The function's own docstring promises a fallback to `escapeRegex(phaseNum)` for custom IDs, but that branch is unreachable for project-code-prefixed numeric IDs because the stripped form (`42`) still satisfies the numeric regex on line 681.

Two-pass at the call site (rather than baking alternation into the regex source) is required because regex match-position is leftmost-wins: a roadmap that contains both `### Phase 42:` and `### Phase PROJ-42:` cannot be disambiguated by a single alternation; the bare numeric heading would always intercept the match.

## Testing

### How I verified the fix

- RED: temp-project repro showed `roadmap get-phase PROJ-42` returning `{found: false}` with a `### Phase PROJ-42:` heading present.
- GREEN: 4/4 new tests pass after the fix (`node --test tests/bug-3599-...test.cjs`).
- Related: `tests/roadmap-phase-fallback.test.cjs`, `tests/bug-3537-padded-id-against-unpadded-roadmap.test.cjs`, `tests/roadmap-mode-field.test.cjs`, `tests/roadmap-command-router.test.cjs` — 23/23 pass (#3537 contract intact).
- `npm run lint:tests` — clean.

### Regression test added?

- [x] Yes — `tests/bug-3599-roadmap-get-phase-project-code-prefix.test.cjs`:
  1. Happy path: `PROJ-42` query finds `### Phase PROJ-42:`.
  2. Counter-test: bare `42` query must NOT match `### Phase PROJ-42:` (no spurious cross-matching).
  3. #3537 contract preserved: `CK-01` query → `### Phase 1:` prose.
  4. Disambiguation: when both `### Phase 42:` and `### Phase PROJ-42:` coexist, each query resolves to its specific match.

All assertions go through `runGsdTools` + JSON.parse on `--json` output — typed payload (`found`, `phase_name`, `goal`), no raw text matching on stdout per CONTRIBUTING.md.

### Platforms tested

- [x] N/A (regex / lookup logic — not platform-specific)

### Runtimes tested

- [x] N/A (CJS gsd-tools is shared across runtimes)

---

## Checklist

- [x] Issue linked above with `Fixes #3599`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (with counter-test and contract-preservation cases)
- [x] All existing tests pass (related suites — 23/23)
- [x] `.changeset/` fragment added (`.changeset/3599-roadmap-get-phase-project-code-prefix.md`)
- [x] No unnecessary dependencies added

## Breaking changes

None. The two-pass adds an exact-prefix lookup BEFORE the existing numeric lookup, so:
- Un-prefixed inputs (`1`, `02.7`, `12A`) behave identically (exact-pass returns null, falls through to numeric).
- Prefixed inputs whose roadmap uses the numeric form (`CK-01` → `Phase 1:`) behave identically (exact-pass returns no match, falls through to numeric).
- Prefixed inputs whose roadmap uses the prefixed form (`PROJ-42` → `Phase PROJ-42:`) now resolve correctly where they previously returned `{found: false}`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `roadmap get-phase` to correctly match phases with project-code-prefixed identifiers (e.g., `PROJ-42`).
  * Improved lookup precedence and disambiguation so a prefixed phase heading (### Phase PROJ-42:) is preferred over numeric-only matches when both exist.

* **Tests**
  * Added comprehensive tests covering prefixed phase lookups, numeric/backward-compatibility scenarios, and disambiguation cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3616?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->