### PR TITLE
fix(3643): resolve full Claude model id under resolve_model_ids: true

### DIFF
--- a/.changeset/3643-resolve-model-claude-runtime.md
+++ b/.changeset/3643-resolve-model-claude-runtime.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3648
 ---
 **`gsd-sdk query resolve-model` now honors `resolve_model_ids: true` under `runtime: "claude"`** — previously the resolver bailed out of `resolveRuntimeTier` for Claude (because Claude is the implicit/default runtime in `config-query.ts:149`) and fell through to the alias-return path on line 243 without consulting the catalog. Consumers asking for resolved model IDs received the tier alias (`opus` / `sonnet` / `haiku`) instead of the full Claude model ID (`claude-opus-4-7` / `claude-sonnet-4-6` / `claude-haiku-4-5`). The CJS branch at `get-shit-done/bin/lib/core.cjs:1348-1350` (`if (config.resolve_model_ids) return MODEL_ALIAS_MAP[alias] || alias;`) was missing from the TS port. Added a `runtime === 'claude' && resolveModelIds === true` branch that calls `resolveRuntimeTierDefault('claude', tier)` from the shared model-catalog so both runtimes derive Claude IDs from the same source of truth. `model_overrides`, the phase-type tier override (`config.models[phaseType]`), and `resolve_model_ids: "omit"` all retain their existing precedence. (#3643)

--- a/.changeset/3643-resolve-model-claude-runtime.md
+++ b/.changeset/3643-resolve-model-claude-runtime.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**`gsd-sdk query resolve-model` now honors `resolve_model_ids: true` under `runtime: "claude"`** — previously the resolver bailed out of `resolveRuntimeTier` for Claude (because Claude is the implicit/default runtime in `config-query.ts:149`) and fell through to the alias-return path on line 243 without consulting the catalog. Consumers asking for resolved model IDs received the tier alias (`opus` / `sonnet` / `haiku`) instead of the full Claude model ID (`claude-opus-4-7` / `claude-sonnet-4-6` / `claude-haiku-4-5`). The CJS branch at `get-shit-done/bin/lib/core.cjs:1348-1350` (`if (config.resolve_model_ids) return MODEL_ALIAS_MAP[alias] || alias;`) was missing from the TS port. Added a `runtime === 'claude' && resolveModelIds === true` branch that calls `resolveRuntimeTierDefault('claude', tier)` from the shared model-catalog so both runtimes derive Claude IDs from the same source of truth. `model_overrides`, the phase-type tier override (`config.models[phaseType]`), and `resolve_model_ids: "omit"` all retain their existing precedence. (#3643)

--- a/sdk/src/query/config-query.test.ts
+++ b/sdk/src/query/config-query.test.ts
@@ -259,6 +259,111 @@ describe('resolveModel', () => {
     expect(planner).not.toHaveProperty('reasoning_effort');
   });
 
+  // ─── #3643: runtime:claude + resolve_model_ids:true must return full IDs ──
+  // Symptom: aliases (opus/sonnet/haiku) leaked through to consumers that asked
+  // for resolved model IDs because resolveRuntimeTier bails for runtime:claude
+  // and the alias-return fall-through ignored resolve_model_ids. CJS branch at
+  // get-shit-done/bin/lib/core.cjs:1348-1350 has the missing guard.
+  it('#3643: runtime:claude + resolve_model_ids:true + balanced returns full sonnet id', async () => {
+    const { resolveModel } = await import('./config-query.js');
+    await writeFile(
+      join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({
+        model_profile: 'balanced',
+        runtime: 'claude',
+        resolve_model_ids: true,
+      }),
+    );
+    const result = await resolveModel(['gsd-executor'], tmpDir);
+    expect(result.data).toEqual({ model: 'claude-sonnet-4-6', profile: 'balanced' });
+  });
+
+  it('#3643: runtime:claude + resolve_model_ids:true + quality returns full opus id', async () => {
+    const { resolveModel } = await import('./config-query.js');
+    await writeFile(
+      join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({
+        model_profile: 'quality',
+        runtime: 'claude',
+        resolve_model_ids: true,
+      }),
+    );
+    const result = await resolveModel(['gsd-planner'], tmpDir);
+    expect(result.data).toEqual({ model: 'claude-opus-4-7', profile: 'quality' });
+  });
+
+  it('#3643: runtime:claude + resolve_model_ids:true + budget returns full haiku id', async () => {
+    const { resolveModel } = await import('./config-query.js');
+    await writeFile(
+      join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({
+        model_profile: 'budget',
+        runtime: 'claude',
+        resolve_model_ids: true,
+      }),
+    );
+    // gsd-verifier maps to 'haiku' under budget profile per model-catalog.json.
+    const result = await resolveModel(['gsd-verifier'], tmpDir);
+    expect(result.data).toEqual({ model: 'claude-haiku-4-5', profile: 'budget' });
+  });
+
+  it('#3643: phase-type tier override (models.execution=opus) wins under claude+resolve_model_ids', async () => {
+    const { resolveModel } = await import('./config-query.js');
+    await writeFile(
+      join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({
+        model_profile: 'budget',
+        runtime: 'claude',
+        resolve_model_ids: true,
+        models: { execution: 'opus' },
+      }),
+    );
+    const result = await resolveModel(['gsd-executor'], tmpDir);
+    expect(result.data).toEqual({ model: 'claude-opus-4-7', profile: 'budget' });
+  });
+
+  it('#3643 regression-guard: runtime:claude WITHOUT resolve_model_ids still returns alias', async () => {
+    const { resolveModel } = await import('./config-query.js');
+    await writeFile(
+      join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({
+        model_profile: 'balanced',
+        runtime: 'claude',
+      }),
+    );
+    const result = await resolveModel(['gsd-executor'], tmpDir);
+    expect(result.data).toEqual({ model: 'sonnet', profile: 'balanced' });
+  });
+
+  it('#3643 regression-guard: runtime:claude + resolve_model_ids:"omit" still wins over alias mapping', async () => {
+    const { resolveModel } = await import('./config-query.js');
+    await writeFile(
+      join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({
+        model_profile: 'balanced',
+        runtime: 'claude',
+        resolve_model_ids: 'omit',
+      }),
+    );
+    const result = await resolveModel(['gsd-executor'], tmpDir);
+    expect(result.data).toEqual({ model: '', profile: 'balanced' });
+  });
+
+  it('#3643 regression-guard: model_overrides[agent] beats claude+resolve_model_ids:true', async () => {
+    const { resolveModel } = await import('./config-query.js');
+    await writeFile(
+      join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({
+        model_profile: 'balanced',
+        runtime: 'claude',
+        resolve_model_ids: true,
+        model_overrides: { 'gsd-executor': 'custom-anthropic-id' },
+      }),
+    );
+    const result = await resolveModel(['gsd-executor'], tmpDir);
+    expect((result.data as Record<string, unknown>).model).toBe('custom-anthropic-id');
+  });
+
   it('resolveModel uses workstream config when --ws is specified', async () => {
     const { resolveModel } = await import('./config-query.js');
     // Root config: balanced profile → gsd-executor resolves to 'sonnet'

--- a/sdk/src/query/config-query.ts
+++ b/sdk/src/query/config-query.ts
@@ -249,7 +249,11 @@ export const resolveModel: QueryHandler = async (args, projectDir, workstream) =
   const runtime = typeof (config as Record<string, unknown>).runtime === 'string'
     ? ((config as Record<string, unknown>).runtime as string)
     : '';
-  if (resolveModelIds === true && runtime === 'claude' && isRuntimeTierName(tier)) {
+  // Empty/missing runtime is implicit Claude (per the resolveRuntimeTier bail-out
+  // at line ~149); without this branch the resolved-IDs path silently fell
+  // through to the alias return for projects that never set `runtime` explicitly.
+  const isClaudeRuntime = runtime === '' || runtime === 'claude';
+  if (resolveModelIds === true && isClaudeRuntime && isRuntimeTierName(tier)) {
     const claudeDefault = resolveRuntimeTierDefault('claude', tier);
     if (claudeDefault?.model) {
       return { data: { model: claudeDefault.model, profile } };

--- a/sdk/src/query/config-query.ts
+++ b/sdk/src/query/config-query.ts
@@ -240,5 +240,21 @@ export const resolveModel: QueryHandler = async (args, projectDir, workstream) =
     return { data: { model: '', profile } };
   }
 
+  // #3643: runtime:claude bails out of resolveRuntimeTier (line 149) because
+  // Claude is the implicit/default runtime, but consumers that asked for
+  // resolved model IDs still need the full ID (e.g. "claude-sonnet-4-6"), not
+  // the tier alias. Mirror the CJS branch at get-shit-done/bin/lib/core.cjs
+  // (`if (config.resolve_model_ids) return MODEL_ALIAS_MAP[alias] || alias;`)
+  // by consulting the catalog's claude runtime defaults for the resolved tier.
+  const runtime = typeof (config as Record<string, unknown>).runtime === 'string'
+    ? ((config as Record<string, unknown>).runtime as string)
+    : '';
+  if (resolveModelIds === true && runtime === 'claude' && isRuntimeTierName(tier)) {
+    const claudeDefault = resolveRuntimeTierDefault('claude', tier);
+    if (claudeDefault?.model) {
+      return { data: { model: claudeDefault.model, profile } };
+    }
+  }
+
   return { data: { model: alias, profile } };
 };


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3643

> The linked issue has the `confirmed-bug` label.

---

## What was broken

`gsd-sdk query resolve-model <agent>` with `{ runtime: "claude", resolve_model_ids: true }` returned the tier alias (`"sonnet"`) instead of the full Claude model id (`"claude-sonnet-4-6"`), breaking parity with the CJS resolver and causing downstream orchestrators to omit `model=` on Task spawns.

## What this fix does

Adds a `runtime === 'claude' && resolveModelIds === true` branch in `sdk/src/query/config-query.ts` that consults `resolveRuntimeTierDefault('claude', tier)` from the shared model catalog when the existing `resolveRuntimeTier` short-circuit bails out for Claude. The CJS counterpart at `get-shit-done/bin/lib/core.cjs:1348-1350` already did this via `MODEL_ALIAS_MAP[alias]`; SDK now matches.

## Root cause

`resolveModel` in `sdk/src/query/config-query.ts` bails out of `resolveRuntimeTier` for `runtime === 'claude'` (line 149) because Claude is the implicit/default runtime, and then falls through to `return { data: { model: alias, profile } }` at line 243 without consulting the catalog when the caller asked for resolved IDs. The CJS branch that handled the `resolve_model_ids: true` case was never ported to the TS resolver. Existing precedence — `model_overrides` > phase-type tier (`config.models[phaseType]`) > profile-derived tier > `resolve_model_ids: "omit"` > alias return — is preserved.

## Testing

### How I verified the fix

`cd sdk && npx vitest run src/query/config-query.test.ts` → **31 pass / 0 fail** (24 existing + 7 new). RED→GREEN proof captured: pre-fix returned `{ model: 'sonnet' }`; post-fix returns `{ model: 'claude-sonnet-4-6' }`.

### Regression test added?

- [x] Yes — added `sdk/src/query/config-query.test.ts` cases covering: claude+`resolve_model_ids:true` × {budget, balanced, quality} × {gsd-executor, gsd-planner} → full Claude IDs; claude + phase-type override → opus full id; claude WITHOUT `resolve_model_ids` → alias (regression guard); claude + `resolve_model_ids:"omit"` → still wins; `model_overrides[agentType]` → still wins.

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #3643`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/3643-resolve-model-claude-runtime.md` added (`type: Fixed`)
- [x] No unnecessary dependencies added

## Breaking changes

None. Behaviour for `runtime: "claude"` without `resolve_model_ids` is unchanged (still returns alias). Behaviour for non-Claude runtimes is unchanged. `resolve_model_ids: "omit"` continues to take precedence over alias return. `model_overrides` and phase-type tier overrides retain their precedence.

> *This PR description was assisted by AI.*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Claude model resolution now correctly returns full Claude model IDs (not tier aliases) when model ID resolution is enabled. Existing precedence for explicit model overrides, phase-type overrides, and omit behavior remains unchanged.

* **Tests**
  * Added regression tests covering Claude model resolution across profiles, resolve/omit modes, and override precedence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3648?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->