### PR TITLE
fix(3749): port strategy-branch creation from CJS to SDK commit handler

### DIFF
--- a/.changeset/clever-otters-rest.md
+++ b/.changeset/clever-otters-rest.md
@@ -1,5 +1,5 @@
 ---
 type: Fixed
-pr: 3770
+pr: 3771
 ---
 Pre-execution commits via `gsd-sdk query commit` (used by /gsd-discuss-phase, /gsd-plan-phase) now honor `git.branching_strategy`. Ports PR #1279's strategy-branch-before-commit logic from the CJS `cmdCommit` path to the SDK commit handler so planning artifacts land on the configured phase/milestone branch instead of `main`.

--- a/.changeset/clever-otters-rest.md
+++ b/.changeset/clever-otters-rest.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3770
+---
+Pre-execution commits via `gsd-sdk query commit` (used by /gsd-discuss-phase, /gsd-plan-phase) now honor `git.branching_strategy`. Ports PR #1279's strategy-branch-before-commit logic from the CJS `cmdCommit` path to the SDK commit handler so planning artifacts land on the configured phase/milestone branch instead of `main`.

--- a/sdk/src/query/commit.test.ts
+++ b/sdk/src/query/commit.test.ts
@@ -483,3 +483,129 @@ describe('commit --respect-staged (#3522)', () => {
     expect(diff).toContain('// modified in working tree');
   });
 });
+
+// ─── branching strategy (#1279, #3749) ─────────────────────────────────────
+
+describe('commit branching strategy (#1279, #3749)', () => {
+  function currentBranch(cwd: string): string {
+    return execSync('git rev-parse --abbrev-ref HEAD', { cwd, encoding: 'utf-8' }).trim();
+  }
+
+  beforeEach(() => {
+    // Pin the initial branch name so the assertion does not depend on the
+    // local `init.defaultBranch` git config (defaults vary across machines).
+    execSync('git checkout -b main', { cwd: tmpDir, stdio: 'pipe' });
+    execSync('git config user.email "test@test.com"', { cwd: tmpDir, stdio: 'pipe' });
+    execSync('git config user.name "Test User"', { cwd: tmpDir, stdio: 'pipe' });
+  });
+
+  async function seedInitialCommit(): Promise<void> {
+    // Seed an initial commit so HEAD is resolvable when the handler runs
+    // `git rev-parse --abbrev-ref HEAD` before staging.
+    await writeFile(join(tmpDir, 'README.md'), '# repro');
+    execSync('git add README.md', { cwd: tmpDir, stdio: 'pipe' });
+    execSync('git commit -m "init"', { cwd: tmpDir, stdio: 'pipe' });
+  }
+
+  it('creates strategy branch before first commit when branching_strategy is phase', async () => {
+    await seedInitialCommit();
+    const { commit } = await import('./commit.js');
+    await writeFile(
+      join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({
+        commit_docs: true,
+        git: { branching_strategy: 'phase', phase_branch_template: 'gsd/phase-{phase}-{slug}' },
+      }),
+    );
+    await mkdir(join(tmpDir, '.planning', 'phases', '01-setup'), { recursive: true });
+    await writeFile(
+      join(tmpDir, '.planning', 'ROADMAP.md'),
+      '# Roadmap\n\n## Phase 1: Setup\nGoal: Initial setup\n',
+    );
+    await writeFile(join(tmpDir, '.planning', 'phases', '01-setup', '01-CONTEXT.md'), '# Context\n');
+
+    const result = await commit(
+      ['docs(01): add context', '--files', '.planning/phases/01-setup/01-CONTEXT.md'],
+      tmpDir,
+    );
+    expect((result.data as { committed: boolean }).committed).toBe(true);
+    expect(currentBranch(tmpDir)).toBe('gsd/phase-01-setup');
+  });
+
+  it('creates strategy branch before first commit when branching_strategy is milestone', async () => {
+    await seedInitialCommit();
+    const { commit } = await import('./commit.js');
+    await writeFile(
+      join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({
+        commit_docs: true,
+        git: {
+          branching_strategy: 'milestone',
+          milestone_branch_template: 'gsd/{milestone}-{slug}',
+        },
+      }),
+    );
+    // getMilestoneInfo() reads ROADMAP.md for the version and name.
+    await writeFile(
+      join(tmpDir, '.planning', 'ROADMAP.md'),
+      '## v1.0: Initial Release\n\n### Phase 1: Setup\n',
+    );
+    await writeFile(join(tmpDir, '.planning', 'test-context.md'), '# Context\n');
+
+    const result = await commit(
+      ['docs: add context', '--files', '.planning/test-context.md'],
+      tmpDir,
+    );
+    expect((result.data as { committed: boolean }).committed).toBe(true);
+    expect(currentBranch(tmpDir)).toBe('gsd/v1.0-initial-release');
+  });
+
+  it('captures decimal phase numbers in the strategy branch name', async () => {
+    await seedInitialCommit();
+    const { commit } = await import('./commit.js');
+    await writeFile(
+      join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({
+        commit_docs: true,
+        git: { branching_strategy: 'phase', phase_branch_template: 'gsd/phase-{phase}-{slug}' },
+      }),
+    );
+    await mkdir(join(tmpDir, '.planning', 'phases', '45.14-golden-capture'), { recursive: true });
+    await writeFile(
+      join(tmpDir, '.planning', 'ROADMAP.md'),
+      '# Roadmap\n\n## Phase 45.14: Golden Capture\nGoal: Capture golden standard\n',
+    );
+    await writeFile(
+      join(tmpDir, '.planning', 'phases', '45.14-golden-capture', '45.14-CONTEXT.md'),
+      '# Context\n',
+    );
+
+    const result = await commit(
+      [
+        'docs(45.14): add context',
+        '--files',
+        '.planning/phases/45.14-golden-capture/45.14-CONTEXT.md',
+      ],
+      tmpDir,
+    );
+    expect((result.data as { committed: boolean }).committed).toBe(true);
+    expect(currentBranch(tmpDir)).toBe('gsd/phase-45.14-golden-capture');
+  });
+
+  it('does not switch branches when branching_strategy is none', async () => {
+    await seedInitialCommit();
+    const { commit } = await import('./commit.js');
+    await writeFile(
+      join(tmpDir, '.planning', 'config.json'),
+      JSON.stringify({ commit_docs: true, git: { branching_strategy: 'none' } }),
+    );
+    await writeFile(join(tmpDir, '.planning', 'note.md'), '# Note\n');
+
+    const result = await commit(
+      ['docs: add note', '--files', '.planning/note.md'],
+      tmpDir,
+    );
+    expect((result.data as { committed: boolean }).committed).toBe(true);
+    expect(currentBranch(tmpDir)).toBe('main');
+  });
+});

