### PR TITLE
fix(3687): rewrite stale insert-phase command refs to /gsd:phase --insert

### DIFF
--- a/agents/gsd-roadmapper.md
+++ b/agents/gsd-roadmapper.md
@@ -202,7 +202,7 @@ Track coverage as you go.
 **Integer phases (1, 2, 3):** Planned milestone work.
 
 **Decimal phases (2.1, 2.2):** Urgent insertions after planning.
-- Created via `/gsd:phase insert`
+- Created via `/gsd:phase --insert`
 - Execute between integers: 1 → 1.1 → 1.2 → 2
 
 **Starting number:**

--- a/get-shit-done/workflows/insert-phase.md
+++ b/get-shit-done/workflows/insert-phase.md
@@ -13,7 +13,7 @@ Parse the command arguments:
 - First argument: integer phase number to insert after
 - Remaining arguments: phase description
 
-Example: `/gsd-insert-phase 72 Fix critical auth bug`
+Example: `/gsd:phase --insert 72 Fix critical auth bug`
 -> after = 72
 -> description = "Fix critical auth bug"
 
@@ -21,8 +21,8 @@ If arguments missing:
 
 ```
 ERROR: Both phase number and description required
-Usage: /gsd-insert-phase <after> <description>
-Example: /gsd-insert-phase 72 Fix critical auth bug
+Usage: /gsd:phase --insert <after> <description>
+Example: /gsd:phase --insert 72 Fix critical auth bug
 ```
 
 Exit.

--- a/tests/docs-phase-router-invariants.test.cjs
+++ b/tests/docs-phase-router-invariants.test.cjs
@@ -1,0 +1,118 @@
+/**
+ * Phase router invariants for source docs.
+ *
+ * `commands/gsd/phase.md` routes on a leading flag (`--insert`, `--remove`,
+ * `--edit`) and falls through a catch-all default that passes `$ARGUMENTS`
+ * straight to add-phase as a description. Any first token that is not a
+ * `--flag` is therefore silently treated as a new-phase title.
+ *
+ * That catch-all turns **bare-token forms** in docs — e.g.
+ * `/gsd:phase insert 1 Fix Critical Bug` — into roadmap corruption: the
+ * router creates an integer phase titled with the literal verb instead of
+ * the intended decimal insertion / removal / edit. Originating bug: #3687
+ * (`agents/gsd-roadmapper.md` documented decimal phases as "Created via
+ * `/gsd:phase insert`", which agents reading their own prompts would emit
+ * verbatim).
+ *
+ * This file enforces a structural invariant: in `agents/`, `commands/gsd/`,
+ * and `get-shit-done/workflows/`, every `/gsd:phase ` or `/gsd-phase `
+ * reference that has a following token must be followed by either
+ *
+ *   - a `--flag` (which the router branches on), or
+ *   - a description-shaped token (`"`, `'`, backtick, `<`, `[`, an uppercase
+ *     letter, or a digit).
+ *
+ * Bare lowercase identifiers fail the test regardless of whether the
+ * specific verb (`insert`, `remove`, `edit`, etc.) was on a known-bad list
+ * — the check is by shape, not by string.
+ *
+ * `docs/FEATURES.md` is excluded by virtue of not being under the scanned
+ * directories; the deprecation contract there names retired commands
+ * intentionally.
+ */
+
+'use strict';
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const REPO_ROOT = path.join(__dirname, '..');
+
+const SCAN_DIRS = [
+  path.join(REPO_ROOT, 'agents'),
+  path.join(REPO_ROOT, 'commands', 'gsd'),
+  path.join(REPO_ROOT, 'get-shit-done', 'workflows'),
+];
+
+function* walkMarkdown(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkMarkdown(full);
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      yield full;
+    }
+  }
+}
+
+function scanAll() {
+  const files = [];
+  for (const dir of SCAN_DIRS) {
+    if (!fs.existsSync(dir)) continue;
+    for (const f of walkMarkdown(dir)) files.push(f);
+  }
+  return files;
+}
+
+function rel(p) {
+  return path.relative(REPO_ROOT, p);
+}
+
+describe('docs/phase-router invariants', () => {
+  test('no doc emits a bare-token form after /gsd:phase or /gsd-phase', () => {
+    // Match `/gsd:phase` or `/gsd-phase` followed by whitespace and a
+    // lowercase identifier as the first non-whitespace token. Such a
+    // token does not start with `--`, so commands/gsd/phase.md's first-
+    // token check falls through to the add-phase default.
+    //
+    // Allowed forms (NOT matched by this regex):
+    //   - /gsd:phase --insert ...        → starts with `--`
+    //   - /gsd:phase "Add admin dashboard" → starts with `"`
+    //   - /gsd:phase `description`       → starts with backtick
+    //   - /gsd:phase <description>       → starts with `<`
+    //   - /gsd:phase Add admin dashboard → starts with uppercase letter
+    //   - /gsd:phase 1.2 placeholder     → starts with digit
+    //   - /gsd:phase                     → no following token on the line
+    const pattern = /\/gsd[:-]phase\s+([a-z][a-z0-9-]*)\b/g;
+
+    const offenders = [];
+    for (const file of scanAll()) {
+      const body = fs.readFileSync(file, 'utf-8');
+      for (const m of body.matchAll(pattern)) {
+        offenders.push({
+          file: rel(file),
+          token: m[1],
+          context: m[0],
+        });
+      }
+    }
+
+    assert.deepEqual(
+      offenders,
+      [],
+      [
+        'Bare-token forms after /gsd:phase appear in scanned docs.',
+        'commands/gsd/phase.md only routes on leading --flags; any other',
+        'first token silently falls through to add-phase and creates a',
+        'wrong roadmap entry. Use --insert / --remove / --edit, or wrap',
+        'descriptions in quotes / backticks / angle brackets / a leading',
+        'uppercase letter.',
+        '',
+        'Offending forms:',
+        ...offenders.map((o) => `  - ${o.file}: "${o.context}" → bare verb "${o.token}"`),
+      ].join('\n'),
+    );
+  });
+});


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3687

