### PR TITLE
fix(3774): treat 999 as exact sentinel in phase-lifecycle-policy

### DIFF
--- a/.changeset/bold-orcas-howl.md
+++ b/.changeset/bold-orcas-howl.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3792
+---
+phase.add no longer returns 1 on projects using canonical phase IDs 1000 or higher.

--- a/get-shit-done/bin/lib/phase.cjs
+++ b/get-shit-done/bin/lib/phase.cjs
@@ -607,7 +607,7 @@ function cmdPhaseAdd(cwd, description, raw, customId) {
       let m;
       while ((m = phasePattern.exec(content)) !== null) {
         const num = parseInt(m[1], 10);
-        if (num >= 999) continue; // backlog phases use 999.x numbering
+        if (num === 999) continue; // backlog phases use 999.x numbering
         if (num > maxPhase) maxPhase = num;
       }
 
@@ -621,7 +621,7 @@ function cmdPhaseAdd(cwd, description, raw, customId) {
           const match = entry.match(dirNumPattern);
           if (!match) continue;
           const num = parseInt(match[1], 10);
-          if (num >= 999) continue; // skip backlog orphans
+          if (num === 999) continue; // skip backlog orphans
           if (num > maxPhase) maxPhase = num;
         }
       }
@@ -685,7 +685,7 @@ function cmdPhaseAddBatch(cwd, descriptions, raw) {
       let m;
       while ((m = phasePattern.exec(content)) !== null) {
         const num = parseInt(m[1], 10);
-        if (num >= 999) continue;
+        if (num === 999) continue;
         if (num > maxPhase) maxPhase = num;
       }
       const phasesOnDisk = path.join(planningDir(cwd), 'phases');
@@ -695,7 +695,7 @@ function cmdPhaseAddBatch(cwd, descriptions, raw) {
           const match = entry.match(dirNumPattern);
           if (!match) continue;
           const num = parseInt(match[1], 10);
-          if (num >= 999) continue;
+          if (num === 999) continue;
           if (num > maxPhase) maxPhase = num;
         }
       }

