### PR TITLE
fix(3677): normalize /gsd:<cmd> → /gsd-<cmd> in agent bodies for hyphen-name runtimes

### DIFF
--- a/.changeset/fix-3677-agent-colon-namespace-leak.md
+++ b/.changeset/fix-3677-agent-colon-namespace-leak.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 0
+pr: 3680
 ---
 **Installed agent bodies no longer leak retired `/gsd:<cmd>` colon refs on Claude / Qwen / Hermes (#3677)** — `bin/install.js` now applies the same hyphen-namespace normalizer that #3629 wired into SKILL.md bodies to agent bodies as well. A new pure predicate `shouldNormalizeHyphenNamespaceInAgentBody(runtime)` and helper `normalizeAgentBodyForRuntime(content, runtime, cmdNames)` are exported from `bin/install.js` and called from the agent install loop after all runtime-specific conversions. Explicit allow-list (`claude`, `qwen`, `hermes`) — unknown / future runtimes default to no rewrite. Gemini (intentionally colon-namespaced) and self-converting runtimes (Copilot/Codex/Cursor/Antigravity/Windsurf/Augment/Trae/Codebuddy/Cline/Opencode/Kilo) are unaffected. Sibling fixes #3583/#3629 (SKILL.md bodies) and #3584/#3606 (runtime emissions) complete the three-surface coverage.

--- a/.changeset/fix-3677-agent-colon-namespace-leak.md
+++ b/.changeset/fix-3677-agent-colon-namespace-leak.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 0
+---
+**Installed agent bodies no longer leak retired `/gsd:<cmd>` colon refs on Claude / Qwen / Hermes (#3677)** — `bin/install.js` now applies the same hyphen-namespace normalizer that #3629 wired into SKILL.md bodies to agent bodies as well. A new pure predicate `shouldNormalizeHyphenNamespaceInAgentBody(runtime)` and helper `normalizeAgentBodyForRuntime(content, runtime, cmdNames)` are exported from `bin/install.js` and called from the agent install loop after all runtime-specific conversions. Explicit allow-list (`claude`, `qwen`, `hermes`) — unknown / future runtimes default to no rewrite. Gemini (intentionally colon-namespaced) and self-converting runtimes (Copilot/Codex/Cursor/Antigravity/Windsurf/Augment/Trae/Codebuddy/Cline/Opencode/Kilo) are unaffected. Sibling fixes #3583/#3629 (SKILL.md bodies) and #3584/#3606 (runtime emissions) complete the three-surface coverage.

--- a/bin/install.js
+++ b/bin/install.js
@@ -29,6 +29,39 @@ const {
   readCmdNames: readGsdCommandNames,
 } = require(path.join(__dirname, '..', 'scripts', 'fix-slash-commands.cjs'));
 
+/**
+ * Runtimes that register hyphen-form `name:` per #2808 AND copy agent bodies
+ * verbatim (only branding swaps, no namespace conversion), so retired
+ * `/gsd:<cmd>` colon refs leak into installed agent prose. Sibling fixes
+ * #3583 / #3629 covered SKILL.md bodies, #3584 / #3606 covered runtime
+ * emissions — this is the agent-body surface (#3677).
+ *
+ * Explicit allow-list rather than deny-list so unknown / future runtimes
+ * default to "no rewrite" (better to leak than to mangle a runtime whose
+ * namespace behavior we haven't verified).
+ */
+const HYPHEN_NAME_AGENT_RUNTIMES = new Set(['claude', 'qwen', 'hermes']);
+
+/**
+ * #3677 predicate — true when an agent body needs `/gsd:<cmd>` → `/gsd-<cmd>`
+ * normalization at install time.
+ */
+function shouldNormalizeHyphenNamespaceInAgentBody(runtime) {
+  if (typeof runtime !== 'string' || runtime === '') return false;
+  return HYPHEN_NAME_AGENT_RUNTIMES.has(runtime);
+}
+
+/**
+ * #3677 helper — applies the hyphen-namespace transform iff the predicate
+ * says so. Pure function; safe to call unconditionally from the install
+ * loop. Returns the input unchanged for runtimes that self-convert or
+ * intentionally keep colon refs.
+ */
+function normalizeAgentBodyForRuntime(content, runtime, cmdNames) {
+  if (!shouldNormalizeHyphenNamespaceInAgentBody(runtime)) return content;
+  return transformContentToHyphen(content, cmdNames);
+}
+
 // Colors
 const cyan = '\x1b[36m';
 const green = '\x1b[32m';
@@ -8440,6 +8473,13 @@ function install(isGlobal, runtime = 'claude', options = {}) {
           content = content.replace(/\bClaude Code\b/g, 'Hermes Agent');
           content = content.replace(/\.claude\//g, '.hermes/');
         }
+        // #3677 — normalize retired `/gsd:<cmd>` colon refs in the agent body
+        // to the canonical hyphen form `/gsd-<cmd>` for hyphen-`name:`
+        // runtimes (claude / qwen / hermes). Self-converting runtimes and
+        // Gemini are skipped by the predicate — see
+        // shouldNormalizeHyphenNamespaceInAgentBody above. Mirrors the
+        // SKILL.md-body fix shipped via #3629.
+        content = normalizeAgentBodyForRuntime(content, runtime, readGsdCommandNames());
         const destName = isCopilot ? entry.name.replace('.md', '.agent.md') : entry.name;
         fs.writeFileSync(path.join(agentsDest, destName), content);
       }
@@ -11054,6 +11094,9 @@ function installAllRuntimes(runtimes, isGlobal, isInteractive) {
 // converter functions when called from within the CLI path (circular require).
 // The main() block below is gated on !GSD_TEST_MODE, as before.
 module.exports = {
+    // #3677 — hyphen-namespace normalization seam for agent bodies
+    shouldNormalizeHyphenNamespaceInAgentBody,
+    normalizeAgentBodyForRuntime,
     yamlIdentifier,
     computePathPrefix,
     getCodexSkillAdapterHeader,

--- a/tests/bug-3677-agent-colon-namespace-leak.test.cjs
+++ b/tests/bug-3677-agent-colon-namespace-leak.test.cjs
@@ -1,0 +1,174 @@
+// allow-test-rule: source-text-is-the-product
+// Tests A1/A2/B inspect agent / installed `.md` bodies whose deployed text IS
+// the runtime contract. Tests C exercises the install.js exported pure helper
+// `shouldNormalizeHyphenNamespaceInAgentBody` directly — purely behavioral.
+
+/**
+ * Regression for #3677 — installed agent bodies leak `/gsd:<cmd>` colon refs
+ * for Claude / Qwen / Hermes (unroutable since #2808).
+ *
+ * Root cause: `bin/install.js` agent install loop (around line 8350-8447)
+ * reads each agent .md, runs runtime-specific transforms via
+ * `convertClaudeAgentToXAgent()`, then writes the result. For:
+ *   - Self-converting runtimes (Copilot/Codex/Cursor/Windsurf/Augment/Trae/
+ *     Codebuddy/Cline/Antigravity/Opencode/Kilo): their converters handle
+ *     namespace themselves.
+ *   - Gemini: intentionally uses colon namespace.
+ *   - Claude-default / Qwen / Hermes: register hyphen-form `name:` (#2808)
+ *     but copy bodies verbatim (Qwen/Hermes do branding-only swaps; Claude
+ *     does no namespace work). The retired `/gsd:<cmd>` colon refs leak.
+ *
+ * Sibling fixes #3583 (SKILL.md, via #3629) and #3584 (runtime emissions, via
+ * #3606) covered the other two surfaces. This is the agent-body surface.
+ *
+ * Fix surface:
+ *   1. `bin/install.js` exports a pure predicate
+ *      `shouldNormalizeHyphenNamespaceInAgentBody(runtime)` plus a helper
+ *      `normalizeAgentBodyForRuntime(content, runtime, cmdNames)` that
+ *      conditionally applies `transformContentToHyphen` from
+ *      scripts/fix-slash-commands.cjs.
+ *   2. The agent install loop calls the helper after all runtime-specific
+ *      conversions but before writeFileSync.
+ *   3. This regression test guards both the predicate and the integration.
+ */
+
+'use strict';
+
+process.env.GSD_TEST_MODE = '1';
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+// Single `..` traversal matches the existing tests/helpers.cjs convention
+// (TOOLS_PATH at tests/helpers.cjs:21). Avoids `..` chains per CLAUDE.md and
+// works in the docker mirror at /work/tests (which has no `.git` to anchor on).
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+const install = require(path.join(REPO_ROOT, 'bin', 'install.js'));
+const { transformContentToHyphen } = require(path.join(REPO_ROOT, 'scripts', 'fix-slash-commands.cjs'));
+
+// Snapshot of all runtime IDs in the layout table at the time of this fix.
+// Keep these two sets covering: any runtime listed in
+// runtime-artifact-layout.cjs MUST appear in exactly one bucket.
+const HYPHEN_NAME_AGENT_RUNTIMES = ['claude', 'qwen', 'hermes'];
+const SELF_CONVERTING_OR_COLON_RUNTIMES = [
+  'gemini',     // intentionally colon-namespaced
+  'codex', 'copilot', 'antigravity', 'cursor', 'windsurf', 'augment',
+  'trae', 'codebuddy', 'cline',
+  'opencode', 'kilo',
+];
+
+describe('bug #3677 — agent body colon-namespace leak (Claude / Qwen / Hermes)', () => {
+
+  describe('A — install.js exports the pure predicate + helper', () => {
+    test('A1: shouldNormalizeHyphenNamespaceInAgentBody is an exported function', () => {
+      assert.strictEqual(
+        typeof install.shouldNormalizeHyphenNamespaceInAgentBody,
+        'function',
+        'bin/install.js must export shouldNormalizeHyphenNamespaceInAgentBody as the runtime predicate (regression seam for #3677)',
+      );
+    });
+
+    test('A2: normalizeAgentBodyForRuntime is an exported function', () => {
+      assert.strictEqual(
+        typeof install.normalizeAgentBodyForRuntime,
+        'function',
+        'bin/install.js must export normalizeAgentBodyForRuntime as the wired helper called by the agent install loop',
+      );
+    });
+  });
+
+  describe('B — predicate returns true for hyphen-`name:` runtimes and false otherwise', () => {
+    const { shouldNormalizeHyphenNamespaceInAgentBody } = install;
+
+    for (const runtime of HYPHEN_NAME_AGENT_RUNTIMES) {
+      test(`B+ '${runtime}': normalize hyphen namespace (true)`, () => {
+        assert.strictEqual(
+          shouldNormalizeHyphenNamespaceInAgentBody(runtime),
+          true,
+          `${runtime} registers hyphen-form 'name:' (#2808) and copies agent bodies verbatim — must normalize`,
+        );
+      });
+    }
+
+    for (const runtime of SELF_CONVERTING_OR_COLON_RUNTIMES) {
+      test(`B- '${runtime}': skip normalization (false)`, () => {
+        assert.strictEqual(
+          shouldNormalizeHyphenNamespaceInAgentBody(runtime),
+          false,
+          `${runtime} either self-converts via convertClaudeAgentToXAgent or intentionally uses colon — must NOT re-rewrite`,
+        );
+      });
+    }
+
+    test('B?: unknown runtime defaults to false (conservative)', () => {
+      assert.strictEqual(
+        shouldNormalizeHyphenNamespaceInAgentBody('bogus-runtime-id'),
+        false,
+        'unknown runtimes must not be normalized — better to leak than to mangle',
+      );
+    });
+  });
+
+  describe('C — normalizeAgentBodyForRuntime applies transformContentToHyphen iff predicate is true', () => {
+    const { normalizeAgentBodyForRuntime } = install;
+    // Sample agent body with colon refs that #2808 retired.
+    const inputBody = [
+      '# Agent prose',
+      '',
+      'Run `/gsd:execute-phase 1 --tdd` to execute the phase.',
+      'Then `/gsd:verify-work 1` to verify.',
+      'Reference unchanged: `gsd-sdk query commit` (this is a CLI binary, not a slash command).',
+    ].join('\n');
+    // Only known commands from commands/gsd/*.md should be rewritten; gsd-sdk
+    // (a binary) must stay untouched.
+    const cmdNames = ['execute-phase', 'verify-work', 'plan-phase'];
+
+    test('C1: claude — rewrites both colon refs to hyphen', () => {
+      const out = normalizeAgentBodyForRuntime(inputBody, 'claude', cmdNames);
+      assert.ok(out.includes('/gsd-execute-phase'), 'execute-phase must be rewritten to hyphen form');
+      assert.ok(out.includes('/gsd-verify-work'), 'verify-work must be rewritten to hyphen form');
+      assert.ok(!out.includes('/gsd:execute-phase'), 'colon form for execute-phase must be gone');
+      assert.ok(!out.includes('/gsd:verify-work'), 'colon form for verify-work must be gone');
+      assert.ok(out.includes('gsd-sdk query commit'), 'gsd-sdk (CLI binary) must not be touched');
+    });
+
+    test('C2: qwen — same transform applies', () => {
+      const out = normalizeAgentBodyForRuntime(inputBody, 'qwen', cmdNames);
+      assert.ok(out.includes('/gsd-execute-phase'));
+      assert.ok(!out.includes('/gsd:execute-phase'));
+    });
+
+    test('C3: hermes — same transform applies', () => {
+      const out = normalizeAgentBodyForRuntime(inputBody, 'hermes', cmdNames);
+      assert.ok(out.includes('/gsd-execute-phase'));
+      assert.ok(!out.includes('/gsd:execute-phase'));
+    });
+
+    test('C4: gemini — colon refs preserved (intentional namespace)', () => {
+      const out = normalizeAgentBodyForRuntime(inputBody, 'gemini', cmdNames);
+      assert.ok(out.includes('/gsd:execute-phase'), 'Gemini intentionally uses colon namespace; do not rewrite');
+      assert.ok(!out.includes('/gsd-execute-phase'), 'Gemini agents must NOT have hyphen form');
+    });
+
+    test('C5: self-converting runtime (copilot) — body returned unchanged at this layer', () => {
+      const out = normalizeAgentBodyForRuntime(inputBody, 'copilot', cmdNames);
+      // Copilot has its own convertClaudeAgentToCopilotAgent that handles
+      // namespace — the normalize layer is a no-op for it.
+      assert.strictEqual(out, inputBody);
+    });
+  });
+
+  describe('D — sanity check: the underlying transform actually works against real cmd names', () => {
+    test('D1: transformContentToHyphen rewrites /gsd:<cmd> to /gsd-<cmd> for known cmds only', () => {
+      const out = transformContentToHyphen(
+        'A /gsd:execute-phase B /gsd:unknown-cmd C /gsd-sdk D',
+        ['execute-phase'],
+      );
+      assert.ok(out.includes('/gsd-execute-phase'), 'known cmd rewritten');
+      assert.ok(out.includes('/gsd:unknown-cmd'), 'unknown cmd preserved (longest-first matcher only rewrites registered names)');
+      assert.ok(out.includes('/gsd-sdk'), 'gsd-sdk (binary, not slash command) preserved');
+    });
+  });
+});

--- a/tests/bug-3677-agent-colon-namespace-leak.test.cjs
+++ b/tests/bug-3677-agent-colon-namespace-leak.test.cjs
@@ -171,4 +171,72 @@ describe('bug #3677 — agent body colon-namespace leak (Claude / Qwen / Hermes)
       assert.ok(out.includes('/gsd-sdk'), 'gsd-sdk (binary, not slash command) preserved');
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // E — Behavioral coverage ported from PR #3681 (johnzilla / John Turner).
+  //
+  // #3681 proposed the same allow-list fix independently and was closed by its
+  // author in favor of this PR. Its test file contributed two coverage angles
+  // worth keeping: real-source efficacy against every `agents/gsd-*.md` (the
+  // shape of bug that pure-function tests miss) and idempotence-via-fixpoint
+  // (guards against double-rewrite on reinstall). Credit: johnzilla.
+  // ---------------------------------------------------------------------------
+  describe('E — real-source efficacy + idempotence (ported from #3681, credit: johnzilla)', () => {
+    const fs = require('node:fs');
+    const { readCmdNames } = require(path.join(REPO_ROOT, 'scripts', 'fix-slash-commands.cjs'));
+    const cmdNames = readCmdNames();
+
+    // Roster regex matches any registered command in `gsd:<cmd>` form with a
+    // negative lookbehind (so `mygsd:foo` is ignored) and a non-word lookahead
+    // (so `plan-phase-extra` is not a false match for `plan-phase`).
+    const roster = () => new RegExp(
+      `(?<![a-zA-Z0-9_-])gsd:(${[...cmdNames].sort((a, b) => b.length - a.length).join('|')})(?=[^a-zA-Z0-9_-]|$)`,
+    );
+
+    test('E0: command roster is populated and contains the symptom commands', () => {
+      assert.ok(cmdNames.length > 0, 'command roster must be populated');
+      assert.ok(cmdNames.includes('execute-phase'));
+      assert.ok(cmdNames.includes('plan-phase'));
+    });
+
+    test('E1: every agents/gsd-*.md transforms clean — no roster colon refs survive', () => {
+      const agentsDir = path.join(REPO_ROOT, 'agents');
+      const offenders = [];
+      for (const f of fs.readdirSync(agentsDir)) {
+        if (!f.startsWith('gsd-') || !f.endsWith('.md')) continue;
+        const src = fs.readFileSync(path.join(agentsDir, f), 'utf-8');
+        const out = transformContentToHyphen(src, cmdNames);
+        if (roster().test(out)) offenders.push(f);
+      }
+      assert.deepEqual(
+        offenders,
+        [],
+        `agents still carry roster colon refs after transform: ${offenders.join(', ')}`,
+      );
+    });
+
+    test('E2: idempotent — transform of already-hyphenated input is a no-op', () => {
+      const input = 'use /gsd-plan-phase next, then /gsd-execute-phase';
+      assert.strictEqual(
+        transformContentToHyphen(input, cmdNames),
+        input,
+        'reinstalls re-run the transform; double application must not mangle the body',
+      );
+    });
+
+    test('E3: word boundary — /gsd:plan-phase-extra is not a roster match', () => {
+      assert.strictEqual(
+        transformContentToHyphen('/gsd:plan-phase-extra', cmdNames),
+        '/gsd:plan-phase-extra',
+      );
+    });
+
+    test('E4: rewrites bare `gsd:<cmd>` shorthand (no leading slash)', () => {
+      const out = transformContentToHyphen(
+        'Spawned by the gsd:execute-phase orchestrator.',
+        cmdNames,
+      );
+      assert.strictEqual(out, 'Spawned by the gsd-execute-phase orchestrator.');
+    });
+  });
 });


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3677

> Issue carries both `confirmed` (canonical) and `confirmed-bug` (template-required) labels.

---

## What was broken

After `npm install -g get-shit-done-cc` on Claude / Qwen / Hermes, the installed agent files at `~/.claude/agents/gsd-*.md` (and the per-runtime equivalents) still contained retired `/gsd:<cmd>` colon-form command references in their prose. Every GSD skill / agent has registered under the canonical hyphen `name:` form since #2808, so the colon refs are unroutable — Claude Code rejects them with `Unknown command: /gsd:execute-phase. Did you mean /gsd-execute-phase?`. Reporter measured ~28 affected agent files / ~96 leaked references on a full Claude global install.

## What this fix does

Wires the existing `transformContentToHyphen` (from `scripts/fix-slash-commands.cjs`) into the agent install loop in `bin/install.js`, gated by an explicit allow-list of hyphen-`name:` runtimes (`claude`, `qwen`, `hermes`). Other runtimes either self-convert via `convertClaudeAgentToXAgent()` or intentionally keep colon (Gemini) — they're skipped by the predicate so we don't double-rewrite or mangle Gemini's intentional namespace.

## Root cause

This is the **agent-body surface** of the same class of bug as two already-fixed sibling surfaces:

- **#3583** (SKILL.md skill bodies) — fixed via #3629
- **#3584** (user-facing runtime "Next step: /gsd:…" emissions) — fixed via #3606

The agent install loop in `bin/install.js` (around line 8350-8447) reads each agent .md, runs runtime-specific transforms via `convertClaudeAgentToXAgent()`, then writes the result. For Claude-default, Qwen, and Hermes the runtime-specific transforms are either nothing (Claude-default falls through with no body conversion) or branding-only (Qwen / Hermes swap `CLAUDE.md` → `QWEN.md` / `HERMES.md`). No namespace normalization. The retired colon refs in the source bodies leak verbatim into the installed runtime.

Self-converting runtimes (Copilot/Codex/Cursor/Antigravity/Windsurf/Augment/Trae/Codebuddy/Cline/Opencode/Kilo) and Gemini handle namespace themselves in their converters and are unaffected.

## Testing

### How I verified the fix

`node --test tests/bug-3677-agent-colon-namespace-leak.test.cjs` — 24/24 pass. The test runs RED before the fix (23 fail / 1 pass — only the unrelated `transformContentToHyphen` sanity check passes), GREEN after the source change. Predicate uses an explicit allow-list rather than a deny-list so unknown / future runtimes default to "no rewrite" (better to leak than to mangle).

### Regression test added?

- [x] Yes — `tests/bug-3677-agent-colon-namespace-leak.test.cjs` (185 LOC, 24 tests across 4 describe groups). Carries `// allow-test-rule: source-text-is-the-product` for agent-body inspection.

Coverage:

| Group | What it asserts |
|---|---|
| A (2 tests) | `bin/install.js` exports the new `shouldNormalizeHyphenNamespaceInAgentBody` predicate and `normalizeAgentBodyForRuntime` helper |
| B (16 tests) | Predicate returns `true` for `claude` / `qwen` / `hermes` and `false` for all 12 other runtimes in the layout table (gemini + 11 self-converters) AND for unknown runtimes (conservative default) |
| C (5 tests) | Normalize helper rewrites colon refs for the 3 hyphen-name runtimes, preserves them for Gemini (intentional namespace), and is a no-op for self-converters (whose own converters handle namespace) |
| D (1 test) | Sanity check that the underlying `transformContentToHyphen` only rewrites known command names — `/gsd-sdk` (CLI binary, not a slash command) and unknown commands are preserved |

### Platforms tested

- [x] macOS (local `node --test`)
- [x] Linux (docker via `gsd-test-summary`, host `holodeck` — 11769/0 fail)
- [ ] Windows — N/A (no path-handling code touched; only JS exports and a body-text transform that goes through `String.prototype.replace`)

### Runtimes tested

- [x] Claude Code (`isQwen`/`isHermes`/Claude-default branches of agent loop; predicate returns true)
- [x] Qwen Code
- [x] Hermes Agent
- [x] Gemini (predicate returns false; colon refs preserved)
- [x] Copilot / Codex / Cursor / Antigravity / Windsurf / Augment / Trae / Codebuddy / Cline / Opencode / Kilo (predicate returns false; converters handle namespace)

---

## Scope confirmation

- [x] Bug spec is the issue body; root cause matches reporter's hypothesis exactly (reporter even pointed at the right code path — `bin/install.js` agent-write loop missing the transform applied to SKILL.md bodies by #3629)
- [x] No scope creep — fix is exactly what #3629 did for SKILL.md, transposed to the agent loop. No other runtimes touched. No other transforms changed.

---

## Documentation

- [x] No user-facing docs need updating — this is an internal install-time transform fix. The behavior the user sees is "the retired colon refs in installed agent prose are now the canonical hyphen form," which restores the contract documented by #2808.
- [x] Changeset fragment added

## Checklist

- [x] Issue linked above with `Fixes #3677`
- [x] Linked issue has `confirmed` + `confirmed-bug` labels
- [x] All existing tests pass (76/76 across slash-namespace siblings, 54/54 install-minimal after local SDK build, 11769/0 full docker)
- [x] New tests cover predicate, helper, and sibling matrix
- [x] `.changeset/` fragment added
- [x] No new dependencies
- [x] Works on Windows — no path-handling code touched

## Breaking changes

**None.** The fix is purely additive: two new functions exported from `bin/install.js`, one new call site in the agent install loop. The transform only fires for the three runtimes that demonstrably need it; all other runtimes get identical behavior.

For Claude / Qwen / Hermes users: their installed agent bodies will now contain `/gsd-<cmd>` (hyphen) instead of `/gsd:<cmd>` (colon) — but that's the actual canonical form per #2808 and the only one their runtimes accept.

## Discovery context

Diagnosed via the `/diagnose` skill discipline:
- **Phase 1 (feedback loop):** unit test against the pure helpers + structural cover via the predicate matrix (16 runtimes).
- **Phase 2 (reproduce):** code-traced from the reporter's exact line citation (`bin/install.js` agent-write loop missing transformContentToHyphen). Confirmed `stageAgentsForProfile` uses `fs.copyFileSync` (no body transform). Confirmed the agent install loop's per-runtime branches do branding swaps only for Qwen/Hermes and nothing for Claude-default.
- **Phase 3 (hypothesise):** reporter's hypothesis was confirmed by code-reading; no other plausible cause.
- **Phase 4-5:** TDD red-green; predicate inverted from deny-list to allow-list during fix when the unknown-runtime test caught the conservative-default requirement.
- **Phase 6:** no `[DEBUG-*]` instrumentation needed; regression test prevents drift via the explicit runtime matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented retired command references from leaking into installed agent content by normalizing command namespace for affected runtimes (e.g., Claude, Qwen, Hermes).

* **Tests**
  * Added regression and integration tests to ensure command-reference normalization, idempotence, and correct behavior across different runtimes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3680?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->