### PR TITLE
fix(ci): pr-template-policy.cjs minimatch crash blocks all PR template-format checks

### DIFF
--- a/scripts/pr-template-policy.cjs
+++ b/scripts/pr-template-policy.cjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const { minimatch } = require('minimatch');
+const { matchesGlob } = require('path');
 
 const TRUSTED_AUTHOR_ASSOCIATIONS = new Set([
   'CONTRIBUTOR',
@@ -145,7 +145,7 @@ function matchingTemplate(body) {
 function allPathsAreTooling(changedFiles, allowlist) {
   if (!Array.isArray(changedFiles) || changedFiles.length === 0) return false;
   return changedFiles.every((file) =>
-    allowlist.some((pattern) => minimatch(file, pattern, { matchBase: false, dot: true })),
+    allowlist.some((pattern) => matchesGlob(file, pattern)),
   );
 }
 


### PR DESCRIPTION
## Fix PR

> Using the typed fix template.

---

## Linked Issue

Closes #3700

> The linked issue has the `bug` + `needs-triage` labels (auto-applied via `.github/ISSUE_TEMPLATE/bug_report.yml`). Maintainer should add `confirmed-bug` before merging if that gate is enforced; the bug is trivially reproducible (every open PR's `Pull request template format` check is red with `Cannot find module 'minimatch'`).

---

## What was broken

`scripts/pr-template-policy.cjs:3` does `const { minimatch } = require('minimatch');`, but `minimatch` is not in `package.json` (neither `dependencies` nor `devDependencies`). The `.github/workflows/pr-template-format.yml` workflow checks out main and runs the script directly with no `npm ci` / `npm install` step, so every PR's `Pull request template format` check crashes with `MODULE_NOT_FOUND`.

Because the workflow uses `pull_request_target` + `actions/checkout` without `ref:`, it always runs **main's** code — so even PRs that don't touch the policy script fail this check until main is fixed.

## What this fix does

Replaces `const { minimatch } = require('minimatch')` with `const { matchesGlob } = require('path')` (Node built-in, stable since Node 22; project's `engines.node` is `>=22.0.0`), and rewrites the one call site `minimatch(file, pattern, { matchBase: false, dot: true })` as `matchesGlob(file, pattern)`. The function's public API (`allPathsAreTooling(changedFiles, allowlist)`) is unchanged. Two-line diff. No new dependency. No workflow change.

## Root cause

Commit `e50ad812 — fix(3696): pr-template enforcer recognises CI/tooling carve-out (#3697)` added a `require('minimatch')` to `scripts/pr-template-policy.cjs` without adding `minimatch` to `package.json`, and without adding an install step to `.github/workflows/pr-template-format.yml`. The PR's checks passed at the time because, with `pull_request_target` + plain checkout, the workflow on the introducing PR ran the **base branch's** (still-working) script — the breakage only surfaced on subsequent PRs once #3697 merged to main.

### Fix choice and reason

Two valid options:

- **(A) Add `minimatch` to `dependencies` + add `- run: npm ci` to the workflow.** Heavier — adds a transitive tree and an install step on every PR.
- **(B) Use Node's built-in `path.matchesGlob`.** No new dep, no workflow change.

Picked **(B)**. The single `minimatch` call uses only simple glob patterns (`**`, `*`, `*.md`, `requirements*.txt`) — no extglobs, no brace-expansion-with-alternation, no negation. Node 22's `path.matchesGlob` covers every required case (including dot-files like `.github/**`, which is why the original passed `dot: true`). Verified against every pattern in `TOOLING_PATH_ALLOWLIST`.

## Testing

### How I verified the fix

- Ran the full existing suite: `node --test tests/pr-template-policy.test.cjs` → **25/25 pass**, covering the tooling carve-out paths (`.github/workflows/*`, `docs/`, `package.json`/`package-lock.json`), exempt-marker handling, default-template rejection, and all three typed templates (fix/enhancement/feature).
- Direct script invocation reproducing the workflow's env:
  - `CHANGED_FILES=".github/workflows/install-smoke.yml" PR_BODY="" AUTHOR_ASSOCIATION="MEMBER" node scripts/pr-template-policy.cjs` → `{"valid":true,"action":"pass","skipped":"tooling-paths"}` (the carve-out PR #3697 was meant to add — still works)
  - Mixed (tooling + source) changed-files → carve-out correctly does NOT trigger, falls through to template enforcement.
  - Full docker test harness: `gsd-test-summary` on randomized host `plex2` → **11830 passed, 0 failed**.

### Regression test added?

- [ ] Yes — added a test that would have caught this bug
- [x] No — explain why: the existing `tests/pr-template-policy.test.cjs` covers the function behavior thoroughly; the bug is a missing-dep / runtime-load failure that any direct `require` of the script catches. All 25 tests already exercise `allPathsAreTooling` against every allowlist pattern, so they would catch any regression in the glob-matching swap. A separate test for "the file loads" would be duplicate coverage — the existing tests load the module on every run.

### Platforms tested

- [x] macOS (local node 26 + docker harness)
- [ ] Windows (including backslash path handling)
- [x] Linux (docker harness)
- [ ] N/A (not platform-specific)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [x] N/A (not runtime-specific — repo CI policy script)

---

## Checklist

- [x] Issue linked above with `Closes #3700` — PR will be auto-closed if missing
- [ ] Linked issue has the `confirmed-bug` label — pending maintainer triage (auto-labels are `bug` + `needs-triage`)
- [x] Fix is scoped to the reported bug — no unrelated changes included (2-line diff)
- [x] Regression test added (or explained why not) — see Testing section
- [x] All existing tests pass (`npm test` equivalent: `node --test tests/pr-template-policy.test.cjs` 25/25; full docker harness 11830/0)
- [x] `.changeset/` fragment added if this is a user-facing fix — N/A, this is an internal CI policy script with no user-facing surface
- [x] No unnecessary dependencies added (the fix removes a missing dependency rather than adding one)

## Breaking changes

None. The function signature and observable behavior of `allPathsAreTooling`, `evaluatePrTemplate`, and every exported helper are identical. The only difference is the engine doing the glob match.

---

### Important caveat for the reviewer

**This PR's own `Pull request template format` check will fail** for the exact same reason every other open PR is currently failing — because `pull_request_target` runs main's (still-broken) script regardless of what's on the PR branch. The PR itself is correct; the check needs to be bypassed once for this PR to merge, after which the check will run from this fixed code on main and every subsequent PR will pass cleanly. After merge, please re-run the failing checks on the other open PRs (or push an empty commit) and they'll go green without any further changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal development script to use native Node.js utilities for file matching, improving consistency with platform-standard tooling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3701?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->