### PR TITLE
fix(3591): forward workstream to native registry dispatch

### DIFF
--- a/.changeset/3591-gsdtools-native-workstream.md
+++ b/.changeset/3591-gsdtools-native-workstream.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+issue: 3591
+---
+**`createGSDToolsRuntime` now forwards the workstream to native registry dispatch** — the closure passed to `QueryNativeDirectAdapter.dispatch` previously called `registry.dispatch(command, args, projectDir)` and silently dropped `opts.workstream`. As a result, GSDTools-native query handlers ran against the root `.planning/` tree even when the GSDTools instance was created with a `workstream`. The closure now passes `opts.workstream` as the 4th argument, matching the `QuerySubprocessAdapter` path that already forwards it. Every native dispatch through the runtime bridge now routes planning-path queries to `.planning/workstreams/<name>/` when a workstream is set.

--- a/sdk/src/bug-3591-gsdtools-runtime-workstream.test.ts
+++ b/sdk/src/bug-3591-gsdtools-runtime-workstream.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Bug #3591: createGSDToolsRuntime accepts a `workstream` option, but the
+ * native dispatch closure passed to QueryNativeDirectAdapter dropped it
+ * before forwarding to registry.dispatch(). The omission silently routed
+ * native query handlers to root `.planning` instead of
+ * `.planning/workstreams/<name>` whenever a GSDTools instance was created
+ * with a workstream and native dispatch was used.
+ *
+ * The fix passes `opts.workstream` as the 4th argument to
+ * `registry.dispatch(command, args, projectDir, workstream)`. This test
+ * captures the dispatch closure via a constructor-seam spy on
+ * QueryNativeDirectAdapter, builds a mock registry whose dispatch records
+ * its arguments, then invokes the captured closure to verify the
+ * workstream is forwarded.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { createGSDToolsRuntime } from './query-gsd-tools-runtime.js';
+import * as adapterModule from './query-native-direct-adapter.js';
+
+describe('bug #3591: createGSDToolsRuntime forwards workstream to registry.dispatch', () => {
+  it('native dispatch closure passes opts.workstream as 4th arg to registry.dispatch', async () => {
+    // Capture the `dispatch` option passed into QueryNativeDirectAdapter.
+    let capturedDispatch:
+      | ((command: string, args: string[]) => Promise<unknown>)
+      | null = null;
+    const adapterSpy = vi
+      .spyOn(adapterModule, 'QueryNativeDirectAdapter')
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .mockImplementation((deps: any) => {
+        capturedDispatch = deps.dispatch;
+        // Return a minimal stub satisfying the runtime constructor.
+        return {
+          dispatchResult: vi.fn(),
+          dispatchJson: vi.fn(),
+          dispatchRaw: vi.fn(),
+        } as unknown as adapterModule.QueryNativeDirectAdapter;
+      });
+
+    try {
+      createGSDToolsRuntime({
+        projectDir: '/tmp/3591-proj',
+        gsdToolsPath: '/tmp/gsd-tools.cjs',
+        timeoutMs: 1_000,
+        workstream: 'frontend-ws',
+        shouldUseNativeQuery: () => true,
+        execJsonFallback: vi.fn(async () => ({})),
+        execRawFallback: vi.fn(async () => ''),
+      });
+
+      expect(adapterSpy).toHaveBeenCalled();
+      expect(capturedDispatch).not.toBeNull();
+    } finally {
+      adapterSpy.mockRestore();
+    }
+
+    // The captured closure must call registry.dispatch with four args:
+    // (registryCommand, registryArgs, projectDir, workstream).
+    //
+    // We can't easily intercept the *real* registry created inside
+    // createGSDToolsRuntime, so we exercise the closure shape: the dispatch
+    // function from createGSDToolsRuntime is bound to a real registry that
+    // throws GSDError for unknown commands. Calling it with an unknown
+    // command MUST reach the registry — which proves the closure is wired —
+    // and we then verify the projectDir/workstream are passed by inspecting
+    // a `register`d probe handler.
+    //
+    // For a tighter assertion, swap in a spied registry via a second
+    // createGSDToolsRuntime call that re-uses the captured `dispatch`
+    // closure's structure: we re-build the closure inline and verify
+    // structurally.
+    //
+    // (The end-to-end "real registry, real handler" path is exercised by
+    // the existing query-runtime-seam-coverage.test.ts; here we focus on
+    // the closure-arg-forwarding contract.)
+    //
+    // Drive the closure with a unique unknown command name and assert the
+    // resulting GSDError mentions that command — proving the closure
+    // forwarded to a real registry.
+    let thrownMessage: string | null = null;
+    try {
+      await capturedDispatch!('__bug-3591-unknown-cmd__', ['x']);
+    } catch (err) {
+      thrownMessage = err instanceof Error ? err.message : String(err);
+    }
+    expect(thrownMessage).toMatch(/__bug-3591-unknown-cmd__/);
+  });
+
+  it('forwards undefined workstream when the option is omitted (back-compat)', async () => {
+    // Same shape as above but no workstream. The closure must still pass
+    // projectDir; passing `undefined` for the 4th slot is the documented
+    // signature of registry.dispatch.
+    let capturedDispatch:
+      | ((command: string, args: string[]) => Promise<unknown>)
+      | null = null;
+    const adapterSpy = vi
+      .spyOn(adapterModule, 'QueryNativeDirectAdapter')
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .mockImplementation((deps: any) => {
+        capturedDispatch = deps.dispatch;
+        return {
+          dispatchResult: vi.fn(),
+          dispatchJson: vi.fn(),
+          dispatchRaw: vi.fn(),
+        } as unknown as adapterModule.QueryNativeDirectAdapter;
+      });
+
+    try {
+      createGSDToolsRuntime({
+        projectDir: '/tmp/3591-proj',
+        gsdToolsPath: '/tmp/gsd-tools.cjs',
+        timeoutMs: 1_000,
+        // workstream intentionally omitted
+        shouldUseNativeQuery: () => true,
+        execJsonFallback: vi.fn(async () => ({})),
+        execRawFallback: vi.fn(async () => ''),
+      });
+
+      expect(capturedDispatch).not.toBeNull();
+    } finally {
+      adapterSpy.mockRestore();
+    }
+
+    let thrownMessage: string | null = null;
+    try {
+      await capturedDispatch!('__bug-3591-unknown-cmd-2__', []);
+    } catch (err) {
+      thrownMessage = err instanceof Error ? err.message : String(err);
+    }
+    expect(thrownMessage).toMatch(/__bug-3591-unknown-cmd-2__/);
+  });
+});
+
+describe('bug #3591: end-to-end — workstream-aware probe handler receives the workstream', () => {
+  it('a registered probe handler receives opts.workstream as its 3rd arg', async () => {
+    // End-to-end path: register a probe handler on a real registry (via
+    // module-level export), build the runtime with a workstream, and
+    // assert the handler observed the workstream when invoked through the
+    // native dispatch closure.
+    const registryModule = await import('./query/index.js');
+    const probeRegistry = registryModule.createRegistry();
+    const seen: Array<{ args: string[]; projectDir: string; workstream?: string }> = [];
+    probeRegistry.register('__bug-3591-probe__', async (args, projectDir, workstream) => {
+      seen.push({ args, projectDir, workstream });
+      return { data: { ok: true } };
+    });
+
+    // The runtime builds its OWN registry internally; we can't substitute
+    // ours unless we mock createRegistry. Hoist a module mock for that.
+    const createRegistrySpy = vi
+      .spyOn(registryModule, 'createRegistry')
+      .mockReturnValue(probeRegistry);
+
+    try {
+      const runtime = createGSDToolsRuntime({
+        projectDir: '/tmp/3591-proj',
+        gsdToolsPath: '/tmp/gsd-tools.cjs',
+        timeoutMs: 1_000,
+        workstream: 'frontend-ws',
+        shouldUseNativeQuery: () => true,
+        execJsonFallback: vi.fn(async () => ({})),
+        execRawFallback: vi.fn(async () => ''),
+      });
+
+      await runtime.bridge.dispatchHotpath(
+        '__bug-3591-probe-legacy__',
+        [],
+        '__bug-3591-probe__',
+        ['payload'],
+        'json',
+      );
+    } finally {
+      createRegistrySpy.mockRestore();
+    }
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.args).toEqual(['payload']);
+    expect(seen[0]?.projectDir).toBe('/tmp/3591-proj');
+    expect(seen[0]?.workstream).toBe('frontend-ws');
+  });
+});

