### PR TITLE
fix(3579): ship graphify hook + lib/ helper through build-hooks + install

### DIFF
--- a/.changeset/fix-3579-graphify-hook-publish.md
+++ b/.changeset/fix-3579-graphify-hook-publish.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3579
+---
+**Graphify auto-update hook now ships to install targets** — `gsd-graphify-update.sh` was missing from `scripts/build-hooks.js` `HOOKS_TO_COPY`, so it never landed in `hooks/dist/` and the installer's flat-readdir loop never copied it to `~/.claude/hooks/`. The hook's detached rebuild helper at `hooks/lib/gsd-graphify-rebuild.sh` was also dropped because both `build-hooks.js` and `bin/install.js` only walked top-level files. Both gaps are fixed: the allowlist now includes the hook, `build-hooks.js` copies whitelisted hook subdirectories into `hooks/dist/`, and `bin/install.js` mirrors hook subdirs to the target. Added a coverage drift guard so every top-level `hooks/*.sh` must be listed in `HOOKS_TO_COPY` going forward (#3579).

--- a/bin/install.js
+++ b/bin/install.js
@@ -8661,6 +8661,27 @@ function install(isGlobal, runtime = 'claude', options = {}) {
               fs.copyFileSync(srcFile, destFile);
             }
           }
+        } else if (fs.statSync(srcFile).isDirectory()) {
+          // #3579: recurse one level into hook subdirs (lib/ etc.). The
+          // graphify auto-update hook's rebuild helper lives at
+          // hooks/dist/lib/gsd-graphify-rebuild.sh and must land at the
+          // mirrored target path so the hook's REBUILD_SCRIPT lookup resolves.
+          const subDest = path.join(hooksDest, entry);
+          fs.mkdirSync(subDest, { recursive: true });
+          const subEntries = fs.readdirSync(srcFile);
+          for (const subEntry of subEntries) {
+            const subSrcFile = path.join(srcFile, subEntry);
+            if (!fs.statSync(subSrcFile).isFile()) continue;
+            const subDestFile = path.join(subDest, subEntry);
+            if (subEntry.endsWith('.sh')) {
+              let content = fs.readFileSync(subSrcFile, 'utf8');
+              content = content.replace(/\{\{GSD_VERSION\}\}/g, pkg.version);
+              fs.writeFileSync(subDestFile, content);
+              try { fs.chmodSync(subDestFile, 0o755); } catch (e) { /* Windows */ }
+            } else {
+              fs.copyFileSync(subSrcFile, subDestFile);
+            }
+          }
         }
       }
       if (verifyInstalled(hooksDest, 'hooks')) {

--- a/scripts/build-hooks.js
+++ b/scripts/build-hooks.js
@@ -36,8 +36,17 @@ const HOOKS_TO_COPY = [
   // Community hooks (bash, opt-in via .planning/config.json hooks.community)
   'gsd-session-state.sh',
   'gsd-validate-commit.sh',
-  'gsd-phase-boundary.sh'
+  'gsd-phase-boundary.sh',
+  // Graphify auto-update hook (#3347 / PR #3557 / #3579). Opt-in via
+  // .planning/config.json graphify.auto_update; off by default.
+  'gsd-graphify-update.sh'
 ];
+
+// Subdirectories under hooks/ whose contents must also ship to dist. Each
+// entry is copied as `hooks/<dir>/*` → `hooks/dist/<dir>/*` so detached
+// helpers (e.g. hooks/lib/gsd-graphify-rebuild.sh) resolve from the hook's
+// installed runtime path. See #3579.
+const HOOKS_SUBDIRS_TO_COPY = ['lib'];
 
 // Sync millisecond sleep using Atomics.wait on a throwaway SharedArrayBuffer.
 // Used between Windows rename retries; this script is sync end-to-end so
@@ -167,6 +176,37 @@ function build() {
       try { fs.chmodSync(stagedDest, 0o755); } catch (e) { /* Windows */ }
     }
     renameAtomicWithRetry(stagedDest, dest, hook);
+  }
+
+  // Copy whitelisted hook subdirectories (e.g. hooks/lib/) into dist so the
+  // installer's readdir-and-isFile loop in bin/install.js sees them and
+  // detached hook helpers resolve from the installed runtime path (#3579).
+  for (const subdir of HOOKS_SUBDIRS_TO_COPY) {
+    const srcDir = path.join(HOOKS_DIR, subdir);
+    if (!fs.existsSync(srcDir)) continue;
+    const destDir = path.join(DIST_DIR, subdir);
+    fs.mkdirSync(destDir, { recursive: true });
+    const entries = fs.readdirSync(srcDir, { withFileTypes: true });
+    for (const ent of entries) {
+      if (!ent.isFile()) continue;
+      const srcFile = path.join(srcDir, ent.name);
+      const destFile = path.join(destDir, ent.name);
+      if (ent.name.endsWith('.js')) {
+        const syntaxError = validateSyntax(srcFile);
+        if (syntaxError) {
+          console.error(`\x1b[31m✗ ${subdir}/${ent.name}: SyntaxError — ${syntaxError}\x1b[0m`);
+          hasErrors = true;
+          continue;
+        }
+      }
+      console.log(`\x1b[32m✓\x1b[0m Copying ${subdir}/${ent.name}...`);
+      const stagedDest = path.join(STAGE_DIR, `${subdir}__${ent.name}.${Date.now()}`);
+      fs.copyFileSync(srcFile, stagedDest);
+      if (ent.name.endsWith('.sh')) {
+        try { fs.chmodSync(stagedDest, 0o755); } catch (e) { /* Windows */ }
+      }
+      renameAtomicWithRetry(stagedDest, destFile, `${subdir}/${ent.name}`);
+    }
   }
 
   // Best-effort cleanup of this process's own staging dir. Since STAGE_DIR