--- a/sdk/src/query/phase-lifecycle-policy.ts
+++ b/sdk/src/query/phase-lifecycle-policy.ts
@@ -60,7 +60,7 @@ export function extractOneLinerFromBody(content: string): string | null {
 
 /**
  * Scan highest sequential phase number in milestone content.
- * Skips backlog lanes (`999.x`).
+ * Skips exactly the backlog sentinel (`999`); phases 1000+ are valid canonical IDs.
  */
 export function scanSequentialMaxPhaseFromMilestone(milestoneContent: string): number {
   const phasePattern = /(?:^|\n)\s*(?:[-*]\s*(?:\[[x ]\]\s*)?|#{2,4}\s*|\*{1,2}\s*)Phase\s+(\d+)[A-Z]?(?:\.\d+)*:/gi;
@@ -68,7 +68,7 @@ export function scanSequentialMaxPhaseFromMilestone(milestoneContent: string): n
   let m: RegExpExecArray | null;
   while ((m = phasePattern.exec(milestoneContent)) !== null) {
     const num = parseInt(m[1], 10);
-    if (num >= 999) continue;
+    if (num === 999) continue;
     if (num > maxPhase) maxPhase = num;
   }
   return maxPhase;
@@ -85,7 +85,7 @@ export function scanSequentialMaxPhaseFromDirs(dirNames: string[]): number {
     const match = dirNumPattern.exec(dirName);
     if (!match) continue;
     const num = parseInt(match[1], 10);
-    if (num >= 999) continue;
+    if (num === 999) continue;
     if (num > maxPhase) maxPhase = num;
   }
   return maxPhase;

--- a/sdk/src/query/phase-lifecycle.test.ts
+++ b/sdk/src/query/phase-lifecycle.test.ts
@@ -392,6 +392,52 @@ describe('phaseAdd', () => {
     expect(data.phase_number).toBe(1501);
   });
 
+  it('distinguishes === 999 guard from === 1000 off-by-one: [999, 1000] fixture must yield 1001 (regression #3774)', async () => {
+    // Distinguishing fixture: phases [999, 1000] on disk + in ROADMAP.
+    // With correct guard (=== 999): skips 999, keeps 1000 as max → next = 1001 ✓
+    // With off-by-one guard (=== 1000): skips 1000, keeps 999 → max = 999 but
+    //   999 is itself skipped by the equality guard (999 === 999 is true when
+    //   the guard fires), so actually keeps nothing → max = 0 → next = 1 ✗.
+    //   Either way, the result diverges from 1001, catching the regression.
+    const { phaseAdd } = await import('./phase-lifecycle.js');
+
+    const roadmapWith999and1000 = [
+      '# Roadmap',
+      '',
+      '## Current Milestone: v1.0',
+      '',
+      '### Phase 999: Backlog',
+      '',
+      '**Goal:** Backlog sentinel',
+      '**Plans:** 0 plans',
+      '',
+      '### Phase 1000: First Four-Digit Phase',
+      '',
+      '**Goal:** First canonical phase above backlog sentinel',
+      '**Requirements**: TBD',
+      '**Plans:** 1 plans',
+      '',
+      'Plans:',
+      '- [x] 1000-01 (initial work)',
+      '',
+      '---',
+      '*Last updated: 2026-05-21*',
+      '',
+    ].join('\n');
+
+    const phases = [
+      '999-backlog',
+      '1000-first-four-digit',
+    ];
+
+    await setupTestProject(tmpDir, { roadmap: roadmapWith999and1000, phases });
+
+    const result = await phaseAdd(['After One Thousand'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+    // Must be 1001: skips 999 (backlog sentinel), keeps 1000 as max, adds 1
+    expect(data.phase_number).toBe(1001);
+  });
+
   it('throws GSDError with Validation for empty description', async () => {
     const { phaseAdd } = await import('./phase-lifecycle.js');
     await setupTestProject(tmpDir);

--- a/sdk/src/query/phase-lifecycle.test.ts
+++ b/sdk/src/query/phase-lifecycle.test.ts
@@ -325,7 +325,7 @@ describe('phaseAdd', () => {
     expect(roadmap).toContain('**Goal:** [To be planned]');
   });
 
-  it('skips phases >= 999 when calculating next number (backlog exclusion)', async () => {
+  it('skips exactly phase 999 (backlog sentinel) when calculating next number', async () => {
     const { phaseAdd } = await import('./phase-lifecycle.js');
     const roadmapWith999 = MINIMAL_ROADMAP.replace(
       '---\n*Last updated',
@@ -337,6 +337,59 @@ describe('phaseAdd', () => {
     const data = result.data as Record<string, unknown>;
     // Should be 11, not 1000
     expect(data.phase_number).toBe(11);
+  });
+
+  it('returns correct next phase id for projects using 1000+ canonical phase numbers (regression #3774)', async () => {
+    // Bug: scanSequentialMaxPhaseFromMilestone and scanSequentialMaxPhaseFromDirs
+    // used `num >= 999` instead of `num === 999`, causing every phase ≥ 1000 to be
+    // excluded from the max-scan. computeNextSequentialPhaseId returned 1 (0+1)
+    // instead of 1501 for a project whose highest phase is 1500.
+    const { phaseAdd } = await import('./phase-lifecycle.js');
+
+    const roadmapWith1000Plus = [
+      '# Roadmap',
+      '',
+      '## Current Milestone: v10.0 Large Project',
+      '',
+      '### Phase 1000: Foundation',
+      '',
+      '**Goal:** Foundation',
+      '**Requirements**: TBD',
+      '**Plans:** 1 plans',
+      '',
+      'Plans:',
+      '- [x] 1000-01 (Foundation setup)',
+      '',
+      '### Phase 1500: Latest',
+      '',
+      '**Goal:** Latest',
+      '**Requirements**: TBD',
+      '**Depends on:** Phase 1499',
+      '**Plans:** 1 plans',
+      '',
+      'Plans:',
+      '- [x] 1500-01 (Latest step)',
+      '',
+      '---',
+      '*Last updated: 2026-05-20*',
+      '',
+    ].join('\n');
+
+    const phases = [
+      '1000-foundation',
+      '1100-alpha',
+      '1200-beta',
+      '1300-gamma',
+      '1400-delta',
+      '1500-latest',
+    ];
+
+    await setupTestProject(tmpDir, { roadmap: roadmapWith1000Plus, phases });
+
+    const result = await phaseAdd(['Next After 1500'], tmpDir);
+    const data = result.data as Record<string, unknown>;
+    // Must be 1501, not 1 (the pre-fix bug value)
+    expect(data.phase_number).toBe(1501);
   });
 
   it('throws GSDError with Validation for empty description', async () => {

--- a/tests/phase.test.cjs
+++ b/tests/phase.test.cjs
@@ -932,6 +932,62 @@ describe('phase add command', () => {
       'directory should be 04-dashboard, not 1000-dashboard'
     );
   });
+
+  test('CJS scanner [999, 1000] fixture: skips exactly 999 and returns 1001 (regression #3774)', () => {
+    // Locks the BLOCKER fix in phase.cjs: guards at :610, :624, :688, :698 must
+    // use === 999 (not >= 999). With >= 999, phase 1000 is excluded from the
+    // max-scan and the result collapses back toward 1 instead of 1001.
+    //
+    // GSD_WORKSTREAM=ws1 forces the CJS fallback in phase-command-router.cjs.
+    // When GSD_WORKSTREAM is set, planningDir resolves to
+    //   .planning/workstreams/<ws>/ — so ROADMAP.md and phases/ live there.
+    const ws = 'ws1';
+    const planningBase = path.join(tmpDir, '.planning', 'workstreams', ws);
+    fs.mkdirSync(path.join(planningBase, 'phases'), { recursive: true });
+
+    fs.writeFileSync(
+      path.join(planningBase, 'ROADMAP.md'),
+      [
+        '# Roadmap',
+        '',
+        '## Current Milestone: v1.0',
+        '',
+        '### Phase 999: Backlog',
+        '',
+        '**Goal:** Backlog sentinel',
+        '**Plans:** 0 plans',
+        '',
+        '### Phase 1000: First Four-Digit Phase',
+        '',
+        '**Goal:** First canonical phase above backlog sentinel',
+        '**Requirements**: TBD',
+        '**Plans:** 1 plans',
+        '',
+        'Plans:',
+        '- [x] 1000-01 (initial work)',
+        '',
+        '---',
+        '*Last updated: 2026-05-21*',
+        '',
+      ].join('\n')
+    );
+
+    // Create matching phase directories on disk (inside the workstream planning dir)
+    fs.mkdirSync(path.join(planningBase, 'phases', '999-backlog'), { recursive: true });
+    fs.mkdirSync(path.join(planningBase, 'phases', '1000-first-four-digit'), { recursive: true });
+
+    const result = runGsdTools('phase add After One Thousand', tmpDir, { GSD_WORKSTREAM: ws });
+    assert.ok(result.success, `CJS phase add failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    // Must be 1001: skips 999 (backlog sentinel), keeps 1000, adds 1.
+    // With the old >= 999 guard: phase 1000 is excluded → max stays 0 → result = 1.
+    assert.strictEqual(output.phase_number, 1001, 'CJS scanner must return 1001, not 1 (regression #3774)');
+    assert.ok(
+      fs.existsSync(path.join(planningBase, 'phases', '1001-after-one-thousand')),
+      'directory should be 1001-after-one-thousand'
+    );
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Fix PR

## Linked Issue

Fixes #3774

> The linked issue has the `confirmed-bug` label.

---

## What was broken

`phase.add` returned phase ID `1` (instead of the correct next sequential ID) on projects whose canonical phase numbers are 1000 or higher. For example, a project with phases 1000–1500 would receive phase ID `1` instead of `1501`.

## What this fix does

Changes the sentinel guard in `scanSequentialMaxPhaseFromMilestone` and `scanSequentialMaxPhaseFromDirs` from `num >= 999` to `num === 999`, so only the exact backlog sentinel (`999`) is excluded from the max-scan. Phase IDs 1000+ are valid canonical numbers and are now correctly included.

## Root cause

Both scanner functions in `sdk/src/query/phase-lifecycle-policy.ts` (lines 71 and 88) used `>= 999` to skip the `999.x` backlog lane. This over-broad guard excluded every phase ≥ 1000, causing `computeNextSequentialPhaseId` to see max=0 and return `0 + 1 = 1`.

## Antipattern hunt results

Searched `sdk/src/` for all `>= 999`, `<= 999`, `> 999`, `=== 999` patterns:

- `sdk/src/query/phase-lifecycle-policy.ts:71` and `:88` — the two bug locations, fixed here.
- `sdk/src/query/phase-lifecycle.ts:762`, `:819`, `:832`, `:842` — these use `>= 999` intentionally in **decrement/renumbering** helpers (phase removal). They protect the `999.x` backlog lane from being renumbered when a lower phase is deleted. Using `>= 999` there is correct: no phase ≥ 999 should be renumbered during sequential phase removal. These are NOT bugs and are NOT changed.

## Testing

### How I verified the fix

Added a regression test to `sdk/src/query/phase-lifecycle.test.ts` (added to existing file — `phaseAdd` describe block):

- Fixture: ROADMAP with `Phase 1000` and `Phase 1500` entries; on-disk dirs `1000-foundation` through `1500-latest`.
- Asserts: `phaseAdd(['Next After 1500'], tmpDir)` returns `phase_number === 1501`.
- Pre-fix: test fails with `expected 1501, received 1`.
- Post-fix: test passes.

The existing test (`skips exactly phase 999 (backlog sentinel) when calculating next number`) provides the counter-test: confirms 999 is still excluded. Together the pair proves the exact-sentinel semantics.

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS (537 suites, 0 failed)
- [ ] Windows (including backslash path handling)
- [x] Linux / Docker (1697 suites, 0 failed — `gsd-test-summary --both` 2026-05-21)
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #3774` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added if this is a user-facing fix (`npm run changeset -- --type Fixed --pr <NNN> --body "..."`) — or `no-changelog` label applied
- [x] No unnecessary dependencies added

## Updates after review (2026-05-21)

### F1 (BLOCKER) — 4 CJS scanner twins fixed

`get-shit-done/bin/lib/phase.cjs` is hand-maintained (not generated). Four scanner sites in `cmdPhaseAdd` and `cmdPhaseAddBatch` still carried `>= 999` guards — the same over-broad sentinel that was fixed in the TS layer. These are reachable when `GSD_WORKSTREAM` is set (routes through CJS path regardless of SDK availability) or when the SDK build is absent.

Fixed sites (narrowed from `>= 999` to `=== 999`):
- `:610` — roadmap-scan loop in `cmdPhaseAdd`
- `:624` — disk-dir scan loop in `cmdPhaseAdd`
- `:688` — roadmap-scan `while` loop in `cmdPhaseAddBatch`
- `:698` — disk-dir `for` loop in `cmdPhaseAddBatch`

Intentionally left unchanged (decrement/rename helpers with different semantics):
- `:893` (`renameIntegerPhases`) — uses `< 999` as an upper-bound guard, not a skip filter
- `:922`, `:930`, `:936` (`decrementRoadmap*`) — protect the 999.x backlog lane from renumbering during phase removal; `>= 999` here correctly means "don't touch anything in or above the backlog lane"

### F2 (MAJOR) — regression test now distinguishes `=== 999` from `=== 1000`

Added `[999, 1000]` fixture tests to both:

- `sdk/src/query/phase-lifecycle.test.ts` — TS path: fixture with Phase 999 + Phase 1000, asserts `phaseAdd` returns `phase_number === 1001`. With the old `>= 999` guard the 1000 phase would have been excluded and the result would diverge.
- `tests/phase.test.cjs` — CJS path: same fixture via `GSD_WORKSTREAM=ws1` to force the CJS scanner. Asserts `phase_number === 1001` and that the `1001-after-one-thousand` directory is created.

The previous `[1000, 1500]` fixture was insufficient — it couldn't distinguish a bug where `=== 1000` was used instead of `=== 999`.

## Breaking changes

None