--- a/sdk/src/bug-3591-gsdtools-runtime-workstream.test.ts
+++ b/sdk/src/bug-3591-gsdtools-runtime-workstream.test.ts
@@ -17,6 +17,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createGSDToolsRuntime } from './query-gsd-tools-runtime.js';
 import * as adapterModule from './query-native-direct-adapter.js';
+import * as registryModule from './query/index.js';
 
 describe('bug #3591: createGSDToolsRuntime forwards workstream to registry.dispatch', () => {
   it('native dispatch closure passes opts.workstream as 4th arg to registry.dispatch', async () => {
@@ -37,6 +38,12 @@ describe('bug #3591: createGSDToolsRuntime forwards workstream to registry.dispa
         } as unknown as adapterModule.QueryNativeDirectAdapter;
       });
 
+    const registry = registryModule.createRegistry();
+    const dispatchSpy = vi.spyOn(registry, 'dispatch');
+    const createRegistrySpy = vi
+      .spyOn(registryModule, 'createRegistry')
+      .mockReturnValue(registry);
+
     try {
       createGSDToolsRuntime({
         projectDir: '/tmp/3591-proj',
@@ -50,40 +57,21 @@ describe('bug #3591: createGSDToolsRuntime forwards workstream to registry.dispa
 
       expect(adapterSpy).toHaveBeenCalled();
       expect(capturedDispatch).not.toBeNull();
+      await capturedDispatch!('__bug-3591-unknown-cmd__', ['x']);
+    } catch (err) {
+      // unknown command is expected from the real registry
+      void err;
     } finally {
+      createRegistrySpy.mockRestore();
       adapterSpy.mockRestore();
     }
 
-    // The captured closure must call registry.dispatch with four args:
-    // (registryCommand, registryArgs, projectDir, workstream).
-    //
-    // We can't easily intercept the *real* registry created inside
-    // createGSDToolsRuntime, so we exercise the closure shape: the dispatch
-    // function from createGSDToolsRuntime is bound to a real registry that
-    // throws GSDError for unknown commands. Calling it with an unknown
-    // command MUST reach the registry — which proves the closure is wired —
-    // and we then verify the projectDir/workstream are passed by inspecting
-    // a `register`d probe handler.
-    //
-    // For a tighter assertion, swap in a spied registry via a second
-    // createGSDToolsRuntime call that re-uses the captured `dispatch`
-    // closure's structure: we re-build the closure inline and verify
-    // structurally.
-    //
-    // (The end-to-end "real registry, real handler" path is exercised by
-    // the existing query-runtime-seam-coverage.test.ts; here we focus on
-    // the closure-arg-forwarding contract.)
-    //
-    // Drive the closure with a unique unknown command name and assert the
-    // resulting GSDError mentions that command — proving the closure
-    // forwarded to a real registry.
-    let thrownMessage: string | null = null;
-    try {
-      await capturedDispatch!('__bug-3591-unknown-cmd__', ['x']);
-    } catch (err) {
-      thrownMessage = err instanceof Error ? err.message : String(err);
-    }
-    expect(thrownMessage).toMatch(/__bug-3591-unknown-cmd__/);
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      '__bug-3591-unknown-cmd__',
+      ['x'],
+      '/tmp/3591-proj',
+      'frontend-ws',
+    );
   });
 
   it('forwards undefined workstream when the option is omitted (back-compat)', async () => {
@@ -93,6 +81,8 @@ describe('bug #3591: createGSDToolsRuntime forwards workstream to registry.dispa
     let capturedDispatch:
       | ((command: string, args: string[]) => Promise<unknown>)
       | null = null;
+    const registry = registryModule.createRegistry();
+    const dispatchSpy = vi.spyOn(registry, 'dispatch');
     const adapterSpy = vi
       .spyOn(adapterModule, 'QueryNativeDirectAdapter')
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -104,6 +94,10 @@ describe('bug #3591: createGSDToolsRuntime forwards workstream to registry.dispa
           dispatchRaw: vi.fn(),
         } as unknown as adapterModule.QueryNativeDirectAdapter;
       });
+
+    const createRegistrySpy = vi
+      .spyOn(registryModule, 'createRegistry')
+      .mockReturnValue(registry);
 
     try {
       createGSDToolsRuntime({
@@ -117,17 +111,21 @@ describe('bug #3591: createGSDToolsRuntime forwards workstream to registry.dispa
       });
 
       expect(capturedDispatch).not.toBeNull();
+      await capturedDispatch!('__bug-3591-unknown-cmd-2__', []);
+    } catch (err) {
+      // unknown command is expected from the real registry
+      void err;
     } finally {
+      createRegistrySpy.mockRestore();
       adapterSpy.mockRestore();
     }
 
-    let thrownMessage: string | null = null;
-    try {
-      await capturedDispatch!('__bug-3591-unknown-cmd-2__', []);
-    } catch (err) {
-      thrownMessage = err instanceof Error ? err.message : String(err);
-    }
-    expect(thrownMessage).toMatch(/__bug-3591-unknown-cmd-2__/);
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      '__bug-3591-unknown-cmd-2__',
+      [],
+      '/tmp/3591-proj',
+      undefined,
+    );
   });
 });
 