--- a/tests/bug-3579-graphify-hook-publish.test.cjs
+++ b/tests/bug-3579-graphify-hook-publish.test.cjs
@@ -1,0 +1,146 @@
+'use strict';
+
+/**
+ * Regression tests for #3579 — graphify auto-update hook (#3347 / PR #3557)
+ * was dead-on-arrival in 1.50.0-canary.x because:
+ *
+ *   Gap 1: scripts/build-hooks.js HOOKS_TO_COPY did not include
+ *          gsd-graphify-update.sh, so it never landed in hooks/dist/ — the
+ *          installer's bin/install.js readdir loop then never copied it to
+ *          ~/.claude/hooks/.
+ *   Gap 2: build-hooks.js (flat allowlist) and bin/install.js (readdir +
+ *          isFile filter) never copied hooks/lib/gsd-graphify-rebuild.sh.
+ *          Without the helper the hook resolves rebuild script → not found →
+ *          exit 0 — feature silently dead.
+ *
+ * Beyond these two gaps the issue body lists a Gap 3 (npm tarball missing
+ * the source files). Inspection of `npm pack --dry-run --json` on origin/main
+ * shows both files are now present in the tarball, so the tarball-side
+ * regression is not reproduced; only Gaps 1 & 2 are in scope here.
+ *
+ * Test strategy — three layers, each independent:
+ *   1. build-hooks.js HOOKS_TO_COPY includes every top-level .sh under hooks/
+ *      (allowlist-coverage drift guard). This generalizes beyond graphify so
+ *      the next .sh added cannot drift back into the gap.
+ *   2. After running scripts/build-hooks.js, hooks/dist/gsd-graphify-update.sh
+ *      and hooks/dist/lib/gsd-graphify-rebuild.sh both exist.
+ *   3. After installing into a temp config dir, both files land at
+ *      hooks/gsd-graphify-update.sh and hooks/lib/gsd-graphify-rebuild.sh
+ *      and the installer does not emit the "Missing expected hook" warning
+ *      for gsd-graphify-update.sh.
+ */
+
+const { test, describe, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const { execFileSync } = require('node:child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const HOOKS_DIR = path.join(REPO_ROOT, 'hooks');
+const DIST_DIR = path.join(HOOKS_DIR, 'dist');
+const BUILD_SCRIPT = path.join(REPO_ROOT, 'scripts', 'build-hooks.js');
+const INSTALL_SCRIPT = path.join(REPO_ROOT, 'bin', 'install.js');
+
+// ─── Coverage guard ─────────────────────────────────────────────────────────
+
+describe('#3579 Gap 1: build-hooks.js HOOKS_TO_COPY covers every top-level hooks/*.sh', () => {
+  test('every top-level hooks/*.sh appears in HOOKS_TO_COPY (drift guard)', () => {
+    const buildSource = fs.readFileSync(BUILD_SCRIPT, 'utf-8');
+
+    // Parse the HOOKS_TO_COPY literal by extracting quoted filenames inside
+    // the array. Avoids dynamic code evaluation while still being resilient
+    // to comment lines and surrounding whitespace.
+    const match = buildSource.match(/const\s+HOOKS_TO_COPY\s*=\s*\[([\s\S]*?)\]\s*;/);
+    assert.ok(match, 'expected HOOKS_TO_COPY = [...] literal in scripts/build-hooks.js');
+    const hooksToCopy = Array.from(match[1].matchAll(/['"]([^'"]+\.(?:sh|js))['"]/g)).map(
+      (m) => m[1]
+    );
+    assert.ok(hooksToCopy.length > 0, 'HOOKS_TO_COPY parsed an empty list');
+
+    const topLevelSh = fs
+      .readdirSync(HOOKS_DIR, { withFileTypes: true })
+      .filter((e) => e.isFile() && e.name.endsWith('.sh'))
+      .map((e) => e.name);
+
+    const missing = topLevelSh.filter((sh) => !hooksToCopy.includes(sh));
+    assert.deepStrictEqual(
+      missing,
+      [],
+      `every top-level hooks/*.sh must be listed in HOOKS_TO_COPY; missing: ${JSON.stringify(missing)}`
+    );
+  });
+});
+
+// ─── build-hooks emits dist/ files ──────────────────────────────────────────
+
+describe('#3579 Gap 1 + Gap 2: build-hooks.js populates dist with graphify hook + lib helper', () => {
+  before(() => {
+    execFileSync(process.execPath, [BUILD_SCRIPT], { encoding: 'utf-8', stdio: 'pipe' });
+  });
+
+  test('hooks/dist/gsd-graphify-update.sh exists after build', () => {
+    assert.ok(
+      fs.existsSync(path.join(DIST_DIR, 'gsd-graphify-update.sh')),
+      'expected hooks/dist/gsd-graphify-update.sh to exist after build (Gap 1)'
+    );
+  });
+
+  test('hooks/dist/lib/gsd-graphify-rebuild.sh exists after build', () => {
+    assert.ok(
+      fs.existsSync(path.join(DIST_DIR, 'lib', 'gsd-graphify-rebuild.sh')),
+      'expected hooks/dist/lib/gsd-graphify-rebuild.sh to exist after build (Gap 2)'
+    );
+  });
+});
+
+// ─── install lands the files at the target ──────────────────────────────────
+
+describe('#3579: installer deploys graphify hook + lib helper to target', () => {
+  let tmpDir;
+  let installStdout;
+
+  before(() => {
+    execFileSync(process.execPath, [BUILD_SCRIPT], { encoding: 'utf-8', stdio: 'pipe' });
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-3579-install-'));
+    installStdout = execFileSync(
+      process.execPath,
+      [INSTALL_SCRIPT, '--claude', '--global', '--yes', '--no-sdk'],
+      {
+        encoding: 'utf-8',
+        stdio: 'pipe',
+        env: { ...process.env, CLAUDE_CONFIG_DIR: tmpDir },
+      }
+    );
+  });
+
+  after(() => {
+    if (tmpDir) {
+      try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+    }
+  });
+
+  test('hooks/gsd-graphify-update.sh present at install target', () => {
+    const dest = path.join(tmpDir, 'hooks', 'gsd-graphify-update.sh');
+    assert.ok(fs.existsSync(dest), `expected ${dest} to exist after install`);
+  });
+
+  test('hooks/lib/gsd-graphify-rebuild.sh present at install target', () => {
+    const dest = path.join(tmpDir, 'hooks', 'lib', 'gsd-graphify-rebuild.sh');
+    assert.ok(fs.existsSync(dest), `expected ${dest} to exist after install`);
+  });
+
+  test('installer does not warn about missing gsd-graphify-update.sh', () => {
+    assert.ok(
+      !installStdout.includes('Missing expected hook: gsd-graphify-update.sh'),
+      `installer output must not warn about missing graphify hook; got:\n${installStdout}`
+    );
+    assert.ok(
+      !installStdout.includes(
+        'Skipped graphify auto-update hook — gsd-graphify-update.sh not found'
+      ),
+      `installer must not skip graphify hook configuration; got:\n${installStdout}`
+    );
+  });
+});

--- a/tests/bug-3579-graphify-hook-publish.test.cjs
+++ b/tests/bug-3579-graphify-hook-publish.test.cjs
@@ -45,30 +45,34 @@ const INSTALL_SCRIPT = path.join(REPO_ROOT, 'bin', 'install.js');
 
 // ─── Coverage guard ─────────────────────────────────────────────────────────
 
-describe('#3579 Gap 1: build-hooks.js HOOKS_TO_COPY covers every top-level hooks/*.sh', () => {
-  test('every top-level hooks/*.sh appears in HOOKS_TO_COPY (drift guard)', () => {
-    const buildSource = fs.readFileSync(BUILD_SCRIPT, 'utf-8');
+describe('#3579 Gap 1: build-hooks.js packages every top-level hooks/*.sh into dist', () => {
+  // Behavior-based drift guard: rather than parsing the HOOKS_TO_COPY literal
+  // out of scripts/build-hooks.js as text (a source-grep that breaks under
+  // harmless refactors and fails to catch any other reason a file might get
+  // dropped on the floor), we run the actual build and assert the actual
+  // filesystem outcome: every top-level hooks/*.sh has a corresponding file
+  // in hooks/dist/. This catches the original gap (missing allowlist entry)
+  // AND any future regression that silently drops a hook for any other
+  // reason (e.g. a copy that swallows errors, a syntax-validator bug, etc.).
+  before(() => {
+    execFileSync(process.execPath, [BUILD_SCRIPT], { encoding: 'utf-8', stdio: 'pipe' });
+  });
 
-    // Parse the HOOKS_TO_COPY literal by extracting quoted filenames inside
-    // the array. Avoids dynamic code evaluation while still being resilient
-    // to comment lines and surrounding whitespace.
-    const match = buildSource.match(/const\s+HOOKS_TO_COPY\s*=\s*\[([\s\S]*?)\]\s*;/);
-    assert.ok(match, 'expected HOOKS_TO_COPY = [...] literal in scripts/build-hooks.js');
-    const hooksToCopy = Array.from(match[1].matchAll(/['"]([^'"]+\.(?:sh|js))['"]/g)).map(
-      (m) => m[1]
-    );
-    assert.ok(hooksToCopy.length > 0, 'HOOKS_TO_COPY parsed an empty list');
-
+  test('every top-level hooks/*.sh is emitted to hooks/dist/ by the build', () => {
     const topLevelSh = fs
       .readdirSync(HOOKS_DIR, { withFileTypes: true })
       .filter((e) => e.isFile() && e.name.endsWith('.sh'))
       .map((e) => e.name);
 
-    const missing = topLevelSh.filter((sh) => !hooksToCopy.includes(sh));
+    assert.ok(topLevelSh.length > 0, 'expected at least one top-level hooks/*.sh in source');
+
+    const missing = topLevelSh.filter(
+      (sh) => !fs.existsSync(path.join(DIST_DIR, sh))
+    );
     assert.deepStrictEqual(
       missing,
       [],
-      `every top-level hooks/*.sh must be listed in HOOKS_TO_COPY; missing: ${JSON.stringify(missing)}`
+      `every top-level hooks/*.sh must be emitted to hooks/dist/ by scripts/build-hooks.js; missing from dist: ${JSON.stringify(missing)}`
     );
   });
 });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3579

> The linked issue has `confirmed-bug` label.

---

## What was broken

The graphify auto-update hook (#3347 / PR #3557) was dead-on-arrival in 1.50.0-canary.x:

- **Gap 1** — `scripts/build-hooks.js` `HOOKS_TO_COPY` allowlist was missing `gsd-graphify-update.sh`. The hook never landed in `hooks/dist/`. `bin/install.js` `readdirSync`s `hooks/dist/` and so never copied it to the target.
- **Gap 2** — `hooks/lib/gsd-graphify-rebuild.sh` (the hook's detached rebuild helper) was never copied at all. `build-hooks.js` only iterates a flat allowlist; `bin/install.js` only iterates top-level files (`isFile()` filter, no subdir walk). The hook would have resolved `REBUILD_SCRIPT="$HOOK_DIR/lib/gsd-graphify-rebuild.sh"`, missed the file, and silently `exit 0`.

**Gap 3** (issue body's published-tarball-missing-source-files claim) is not reproduced on origin/main. `npm pack --dry-run --json` shows both `hooks/gsd-graphify-update.sh` and `hooks/lib/gsd-graphify-rebuild.sh` are present in the tarball today. The tarball-side regression is out of scope for this PR.

## What changed

**`scripts/build-hooks.js`:**
- Added `gsd-graphify-update.sh` to `HOOKS_TO_COPY`.
- Added `HOOKS_SUBDIRS_TO_COPY = ['lib']` and a subdirectory-copy pass that walks each whitelisted subdir, runs syntax-validation on `.js` files, preserves the `+x` bit on `.sh` files, and uses the same atomic per-process staging-dir + `renameAtomicWithRetry` path the top-level loop uses.

**`bin/install.js`:**
- The hook copy loop now recurses one level into any directory entry under `hooks/dist/`. Subdir files (e.g. `lib/gsd-graphify-rebuild.sh`) land at the mirrored target path so the hook's `REBUILD_SCRIPT` lookup resolves. The top-level `if/else` structure for files is preserved unchanged (so #1834's source-grep test continues to assert it).

## Regression test

`tests/bug-3579-graphify-hook-publish.test.cjs` covers three independent layers:

1. **Coverage drift guard** — every top-level `hooks/*.sh` must appear in `HOOKS_TO_COPY`. Generalizes beyond graphify so the next `.sh` hook added cannot regress.
2. **Build-side** — after `node scripts/build-hooks.js`, both `hooks/dist/gsd-graphify-update.sh` and `hooks/dist/lib/gsd-graphify-rebuild.sh` exist.
3. **Install-side** — after `bin/install.js --claude --global --yes --no-sdk` into a temp `CLAUDE_CONFIG_DIR`, both files land at the target and no `Missing expected hook: gsd-graphify-update.sh` / `Skipped graphify auto-update hook` warnings are emitted.

All 18 tests across `bug-3579`, `bug-1834-sh-hooks-installed`, and `orphaned-hooks` pass.

## Precedent

Same bug class as the previously-fixed cases referenced in the issue body: #1656, #1834, #2373, #2406. The drift guard introduced here is the regression test #2406 proposed but never implemented.

> *This PR description was assisted by AI during issue triage and fix authoring.*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Packaged and installed the previously-missing auto-update hook and its helper files, including support for one-level hook subdirectories and preserving executable scripts during install.

* **Tests**
  * Added regression tests to verify hook/build packaging and installer behavior end-to-end, ensuring emitted hooks are present and installed without warnings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3640?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->