--- a/sdk/src/query/commit.ts
+++ b/sdk/src/query/commit.ts
@@ -20,7 +20,10 @@
 import { readFile } from 'node:fs/promises';
 import { spawnSync } from 'node:child_process';
 import { GSDError } from '../errors.js';
+import { loadConfig } from '../config.js';
 import { planningPaths, resolvePathUnderProject } from './helpers.js';
+import { findPhase } from './phase.js';
+import { getMilestoneInfo } from './roadmap.js';
 import type { QueryHandler } from './utils.js';
 
 // ─── execGit ──────────────────────────────────────────────────────────────
@@ -81,6 +84,84 @@ export function sanitizeCommitMessage(text: string): string {
   sanitized = sanitized.replace(/<<\s*SYS\s*>>/gi, '\u00ABSYS-TEXT\u00BB');
 
   return sanitized;
+}
+
+// ─── ensureStrategyBranch ─────────────────────────────────────────────────
+
+/**
+ * Ensure the configured branching-strategy branch exists before the first
+ * pre-execution commit. Ported from `cmdCommit` in
+ * `get-shit-done/bin/lib/commands.cjs:285-320` (PR #1279) so the SDK commit
+ * handler creates the same branch the CJS path does. Without this port,
+ * pre-execution workflows (`/gsd-discuss-phase`, `/gsd-plan-phase`) that
+ * commit through `gsd-sdk query commit` land their artifacts on whatever
+ * branch the user happened to be on — typically `main` (#3749).
+ *
+ * No-ops when `branching_strategy` is `none` or unset, or when the resolved
+ * branch matches the current branch. Failures to read config, locate the
+ * phase, or run git are swallowed so a config-resolution problem never
+ * blocks an otherwise-valid commit.
+ */
+async function ensureStrategyBranch(
+  projectDir: string,
+  files: string[],
+  workstream?: string,
+): Promise<void> {
+  let config;
+  try {
+    config = await loadConfig(projectDir, workstream);
+  } catch {
+    return;
+  }
+  const strategy = config.git?.branching_strategy;
+  if (!strategy || strategy === 'none') return;
+
+  let branchName: string | null = null;
+
+  if (strategy === 'phase') {
+    const phaseMatch = files.join(' ').match(/(\d+(?:\.\d+)*)-/);
+    if (!phaseMatch) return;
+    const phaseNum = phaseMatch[1];
+    let phaseInfo;
+    try {
+      const result = await findPhase([phaseNum], projectDir, workstream);
+      phaseInfo = result.data as { found: boolean; phase_number: string | null; phase_slug: string | null };
+    } catch {
+      return;
+    }
+    if (!phaseInfo || !phaseInfo.found || !phaseInfo.phase_number) return;
+    branchName = config.git.phase_branch_template
+      .replace('{phase}', phaseInfo.phase_number)
+      .replace('{slug}', phaseInfo.phase_slug || 'phase');
+  } else if (strategy === 'milestone') {
+    let milestone;
+    try {
+      milestone = await getMilestoneInfo(projectDir, workstream);
+    } catch {
+      return;
+    }
+    if (!milestone || !milestone.version) return;
+    const slug = (milestone.name || 'milestone')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .substring(0, 60) || 'milestone';
+    branchName = config.git.milestone_branch_template
+      .replace('{milestone}', milestone.version)
+      .replace('{slug}', slug);
+  }
+
+  if (!branchName) return;
+
+  const currentBranch = execGit(projectDir, ['rev-parse', '--abbrev-ref', 'HEAD']);
+  if (currentBranch.exitCode !== 0) return;
+  if (currentBranch.stdout === branchName) return;
+
+  // Try to create the branch; if it already exists, switch to it instead.
+  const create = execGit(projectDir, ['checkout', '-b', branchName]);
+  if (create.exitCode !== 0) {
+    execGit(projectDir, ['checkout', branchName]);
+  }
 }
 
 // ─── commit ───────────────────────────────────────────────────────────────
