### PR TITLE
fix(phase): case-insensitive depends_on resolution

### DIFF
--- a/get-shit-done/bin/lib/phase.cjs
+++ b/get-shit-done/bin/lib/phase.cjs
@@ -446,10 +446,13 @@ function cmdPhasePlanIndex(cwd, phase, raw) {
 
   // Build a map from plan ID → raw plan for fast lookup.
   // Deps that reference plans outside this phase are treated as external and ignored.
-  const planMap = new Map(rawPlans.map(p => [p.id, p]));
+  // Plan-id lookups are case-insensitive: map keys are lowercased and dep
+  // lookups are lowercased at query time so that depends_on: ['05c-01'] resolves
+  // to a plan with on-disk ID '05C-01-foo'.
+  const planMap = new Map(rawPlans.map(p => [p.id.toLowerCase(), p]));
   // Secondary index: canonical prefix → full plan ID, so depends_on: ['03-01'] resolves
   // to '03-01-auth-hardening-PLAN.md'-derived ID '03-01-auth-hardening' (k015).
-  const canonicalToId = new Map(rawPlans.map(p => [extractCanonicalPlanId(p.id), p.id]));
+  const canonicalToId = new Map(rawPlans.map(p => [extractCanonicalPlanId(p.id).toLowerCase(), p.id]));
 
   // Kahn's algorithm — compute in-degree and adjacency for in-phase deps only.
   const level = new Map();
@@ -461,7 +464,9 @@ function cmdPhasePlanIndex(cwd, phase, raw) {
     if (!adj.has(p.id)) adj.set(p.id, []);
     for (const dep of p.dependsOn) {
       // Accept both full-stem ('03-01-auth-hardening') and canonical-prefix ('03-01') forms.
-      const resolvedDep = planMap.has(dep) ? dep : canonicalToId.get(dep);
+      // Lookups are case-insensitive.
+      const depKey = dep.toLowerCase();
+      const resolvedDep = planMap.has(depKey) ? planMap.get(depKey).id : canonicalToId.get(depKey);
       if (!resolvedDep) continue; // external dep — ignore
       if (!adj.has(resolvedDep)) adj.set(resolvedDep, []);
       adj.get(resolvedDep).push(p.id);

--- a/sdk/src/query/phase.test.ts
+++ b/sdk/src/query/phase.test.ts
@@ -648,4 +648,38 @@ describe('phasePlanIndex', () => {
     // A clear, dedicated warning naming the unresolved reference must surface.
     expect(warnings.some(w => /unresolved/i.test(w) && w.includes('does-not-exist'))).toBe(true);
   });
+
+  it('case-insensitive depends_on: lowercase dep resolves to uppercase-suffix plan ID', async () => {
+    const phase05c = join(tmpDir, '.planning', 'phases', '05C-letter-suffix');
+    await mkdir(phase05c, { recursive: true });
+    await writeFile(join(phase05c, '05C-01-PLAN.md'), [
+      '---',
+      'phase: 05C',
+      'plan: 01',
+      'wave: 1',
+      'autonomous: true',
+      'depends_on: []',
+      '---',
+      '<objective>Plan A with uppercase suffix.</objective>',
+    ].join('\n'));
+    await writeFile(join(phase05c, '05C-02-PLAN.md'), [
+      '---',
+      'phase: 05C',
+      'plan: 02',
+      'wave: 2',
+      'autonomous: true',
+      'depends_on: [05c-01]',
+      '---',
+      '<objective>Plan B references plan A via lowercase canonical-prefix form.</objective>',
+    ].join('\n'));
+
+    const result = await phasePlanIndex(['05C'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+    const waves = data.waves as Record<string, string[]>;
+    const warnings = (data.warnings as string[] | undefined) ?? [];
+
+    expect(waves['1']).toEqual(['05C-01']);
+    expect(waves['2']).toEqual(['05C-02']);
+    expect(warnings).toEqual([]);
+  });
 });

--- a/sdk/src/query/phase.ts
+++ b/sdk/src/query/phase.ts
@@ -435,10 +435,19 @@ export const phasePlanIndex: QueryHandler = async (args, projectDir, workstream)
   // Build a map from plan ID → RawPlan for fast lookup.
   // Deps that reference plans outside this phase are silently ignored (treated
   // as already-satisfied external deps — the plan becomes a source node).
-  const planMap = new Map<string, RawPlan>(rawPlans.map(p => [p.id, p]));
+  // Plan-id lookups are case-insensitive: map keys are lowercased and dep
+  // lookups are lowercased at query time so that depends_on: ['05c-01'] resolves
+  // to a plan with on-disk ID '05C-01-foo'. Plan-id namespace is narrow enough
+  // (NN, NN-NN, NN-NN-slug, plus optional letter suffix on phase) that
+  // case-folding collisions are not a practical concern, and a single phase
+  // directory cannot host two plans whose IDs differ only in case (canonical-
+  // prefix indexing would collide first).
+  const planMap = new Map<string, RawPlan>(rawPlans.map(p => [p.id.toLowerCase(), p]));
   // Secondary index: canonical prefix → full plan ID, so depends_on: ['03-01'] resolves
   // to '03-01-auth-hardening-PLAN.md'-derived ID '03-01-auth-hardening' (k015).
-  const canonicalToId = new Map<string, string>(rawPlans.map(p => [extractCanonicalPlanId(p.id), p.id]));
+  const canonicalToId = new Map<string, string>(
+    rawPlans.map(p => [extractCanonicalPlanId(p.id).toLowerCase(), p.id]),
+  );
   // Tertiary index: same-phase short-form ('01') → full plan ID, derived from each plan's
   // canonical '<phase>-<plan>' by splitting on the LAST '-'. The phase segment may
   // contain dots (e.g. '99.9') or letters (e.g. '02A'); only the trailing '-NN' is the
@@ -449,7 +458,7 @@ export const phasePlanIndex: QueryHandler = async (args, projectDir, workstream)
     const canonical = extractCanonicalPlanId(p.id);
     const lastDash = canonical.lastIndexOf('-');
     if (lastDash > 0 && lastDash < canonical.length - 1) {
-      const shortForm = canonical.slice(lastDash + 1);
+      const shortForm = canonical.slice(lastDash + 1).toLowerCase();
       // First write wins — preserve deterministic ordering from sorted planFiles.
       if (!shortFormToId.has(shortForm)) {
         shortFormToId.set(shortForm, p.id);
@@ -470,14 +479,17 @@ export const phasePlanIndex: QueryHandler = async (args, projectDir, workstream)
       // Accept full-stem ('03-01-auth-hardening'), canonical-prefix ('03-01'),
       // and same-phase short-form ('01') forms. The short-form lookup (#3488)
       // is keyed off the plan-id suffix so it works for integer ('99'), letter
-      // ('02A'), and decimal ('99.9') phase IDs alike.
+      // ('02A'), and decimal ('99.9') phase IDs alike. Lookups are case-
+      // insensitive; see map construction above. depKey is lowercased;
+      // resolvedDep keeps the canonical-cased plan ID stored as map value.
+      const depKey = dep.toLowerCase();
       let resolvedDep: string | undefined;
-      if (planMap.has(dep)) {
-        resolvedDep = dep;
-      } else if (canonicalToId.has(dep)) {
-        resolvedDep = canonicalToId.get(dep);
-      } else if (shortFormToId.has(dep)) {
-        resolvedDep = shortFormToId.get(dep);
+      if (planMap.has(depKey)) {
+        resolvedDep = planMap.get(depKey)!.id;
+      } else if (canonicalToId.has(depKey)) {
+        resolvedDep = canonicalToId.get(depKey);
+      } else if (shortFormToId.has(depKey)) {
+        resolvedDep = shortFormToId.get(depKey);
       }
       if (!resolvedDep) {
         // Looks like an in-phase short-form / canonical reference that didn't resolve.


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3785

## What was broken

`phase.plan-index` resolved `depends_on` references with strict-case `Map.has()` lookups, so `depends_on: [05c-01]` did not match a sibling plan whose on-disk ID was `05C-01`. The dropped edge collapsed the dependent plan into wave 1 and surfaced only a misleading "declared wave: N but depends_on DAG places it in wave 1" warning.

## What this fix does

Plan-id lookup maps (`planMap`, `canonicalToId`, `shortFormToId`) now key on the lowercased plan ID, and `dep` is lowercased at lookup time. Resolved deps return the canonical-cased plan ID stored as the map value, so wave output and warning messages still use on-disk casing.

## Root cause

The three lookup maps were keyed off the raw plan ID exactly as derived from the filename, and `Map.has(dep)` is case-sensitive. The `unresolvedDeps` path is only populated when all three maps miss, so a lowercase-on-uppercase mismatch landed silently in the dropped-edge state rather than surfacing as an unresolved-reference warning. Plans authored by the `gsd-planner` agent occasionally lowercase letter-suffix phase IDs even though filenames on disk use uppercase, which is how this surfaced in practice.

## Testing

### How I verified the fix

New `phase.test.ts` case: a `05C` phase with sibling plans `05C-01-PLAN.md` and `05C-02-PLAN.md` where `05C-02` declares `depends_on: [05c-01]` (lowercase canonical-prefix form). The test asserts wave 1 contains `05C-01`, wave 2 contains `05C-02`, and `warnings` is empty (no unresolved-reference warning, no wave-mismatch warning).

Patch also verified in a downstream Claude Code plugin packaging of GSD (jnuyens/gsd-plugin@v2.43.5) where the same byte-identical fix passes 30/30 in `phase.test.ts`.

### Regression test added?

- [x] Yes — added a test that would have caught this bug
- [ ] No — explain why:

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [ ] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #NNN`
- [ ] Linked issue has the `confirmed-bug` label (issue #3785 just filed, awaiting maintainer triage)
- [x] Fix is scoped to the reported bug, no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`phase.test.ts` 30/30 in downstream verification; upstream npm test not run because the fork was cloned shallow without deps installed)
- [ ] `.changeset/` fragment added if this is a user-facing fix, or `no-changelog` label applied (please advise; I can add either, this is the first time I have contributed here)
- [x] No unnecessary dependencies added

## Breaking changes

None. Plan-id namespace is `NN`, `NN-NN`, or `NN-NN-slug` with an optional letter suffix on the phase segment. A single phase directory cannot host two plans whose IDs differ only in case (canonical-prefix indexing would collide first), and POSIX filesystems treat them as distinct files anyway. Case-folding introduces no new collision surface, and the canonical-cased plan ID is preserved in map values so wave output and warning messages remain byte-identical for all previously-resolving cases.