### PR TITLE
docs(3635): add v1.42.3 release notes and link from docs index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Language versions: [English](README.md) · [Português (pt-BR)](pt-BR/README.md)
 | [Architecture](ARCHITECTURE.md) | Contributors, advanced users | System architecture, agent model, data flow, and internal design |
 | [Installer Migrations](installer-migrations.md) | Contributors | Architecture for safe install-time migrations, cleanup, preservation, dry-run planning, and rollback |
 | [Feature Reference](FEATURES.md) | All users | Feature narratives and requirements for released features (see [CHANGELOG](../CHANGELOG.md) for latest additions) |
+| [v1.42.3 Release Notes](RELEASE-v1.42.3.md) | All users | Hotfix release notes for 1.42.3 — Codex CLI 0.130.0 install routability and 11 other fixes |
 | [v1.42.1 Release Notes](RELEASE-v1.42.1.md) | All users | Stable release notes for the 1.42.1 release |
 | [Command Reference](COMMANDS.md) | All users | Stable commands with syntax, flags, options, and examples |
 | [Configuration Reference](CONFIGURATION.md) | All users | Full config schema, workflow toggles, model profiles, git branching |
@@ -26,7 +27,7 @@ Language versions: [English](README.md) · [Português (pt-BR)](pt-BR/README.md)
 
 ## Quick Links
 
-- **What's new:** see [v1.42.1 Release Notes](RELEASE-v1.42.1.md), [CHANGELOG](../CHANGELOG.md), and upstream [README](../README.md) for release highlights
+- **What's new:** see [v1.42.3 Release Notes](RELEASE-v1.42.3.md) (latest hotfix), [v1.42.1 Release Notes](RELEASE-v1.42.1.md), [CHANGELOG](../CHANGELOG.md), and upstream [README](../README.md) for release highlights
 - **Canary preview:** [`docs/CANARY.md`](CANARY.md) — opt into the early-preview stream from `dev`. Active cut: [`v1.50.0-canary.1`](RELEASE-v1.50.0-canary.1.md)
 - **Getting started:** [README](../README.md) → install → `/gsd-new-project`
 - **Full workflow walkthrough:** [User Guide](USER-GUIDE.md)

