### PR TITLE
fix(ci): unblock main — coverage heap budget + Windows npm timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -219,6 +219,8 @@ jobs:
         run: npm run build:sdk
       - name: Unit coverage
         shell: bash
+        env:
+          NODE_OPTIONS: --max-old-space-size=6144
         run: npm run test:coverage:unit
       - name: Upload coverage artifact
         if: always()

--- a/tests/helpers.cjs
+++ b/tests/helpers.cjs
@@ -250,7 +250,7 @@ function runNpm(args, options = {}) {
   const defaults = {
     encoding: 'utf-8',
     shell: isWindows,
-    timeout: 55000,
+    timeout: 180000,
   };
   return execFileSync(npmCmd, args, { ...defaults, ...options }).trim();
 }


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Closes #3703

---

## What was broken

The `Unit coverage` CI job terminates with `FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory` on Linux Node 24 because no `NODE_OPTIONS` is set and the default v8 heap cap (~4 GB) is exhausted by the c8 report phase.

The `install-smoke` Windows matrix job fails with `ETIMEDOUT` at 58 s because `runNpm` has a hard-coded 55 000 ms default timeout — shorter than the 60–90 s a cold-cache `npm install -g <tarball>` takes on `windows-latest` (NTFS + Defender overhead). The 58 s ETIMEDOUT = 55 s timeout + ~3 s cmd.exe teardown — an arithmetic match.

## What this fix does

`.github/workflows/test.yml:220-222`: Adds `env: NODE_OPTIONS: --max-old-space-size=6144` to the `Unit coverage` step, raising the available heap from ~4 GB to 6 GB.

`tests/helpers.cjs:253`: Changes the `runNpm` default `timeout` from 55 000 → 180 000 ms, giving Windows cold-cache installs room to complete within the per-job cap.

## Root cause

**OOM:** No `NODE_OPTIONS` was set on the coverage step, so Node used the default v8 heap limit (~4 GB). On Linux Node 24, the c8 source-map processing during report generation has grown enough to exceed that cap. The runner has 7 GB available — the budget was simply never claimed.

**Windows ETIMEDOUT:** `runNpm` was written when the timeout only needed to cover fast operations. When the Windows install-smoke test was added in #3686, it reused the same helper with the 55 s default, which is shorter than a cold-cache `npm install -g <tarball>` on `windows-latest`. NTFS metadata overhead and Windows Defender real-time scanning add ~30–40 s over an equivalent Linux run. The 55 s limit is not a job-level timeout — it is a `spawnSync` / child-process wall-clock limit that fires before the install completes.

## Fix choice and reason

**6 GB heap (not 7 GB):** The `ubuntu-latest` runner provides 7 GB. Setting 6144 MB leaves ~1 GB for the Node process overhead and OS, so we never risk the runner itself OOMing. If c8 continues to grow, there is still headroom before the next budget bump is needed.

**180 000 ms timeout (3 min, not 15 min):** The `windows-latest` job cap is 15 min. 3 min is 5× the observed worst-case runtime (≈60–90 s), which absorbs transient Defender delays without burning the full job budget on a hung process.

## Testing

### How I verified the fix

Full docker harness via `gsd-test-summary` on host `plex2` → **11858 passed, 0 failed**. Both edits verified via `git diff`. `node --check tests/helpers.cjs` passes. The definitive verification is the next main CI run on GitHub Actions.

### Regression test added?

- [x] No — explain why: These are CI environment-knob fixes (heap budget, child-process timeout), not code paths exercisable in unit tests. A regression test would require simulating runner heap budget exhaustion or Windows Defender latency — which is exactly what real CI does. There is no code-level seam to inject.

### Platforms tested

- [x] macOS (local docker harness running Linux containers)
- [ ] Windows — cannot test locally; verification comes from the next main CI run
- [x] Linux (via docker harness)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Closes #3703` — **PR will be auto-closed if missing**
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment: not needed — pure CI/infrastructure with no user-facing impact (`no-changelog` label applied below)

<!-- docs-exempt: CI infra knob change, no user surface -->

## Breaking changes

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased Node.js memory allocation for unit test coverage to improve test reliability.
  * Extended timeout duration for npm command execution during test runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gsd-build/get-shit-done/pull/3704?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->