### PR TITLE
fix(#3689): use find instead of chained ls for continue-here scan

### DIFF
--- a/.changeset/3689-resume-glob-nomatch-fix.md
+++ b/.changeset/3689-resume-glob-nomatch-fix.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3690
+---
+**`/gsd-resume-work` no longer drops `.planning/.continue-here*.md` checkpoints under zsh's default `NOMATCH`** — the chained `ls` of bare globs in `resume-project.md`'s `check_incomplete_work` step aborted on the first non-matching pattern, silently swallowing every later pattern (including the one that surfaces top-level handoff files). Replaced with `find .planning -maxdepth 3` + `find . -maxdepth 1`, which doesn't use shell glob expansion and tolerates absent directories on both bash and zsh.

--- a/.changeset/3689-resume-glob-nomatch-fix.md
+++ b/.changeset/3689-resume-glob-nomatch-fix.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 3690
+pr: 3693
 ---
 **`/gsd-resume-work` no longer drops `.planning/.continue-here*.md` checkpoints under zsh's default `NOMATCH`** — the chained `ls` of bare globs in `resume-project.md`'s `check_incomplete_work` step aborted on the first non-matching pattern, silently swallowing every later pattern (including the one that surfaces top-level handoff files). Replaced with `find .planning -maxdepth 3` + `find . -maxdepth 1`, which doesn't use shell glob expansion and tolerates absent directories on both bash and zsh.

--- a/get-shit-done/workflows/resume-project.md
+++ b/get-shit-done/workflows/resume-project.md
@@ -66,13 +66,15 @@ Look for incomplete work that needs attention:
 # Check for structured handoff (preferred — machine-readable)
 cat .planning/HANDOFF.json 2>/dev/null || true
 
-# Check for continue-here files (phase + non-phase + legacy fallback)
-ls .planning/phases/*/.continue-here*.md \
-   .planning/spikes/*/.continue-here*.md \
-   .planning/sketches/*/.continue-here*.md \
-   .planning/deliberations/.continue-here*.md \
-   .planning/.continue-here*.md \
-   .continue-here*.md 2>/dev/null || true
+# Check for continue-here files (phase + non-phase + legacy fallback).
+# Use `find` rather than a chained `ls` of bare globs: under zsh's default
+# NOMATCH option (macOS default shell), a single non-matching glob aborts
+# the entire command during word-expansion — silently dropping every
+# pattern after the first miss, including `.planning/.continue-here*.md`.
+# `find` does not use shell glob expansion and tolerates absent
+# directories on both bash and zsh.
+find .planning -maxdepth 3 -name '.continue-here*.md' -print 2>/dev/null
+find . -maxdepth 1 -name '.continue-here*.md' -print 2>/dev/null
 
 # Check for plans without summaries (incomplete execution)
 for plan in .planning/phases/*/*-PLAN.md; do

--- a/get-shit-done/workflows/resume-project.md
+++ b/get-shit-done/workflows/resume-project.md
@@ -73,8 +73,8 @@ cat .planning/HANDOFF.json 2>/dev/null || true
 # pattern after the first miss, including `.planning/.continue-here*.md`.
 # `find` does not use shell glob expansion and tolerates absent
 # directories on both bash and zsh.
-find .planning -maxdepth 3 -name '.continue-here*.md' -print 2>/dev/null
-find . -maxdepth 1 -name '.continue-here*.md' -print 2>/dev/null
+find .planning -maxdepth 3 -name '.continue-here*.md' -print 2>/dev/null || true
+find . -maxdepth 1 -name '.continue-here*.md' -print 2>/dev/null || true
 
 # Check for plans without summaries (incomplete execution)
 for plan in .planning/phases/*/*-PLAN.md; do

--- a/tests/bug-3446-resume-continue-here-discovery.test.cjs
+++ b/tests/bug-3446-resume-continue-here-discovery.test.cjs
@@ -24,8 +24,12 @@ function extractCheckBlock() {
   const stepStart = md.indexOf('<step name="check_incomplete_work">');
   assert.ok(stepStart >= 0, 'resume-project.md must contain a check_incomplete_work step');
   const stepEnd = md.indexOf('</step>', stepStart);
+  assert.ok(
+    stepEnd >= 0,
+    'check_incomplete_work step must have a closing </step> tag',
+  );
   const stepBody = md.slice(stepStart, stepEnd);
-  const fenceMatch = stepBody.match(/```(?:bash|sh)\r?\n([\s\S]*?)```/);
+  const fenceMatch = stepBody.match(/```(?:bash|sh)\r?\n([\s\S]*?)\r?\n```/);
   assert.ok(fenceMatch, 'check_incomplete_work step must embed a ```bash code block');
   return fenceMatch[1];
 }

--- a/tests/bug-3446-resume-continue-here-discovery.test.cjs
+++ b/tests/bug-3446-resume-continue-here-discovery.test.cjs
@@ -25,7 +25,7 @@ function extractCheckBlock() {
   assert.ok(stepStart >= 0, 'resume-project.md must contain a check_incomplete_work step');
   const stepEnd = md.indexOf('</step>', stepStart);
   const stepBody = md.slice(stepStart, stepEnd);
-  const fenceMatch = stepBody.match(/```bash\n([\s\S]*?)\n```/);
+  const fenceMatch = stepBody.match(/```(?:bash|sh)\r?\n([\s\S]*?)```/);
   assert.ok(fenceMatch, 'check_incomplete_work step must embed a ```bash code block');
   return fenceMatch[1];
 }

--- a/tests/bug-3446-resume-continue-here-discovery.test.cjs
+++ b/tests/bug-3446-resume-continue-here-discovery.test.cjs
@@ -1,55 +1,107 @@
+// allow-test-rule: source-text-is-the-product
+// Workflow `.md` files are the runtime contract executed by Claude Code as
+// embedded bash. This test extracts the actual `check_incomplete_work` bash
+// block from resume-project.md and exercises it against a planted directory
+// layout — that's a behavioral integration test of the workflow contract,
+// not regex-on-source.
+
 'use strict';
 
-const { test, describe } = require('node:test');
+const { test, describe, before, after } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+const { createTempDir, cleanup } = require('./helpers.cjs');
+
+const WORKFLOW_PATH = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'resume-project.md');
+
+// Extract the first ```bash``` code block inside the
+// `<step name="check_incomplete_work">` element. That's the snippet the
+// runtime actually executes; it's what we want to validate.
+function extractCheckBlock() {
+  const md = fs.readFileSync(WORKFLOW_PATH, 'utf8');
+  const stepStart = md.indexOf('<step name="check_incomplete_work">');
+  assert.ok(stepStart >= 0, 'resume-project.md must contain a check_incomplete_work step');
+  const stepEnd = md.indexOf('</step>', stepStart);
+  const stepBody = md.slice(stepStart, stepEnd);
+  const fenceMatch = stepBody.match(/```bash\n([\s\S]*?)\n```/);
+  assert.ok(fenceMatch, 'check_incomplete_work step must embed a ```bash code block');
+  return fenceMatch[1];
+}
+
+function runSnippet(cwd, snippet) {
+  // has_interrupted_agent is a downstream-orchestrator variable; default it
+  // to "false" so the embedded `if` branch is a no-op during this test.
+  return spawnSync('bash', ['-c', snippet], {
+    cwd,
+    encoding: 'utf8',
+    env: { ...process.env, has_interrupted_agent: 'false', interrupted_agent_id: '' },
+  });
+}
 
 describe('bug #3446: resume-project detects non-phase and legacy continue-here handoffs', () => {
-  const workflowPath = path.join(__dirname, '..', 'get-shit-done', 'workflows', 'resume-project.md');
-  const workflowContent = fs.readFileSync(workflowPath, 'utf8');
+  let tmpDir;
+  let snippet;
 
-  function readCheckBlock() {
-    const stepStart = workflowContent.indexOf('<step name="check_incomplete_work">');
-    const stepEnd = workflowContent.indexOf('</step>', stepStart);
-    return workflowContent.slice(stepStart, stepEnd);
-  }
+  before(() => {
+    snippet = extractCheckBlock();
+    tmpDir = createTempDir('gsd-bug-3446-');
 
-  // Bug #3446 originally enforced three text invariants on a chained `ls` of
-  // bare globs. Bug #3689 replaced that chain with two `find` invocations
-  // because the chained ls aborted under zsh's default NOMATCH option,
-  // silently dropping every pattern after the first miss. These tests now
-  // assert that the same three discovery contracts are still satisfied by
-  // the find-based scan.
+    // Plant the three discovery surfaces that bug #3446 was originally
+    // filed to cover.
+    fs.mkdirSync(path.join(tmpDir, '.planning'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', '.continue-here.md'),
+      '---\ncontext: default\n---\nroot-of-.planning handoff\n',
+      'utf8',
+    );
 
-  test('check_incomplete_work scans .planning-root continue-here fallback (depth 1 under .planning)', () => {
-    const block = readCheckBlock();
-    assert.match(
-      block,
-      /find \.planning -maxdepth 3 -name '\.continue-here\*\.md'/,
-      'resume workflow must scan .planning/.continue-here*.md fallback path written by pause-work; the find .planning -maxdepth 3 invocation covers it at depth 1'
+    fs.mkdirSync(path.join(tmpDir, '.planning', 'sketches', 'SKETCH-001'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'sketches', 'SKETCH-001', '.continue-here.md'),
+      '---\ncontext: sketch\n---\nsketch handoff\n',
+      'utf8',
+    );
+
+    fs.writeFileSync(
+      path.join(tmpDir, '.continue-here.md'),
+      '---\ncontext: legacy\n---\nlegacy repo-root handoff\n',
+      'utf8',
     );
   });
 
-  test('check_incomplete_work scans sketch subdirectory continue-here checkpoints (depth 3 under .planning)', () => {
-    const block = readCheckBlock();
-    // .planning/sketches/SKETCH-NNN/.continue-here*.md sits at depth 3 from
-    // the .planning starting point. The find call must use maxdepth >= 3.
-    const findMatch = block.match(/find \.planning -maxdepth (\d+) -name '\.continue-here\*\.md'/);
-    assert.ok(findMatch, 'resume workflow must use find .planning -maxdepth N -name .continue-here*.md');
-    const depth = Number(findMatch[1]);
-    assert.ok(
-      depth >= 3,
-      `resume workflow .planning find must use -maxdepth 3 or greater to reach sketch/spike/deliberation subdirectories; got -maxdepth ${depth}`
+  after(() => {
+    cleanup(tmpDir);
+  });
+
+  test('check_incomplete_work surfaces .planning/.continue-here.md (depth 1 under .planning)', () => {
+    const result = runSnippet(tmpDir, snippet);
+    assert.equal(result.status, 0, `snippet exited ${result.status}; stderr=${result.stderr}`);
+    assert.match(
+      result.stdout,
+      /\.planning\/\.continue-here\.md/,
+      `expected .planning/.continue-here.md in stdout; got: ${JSON.stringify(result.stdout)}`,
     );
   });
 
-  test('check_incomplete_work scans legacy repo-root continue-here fallback', () => {
-    const block = readCheckBlock();
+  test('check_incomplete_work surfaces .planning/sketches/SKETCH-001/.continue-here.md (depth 3 under .planning)', () => {
+    const result = runSnippet(tmpDir, snippet);
+    assert.equal(result.status, 0, `snippet exited ${result.status}; stderr=${result.stderr}`);
     assert.match(
-      block,
-      /find \. -maxdepth 1 -name '\.continue-here\*\.md'/,
-      'resume workflow must scan legacy repo-root .continue-here*.md handoff path via a separate find . -maxdepth 1 invocation'
+      result.stdout,
+      /\.planning\/sketches\/SKETCH-001\/\.continue-here\.md/,
+      `expected sketch handoff in stdout; got: ${JSON.stringify(result.stdout)}`,
+    );
+  });
+
+  test('check_incomplete_work surfaces legacy repo-root .continue-here.md', () => {
+    const result = runSnippet(tmpDir, snippet);
+    assert.equal(result.status, 0, `snippet exited ${result.status}; stderr=${result.stderr}`);
+    assert.match(
+      result.stdout,
+      /(^|\n)\.\/\.continue-here\.md(\n|$)/,
+      `expected legacy ./.continue-here.md in stdout; got: ${JSON.stringify(result.stdout)}`,
     );
   });
 });

--- a/tests/bug-3446-resume-continue-here-discovery.test.cjs
+++ b/tests/bug-3446-resume-continue-here-discovery.test.cjs
@@ -15,21 +15,32 @@ describe('bug #3446: resume-project detects non-phase and legacy continue-here h
     return workflowContent.slice(stepStart, stepEnd);
   }
 
-  test('check_incomplete_work scans .planning-root continue-here fallback', () => {
+  // Bug #3446 originally enforced three text invariants on a chained `ls` of
+  // bare globs. Bug #3689 replaced that chain with two `find` invocations
+  // because the chained ls aborted under zsh's default NOMATCH option,
+  // silently dropping every pattern after the first miss. These tests now
+  // assert that the same three discovery contracts are still satisfied by
+  // the find-based scan.
+
+  test('check_incomplete_work scans .planning-root continue-here fallback (depth 1 under .planning)', () => {
     const block = readCheckBlock();
     assert.match(
       block,
-      /\.planning\/\.continue-here\*\.md/,
-      'resume workflow must scan .planning/.continue-here*.md fallback path written by pause-work'
+      /find \.planning -maxdepth 3 -name '\.continue-here\*\.md'/,
+      'resume workflow must scan .planning/.continue-here*.md fallback path written by pause-work; the find .planning -maxdepth 3 invocation covers it at depth 1'
     );
   });
 
-  test('check_incomplete_work scans sketch subdirectory continue-here checkpoints', () => {
+  test('check_incomplete_work scans sketch subdirectory continue-here checkpoints (depth 3 under .planning)', () => {
     const block = readCheckBlock();
-    assert.match(
-      block,
-      /\.planning\/sketches\/\*\/\.continue-here\*\.md/,
-      'resume workflow must scan .planning/sketches/*/.continue-here*.md for sketch checkpoint handoffs'
+    // .planning/sketches/SKETCH-NNN/.continue-here*.md sits at depth 3 from
+    // the .planning starting point. The find call must use maxdepth >= 3.
+    const findMatch = block.match(/find \.planning -maxdepth (\d+) -name '\.continue-here\*\.md'/);
+    assert.ok(findMatch, 'resume workflow must use find .planning -maxdepth N -name .continue-here*.md');
+    const depth = Number(findMatch[1]);
+    assert.ok(
+      depth >= 3,
+      `resume workflow .planning find must use -maxdepth 3 or greater to reach sketch/spike/deliberation subdirectories; got -maxdepth ${depth}`
     );
   });
 