--- a/docs/RELEASE-v1.42.3.md
+++ b/docs/RELEASE-v1.42.3.md
@@ -1,0 +1,157 @@
+# v1.42.3 Release Notes
+
+Hotfix release. Published to npm under the `latest` tag.
+
+```bash
+npx get-shit-done-cc@latest
+```
+
+---
+
+## What's in this release
+
+1.42.3 is a stability hotfix on top of 1.42.2. The headline is **Codex
+CLI 0.130.0 install routability** — after `npx get-shit-done-cc@latest
+--codex`, `$gsd-*` skills now resolve correctly under Codex 0.130.0 and
+later, where the previous build left users with zero routable
+entrypoints. The release also ships **runtime-aware slash formatting**
+so emitted commands match the install's routing shape (Claude → `/gsd-*`,
+Codex → `$gsd-*`) instead of the deprecated colon form, an **argv-based
+subprocess** fix for `check.ship-ready` that closes a shell-injection
+class through git refnames, the **`phase_status` field on
+init.plan-phase** that gates `/gsd:plan-phase` on closed phases, plus
+correctness fixes for archived-phase warnings, future-phase warnings,
+canonical Codex hooks, and the SDK bridge load path.
+
+### Fixed
+
+- **Codex CLI 0.130.0 install now materializes routable skills** —
+  `bin/install.js` writes `~/.codex/skills/gsd-<name>/SKILL.md` for every
+  shipped command so `$gsd-*` skills resolve after install. Codex 0.130.0
+  dropped the extra-skills-roots discovery the previous build relied on,
+  leaving users with a successful-looking install and zero usable
+  commands. Documented minimum Codex CLI version (0.130.0) inline in the
+  Codex sections of `USER-GUIDE.md` and `CONFIGURATION.md`.
+  ([#3562](https://github.com/gsd-build/get-shit-done/pull/3568),
+  [#3582](https://github.com/gsd-build/get-shit-done/pull/3609))
+
+- **Runtime-aware slash formatter for user-facing emissions** —
+  `runtime-slash.cjs` produces `/gsd-<cmd>` for skills-based runtimes
+  (Claude, Cursor, OpenCode, Kilo, etc.) and `$gsd-<cmd>` for Codex.
+  The deprecated colon form `/gsd:<cmd>` is no longer emitted at
+  runtime, so the recommendations from `init`, `phase`, `verify`,
+  `milestone`, `validate-command-router`, `workstream`, `profile-output`,
+  `drift`, `gsd2-import`, and `commands` now paste cleanly into the
+  active runtime.
+  ([#3584](https://github.com/gsd-build/get-shit-done/pull/3606))
+
+- **Argv-based subprocess for `check.ship-ready`** — every git/gh probe
+  in `sdk/src/query/check-ship-ready.ts` now uses `execFileSync` with an
+  argv array instead of `execSync` with shell-interpolated strings.
+  Closes a shell-injection class where a malicious branch name (e.g.
+  `foo;touch INJ;bar`) interpolated into `git config --get
+  branch.<name>.merge` triggered arbitrary code execution.
+  ([#3587](https://github.com/gsd-build/get-shit-done/pull/3611))
+
+- **`init.plan-phase` surfaces `phase_status`; `/gsd:plan-phase` gates
+  on closed phases** — `init.plan-phase` payload now carries the
+  authoritative phase status (`Pending` / `Planned` / `Executed` /
+  `Complete`) from `determinePhaseStatus`. The plan-phase workflow
+  short-circuits on `Complete` (with `--force` override), and
+  `--reviews` against a closed phase hard-errors with no override.
+  Prevents accidental re-planning over shipped code.
+  ([#3569](https://github.com/gsd-build/get-shit-done/pull/3581))
+
+- **Canonical `[features].hooks` for Codex configs, legacy alias
+  recognized** — Codex config emission uses the canonical
+  `features.hooks` key while still accepting the legacy `codex_hooks`
+  shape on read. Fixes the install where the previous key drift left
+  Codex unable to find managed hooks.
+  ([#3566](https://github.com/gsd-build/get-shit-done/pull/3573))
+
+- **SDK bridge loads via the public package export** — fixes a stale
+  internal path that broke SDK dispatch after install on some package
+  layouts.
+  ([#3567](https://github.com/gsd-build/get-shit-done/pull/3574))
+
+- **W006/W007 health warnings skip archived and future phases** —
+  `/gsd:health` no longer flags phases that are intentionally
+  unimplemented (future) or archived as missing-on-disk or
+  missing-from-roadmap.
+  ([#3559](https://github.com/gsd-build/get-shit-done/pull/3565),
+  [#3560](https://github.com/gsd-build/get-shit-done/pull/3564))
+
+- **Ultraplan runtime gates on Claude Code markers** — `/gsd:ultraplan`
+  detects the runtime via Claude Code markers and fails closed when
+  the version is unavailable, instead of running against an unknown
+  runtime.
+  ([#3561](https://github.com/gsd-build/get-shit-done/pull/3563))
+
+- **Padded phase IDs match unpadded ROADMAP prose** — phase routing
+  through `phaseMarkdownRegexSource` handles `02.7` ↔ `2.7` and
+  similar padding mismatches so `/gsd:phase complete 02` updates a
+  ROADMAP that uses the short `### Phase 2:` form.
+  ([#3537](https://github.com/gsd-build/get-shit-done/pull/3538))
+
+- **W007 ignores archived phase directories** — phases under
+  `.planning/milestones/v*/` no longer trigger
+  "exists on disk but not in roadmap" warnings against the active
+  roadmap.
+  ([#3560](https://github.com/gsd-build/get-shit-done/pull/3564))
+
+- **Prompt-user migration actions resolve in non-TTY runs** —
+  `installer-migration-authoring` flows complete cleanly under CI /
+  non-interactive shells; error grouping clarified.
+  ([#3541](https://github.com/gsd-build/get-shit-done/pull/3547))
+
+- **Executor agents forbidden from `git stash`** — execution agents
+  no longer use shared stash storage, which violated worktree
+  isolation when multiple agents ran in parallel.
+  ([#3542](https://github.com/gsd-build/get-shit-done/pull/3546))
+
+- **Configuration manifests load from the installed payload** —
+  `configuration.generated.cjs` looks in the installed
+  `get-shit-done/bin/shared/` path first, then falls back to
+  source-checkout `sdk/shared/`. Fixes the install where the manifest
+  loader failed on the runtime layout because the source-tree path
+  doesn't exist after install.
+  ([#3571](https://github.com/gsd-build/get-shit-done/pull/3572))
+
+---
+
+## What was in 1.42.1
+
+[`RELEASE-v1.42.1.md`](RELEASE-v1.42.1.md) — package legitimacy gate
+against slopsquatting, skill-surface budgeting (`--profile=core` /
+`standard` / `full`), installer migration framework, configurable
+`/gsd-ship` PR body sections, `review.default_reviewers`, optional
+fallow structural review, structured `--json-errors` CLI mode, plus
+30+ correctness fixes across `project_code` phase prefixes, phase
+completion idempotency, nested git detection, Codex install migration,
+SDK install readiness, and decimal-phase dependencies.
+
+---
+
+## Installing
+
+```bash
+# npm (global)
+npm install -g get-shit-done-cc@latest
+
+# npx (one-shot)
+npx get-shit-done-cc@latest
+
+# Pin to this exact version
+npm install -g get-shit-done-cc@1.42.3
+```
+
+The installer is idempotent — re-running on an existing install
+updates in-place, preserving your `.planning/` directory and local
+patches.
+
+### Codex CLI requirement
+
+Codex installs (`--codex`) require **Codex CLI 0.130.0 or later**.
+Earlier Codex versions used a discovery mechanism that the current
+install layout does not target; upgrade Codex first, then re-run the
+GSD installer.


### PR DESCRIPTION
## Fix PR

## Linked Issue

Closes #3635

This is a docs/chore PR — `no-changelog` label applied since release-notes prose has no user-facing runtime impact beyond what the linked PRs already shipped.

---

## What was broken

`docs/README.md` Documentation Index still pointed at `RELEASE-v1.42.1.md` as the latest release notes. After the v1.42.3 hotfix tag was published, users landing on the docs page had no release-notes narrative to read for what changed since 1.42.1.

## What this fix does

- Adds `docs/RELEASE-v1.42.3.md` following the v1.42.1 structure (hotfix-shaped: `Fixed` only, no `Added`/`Changed`). Twelve user-visible fix categories documented with PR refs.
- Adds a Documentation Index row for v1.42.3 above v1.42.1 in `docs/README.md`.
- Updates the Quick Links "What's new" entry to list v1.42.3 first.
- Documents Codex CLI 0.130.0 as the minimum supported version for the `--codex` installer path inline in the Installing section.

## Root cause

Release-notes files are hand-authored per release; the v1.42.3 hotfix shipped without the matching notes file landing in the same window.

## Testing

### How I verified the fix

- `head -5 docs/RELEASE-v1.42.3.md` — title and "Hotfix release" blurb present.
- `grep RELEASE-v1.42.3 docs/README.md` — Documentation Index row and Quick Links entry both reference the new file.
- Docs-only change; no test suite to run.

### Regression test added?

- [ ] Yes — added a test that would have caught this bug
- [x] No — explain why: docs/release-notes prose; no behavioural surface to test.

### Platforms tested

- [x] N/A (docs-only)

### Runtimes tested

- [x] N/A (docs-only)

---

## Checklist

- [x] Issue linked above with `Closes #3635`
- [ ] Linked issue has the `confirmed-bug` label — it's a `type: chore` / docs issue, not a bug. Approval implicit from maintainer self-confirm.
- [x] Fix is scoped to the reported chore — release-notes file + 2 line edits in docs/README.md
- [x] All existing tests pass (no test paths touched)
- [x] `no-changelog` label requested (docs-only)
- [x] No unnecessary dependencies added

## Breaking changes

None. Documentation addition.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation index to include v1.42.3 hotfix release notes
  * Latest hotfix now referenced as v1.42.3

* **Bug Fixes**
  * Fixed Codex CLI install routability issues
  * Fixed runtime-aware slash formatting
  * Enhanced phase status handling
  * Resolved multiple correctness and warning issues
  * Fixed SDK and configuration path issues
  * Requires Codex CLI 0.130.0+

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3636?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->