### PR TITLE
chore(ci): bump actions/upload-artifact v4.6.2 → v7.0.1 (#3715)

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -214,7 +214,7 @@ jobs:
 
       - name: Upload lifecycle smoke result on failure
         if: steps.skip.outputs.skip != 'true' && failure() && steps.lifecycle-smoke.outcome == 'failure'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-smoke-${{ matrix.os }}-node${{ matrix.node-version }}
           path: /tmp/release-smoke.json

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -231,7 +231,7 @@ jobs:
         run: npm run test:coverage:unit
       - name: Upload coverage artifact
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: coverage-unit
           path: |


### PR DESCRIPTION
## Chore PR

> No template for chore PRs. Using freeform body.

---

## Linked Issue

Closes #3715

---

## What changed

Two files, one line each:

| File | Old SHA / tag | New SHA / tag |
|---|---|---|
| `.github/workflows/test.yml` | `ea165f8d65b6e75b540449e92b4886f43607fa02` / `# v4.6.2` | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` / `# v7.0.1` |
| `.github/workflows/install-smoke.yml` | `ea165f8d65b6e75b540449e92b4886f43607fa02` / `# v4` | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` / `# v7.0.1` |

## Why

`actions/upload-artifact` v4.x ships a Node 20 runner. GitHub Actions is deprecating Node 20 on runners starting **2026-09-16**. v7.0.1 ships Node 24 and is the current stable release.

## Breaking-change audit (v5 / v6 / v7)

- **v5**: introduced `include-hidden-files` option (default `false`). Neither step uses this option; no change in behavior.
- **v6**: no breaking changes to the upload API surface.
- **v7**: no breaking changes to the upload API surface. Node 20 → Node 24 runtime upgrade.
- Artifact names (`coverage-unit`, `release-smoke-<matrix>`) are unique per workflow run — no name-collision concerns introduced by v5's uniqueness enforcement.

## Verification

SHA `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` verified against the [actions/upload-artifact v7.0.1 release tag](https://github.com/actions/upload-artifact/releases/tag/v7.0.1).

## no-changelog rationale

CI infrastructure change; no user-visible behavior affected. `no-changelog` label applied on the linked issue.
