### PR TITLE
fix(3687): rewrite stale insert-phase command refs to /gsd:phase --insert

### DIFF
--- a/agents/gsd-roadmapper.md
+++ b/agents/gsd-roadmapper.md
@@ -202,7 +202,7 @@ Track coverage as you go.
 **Integer phases (1, 2, 3):** Planned milestone work.
 
 **Decimal phases (2.1, 2.2):** Urgent insertions after planning.
-- Created via `/gsd:phase insert`
+- Created via `/gsd:phase --insert`
 - Execute between integers: 1 → 1.1 → 1.2 → 2
 
 **Starting number:**

--- a/get-shit-done/workflows/insert-phase.md
+++ b/get-shit-done/workflows/insert-phase.md
@@ -13,7 +13,7 @@ Parse the command arguments:
 - First argument: integer phase number to insert after
 - Remaining arguments: phase description
 
-Example: `/gsd-insert-phase 72 Fix critical auth bug`
+Example: `/gsd:phase --insert 72 Fix critical auth bug`
 -> after = 72
 -> description = "Fix critical auth bug"
 
@@ -21,8 +21,8 @@ If arguments missing:
 
 ```
 ERROR: Both phase number and description required
-Usage: /gsd-insert-phase <after> <description>
-Example: /gsd-insert-phase 72 Fix critical auth bug
+Usage: /gsd:phase --insert <after> <description>
+Example: /gsd:phase --insert 72 Fix critical auth bug
 ```
 
 Exit.

