### PR TITLE
docs(3621): forbid bundling test-fixture updates into docs: commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,6 +129,7 @@ Contributor requirements (summary):
 - **Link with a closing keyword** — use `Closes #123`, `Fixes #123`, or `Resolves #123` in the PR body. The CI check will fail and the PR will be auto-closed if no valid issue reference is found.
 - **One concern per PR** — bug fixes, enhancements, and features must be separate PRs
 - **No drive-by formatting** — don't reformat code unrelated to your change
+- **Don't bundle test-fixture updates into `docs:` or unrelated commits** — when a production change makes an existing test assertion stale, the test correction MUST land as its own `test:` (or `fix:`) commit, not bundled into a `docs:` commit that also updates the explanation. The release-sdk hotfix cherry-pick filter routes by commit-subject prefix (`fix:`, `chore:`, `test:`); a test-fixture correction packed under a `docs:` prefix is invisible to the picker and ships a half-state to the hotfix branch — production code changed, test assertion stale. v1.42.3 hit this exact mode (#3621). The fix is upstream: keep the test-fixture commit separate.
 - **CI must pass** — all configured matrix jobs must be green. Node 22 remains the compatibility floor; Node 24 is the primary target; Node 26 compatibility must be preserved for code and tests even when a Node 26 CI lane is not yet available.
 - **Scope matches the approved issue** — if your PR does more than what the issue describes, the extra changes will be asked to be removed or moved to a new issue
 


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3621 (acceptance criterion 4: "CONTRIBUTING.md updated with the bundling rule for test fixtures"). The picker-side fix is PR #3623; this PR addresses the remaining contributor-side discipline criterion.

The linked issue has the `confirmed-bug` label.

---

## What was broken

CONTRIBUTING.md's Pull Request Guidelines didn't document the bundling rule for test-fixture updates. v1.42.3 hotfix discovered the missing rule the hard way:

- Commit `36534059 fix(3562): generate Codex skill surface` changed the installer.
- Commit `08848df8 docs(3562): pin minimum Codex CLI version...` bundled the matching test-fixture correction alongside README/CONFIGURATION/USER-GUIDE prose updates.
- The release-sdk hotfix cherry-pick filter saw `docs:` and skipped the whole commit.
- Hotfix branch ended up with new production behavior + stale test assertion → CI red ([run 25949422676](https://github.com/gsd-build/get-shit-done/actions/runs/25949422676)).

## What this fix does

Adds one bullet to the Pull Request Guidelines section ("One concern per PR" neighborhood):

> **Don't bundle test-fixture updates into `docs:` or unrelated commits** — when a production change makes an existing test assertion stale, the test correction MUST land as its own `test:` (or `fix:`) commit, not bundled into a `docs:` commit that also updates the explanation. The release-sdk hotfix cherry-pick filter routes by commit-subject prefix (`fix:`, `chore:`, `test:`); a test-fixture correction packed under a `docs:` prefix is invisible to the picker and ships a half-state to the hotfix branch — production code changed, test assertion stale. v1.42.3 hit this exact mode (#3621). The fix is upstream: keep the test-fixture commit separate.

## Root cause

The picker-side filter in `release-sdk.yml` is intentionally strict (`fix:`/`chore:`/`test:` only — `docs:` and `feat:` are POLICY_SKIPPED). That's the right default; it keeps unrelated history out of the hotfix branch. But it means contributors must not hide test fixes under a `docs:` subject. The contributor-side discipline was never documented; this PR documents it.

PR #3623 broadens the picker to accept `test:` commits and treat test paths as CI-gating. That's a robustness fix on the picker side. This PR is the upstream-discipline complement so the picker isn't relied on to compensate for a bundling mistake.

## Testing

### How I verified the fix

- `grep -n "test-fixture updates" CONTRIBUTING.md` — bullet present in the right neighborhood (Pull Request Guidelines).
- `grep -n "One concern per PR" CONTRIBUTING.md` — ordering preserved (new bullet sits between "No drive-by formatting" and "CI must pass").
- No code paths exercised; documentation-only change.

### Regression test added?

- [ ] Yes — added a test that would have caught this bug
- [x] No — explain why: CONTRIBUTING.md is contributor guidance; behavior coverage of the picker filter that motivated this guidance lives in `tests/bug-3621-cherry-pick-test-fixtures.test.cjs` (PR #3623).

### Platforms tested

- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #3621`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — single-bullet addition to existing list
- [x] Regression test added (or explained why not — covered by PR #3623's behavioral tests)
- [x] All existing tests pass (no code paths touched)
- [x] `no-changelog` label applied (contributor-facing docs change; not user-facing)
- [x] No unnecessary dependencies added

## Breaking changes

None. Documentation-only addition.