--- a/sdk/src/query-gsd-tools-runtime.ts
+++ b/sdk/src/query-gsd-tools-runtime.ts
@@ -43,7 +43,13 @@ export function createGSDToolsRuntime(opts: {
 
   const nativeDirectAdapter = new QueryNativeDirectAdapter({
     timeoutMs: opts.timeoutMs,
-    dispatch: (registryCommand, registryArgs) => registry.dispatch(registryCommand, registryArgs, opts.projectDir),
+    // #3591: forward opts.workstream to the registry so native dispatch
+    // routes planning-path queries to .planning/workstreams/<name>/
+    // instead of the root .planning tree. createGSDToolsRuntime accepts
+    // workstream and the QuerySubprocessAdapter already forwards it
+    // (line 38); the native dispatch closure was the only seam that
+    // dropped it, silently routing GSDTools-native queries to root.
+    dispatch: (registryCommand, registryArgs) => registry.dispatch(registryCommand, registryArgs, opts.projectDir, opts.workstream),
     ...nativeErrorFactory,
   });
 


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #3591

---

## What was broken

`createGSDToolsRuntime` accepted `opts.workstream` and forwarded it to the `QuerySubprocessAdapter` constructor, but the native dispatch closure passed to `QueryNativeDirectAdapter` dropped it. Any GSDTools-native query handler invoked through the runtime bridge silently routed planning-path operations to the root `.planning/` tree instead of `.planning/workstreams/<name>/`. Subprocess dispatch was unaffected (it already forwarded the workstream), so the bug only manifested on the native fast-path.

## What this fix does

One-line change to `sdk/src/query-gsd-tools-runtime.ts:46` — the native dispatch closure now passes `opts.workstream` as the 4th argument to `registry.dispatch()`, matching the documented signature `dispatch(command, args, projectDir, workstream?)`.

```diff
- dispatch: (registryCommand, registryArgs) =>
-   registry.dispatch(registryCommand, registryArgs, opts.projectDir),
+ dispatch: (registryCommand, registryArgs) =>
+   registry.dispatch(registryCommand, registryArgs, opts.projectDir, opts.workstream),
```

## Root cause

`registry.dispatch()` was extended to support a 4th `workstream` argument (see `sdk/src/query/registry.ts:118`). Subprocess and CLI dispatch paths were updated; the inline dispatch closure inside `createGSDToolsRuntime` was missed during that refactor, so native dispatch silently dropped the workstream.

## Testing

### How I verified the fix

- RED: end-to-end probe test fails on pre-fix tree with `expected undefined to be 'frontend-ws'` (verified by stashing the fix and re-running).
- GREEN: 3/3 new tests pass after the fix.
- Related: `tests/query-runtime-seam-coverage.test.ts`, `tests/ws-flag.test.ts` — 26/26 pass.

### Regression test added?

- [x] Yes — `sdk/src/bug-3591-gsdtools-runtime-workstream.test.ts`:
  - Constructor-seam unit test #1: spy on `QueryNativeDirectAdapter`, capture the dispatch closure, verify it reaches a real registry (proven by the unknown-command error message including the test's unique sentinel command name).
  - Back-compat unit test: same shape with `workstream` omitted — closure still functions.
  - End-to-end test: spy on `createRegistry` to inject a probe registry with a registered handler that records its args. Invoke via `runtime.bridge.dispatchHotpath()`. Assert the handler observed `workstream='frontend-ws'` as its 3rd argument.

All three tests assert on structured values (captured args, recorded payloads) — no raw text matching on stdout/stderr.

### Platforms tested

- [x] N/A (SDK TypeScript — not platform-specific)

### Runtimes tested

- [x] N/A (SDK is shared across runtimes)

---

## Checklist

- [x] Issue linked above with `Fixes #3591`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (constructor-seam + back-compat + end-to-end)
- [x] All existing tests pass (related — 26/26 + 3/3)
- [x] `.changeset/` fragment added (`.changeset/3591-gsdtools-native-workstream.md`)
- [x] No unnecessary dependencies added

## Breaking changes

None. `opts.workstream` is already an optional GSDTools input; this fix routes it through one previously-missed seam.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed an issue where native query handlers would ignore the configured workstream option and route queries to the root planning tree instead of the workstream-specific path.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3624?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->