--- a/tests/bug-3687-stale-insert-phase-refs.test.cjs
+++ b/tests/bug-3687-stale-insert-phase-refs.test.cjs
@@ -1,0 +1,112 @@
+/**
+ * Bug #3687: gsd-phase accepts only --insert, but stale docs/agents still suggest insert forms
+ *
+ * Two stale-text patterns remained in current main even after the broader
+ * #2950 cleanup:
+ *
+ *   1. `get-shit-done/workflows/insert-phase.md` still showed
+ *      `/gsd-insert-phase <after> <description>` examples — a command that
+ *      no longer exists (consolidated into `/gsd:phase --insert` by #2790).
+ *
+ *   2. `agents/gsd-roadmapper.md` said decimal phases are
+ *      "Created via `/gsd:phase insert`" — the bare `insert` token form,
+ *      which `commands/gsd/phase.md` does NOT route on. Only the leading
+ *      `--insert` flag is honored, so this doc form silently falls through
+ *      to the add-phase route and creates a wrong roadmap phase.
+ *
+ * Fix: rewrite both files to use the canonical `/gsd:phase --insert` form
+ * and lock in coverage so the strings can't drift back.
+ *
+ * docs/FEATURES.md:2644 is intentionally excluded — REQ-CONSOLIDATE-03
+ * documents the deleted command names as part of the deprecation contract.
+ */
+
+'use strict';
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const REPO_ROOT = path.join(__dirname, '..');
+
+function read(relPath) {
+  return fs.readFileSync(path.join(REPO_ROOT, relPath), 'utf-8');
+}
+
+function* walkMarkdown(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkMarkdown(full);
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      yield full;
+    }
+  }
+}
+
+describe('bug #3687: stale insert-phase command forms in docs/agents', () => {
+  test('workflows/insert-phase.md uses /gsd:phase --insert, not /gsd-insert-phase', () => {
+    const body = read('get-shit-done/workflows/insert-phase.md');
+    assert.ok(
+      !/\/gsd-insert-phase\b/.test(body),
+      'insert-phase.md still references the retired /gsd-insert-phase command',
+    );
+    assert.ok(
+      /\/gsd:phase --insert\b/.test(body),
+      'insert-phase.md should document the canonical /gsd:phase --insert form',
+    );
+  });
+
+  test('agents/gsd-roadmapper.md uses /gsd:phase --insert, not bare "/gsd:phase insert"', () => {
+    const body = read('agents/gsd-roadmapper.md');
+    assert.ok(
+      !/\/gsd:phase insert\b/.test(body),
+      'gsd-roadmapper.md uses the bare "insert" token form, which commands/gsd/phase.md does not route on',
+    );
+    assert.ok(
+      /\/gsd:phase --insert\b/.test(body),
+      'gsd-roadmapper.md should document the canonical /gsd:phase --insert form',
+    );
+  });
+
+  test('no workflow or agent markdown emits the retired /gsd-insert-phase command', () => {
+    const offenders = [];
+    for (const dir of [
+      path.join(REPO_ROOT, 'get-shit-done', 'workflows'),
+      path.join(REPO_ROOT, 'agents'),
+    ]) {
+      for (const file of walkMarkdown(dir)) {
+        const body = fs.readFileSync(file, 'utf-8');
+        if (/\/gsd-insert-phase\b/.test(body)) {
+          offenders.push(path.relative(REPO_ROOT, file));
+        }
+      }
+    }
+    assert.deepEqual(
+      offenders,
+      [],
+      `Files still emit retired /gsd-insert-phase: ${offenders.join(', ')}`,
+    );
+  });
+
+  test('no workflow or agent markdown emits bare "/gsd:phase insert" (the unrouted form)', () => {
+    const offenders = [];
+    for (const dir of [
+      path.join(REPO_ROOT, 'get-shit-done', 'workflows'),
+      path.join(REPO_ROOT, 'agents'),
+    ]) {
+      for (const file of walkMarkdown(dir)) {
+        const body = fs.readFileSync(file, 'utf-8');
+        if (/\/gsd:phase insert\b/.test(body)) {
+          offenders.push(path.relative(REPO_ROOT, file));
+        }
+      }
+    }
+    assert.deepEqual(
+      offenders,
+      [],
+      `Files still emit unrouted /gsd:phase insert form: ${offenders.join(', ')}`,
+    );
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3687

The linked issue carries the \`bug, confirmed\` label.

## What was broken

Two stale-text patterns survived the broader #2950 / #3605 cleanup passes:

1. \`get-shit-done/workflows/insert-phase.md\` still documented the retired \`/gsd-insert-phase\` command (consolidated into \`/gsd:phase --insert\` by #2790) in three example/usage lines.
2. \`agents/gsd-roadmapper.md\` said decimal phases are \"Created via \`/gsd:phase insert\`\" — the **bare-token** form. \`commands/gsd/phase.md\` only routes on the leading \`--insert\` flag, so this form silently falls through to the add-phase route and creates a wrong roadmap phase (per the reporter's repro: an integer phase titled \"insert 1 Fix Critical Bug\" instead of decimal phase 01.1).

## What this fix does

Rewrites both occurrences to the canonical \`/gsd:phase --insert\` form and adds a regression test that scans \`get-shit-done/workflows/\` and \`agents/\` for either stale form.

## Root cause

#2790 consolidated \`/gsd-insert-phase\` into \`/gsd:phase --insert\`, and #2950 / #3605 swept the most-trafficked docs, but two surfaces (\`workflows/insert-phase.md\`, \`agents/gsd-roadmapper.md\`) were missed.

## Testing

### How I verified the fix

- Added regression test first at \`tests/bug-3687-stale-insert-phase-refs.test.cjs\` and confirmed it **failed** against pre-fix \`main\` (\`agents/gsd-roadmapper.md\` flagged for the bare \`/gsd:phase insert\` form).
- Applied the doc fixes; re-ran \`node --test tests/bug-3687-stale-insert-phase-refs.test.cjs\` — all 4 tests pass.
- Verified \`docs/FEATURES.md:2644\` is the only remaining occurrence of \`/gsd-insert-phase\` repo-wide and is intentional (REQ-CONSOLIDATE-03 deprecation contract).

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No

The test extends the coverage pattern of \`tests/bug-2950-stale-command-refs.test.cjs\` to walk \`get-shit-done/workflows/\` and \`agents/\` for both \`/gsd-insert-phase\` and \`/gsd:phase insert\` (bare-token) forms.

### Platforms tested

- [x] macOS
- [ ] Windows
- [ ] Linux
- [x] N/A (markdown-only change; test uses only Node built-ins — \`node:test\`, \`node:assert\`, \`node:fs\`, \`node:path\`)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other
- [x] N/A (not runtime-specific — these are source docs/agents, runtime-namespace transforms already in place handle the rest)

---

## Checklist

- [x] Issue linked above with \`Fixes #3687\`
- [x] Linked issue has the \`confirmed\` label (\`bug, confirmed\`)
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (only ran the new test locally — Netskope corporate proxy blocks \`npm install\`; the new test depends only on Node built-ins, so it is independent of \`node_modules\`)
- [ ] \`.changeset/\` fragment added — **requesting \`no-changelog\` label**: this is a pure stale-doc cleanup with zero behavior change in shipped runtime
- [x] No unnecessary dependencies added

## Breaking changes

None. Source-doc text correction only.

## Notes for reviewer

- \`docs/FEATURES.md:2644\` intentionally retained — REQ-CONSOLIDATE-03 documents the deleted command names as part of the deprecation contract, so removing them would weaken that contract.
- The reporter also suggested optional fail-fast routing in \`commands/gsd/phase.md\` for unrouted bare \`insert\` tokens. That's a separate change scope and could land in a follow-up PR if desired.