@@ -155,6 +236,12 @@ export const commit: QueryHandler = async (args, projectDir, workstream) => {
   // Compute pathspec once: the handler commits exactly the paths it staged,
   // never anything that was pre-staged externally (#3061).
   const pathsToCommit = filePaths.length > 0 ? filePaths : ['.planning/'];
+
+  // Create the configured branching-strategy branch before staging so the
+  // first pre-execution commit lands on it instead of whatever branch the
+  // user started from. Ported from CJS cmdCommit (#1279) — see
+  // ensureStrategyBranch for #3749 context.
+  await ensureStrategyBranch(projectDir, pathsToCommit, workstream);
 
   // When --respect-staged is set, skip re-staging so that per-hunk staging
   // from `git add -p` is preserved. Without the flag, run git add for each


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3749

> Issue has the `confirmed-bug` label and a maintainer triage comment confirming the gap and proposing exactly this fix shape.

## What was broken

`gsd-sdk query commit` (the production dispatch path used by `/gsd-discuss-phase`, `/gsd-plan-phase`, etc.) did not honor `git.branching_strategy: phase | milestone` for the *first* pre-execution commit. Planning artifacts landed on whatever branch the user happened to be on (typically `main`), polluting it before `execute-phase` branched off.

## What this fix does

Ports the strategy-branch-before-commit logic from CJS `bin/lib/commands.cjs::cmdCommit` (PR #1279) to the SDK handler at `sdk/src/query/commit.ts`. A new `ensureStrategyBranch()` helper runs after pathspec resolution and before the `git add` loop, so the configured phase/milestone branch is created (or switched to) before staging.

## Root cause

PR #1279 fixed the bug only in the CJS `cmdCommit` path. The SDK port at `sdk/src/query/commit.ts` was created earlier (`feat(sdk): Phase 1 typed query foundation` #2118) and was never updated when #1279 landed. Once `gsd-sdk query commit` became the production path for `/gsd-discuss-phase` and `/gsd-plan-phase`, the bug surfaced again — but only on the SDK path.

This is the same drift class catalogued in ADR-3524 and prior incidents (#1535, #1542, #2047/#2052, #2638/#2655, #2653/#2670, #2687/#2706, #2798/#2816, #3055/#3116, #3523).

## Testing

### How I verified the fix

1. **Unit/regression** — added 4 tests under `commit branching strategy (#1279, #3749)` in `sdk/src/query/commit.test.ts` covering phase strategy, milestone strategy, decimal phase numbers (`45.14-foo`), and the `branching_strategy=none` no-op. All pass: `npx vitest run src/query/commit.test.ts` → 30/30.
2. **Full root suite** — `npm test` (canonical CI suite, `node:test`) → 6182/6182 pass.
3. **End-to-end repro on a clean project** — scaffolded a minimal repro project with `git.branching_strategy: phase`, ran `gsd-sdk query commit` from `main` with a `.planning/phases/01-pig-latin-cli/CONTEXT.md` file. Without the fix: commit lands on `main`. With the fix: `gsd/phase-01-pig-latin-cli` branch is created and the commit lands there; `main` HEAD unchanged.
4. **`/gsd-discuss-phase` flow** — drove the fix through the actual workflow end-to-end; CONTEXT.md committed onto the strategy branch, `main` clean.

### Regression test added?

- [x] Yes — 4 tests under `'commit branching strategy (#1279, #3749)'` in `sdk/src/query/commit.test.ts`
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`npm test` → 6182/6182)
- [x] `.changeset/` fragment added (`.changeset/clever-otters-rest.md`, type Fixed, pr 3770 — will update if PR number differs)
- [x] No unnecessary dependencies added

## Breaking changes

None. The fix only kicks in when `git.branching_strategy` is `phase` or `milestone`. The `none`/unset path is a no-op.