### PR TITLE
ci: drop Node 26 from test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,17 +40,13 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
-    # Node 26 lanes report forward-compat status without gating the workflow
-    # (setup-node may not yet have stable Node 26 images). 22/24 still gate.
-    continue-on-error: ${{ matrix.node-version == 26 }}
-
     strategy:
       # fail-fast disabled so a single lane failure doesn't cancel the rest;
       # makes OS-specific vs version-specific regressions easier to distinguish.
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [22, 24, 26]
+        node-version: [22, 24]
         # Windows path/separator coverage is also reinforced by hardcoded-paths.test.cjs
         # and windows-robustness.test.cjs (static analysis).
         # A dedicated windows-compat workflow runs on a weekly schedule.


### PR DESCRIPTION
> **Template note**: This is a CI/CD-only change (no user-facing behavior). The default template explicitly permits dropping the typed template for CI/tooling changes. This PR corresponds to the chore issue #3694.

Closes #3694

## Summary

- Remove `node-version: 26` from the `test` job strategy matrix in `.github/workflows/test.yml`
- Remove the `continue-on-error: ${{ matrix.node-version == 26 }}` guard and its two-line explanatory comment block that existed solely to prevent Node 26 failures from blocking the workflow
- Node 22 and Node 24 lanes are preserved unchanged across all three OS runners (ubuntu-latest, macos-latest, windows-latest)

**Why**: Node 26 lanes have been causing recurring instability and CI churn. The `continue-on-error` guard was added specifically because Node 26 setups were flaky. Removing the lane entirely until Node 26 stabilises stops the noise without removing any gates that protect real supported runtimes.

## Files changed

- `.github/workflows/test.yml` — 5 lines removed (node-version: 26 from matrix; continue-on-error guard and 2 comment lines)

## Verification

- `node --test tests/workflow-shell-pinning.test.cjs` — 3/3 pass
- `python3 -c "import yaml; yaml.safe_load(...)"` YAML sanity check — valid
- `node scripts/run-tests.cjs` — ran; 122 failures all pre-existing (config keys, SDK bridge, milestone parsing); zero failures introduced by this edit

## Preserved

- `node-version: [22, 24]` still runs on all three OS lanes
- All other workflow jobs (lint-tests, etc.) are unchanged

## No changelog entry needed

This change has no user-facing impact — `no-changelog` label appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated testing workflow to focus on Node.js versions 22 and 24 across all supported platforms, adjusting the test matrix scope.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3695?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->