The linked issue carries the `bug, confirmed` label.

## What was broken

Two stale-text patterns survived the broader #2950 / #3605 cleanup passes:

1. `get-shit-done/workflows/insert-phase.md` still documented the retired `/gsd-insert-phase` command (consolidated into `/gsd:phase --insert` by #2790) in three example/usage lines.
2. `agents/gsd-roadmapper.md` said decimal phases are "Created via `` `/gsd:phase insert` ``" — the **bare-token** form. `commands/gsd/phase.md` only routes on the leading `--insert` flag, so this form silently falls through to the add-phase route and creates a wrong roadmap phase (per the reporter's repro: an integer phase titled "insert 1 Fix Critical Bug" instead of decimal phase 01.1).

## What this fix does

- Rewrites both occurrences to the canonical `/gsd:phase --insert` form.
- Adds a **structural invariant test** at `tests/docs-phase-router-invariants.test.cjs` that asserts no `/gsd:phase` or `/gsd-phase` reference in `agents/`, `commands/gsd/`, or `get-shit-done/workflows/` is followed by a bare lowercase identifier — i.e., the next token must start with `--` (flag), `"` / `'` / `` ` `` (quoted description), `<` / `[` (placeholder), an uppercase letter (prose description), or a digit. The check is **by shape, not by string**, so future stale verbs (`rename`, `decimal`, `bump`, `migrate`, …) trip it automatically without anyone updating an allowlist.

## Root cause

#2790 consolidated `/gsd-insert-phase` into `/gsd:phase --insert`, and #2950 / #3605 swept the most-trafficked docs, but two surfaces (`workflows/insert-phase.md`, `agents/gsd-roadmapper.md`) were missed. The deeper issue is that `commands/gsd/phase.md`'s router has a catch-all default ("if first token is not `--insert` / `--remove` / `--edit`, treat all of `$ARGUMENTS` as an add-phase description") that turns *any* prose-level mistake into a silent roadmap corruption. The invariant test pins that contract so future mistakes can't reach the router unchallenged.

## Testing

### How I verified the fix

- Wrote the structural invariant test first at `tests/docs-phase-router-invariants.test.cjs`.
- Verified it **fails** against pre-fix state via `git restore --source HEAD~1 agents/gsd-roadmapper.md` — the failure message names the exact file (`agents/gsd-roadmapper.md`), the exact problematic token (`insert`), and the exact match context (`/gsd:phase insert`).
- Applied the doc fixes; re-ran the test — passes cleanly with zero offenders across all three scanned directories.
- Verified `docs/FEATURES.md:2644` is the only remaining occurrence of `/gsd-insert-phase` repo-wide and is intentional (REQ-CONSOLIDATE-03 deprecation contract).

### Regression test added?

- [x] Yes — added a test that catches the entire bug class (any `/gsd:phase <bare-verb>` form), not just the two literal strings #3687 named.
- [ ] No

The test deliberately uses shape-matching rather than string-matching so it has ongoing value: any future PR that introduces `/gsd:phase rename 3 ...`, `/gsd-phase bump 5`, `/gsd:phase decimal-after 2`, etc. will trip it without anyone updating an allowlist.

### Platforms tested

- [x] macOS
- [ ] Windows
- [ ] Linux
- [x] N/A (markdown-only change; test uses only Node built-ins — `node:test`, `node:assert`, `node:fs`, `node:path` — so it runs on any Node 22+ without `node_modules`)

### Runtimes tested

- [ ] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other
- [x] N/A (source-doc fix; runtime-namespace transforms already in place handle per-runtime rendering)

---

## Checklist

- [x] Issue linked above with `Fixes #3687`
- [x] Linked issue has the `confirmed` label (`bug, confirmed`)
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added — structural invariant, catches bug class
- [x] All existing tests pass (only ran the new test locally; the new test depends only on Node built-ins so it's independent of `node_modules`)
- [ ] `.changeset/` fragment added — **requesting `no-changelog` label**: this is a pure stale-doc cleanup with zero behavior change in shipped runtime
- [x] No unnecessary dependencies added

## Breaking changes

None. Source-doc text correction plus a new test file — no runtime behavior changes.

## Notes for reviewer

### Why the test is structural, not string-grepping

A prior iteration of this PR (#3720, closed by the author) shipped a grep-based test that only checked for the two literal strings being removed. That kind of test catches the specific instance once and then sits in CI forever without flagging anything else. It satisfies the CONTRIBUTING checkbox but adds no ongoing safety. The structural invariant in this PR is meant to be a load-bearing guard: it catches the class of mistake (`/gsd:phase` followed by a bare verb that the router can't handle) regardless of which specific verb is used.

### Adjacent debt observed during prototyping (deliberately out of scope)

When prototyping a broader cross-reference invariant ("every `/gsd-<name>` resolves to `commands/gsd/<name>.md`"), I noticed that whole workflow files for retired commands still exist in `get-shit-done/workflows/`:

- `add-phase.md` — 5x references to `/gsd-add-phase`
- `edit-phase.md` — 7x references to `/gsd-edit-phase`
- `remove-phase.md` — 4x references to `/gsd-remove-phase`

Plus stray references in `check-todos.md`, `execute-plan.md`, `explore.md`, `plan-milestone-gaps.md`, `thread.md`, and `insert-phase.md`'s own anti-patterns section. None of these are in #3687's scope, so they're not touched here — but flagging in case a maintainer wants to file a follow-up for a broader sweep of retired-command graveyards in `get-shit-done/workflows/`.

### Intentional non-fixes

- `docs/FEATURES.md:2644` retained — REQ-CONSOLIDATE-03 documents the deleted command names as part of the deprecation contract, so removing them would weaken that contract.
- The reporter also suggested optional fail-fast routing in `commands/gsd/phase.md` for unrouted bare `insert` tokens. That's a behavior change (not a doc fix) and would interact with the per-runtime namespace transform pipeline — proper scope for a separate PR if maintainers want to harden the router itself rather than just the docs that bait it.

### Replacement note

This supersedes PR #3720 (closed by the author). Same author work, raised under a different GitHub account; the structural invariant test in this PR replaces the literal-string regression tests in the prior submission.
