### PR TITLE
fix(sdk): detect repo-local agents during init

### DIFF
--- a/sdk/src/query/init-complex.test.ts
+++ b/sdk/src/query/init-complex.test.ts
@@ -13,9 +13,11 @@ import { initNewProject, initProgress, initManager } from './init-complex.js';
 
 let tmpDir: string;
 let previousGsdAgentsDir: string | undefined;
+let previousClaudeConfigDir: string | undefined;
 
 beforeEach(async () => {
   previousGsdAgentsDir = process.env.GSD_AGENTS_DIR;
+  previousClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
   tmpDir = await mkdtemp(join(tmpdir(), 'gsd-init-complex-'));
 
   // Create minimal .planning structure
@@ -87,6 +89,8 @@ beforeEach(async () => {
 afterEach(async () => {
   if (previousGsdAgentsDir === undefined) delete process.env.GSD_AGENTS_DIR;
   else process.env.GSD_AGENTS_DIR = previousGsdAgentsDir;
+  if (previousClaudeConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+  else process.env.CLAUDE_CONFIG_DIR = previousClaudeConfigDir;
   await rm(tmpDir, { recursive: true, force: true });
 });
 
@@ -122,6 +126,56 @@ describe('initNewProject', () => {
     const result = await initNewProject([], tmpDir);
     const data = result.data as Record<string, unknown>;
     expect(data.planning_exists).toBe(true);
+  });
+
+  it('uses project-local required agents when runtime-global agents are missing', async () => {
+    const { MODEL_PROFILES } = await import('./config-query.js');
+    const localAgentsDir = join(tmpDir, '.claude', 'agents');
+    const emptyClaudeConfigDir = join(tmpDir, 'empty-claude-config');
+    const requiredAgents = [
+      'gsd-project-researcher',
+      'gsd-research-synthesizer',
+      'gsd-roadmapper',
+    ];
+    await mkdir(localAgentsDir, { recursive: true });
+    await mkdir(emptyClaudeConfigDir, { recursive: true });
+    for (const agent of Object.keys(MODEL_PROFILES)) {
+      await writeFile(join(localAgentsDir, `${agent}.md`), '# stub');
+    }
+
+    delete process.env.GSD_AGENTS_DIR;
+    process.env.CLAUDE_CONFIG_DIR = emptyClaudeConfigDir;
+
+    const result = await initNewProject([], tmpDir);
+    const data = result.data as Record<string, unknown>;
+
+    expect(data.agents_installed).toBe(true);
+    expect(data.missing_agents).toEqual([]);
+    expect(data.required_agents).toEqual(requiredAgents);
+    expect(data.required_agents_installed).toBe(true);
+    expect(data.missing_required_agents).toEqual([]);
+    expect(data.agents_dir).toBe(join(emptyClaudeConfigDir, 'agents'));
+  });
+
+  it('reports missing required agents from a partial project-local .claude/agents fallback', async () => {
+    const localAgentsDir = join(tmpDir, '.claude', 'agents');
+    const emptyClaudeConfigDir = join(tmpDir, 'empty-claude-config');
+    await mkdir(localAgentsDir, { recursive: true });
+    await mkdir(emptyClaudeConfigDir, { recursive: true });
+    await writeFile(join(localAgentsDir, 'gsd-project-researcher.md'), '# stub');
+
+    delete process.env.GSD_AGENTS_DIR;
+    process.env.CLAUDE_CONFIG_DIR = emptyClaudeConfigDir;
+
+    const result = await initNewProject([], tmpDir);
+    const data = result.data as Record<string, unknown>;
+
+    expect(data.agents_installed).toBe(false);
+    expect(data.required_agents_installed).toBe(false);
+    expect(data.missing_required_agents).toEqual([
+      'gsd-research-synthesizer',
+      'gsd-roadmapper',
+    ]);
   });
 
   it('separates required agent registration from skill payload availability (#3388)', async () => {

--- a/sdk/src/query/init-complex.ts
+++ b/sdk/src/query/init-complex.ts
@@ -41,7 +41,7 @@ import {
   extractPhasesFromSection,
 } from './roadmap.js';
 import { agentSkills } from './skills.js';
-import { withProjectRoot } from './init.js';
+import { withProjectRoot, getAgentInstallStatus } from './init.js';
 import type { QueryHandler } from './utils.js';
 
 // ─── Internal helpers ──────────────────────────────────────────────────────
@@ -126,11 +126,6 @@ const NEW_PROJECT_REQUIRED_AGENTS = [
   'gsd-research-synthesizer',
   'gsd-roadmapper',
 ];
-
-function hasAgentDefinition(agentsDir: string, agent: string): boolean {
-  return existsSync(join(agentsDir, `${agent}.md`)) ||
-    existsSync(join(agentsDir, `${agent}.agent.md`));
-}
 
 async function resolveAgentSkillPayloadAgents(
   requiredAgents: string[],
@@ -305,9 +300,7 @@ export const initNewProject: QueryHandler = async (_args, projectDir, workstream
   const runtime = detectRuntime(config as { runtime?: unknown });
   const agentsDir = resolveAgentsDir(runtime);
   const gitInfo = gitWorktreeInfo(projectDir);
-  const missingRequiredAgents = NEW_PROJECT_REQUIRED_AGENTS.filter(
-    agent => !hasAgentDefinition(agentsDir, agent),
-  );
+  const requiredAgentStatus = getAgentInstallStatus(projectDir, NEW_PROJECT_REQUIRED_AGENTS, config as { runtime?: unknown });
   const agentSkillPayloadAgents = await resolveAgentSkillPayloadAgents(
     NEW_PROJECT_REQUIRED_AGENTS,
     projectDir,
@@ -343,8 +336,8 @@ export const initNewProject: QueryHandler = async (_args, projectDir, workstream
     agent_runtime: runtime,
     agents_dir: agentsDir,
     required_agents: NEW_PROJECT_REQUIRED_AGENTS,
-    required_agents_installed: missingRequiredAgents.length === 0,
-    missing_required_agents: missingRequiredAgents,
+    required_agents_installed: requiredAgentStatus.agents_installed,
+    missing_required_agents: requiredAgentStatus.missing_agents,
     agent_skill_payloads_available: agentSkillPayloadAgents.length === NEW_PROJECT_REQUIRED_AGENTS.length,
     agent_skill_payload_agents: agentSkillPayloadAgents,
   };

--- a/sdk/src/query/init.test.ts
+++ b/sdk/src/query/init.test.ts
@@ -28,8 +28,12 @@ import {
 } from './init.js';
 
 let tmpDir: string;
+let previousGsdAgentsDir: string | undefined;
+let previousClaudeConfigDir: string | undefined;
 
 beforeEach(async () => {
+  previousGsdAgentsDir = process.env.GSD_AGENTS_DIR;
+  previousClaudeConfigDir = process.env.CLAUDE_CONFIG_DIR;
   tmpDir = await mkdtemp(join(tmpdir(), 'gsd-init-'));
   // Create minimal .planning structure
   await mkdir(join(tmpDir, '.planning', 'phases', '09-foundation'), { recursive: true });
@@ -92,6 +96,10 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  if (previousGsdAgentsDir === undefined) delete process.env.GSD_AGENTS_DIR;
+  else process.env.GSD_AGENTS_DIR = previousGsdAgentsDir;
+  if (previousClaudeConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+  else process.env.CLAUDE_CONFIG_DIR = previousClaudeConfigDir;
   await rm(tmpDir, { recursive: true, force: true });
 });
 
@@ -283,6 +291,41 @@ describe('withProjectRoot', () => {
       if (prevRuntime === undefined) delete process.env.GSD_RUNTIME;
       else process.env.GSD_RUNTIME = prevRuntime;
     }
+  });
+
+  it('falls back to project-local .claude/agents when runtime-global agents are missing', async () => {
+    const { MODEL_PROFILES } = await import('./config-query.js');
+    const localAgentsDir = join(tmpDir, '.claude', 'agents');
+    const emptyClaudeConfigDir = join(tmpDir, 'empty-claude-config');
+    await mkdir(localAgentsDir, { recursive: true });
+    await mkdir(emptyClaudeConfigDir, { recursive: true });
+    for (const name of Object.keys(MODEL_PROFILES)) {
+      await writeFile(join(localAgentsDir, `${name}.md`), '# stub');
+    }
+
+    delete process.env.GSD_AGENTS_DIR;
+    process.env.CLAUDE_CONFIG_DIR = emptyClaudeConfigDir;
+
+    const enriched = withProjectRoot(tmpDir, {}) as Record<string, unknown>;
+    expect(enriched.agents_installed).toBe(true);
+    expect(enriched.missing_agents).toEqual([]);
+  });
+
+  it('keeps explicit GSD_AGENTS_DIR override ahead of project-local .claude/agents', async () => {
+    const { MODEL_PROFILES } = await import('./config-query.js');
+    const localAgentsDir = join(tmpDir, '.claude', 'agents');
+    const explicitAgentsDir = join(tmpDir, 'explicit-empty-agents');
+    await mkdir(localAgentsDir, { recursive: true });
+    await mkdir(explicitAgentsDir, { recursive: true });
+    for (const name of Object.keys(MODEL_PROFILES)) {
+      await writeFile(join(localAgentsDir, `${name}.md`), '# stub');
+    }
+
+    process.env.GSD_AGENTS_DIR = explicitAgentsDir;
+
+    const enriched = withProjectRoot(tmpDir, {}) as Record<string, unknown>;
+    expect(enriched.agents_installed).toBe(false);
+    expect((enriched.missing_agents as string[]).length).toBeGreaterThan(0);
   });
 
   it('GSD_AGENTS_DIR takes precedence over CLAUDE_CONFIG_DIR', async () => {

--- a/sdk/src/query/init.ts
+++ b/sdk/src/query/init.ts
@@ -202,30 +202,43 @@ function getLatestCompletedMilestone(projectDir: string): { version: string; nam
  * (`GSD_RUNTIME` → `config.runtime` → 'claude') and probes that runtime's
  * canonical `agents/` directory. `GSD_AGENTS_DIR` still short-circuits.
  *
- * Port of checkAgentsInstalled from core.cjs lines 1274-1306.
+ * When no explicit override is present, repo-local `.claude/agents` can satisfy
+ * missing runtime-global agents for local/dev installs.
+ *
+ * Port of checkAgentsInstalled from core.cjs lines 1274-1306, with the
+ * repo-local fallback added for SDK init workflows.
  */
-function checkAgentsInstalled(config?: { runtime?: unknown }): { agents_installed: boolean; missing_agents: string[] } {
+export function getAgentInstallStatus(
+  projectDir: string,
+  expectedAgents: string[],
+  config?: { runtime?: unknown },
+): { agents_installed: boolean; missing_agents: string[] } {
   const runtime = detectRuntime(config);
-  const agentsDir = resolveAgentsDir(runtime);
-  const expectedAgents = Object.keys(MODEL_PROFILES);
+  const hasExplicitAgentsDir = Object.prototype.hasOwnProperty.call(process.env, 'GSD_AGENTS_DIR');
+  const explicitAgentsDir = process.env.GSD_AGENTS_DIR;
+  const runtimeAgentsDir = resolveAgentsDir(runtime);
+  const candidateDirs = hasExplicitAgentsDir
+    ? (explicitAgentsDir ? [explicitAgentsDir] : [])
+    : [runtimeAgentsDir, join(projectDir, '.claude', 'agents')];
 
-  if (!existsSync(agentsDir)) {
-    return { agents_installed: false, missing_agents: expectedAgents };
-  }
-
-  const missing: string[] = [];
-  for (const agent of expectedAgents) {
-    const agentFile = join(agentsDir, `${agent}.md`);
-    const agentFileCopilot = join(agentsDir, `${agent}.agent.md`);
-    if (!existsSync(agentFile) && !existsSync(agentFileCopilot)) {
-      missing.push(agent);
-    }
-  }
+  const missing = expectedAgents.filter((agent) => {
+    return !candidateDirs.some((agentsDir) => {
+      return existsSync(join(agentsDir, `${agent}.md`)) ||
+        existsSync(join(agentsDir, `${agent}.agent.md`));
+    });
+  });
 
   return {
     agents_installed: missing.length === 0,
     missing_agents: missing,
   };
+}
+
+function checkAgentsInstalled(
+  projectDir: string,
+  config?: { runtime?: unknown },
+): { agents_installed: boolean; missing_agents: string[] } {
+  return getAgentInstallStatus(projectDir, Object.keys(MODEL_PROFILES), config);
 }
 
 /**
@@ -351,7 +364,7 @@ export function withProjectRoot(
 ): Record<string, unknown> {
   result.project_root = projectDir;
 
-  const agentStatus = checkAgentsInstalled(config);
+  const agentStatus = checkAgentsInstalled(projectDir, config);
   result.agents_installed = agentStatus.agents_installed;
   result.missing_agents = agentStatus.missing_agents;
 


### PR DESCRIPTION
## Summary

- Fix false-negative GSD agent detection during `init.new-project` for Claude local/dev installs.
- Treat repo-local `./.claude/agents` as a valid fallback when `GSD_AGENTS_DIR` is unset and runtime-global agents are missing.
- Preserve explicit `GSD_AGENTS_DIR` precedence and keep `agents_dir` reporting the canonical runtime-global directory.

## Upstream comparison

- Related: #3388 / #3390 split new-project agent diagnostics, but do not cover repo-local agents fallback.
- Related: #3668 addresses local workflow SDK resolution, which is orthogonal to this agent detection path.
- This keeps the #2400 / #2402 runtime-global `resolveAgentsDir()` behavior intact and only extends init detection fallback semantics.

## Test plan

- [x] `pnpm --dir "sdk" exec vitest run src/query/init.test.ts src/query/init-complex.test.ts --project unit -t "falls back to project-local|keeps explicit GSD_AGENTS_DIR override ahead of project-local|uses project-local required agents|reports missing required agents from a partial project-local"`
- [x] `pnpm --dir "sdk" exec vitest run src/query/init.test.ts src/query/init-complex.test.ts --project unit -t "withProjectRoot|initNewProject"`