### PR TITLE
fix(3687): update insert-phase docs and roadmapper to use --insert flag

### DIFF
--- a/agents/gsd-roadmapper.md
+++ b/agents/gsd-roadmapper.md
@@ -202,7 +202,7 @@ Track coverage as you go.
 **Integer phases (1, 2, 3):** Planned milestone work.
 
 **Decimal phases (2.1, 2.2):** Urgent insertions after planning.
-- Created via `/gsd:phase insert`
+- Created via `/gsd:phase --insert`
 - Execute between integers: 1 → 1.1 → 1.2 → 2
 
 **Starting number:**

--- a/get-shit-done/workflows/insert-phase.md
+++ b/get-shit-done/workflows/insert-phase.md
@@ -13,7 +13,7 @@ Parse the command arguments:
 - First argument: integer phase number to insert after
 - Remaining arguments: phase description
 
-Example: `/gsd-insert-phase 72 Fix critical auth bug`
+Example: `/gsd:phase --insert 72 Fix critical auth bug`
 -> after = 72
 -> description = "Fix critical auth bug"
 
@@ -21,8 +21,8 @@ If arguments missing:
 
 ```
 ERROR: Both phase number and description required
-Usage: /gsd-insert-phase <after> <description>
-Example: /gsd-insert-phase 72 Fix critical auth bug
+Usage: /gsd:phase --insert <after> <description>
+Example: /gsd:phase --insert 72 Fix critical auth bug
 ```
 
 Exit.


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3687

---

## What was broken

The `get-shit-done/workflows/insert-phase.md` and `agents/gsd-roadmapper.md` files still referenced retired command syntax (`/gsd-insert-phase` and `/gsd:phase insert`) after the phase command was consolidated into `/gsd:phase --insert`.

## What this fix does

Updates all stale command references to use `/gsd:phase --insert`, matching the actual command router at `commands/gsd/phase.md`.

## Root cause

When `/gsd-insert-phase` was retired per REQ-CONSOLIDATE-03 (#2790), the workflow documentation and agent instructions were not updated. The command router correctly requires `--insert` but the docs still showed the old forms.

## Testing

### How I verified the fix

- Checked `commands/gsd/phase.md` to confirm `--insert` is the correct flag
- Verified all updated references match the command router's routing table
- No code changes — documentation-only fix

### Regression test added?

- [ ] No — explain why: Documentation-only change. No runtime behavior affected.

### Platforms tested

- [x] N/A (not platform-specific)

### Runtimes tested

- [x] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #3687`
- [x] Linked issue has the `confirmed` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [ ] All existing tests pass (`npm test`)
- [ ] `.changeset/` fragment added if this is a user-facing fix — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Breaking changes

None