### PR TITLE
fix(3677): rewrite /gsd: -> /gsd- in installed Claude/Qwen/Hermes agent bodies

### DIFF
--- a/.changeset/3677-agent-body-slash-namespace.md
+++ b/.changeset/3677-agent-body-slash-namespace.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3677
+---
+Agent install for hyphen-`name:` runtimes (Claude default, Qwen, Hermes) now normalizes retired `/gsd:<cmd>` references in `agents/gsd-*.md` bodies to the canonical `gsd-<cmd>` hyphen form, using the shared `transformContentToHyphen` transformer behind a runtime gate in `bin/install.js`. This is the agent-surface analogue of the SKILL.md body fix (#3629) and the user-facing emission fix (#3606). Gemini (intentionally colon-namespaced) and the self-converting adapter runtimes (Copilot, Codex, Cursor, Windsurf, Augment, Trae, Codebuddy, Cline, OpenCode, Kilo) are excluded from the rewrite. Frontmatter `name:` was already correct since #2808; the agent-body colon leakage is now eliminated. Fixes #3677.

--- a/bin/install.js
+++ b/bin/install.js
@@ -8371,6 +8371,11 @@ function install(isGlobal, runtime = 'claude', options = {}) {
   } else if (fs.existsSync(agentsSrc)) {
     fs.mkdirSync(agentsDest, { recursive: true });
 
+    // #3677: roster for the agent-body colon→hyphen normalization below.
+    // Computed once (not per-file) — consumed by the isHyphenNameAgentRuntime
+    // gate inside the loop.
+    const _agentCmdNames = readGsdCommandNames();
+
     // Copy new agents
     const agentEntries = fs.readdirSync(agentsSrc, { withFileTypes: true });
     for (const entry of agentEntries) {
@@ -8439,6 +8444,22 @@ function install(isGlobal, runtime = 'claude', options = {}) {
           content = content.replace(/CLAUDE\.md/g, 'HERMES.md');
           content = content.replace(/\bClaude Code\b/g, 'Hermes Agent');
           content = content.replace(/\.claude\//g, '.hermes/');
+        }
+        // #3677: runtimes that register agents under the canonical hyphen
+        // `name:` (#2808) must not ship retired /gsd:<cmd> colon references
+        // in agent bodies — they are unroutable on those installs (Claude
+        // rejects `/gsd:execute-phase` with "Did you mean /gsd-execute-phase?").
+        // Mirrors the SKILL.md body rewrite (#3583/#3629). The other runtimes
+        // are deliberately excluded: their convertClaudeAgentTo* adapters
+        // already convert command namespaces (Copilot CONV-07, Codex `$gsd-`,
+        // etc.), and Gemini intentionally keeps the colon form because its
+        // slash commands are colon-namespaced.
+        const isHyphenNameAgentRuntime =
+          !isOpencode && !isKilo && !isGemini && !isCodex && !isCopilot &&
+          !isAntigravity && !isCursor && !isWindsurf && !isAugment &&
+          !isTrae && !isCodebuddy && !isCline;
+        if (isHyphenNameAgentRuntime) {
+          content = transformContentToHyphen(content, _agentCmdNames);
         }
         const destName = isCopilot ? entry.name.replace('.md', '.agent.md') : entry.name;
         fs.writeFileSync(path.join(agentsDest, destName), content);

--- a/tests/bug-3677-claude-agent-body-transform.test.cjs
+++ b/tests/bug-3677-claude-agent-body-transform.test.cjs
@@ -1,0 +1,163 @@
+'use strict';
+
+// allow-test-rule: structural-regression-guard
+
+/**
+ * Claude/Qwen/Hermes agent-body slash-namespace transform (#3677).
+ *
+ * Agent-surface analogue of the SKILL.md body fix (#3583, merged via #3629)
+ * and the user-facing emission fix (#3584, merged via #3606). The source repo
+ * authors agent prose with the canonical colon form `/gsd:<cmd>` (enforced by
+ * the #3443 invariant), but since #2808 all GSD agents/skills register under
+ * the hyphen `name:` form, so the colon namespace is unroutable on those
+ * installs. The Claude-default (and Qwen/Hermes) branch of the agent write
+ * loop in bin/install.js copied agent bodies verbatim, leaking the dead colon
+ * form into ~/.claude/agents/gsd-*.md.
+ *
+ * Invariants enforced here:
+ *   1. transformContentToHyphen rewrites known colon commands with
+ *      word-boundary / roster discipline, and is a no-op on already-hyphenated
+ *      input and unknown identifiers.
+ *   2. Applied to real agent source, no roster `/gsd:<cmd>` survives.
+ *   3. bin/install.js wires the transform into the agent write loop, gated so
+ *      Gemini (intentionally colon-namespaced) and the self-converting
+ *      runtimes are never rewritten.
+ */
+
+const { test, describe } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.join(__dirname, '..');
+const {
+  transformContentToHyphen,
+  readCmdNames,
+} = require(path.join(ROOT, 'scripts', 'fix-slash-commands.cjs'));
+
+const cmdNames = readCmdNames();
+
+describe('transformContentToHyphen — agent-body inverse (#3677)', () => {
+  test('roster is non-empty and includes the symptom commands', () => {
+    assert.ok(cmdNames.length > 0, 'command roster must be populated');
+    assert.ok(cmdNames.includes('execute-phase'));
+    assert.ok(cmdNames.includes('plan-phase'));
+  });
+
+  test('rewrites /gsd:<cmd> to /gsd-<cmd> (slash preserved)', () => {
+    const out = transformContentToHyphen('re-run /gsd:plan-phase --research-phase 3', cmdNames);
+    assert.equal(out, 're-run /gsd-plan-phase --research-phase 3');
+  });
+
+  test('rewrites the bare gsd:<cmd> shorthand too', () => {
+    const out = transformContentToHyphen('Spawned by the gsd:execute-phase orchestrator.', cmdNames);
+    assert.equal(out, 'Spawned by the gsd-execute-phase orchestrator.');
+  });
+
+  test('rewrites backtick-wrapped references (real agent prose shape)', () => {
+    const out = transformContentToHyphen('Spawned by `/gsd:plan-phase` orchestrator', cmdNames);
+    assert.equal(out, 'Spawned by `/gsd-plan-phase` orchestrator');
+  });
+
+  test('multiple occurrences in one pass', () => {
+    const out = transformContentToHyphen('/gsd:discuss-phase then /gsd:plan-phase then /gsd:execute-phase', cmdNames);
+    assert.ok(!/\/gsd:[a-z]/.test(out), `no colon form may remain: ${out}`);
+    assert.ok(out.includes('/gsd-discuss-phase') && out.includes('/gsd-execute-phase'));
+  });
+
+  test('idempotent on already-hyphenated input', () => {
+    const input = 'use /gsd-plan-phase next';
+    assert.equal(transformContentToHyphen(input, cmdNames), input);
+  });
+
+  test('word boundary — does not rewrite /gsd:plan-phase-extra', () => {
+    assert.equal(transformContentToHyphen('/gsd:plan-phase-extra', cmdNames), '/gsd:plan-phase-extra');
+  });
+
+  test('word-char lookbehind leaves identifier-embedded mygsd:plan-phase untouched', () => {
+    const input = 'the mygsd:plan-phase token is not a command';
+    assert.equal(transformContentToHyphen(input, cmdNames), input);
+  });
+
+  test('unknown identifier left untouched (roster-checked)', () => {
+    const input = 'the gsd:not-a-real-command token';
+    assert.equal(transformContentToHyphen(input, cmdNames), input);
+  });
+
+  test('empty roster short-circuits (no stray rewrite)', () => {
+    const input = 'run /gsd:plan-phase';
+    assert.equal(transformContentToHyphen(input, []), input);
+  });
+});
+
+describe('real agent source efficacy (#3677)', () => {
+  const roster = () => new RegExp(
+    `(?<![a-zA-Z0-9_-])gsd:(${[...cmdNames].sort((a, b) => b.length - a.length).join('|')})(?=[^a-zA-Z0-9_-]|$)`,
+  );
+
+  test('no roster /gsd:<cmd> survives transform of agents/gsd-executor.md', () => {
+    const src = fs.readFileSync(path.join(ROOT, 'agents', 'gsd-executor.md'), 'utf-8');
+    assert.ok(/\/gsd:plan-phase|gsd:execute-phase/.test(src),
+      'fixture precondition: source agent must contain colon references to be meaningful');
+    const out = transformContentToHyphen(src, cmdNames);
+    assert.ok(!roster().test(out),
+      'no known-command colon reference may remain after the install-time transform');
+  });
+
+  test('every gsd-*.md agent transforms clean (roster colon refs fully eliminated)', () => {
+    const agentsDir = path.join(ROOT, 'agents');
+    const offenders = [];
+    for (const f of fs.readdirSync(agentsDir)) {
+      if (!f.startsWith('gsd-') || !f.endsWith('.md')) continue;
+      const out = transformContentToHyphen(fs.readFileSync(path.join(agentsDir, f), 'utf-8'), cmdNames);
+      if (roster().test(out)) offenders.push(f);
+    }
+    assert.deepEqual(offenders, [],
+      `agents still carrying roster colon refs post-transform: ${offenders.join(', ')}`);
+  });
+});
+
+describe('bin/install.js wires the agent-loop transform (#3677)', () => {
+  const installSrc = fs.readFileSync(path.join(ROOT, 'bin', 'install.js'), 'utf-8');
+
+  test('imports transformContentToHyphen from the shared module', () => {
+    // Tolerate both require styles: a string-literal path
+    // (require('../scripts/fix-slash-commands.cjs')) and the path.join form
+    // (require(path.join(__dirname, '..', 'scripts', 'fix-slash-commands.cjs'))).
+    const importMatch = installSrc.match(
+      /const\s*\{[\s\S]*?\}\s*=\s*require\([\s\S]*?fix-slash-commands\.cjs[\s\S]*?\)/,
+    );
+    assert.ok(importMatch, 'install.js must require scripts/fix-slash-commands.cjs');
+    assert.ok(
+      /\btransformContentToHyphen\b/.test(importMatch[0]),
+      'install.js must import transformContentToHyphen from the shared transformer module',
+    );
+  });
+
+  test('agent write loop applies the transform before writing the agent file', () => {
+    const writeIdx = installSrc.indexOf("fs.writeFileSync(path.join(agentsDest, destName)");
+    assert.ok(writeIdx > 0, 'agent write site must exist');
+    const window = installSrc.slice(Math.max(0, writeIdx - 1400), writeIdx);
+    assert.ok(
+      window.includes('transformContentToHyphen(content'),
+      'transformContentToHyphen must be applied to agent content just before the agent file is written',
+    );
+    assert.ok(
+      window.includes('isHyphenNameAgentRuntime'),
+      'the agent-loop transform must be gated by the hyphen-name-runtime predicate',
+    );
+  });
+
+  test('gate excludes Gemini and the self-converting runtimes', () => {
+    const gateMatch = installSrc.match(/const isHyphenNameAgentRuntime\s*=\s*([\s\S]*?);/);
+    assert.ok(gateMatch, 'isHyphenNameAgentRuntime predicate must be defined');
+    assert.ok(
+      /!isGemini\b/.test(gateMatch[1]),
+      'Gemini must be excluded — regression guard against breaking its intentional colon namespace',
+    );
+    assert.ok(
+      /!isCopilot\b/.test(gateMatch[1]) && /!isCodex\b/.test(gateMatch[1]),
+      'runtimes with their own command-namespace adapters must be excluded to avoid double conversion',
+    );
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3677

## What was broken

After installing GSD for a hyphen-`name:` runtime (Claude default, Qwen, Hermes), the generated agent files at `~/.claude/agents/gsd-*.md` still contained retired colon-form command references `/gsd:<cmd>` in their bodies. Since #2808 those runtimes register agents under the hyphen `name:` form, so the colon namespace is unroutable — Claude Code rejects `/gsd:execute-phase` with `Did you mean /gsd-execute-phase?`. A full Claude install leaked the colon form across ~28 `agents/gsd-*.md` files.

## What this fix does

The agent-write loop in `bin/install.js` now applies the shared `transformContentToHyphen` (from `scripts/fix-slash-commands.cjs`) to agent bodies, gated behind an `isHyphenNameAgentRuntime` predicate. Only the hyphen-`name:` fall-through runtimes (Claude default, Qwen, Hermes) are rewritten; Gemini (intentionally colon-namespaced) and the self-converting adapter runtimes (Copilot, Codex, Cursor, Windsurf, Augment, Trae, Codebuddy, Cline, OpenCode, Kilo) are excluded. Source files keep canonical `/gsd:<cmd>` per the #3443 invariant — only the install-time output changes.

## Root cause

This is the **agent-body surface** of the same class of bug as #3583. The sibling surfaces were fixed independently — SKILL.md skill bodies via #3629 (#3583), user-facing runtime emissions via #3606 (#3584) — but the agent-write loop's Claude-default / Qwen / Hermes branches copied bodies verbatim (Qwen/Hermes do branding swaps only; Claude-default does nothing), so the colon refs leaked. This PR is the agent-loop analogue of #3629, reusing the same merged `transformContentToHyphen` transformer behind a runtime gate.

## Testing

### How I verified the fix

- New regression suite `tests/bug-3677-claude-agent-body-transform.test.cjs` (15 tests): roster/word-boundary/idempotence behavioral cases on `transformContentToHyphen`; real-source efficacy across every `agents/gsd-*.md`; and a structural guard asserting the install.js gate exists, is applied before the agent write, and **excludes Gemini + the self-converting runtimes** (regression guard against breaking Gemini's intentional colon namespace).
- Related suites pass unchanged: `bug-2808-skill-hyphen-name`, `claude-skills-migration`, `qwen-skills-migration`, `hermes-skills-migration` (49/49).
- `node scripts/lint-no-source-grep.cjs`: 0 violations.
- `changeset-required` and `docs-required` lints evaluated against the committed diff: both `ok` (`ok_fragment_present`, `ok_no_triggering_fragments`).

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [x] N/A (not platform-specific — install-time string transform)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [x] Other: Qwen, Hermes (same install-time code path); Gemini exclusion covered by structural regression guard

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [ ] Linked issue has the `confirmed-bug` label *(pending maintainer triage — issue #3677 freshly opened alongside this PR; currently `needs-triage`)*
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (targeted run; awaiting full CI)
- [x] `.changeset/` fragment added (`.changeset/3677-agent-body-slash-namespace.md`)
- [x] No unnecessary dependencies added

## Breaking changes

None. Only install-time output for the Claude-default / Qwen / Hermes agent install paths changes (retired colon refs → canonical hyphen form). Source files in `agents/` are unchanged. Gemini and the self-converting adapter runtimes are explicitly excluded, preserving their existing behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed agent installation to normalize command reference syntax in documentation for supported runtimes, ensuring consistency across agent platforms while excluding specific environments that handle this conversion independently.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3681?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->