@@ -37,8 +48,8 @@ describe('bug #3446: resume-project detects non-phase and legacy continue-here h
     const block = readCheckBlock();
     assert.match(
       block,
-      /\s\.continue-here\*\.md/,
-      'resume workflow must scan legacy repo-root .continue-here*.md handoff path'
+      /find \. -maxdepth 1 -name '\.continue-here\*\.md'/,
+      'resume workflow must scan legacy repo-root .continue-here*.md handoff path via a separate find . -maxdepth 1 invocation'
     );
   });
 });

--- a/tests/bug-3689-resume-glob-nomatch.test.cjs
+++ b/tests/bug-3689-resume-glob-nomatch.test.cjs
@@ -37,9 +37,9 @@
 const { describe, test, before, after } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
-const os = require('node:os');
 const path = require('node:path');
 const { spawnSync } = require('node:child_process');
+const { createTempDir, cleanup } = require('./helpers.cjs');
 
 const REPO_ROOT = path.resolve(__dirname, '..');
 const WORKFLOW_PATH = path.join(REPO_ROOT, 'get-shit-done', 'workflows', 'resume-project.md');
@@ -47,17 +47,9 @@ const WORKFLOW_PATH = path.join(REPO_ROOT, 'get-shit-done', 'workflows', 'resume
 // The exact snippet the workflow now embeds. Keep in sync with
 // resume-project.md `check_incomplete_work` step.
 const FIND_SNIPPET = [
-  "find .planning -maxdepth 3 -name '.continue-here*.md' -print 2>/dev/null",
-  "find . -maxdepth 1 -name '.continue-here*.md' -print 2>/dev/null",
+  "find .planning -maxdepth 3 -name '.continue-here*.md' -print 2>/dev/null || true",
+  "find . -maxdepth 1 -name '.continue-here*.md' -print 2>/dev/null || true",
 ].join('\n');
-
-function makeTmpDir() {
-  return fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-bug-3689-'));
-}
-
-function rmTmpDir(dir) {
-  fs.rmSync(dir, { recursive: true, force: true });
-}
 
 function hasShell(name) {
   const result = spawnSync('which', [name], { encoding: 'utf8' });
@@ -68,7 +60,7 @@ describe('bug #3689 — resume-project.md continue-here scan under zsh NOMATCH',
   let tmpDir;
 
   before(() => {
-    tmpDir = makeTmpDir();
+    tmpDir = createTempDir('gsd-bug-3689-');
     // Reproduce the common new-project layout: a `.planning/` with a
     // suffixed continue-here file and *no* spike / sketch / deliberation
     // subdirectories.
@@ -81,7 +73,7 @@ describe('bug #3689 — resume-project.md continue-here scan under zsh NOMATCH',
   });
 
   after(() => {
-    rmTmpDir(tmpDir);
+    cleanup(tmpDir);
   });
 
   test('zsh -o nomatch lists the .planning/.continue-here-* checkpoint', { skip: !hasShell('zsh') }, () => {
@@ -115,12 +107,12 @@ describe('bug #3689 — empty workspace exits cleanly', () => {
   let tmpDir;
 
   before(() => {
-    tmpDir = makeTmpDir();
+    tmpDir = createTempDir('gsd-bug-3689-');
     // No .planning/ at all, no .continue-here files. Pure greenfield.
   });
 
   after(() => {
-    rmTmpDir(tmpDir);
+    cleanup(tmpDir);
   });
 
   test('zsh -o nomatch with no checkpoints exits 0, empty output', { skip: !hasShell('zsh') }, () => {

--- a/tests/bug-3689-resume-glob-nomatch.test.cjs
+++ b/tests/bug-3689-resume-glob-nomatch.test.cjs
@@ -1,0 +1,150 @@
+// allow-test-rule: source-text-is-the-product
+// Workflow `.md` files are the runtime contract executed by Claude Code as
+// embedded bash. Asserting on the staged text of resume-project.md and on the
+// behavior of the embedded snippet under real shells is a behavioral test of
+// the workflow itself, not source-grep theater.
+
+/**
+ * Regression for #3689 — /gsd-resume-work silently drops
+ * `.planning/.continue-here*.md` checkpoints under zsh's default NOMATCH.
+ *
+ * Root cause: the `check_incomplete_work` step in
+ * `get-shit-done/workflows/resume-project.md` used a chained `ls` with six
+ * bare-glob arguments. Under zsh's default `NOMATCH` setopt the first
+ * non-matching glob aborts the entire command during word-expansion — every
+ * pattern after that point is never evaluated, including the one that holds
+ * valid pause checkpoints (`.planning/.continue-here*.md`). `2>/dev/null ||
+ * true` only suppresses ls's own stderr / exit code; it has no effect on the
+ * shell's pre-exec abort.
+ *
+ * Fix: replace the chained `ls` with two `find` calls. `find` does not use
+ * shell glob expansion, and `find <missing-dir> -maxdepth N -name PATTERN
+ * -print 2>/dev/null` tolerates absent directories on both bash and zsh.
+ *
+ * This test covers:
+ *   1. zsh under `-o nomatch`: checkpoint at `.planning/.continue-here-*.md`
+ *      is listed even when `.planning/spikes`, `.planning/sketches`,
+ *      `.planning/deliberations` are absent (the common new-project layout).
+ *   2. bash default: same behavior.
+ *   3. zsh `-o nomatch` with no `.continue-here` files anywhere: exits 0,
+ *      no output, no error.
+ *   4. Text invariant: resume-project.md no longer carries the brittle
+ *      chained-ls pattern.
+ */
+
+'use strict';
+
+const { describe, test, before, after } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const WORKFLOW_PATH = path.join(REPO_ROOT, 'get-shit-done', 'workflows', 'resume-project.md');
+
+// The exact snippet the workflow now embeds. Keep in sync with
+// resume-project.md `check_incomplete_work` step.
+const FIND_SNIPPET = [
+  "find .planning -maxdepth 3 -name '.continue-here*.md' -print 2>/dev/null",
+  "find . -maxdepth 1 -name '.continue-here*.md' -print 2>/dev/null",
+].join('\n');
+
+function makeTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-bug-3689-'));
+}
+
+function rmTmpDir(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function hasShell(name) {
+  const result = spawnSync('which', [name], { encoding: 'utf8' });
+  return result.status === 0 && result.stdout.trim().length > 0;
+}
+
+describe('bug #3689 — resume-project.md continue-here scan under zsh NOMATCH', () => {
+  let tmpDir;
+
+  before(() => {
+    tmpDir = makeTmpDir();
+    // Reproduce the common new-project layout: a `.planning/` with a
+    // suffixed continue-here file and *no* spike / sketch / deliberation
+    // subdirectories.
+    fs.mkdirSync(path.join(tmpDir, '.planning'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', '.continue-here-AT-1234.md'),
+      '---\ncontext: default\n---\nhandoff body\n',
+      'utf8',
+    );
+  });
+
+  after(() => {
+    rmTmpDir(tmpDir);
+  });
+
+  test('zsh -o nomatch lists the .planning/.continue-here-* checkpoint', { skip: !hasShell('zsh') }, () => {
+    const result = spawnSync('zsh', ['-o', 'nomatch', '-c', FIND_SNIPPET], {
+      cwd: tmpDir,
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0, `zsh exited ${result.status}; stderr=${result.stderr}`);
+    assert.match(
+      result.stdout,
+      /\.planning\/\.continue-here-AT-1234\.md/,
+      `expected checkpoint in stdout, got: ${JSON.stringify(result.stdout)}`,
+    );
+  });
+
+  test('bash default lists the .planning/.continue-here-* checkpoint', { skip: !hasShell('bash') }, () => {
+    const result = spawnSync('bash', ['-c', FIND_SNIPPET], {
+      cwd: tmpDir,
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0, `bash exited ${result.status}; stderr=${result.stderr}`);
+    assert.match(
+      result.stdout,
+      /\.planning\/\.continue-here-AT-1234\.md/,
+      `expected checkpoint in stdout, got: ${JSON.stringify(result.stdout)}`,
+    );
+  });
+});
+
+describe('bug #3689 — empty workspace exits cleanly', () => {
+  let tmpDir;
+
+  before(() => {
+    tmpDir = makeTmpDir();
+    // No .planning/ at all, no .continue-here files. Pure greenfield.
+  });
+
+  after(() => {
+    rmTmpDir(tmpDir);
+  });
+
+  test('zsh -o nomatch with no checkpoints exits 0, empty output', { skip: !hasShell('zsh') }, () => {
+    const result = spawnSync('zsh', ['-o', 'nomatch', '-c', FIND_SNIPPET], {
+      cwd: tmpDir,
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0, `zsh exited ${result.status}; stderr=${result.stderr}`);
+    assert.equal(result.stdout.trim(), '', `expected no stdout, got: ${JSON.stringify(result.stdout)}`);
+  });
+});
+
+describe('bug #3689 — workflow text invariant', () => {
+  test('resume-project.md no longer chains bare globs through ls', () => {
+    const body = fs.readFileSync(WORKFLOW_PATH, 'utf8');
+    assert.doesNotMatch(
+      body,
+      /ls\s+\.planning\/spikes\/\*\/\.continue-here/,
+      'resume-project.md still contains the chained `ls .planning/spikes/*/.continue-here*.md` pattern that aborts under zsh NOMATCH; the find-based scan should replace it.',
+    );
+    assert.match(
+      body,
+      /find \.planning -maxdepth 3 -name '\.continue-here\*\.md'/,
+      'resume-project.md must use the find-based scan introduced by the #3689 fix.',
+    );
+  });
+});


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #3689

> The linked issue must have the `confirmed-bug` label. If it doesn't, ask a maintainer to confirm the bug before continuing.

---

## What was broken

`/gsd-resume-work` silently dropped `.planning/.continue-here*.md` checkpoints under zsh's default `NOMATCH` setopt, so the agent resumed with stale state and lost the prior pause context.

## What this fix does

Replaces the six-pattern chained `ls` in `check_incomplete_work` with two `find` invocations. `find` doesn't use shell glob expansion and tolerates absent directories on both bash and zsh, so every `.continue-here*.md` is surfaced regardless of which sibling subdirectories exist.

## Root cause

In `get-shit-done/workflows/resume-project.md`'s `check_incomplete_work` step, the scan chained six bare-glob `ls` arguments. Under zsh's default `NOMATCH`, the first non-matching glob aborts the entire command during word-expansion — before `ls` runs — silently dropping every later pattern, including `.planning/.continue-here*.md` (which holds the canonical pause checkpoint for default-context handoffs). `2>/dev/null || true` only suppresses `ls`'s own stderr / exit code; it has no effect on the shell's pre-exec glob-abort.

## Testing

### How I verified the fix

Added `tests/bug-3689-resume-glob-nomatch.test.cjs` with three suites that exercise the new snippet under both shells and assert the workflow source no longer carries the brittle pattern. All 4 tests pass locally. Full `npm test` run shows only one pre-existing unrelated failure (`shell-command-projection-dispatch.test.cjs`: exitCode 127 vs 1 for ENOENT — fails identically on `main` without this branch's changes).

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resume workflow reliably detects checkpoint files even when shell wildcards don't match; missing directories no longer abort the search.
  * Replaced brittle glob-based detection with a more tolerant search approach that continues when expected patterns are absent.

* **Tests**
  * Added and revised regression tests to verify checkpoint discovery across shells and in empty or varied workspace layouts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3693?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->