### PR TITLE
fix(3496): include all version patterns in changelog extraction

### DIFF
--- a/.changeset/noble-tigers-parade.md
+++ b/.changeset/noble-tigers-parade.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3796
+---
+**`parseChangelog` now captures multi-line bullets** — bullets where the `(#NNNN)` PR trailer appears on a continuation line are no longer silently dropped. Adds `changeset/cli.cjs extract --from VERSION --to VERSION` for deterministic range-aware changelog extraction in `/gsd:update`.

--- a/get-shit-done/workflows/update.md
+++ b/get-shit-done/workflows/update.md
@@ -372,28 +372,48 @@ Exit.
 <step name="show_changes_and_confirm">
 **If update available**, fetch and show what's new BEFORE updating:
 
-1. Fetch changelog from GitHub raw URL
-2. Extract entries between installed and latest versions
-3. Display preview and ask for confirmation:
+1. Fetch changelog from GitHub raw URL and save to a temp file, e.g. `/tmp/gsd-changelog-$$.md`.
+2. Extract entries between installed and latest versions using the deterministic range helper (fix for #3496 — do NOT use ad-hoc grep/awk extraction which silently skips intermediate versions):
+
+```bash
+CHANGELOG_TMP="/tmp/gsd-changelog-$$.md"
+curl -fsSL "https://raw.githubusercontent.com/gsd-build/get-shit-done/main/CHANGELOG.md" -o "$CHANGELOG_TMP" 2>/dev/null \
+  || wget -qO "$CHANGELOG_TMP" "https://raw.githubusercontent.com/gsd-build/get-shit-done/main/CHANGELOG.md" 2>/dev/null
+
+EXTRACT_JSON=$(node "$GSD_DIR/get-shit-done/scripts/changeset/cli.cjs" extract \
+  --from "$INSTALLED_VERSION" \
+  --to "$LATEST_VERSION" \
+  --changelog "$CHANGELOG_TMP" \
+  --json 2>/dev/null)
+EXTRACT_EXIT=$?
+rm -f "$CHANGELOG_TMP"
+
+if [ "$EXTRACT_EXIT" -eq 2 ]; then
+  # Exit 2 = no releases in range (e.g. versions are equal or changelog is sparse)
+  CHANGELOG_PREVIEW="No changelog updates between v${INSTALLED_VERSION} and v${LATEST_VERSION}."
+elif [ "$EXTRACT_EXIT" -ne 0 ] || [ -z "$EXTRACT_JSON" ]; then
+  CHANGELOG_PREVIEW="(Could not extract changelog — update will still proceed)"
+else
+  # Re-run without --json to get the human-readable markdown for display
+  CHANGELOG_PREVIEW=$(node "$GSD_DIR/get-shit-done/scripts/changeset/cli.cjs" extract \
+    --from "$INSTALLED_VERSION" \
+    --to "$LATEST_VERSION" \
+    --changelog "$CHANGELOG_TMP" 2>/dev/null || echo "(changelog unavailable)")
+fi
+```
+
+3. Display preview and ask for confirmation, using `$CHANGELOG_PREVIEW` from the extract step above:
 
 ```
 ## GSD Update Available
 
-**Installed:** 1.5.10
-**Latest:** 1.5.15
+**Installed:** {INSTALLED_VERSION}
+**Latest:** {LATEST_VERSION}
 
 ### What's New
 ────────────────────────────────────────────────────────────
 
-## [1.5.15] - 2026-01-20
-
-### Added
-- Feature X
-
-## [1.5.14] - 2026-01-18
-
-### Fixed
-- Bug fix Y
+{CHANGELOG_PREVIEW}
 
 ────────────────────────────────────────────────────────────
 

--- a/scripts/changeset/cli.cjs
+++ b/scripts/changeset/cli.cjs
@@ -255,6 +255,14 @@ function cmdExtract(opts) {
 
   const matched = releases.filter((rel) => {
     if (rel.version === 'Unreleased') return false;
+    // Skip pre-release entries (e.g. 1.0.0-rc.1, 1.0.0-beta.2) — they cannot
+    // be range-compared via numeric tuples without implementing full pre-release
+    // ordering (semver §11).  Exclude them silently for now; a consolidation
+    // issue (#F8) will address pre-release ordering across all comparators.
+    if (!SEMVER_RE.test(rel.version)) {
+      process.stderr.write(`[extract] skipping pre-release/non-semver entry: ${rel.version}\n`);
+      return false;
+    }
     // from is exclusive: cmp > 0 means rel.version > from
     const afterFrom = semverCmp(rel.version, from) > 0;
     // to is inclusive: cmp <= 0 means rel.version <= to
@@ -350,7 +358,7 @@ function main() {
   const { opts } = parsed;
   if (opts.cmd !== 'render' && opts.cmd !== 'github-release-notes' && opts.cmd !== 'extract') {
     process.stderr.write(usage());
-    process.exit(2);
+    process.exit(1);
   }
   if (opts.cmd === 'render' && (!opts.version || !opts.date)) {
     process.stderr.write('--version and --date are required for render\n');
@@ -372,6 +380,8 @@ function main() {
       process.stdout.write(JSON.stringify(report, null, 2) + '\n');
     } else if (textOutput) {
       process.stdout.write(textOutput + '\n');
+    } else if (exitCode === 2) {
+      process.stderr.write(`no releases found in range (from=${report.from}, to=${report.to})\n`);
     }
     process.exit(exitCode);
   }

--- a/scripts/changeset/cli.cjs
+++ b/scripts/changeset/cli.cjs
@@ -19,7 +19,7 @@ const path = require('node:path');
 
 const { parseFragment, FRAGMENT_ERROR } = require('./parse.cjs');
 const { renderChangelog } = require('./render.cjs');
-const { serializeChangelog } = require('./serialize.cjs');
+const { serializeChangelog, parseChangelog } = require('./serialize.cjs');
 const { renderGithubReleaseNotes } = require('./github-release-notes.cjs');
 
 function parseArgs(argv) {
@@ -30,6 +30,7 @@ function parseArgs(argv) {
     date: null,
     fromRef: null,
     toRef: null,
+    changelog: null,
     output: null,
     repoSlug: 'gsd-build/get-shit-done',
     installCommand: 'npx get-shit-done-cc@latest',
@@ -59,6 +60,7 @@ function parseArgs(argv) {
       a === '--date' ||
       a === '--from' ||
       a === '--to' ||
+      a === '--changelog' ||
       a === '--output' ||
       a === '--repo-slug' ||
       a === '--install-command'
@@ -70,6 +72,7 @@ function parseArgs(argv) {
       else if (a === '--date') opts.date = r.value;
       else if (a === '--from') opts.fromRef = r.value;
       else if (a === '--to') opts.toRef = r.value;
+      else if (a === '--changelog') opts.changelog = r.value;
       else if (a === '--output') opts.output = r.value;
       else if (a === '--repo-slug') opts.repoSlug = r.value;
       else if (a === '--install-command') opts.installCommand = r.value;
@@ -180,6 +183,92 @@ function cmdRender(opts) {
   };
 }
 
+/**
+ * extract subcommand: extracts all changelog release blocks strictly after
+ * `--from` (exclusive) up to and including `--to` (inclusive).  Both
+ * arguments accept `v`-prefixed semver (e.g. `v1.5.13`).
+ *
+ * Exit codes:
+ *   0  — one or more releases matched, output written.
+ *   2  — no releases fall in the specified range (matches nothing).
+ *   1  — I/O error or missing required flags.
+ *
+ * Fix for #3496: provides a deterministic range-aware helper so the
+ * `/gsd:update` show_changes_and_confirm step no longer relies on
+ * vague/manual extraction that can silently skip intermediate versions.
+ */
+function cmdExtract(opts) {
+  const stripV = (v) => (typeof v === 'string' ? v.replace(/^v/, '') : v);
+  const from = stripV(opts.fromRef);
+  const to = stripV(opts.toRef);
+
+  const changelogPath = opts.changelog
+    ? path.resolve(opts.changelog)
+    : path.join(path.resolve(opts.repo), 'CHANGELOG.md');
+
+  if (!fs.existsSync(changelogPath)) {
+    return {
+      exitCode: 1,
+      report: { error: `CHANGELOG not found: ${changelogPath}`, releases: [] },
+      textOutput: null,
+    };
+  }
+
+  const text = fs.readFileSync(changelogPath, 'utf8');
+  const { releases } = parseChangelog(text);
+
+  // Walk the releases in document order (newest-first in a standard
+  // Keep-a-Changelog file).  Collect every release whose version is
+  // strictly after `from` and up to and including `to`.
+  //
+  // The comparison is semver-aware via the standard numeric-tuple approach
+  // so that "1.5.9" < "1.5.10" (string comparison would fail here).
+  function parseSemver(v) {
+    const parts = String(v).split('.').map(Number);
+    return [parts[0] || 0, parts[1] || 0, parts[2] || 0];
+  }
+
+  function semverCmp(a, b) {
+    const [a0, a1, a2] = parseSemver(a);
+    const [b0, b1, b2] = parseSemver(b);
+    return a0 !== b0 ? a0 - b0 : a1 !== b1 ? a1 - b1 : a2 - b2;
+  }
+
+  const matched = releases.filter((rel) => {
+    if (rel.version === 'Unreleased') return false;
+    // from is exclusive: cmp > 0 means rel.version > from
+    const afterFrom = semverCmp(rel.version, from) > 0;
+    // to is inclusive: cmp <= 0 means rel.version <= to
+    const upToTo = semverCmp(rel.version, to) <= 0;
+    return afterFrom && upToTo;
+  });
+
+  if (matched.length === 0) {
+    return {
+      exitCode: 2,
+      report: { releases: [], from, to },
+      textOutput: null,
+    };
+  }
+
+  return {
+    exitCode: 0,
+    report: { releases: matched, from, to },
+    textOutput: matched
+      .map((rel) => {
+        const header = `## [${rel.version}]${rel.date ? ` - ${rel.date}` : ''}`;
+        const sections = (rel.sections || [])
+          .map((s) => {
+            const bullets = s.bullets.map((b) => `- ${b.body} (#${b.pr})`).join('\n');
+            return `### ${s.type}\n\n${bullets}`;
+          })
+          .join('\n\n');
+        return sections ? `${header}\n\n${sections}` : header;
+      })
+      .join('\n\n'),
+  };
+}
+
 function cmdGithubReleaseNotes(opts) {
   const repo = path.resolve(opts.repo);
   const report = renderGithubReleaseNotes({
@@ -222,6 +311,10 @@ function usage() {
     'usage:',
     '  changeset/cli.cjs render --repo <dir> --version V --date D [--json]',
     '  changeset/cli.cjs github-release-notes --repo <dir> --from REF --to REF [--output FILE] [--repo-slug OWNER/REPO] [--install-command CMD] [--json]',
+    '  changeset/cli.cjs extract --from VERSION --to VERSION [--changelog FILE] [--repo <dir>] [--json]',
+    '    Extracts changelog entries strictly after --from (exclusive) and up to',
+    '    and including --to (inclusive).  Accepts v-prefixed versions.',
+    '    Exit 2 when no releases fall in range.',
     '',
   ].join('\n');
 }
@@ -234,7 +327,7 @@ function main() {
     process.exit(2);
   }
   const { opts } = parsed;
-  if (opts.cmd !== 'render' && opts.cmd !== 'github-release-notes') {
+  if (opts.cmd !== 'render' && opts.cmd !== 'github-release-notes' && opts.cmd !== 'extract') {
     process.stderr.write(usage());
     process.exit(2);
   }
@@ -245,6 +338,21 @@ function main() {
   if (opts.cmd === 'github-release-notes' && (!opts.fromRef || !opts.toRef)) {
     process.stderr.write('--from and --to are required for github-release-notes\n');
     process.exit(2);
+  }
+  if (opts.cmd === 'extract' && (!opts.fromRef || !opts.toRef)) {
+    process.stderr.write('--from and --to are required for extract\n');
+    process.stderr.write(usage());
+    process.exit(1);
+  }
+
+  if (opts.cmd === 'extract') {
+    const { exitCode, report, textOutput } = cmdExtract(opts);
+    if (opts.json) {
+      process.stdout.write(JSON.stringify(report, null, 2) + '\n');
+    } else if (textOutput) {
+      process.stdout.write(textOutput + '\n');
+    }
+    process.exit(exitCode);
   }
 
   const { exitCode, report } = opts.cmd === 'render' ? cmdRender(opts) : cmdGithubReleaseNotes(opts);
@@ -266,4 +374,4 @@ function main() {
 
 if (require.main === module) main();
 
-module.exports = { cmdRender, cmdGithubReleaseNotes, parseArgs, splitChangelog, listFragmentFiles, usage };
+module.exports = { cmdRender, cmdExtract, cmdGithubReleaseNotes, parseArgs, splitChangelog, listFragmentFiles, usage };

--- a/scripts/changeset/cli.cjs
+++ b/scripts/changeset/cli.cjs
@@ -202,6 +202,25 @@ function cmdExtract(opts) {
   const from = stripV(opts.fromRef);
   const to = stripV(opts.toRef);
 
+  // Validate that both bounds are strict semver (N.N.N, digits only).
+  // Coercing a malformed bound like "1.41.x" to "1.41.0" makes range
+  // selection silently wrong; reject early with a structured error.
+  const SEMVER_RE = /^\d+\.\d+\.\d+$/;
+  if (!SEMVER_RE.test(from)) {
+    return {
+      exitCode: 1,
+      report: { error: `invalid semver for --from: "${from}" (expected N.N.N)`, releases: [] },
+      textOutput: null,
+    };
+  }
+  if (!SEMVER_RE.test(to)) {
+    return {
+      exitCode: 1,
+      report: { error: `invalid semver for --to: "${to}" (expected N.N.N)`, releases: [] },
+      textOutput: null,
+    };
+  }
+
   const changelogPath = opts.changelog
     ? path.resolve(opts.changelog)
     : path.join(path.resolve(opts.repo), 'CHANGELOG.md');
@@ -259,7 +278,9 @@ function cmdExtract(opts) {
         const header = `## [${rel.version}]${rel.date ? ` - ${rel.date}` : ''}`;
         const sections = (rel.sections || [])
           .map((s) => {
-            const bullets = s.bullets.map((b) => `- ${b.body} (#${b.pr})`).join('\n');
+            const bullets = s.bullets
+              .map((b) => (b.pr !== null ? `- ${b.body} (#${b.pr})` : `- ${b.body}`))
+              .join('\n');
             return `### ${s.type}\n\n${bullets}`;
           })
           .join('\n\n');

--- a/scripts/changeset/serialize.cjs
+++ b/scripts/changeset/serialize.cjs
@@ -41,15 +41,42 @@ function serializeChangelog(ir) {
  * Inverse parser: extracts the structured releases from a CHANGELOG.md
  * text. Returns { releases: [{ version, date, sections: [{ type, bullets:
  * [{ pr, body }] }] }] }. Tolerates the actual repo's CHANGELOG dialect.
+ *
+ * Multi-line bullets are supported: a bullet opens on a line starting with
+ * `- ` and continues on lines starting with two or more spaces (or a tab).
+ * The `(#NNNN)` PR trailer may appear on any continuation line.  Single-line
+ * bullets (entire entry on one `- ` line) are still handled as before.
+ *
+ * Fix for #3496: the previous implementation only matched single-line bullets
+ * whose `(#NNNN)` suffix was on the same line as the opening `- `.  Long
+ * bullets — which wrap onto indented continuation lines — returned 0 entries
+ * for their section even when the markdown was well-formed.
  */
 function parseChangelog(text) {
   const releases = [];
   const lines = text.split(/\r?\n/);
   let cur = null;
   let curSection = null;
+  // Accumulates lines belonging to the current in-flight bullet (may span
+  // multiple lines).  Flushed when a new block-level element is encountered.
+  let bulletLines = null;
+
+  function flushBullet() {
+    if (bulletLines === null || !curSection) return;
+    const joined = bulletLines.join(' ').trim();
+    // Locate the (# pr) trailer anywhere in the joined text.  The trailer is
+    // expected to be at the very end, but we tolerate trailing whitespace.
+    const trailMatch = joined.match(/^(.*?)\s*\(#(\d+)\)\s*$/);
+    if (trailMatch) {
+      curSection.bullets.push({ body: trailMatch[1].trim(), pr: Number(trailMatch[2]) });
+    }
+    bulletLines = null;
+  }
+
   for (const line of lines) {
     const releaseMatch = line.match(/^##\s+\[([^\]]+)\](?:\s*-\s*(\S+))?/);
     if (releaseMatch) {
+      flushBullet();
       cur = { version: releaseMatch[1], date: releaseMatch[2] || null, sections: [] };
       curSection = null;
       releases.push(cur);
@@ -58,16 +85,32 @@ function parseChangelog(text) {
     if (!cur) continue;
     const sectionMatch = line.match(/^###\s+(.+?)\s*$/);
     if (sectionMatch) {
+      flushBullet();
       curSection = { type: sectionMatch[1], bullets: [] };
       cur.sections.push(curSection);
       continue;
     }
     if (!curSection) continue;
-    const bulletMatch = line.match(/^-\s+(.*?)\s*\(#(\d+)\)\s*$/);
-    if (bulletMatch) {
-      curSection.bullets.push({ body: bulletMatch[1], pr: Number(bulletMatch[2]) });
+
+    // New bullet: line begins with `- ` (after optional leading spaces that
+    // would indicate a nested list — we only handle top-level bullets here).
+    if (/^-\s+/.test(line)) {
+      flushBullet();
+      bulletLines = [line.replace(/^-\s+/, '')];
+      continue;
     }
+
+    // Continuation line: indented with at least two spaces (or a tab).
+    if (bulletLines !== null && /^[ \t]{2}/.test(line)) {
+      bulletLines.push(line.trim());
+      continue;
+    }
+
+    // Any other line (blank, heading, etc.) terminates a pending bullet.
+    flushBullet();
   }
+  flushBullet();
+
   return { releases };
 }
 

--- a/scripts/changeset/serialize.cjs
+++ b/scripts/changeset/serialize.cjs
@@ -69,6 +69,10 @@ function parseChangelog(text) {
     const trailMatch = joined.match(/^(.*?)\s*\(#(\d+)\)\s*$/);
     if (trailMatch) {
       curSection.bullets.push({ body: trailMatch[1].trim(), pr: Number(trailMatch[2]) });
+    } else {
+      // Bullet has no PR trailer — preserve it with pr: null so callers
+      // (e.g. cmdExtract) do not silently drop authored content.
+      curSection.bullets.push({ body: joined, pr: null });
     }
     bulletLines = null;
   }

--- a/scripts/changeset/serialize.cjs
+++ b/scripts/changeset/serialize.cjs
@@ -78,10 +78,17 @@ function parseChangelog(text) {
   }
 
   for (const line of lines) {
-    const releaseMatch = line.match(/^##\s+\[([^\]]+)\](?:\s*-\s*(\S+))?/);
+    // F3: match linked headers: ## [1.42.1](url) - 2026-05-15
+    //     The (?:\([^)]*\))? group skips an optional (url) after the closing ]
+    //     before looking for the optional date suffix.
+    // F6: strip a leading `v` from the captured version so `## [v1.0.0]`
+    //     parses as version "1.0.0" instead of "v1.0.0".
+    const releaseMatch = line.match(/^##\s+\[([^\]]+)\](?:\([^)]*\))?\s*(?:-\s*(\S+))?/);
     if (releaseMatch) {
       flushBullet();
-      cur = { version: releaseMatch[1], date: releaseMatch[2] || null, sections: [] };
+      const rawVersion = releaseMatch[1];
+      const version = rawVersion.replace(/^v/, '');
+      cur = { version, date: releaseMatch[2] || null, sections: [] };
       curSection = null;
       releases.push(cur);
       continue;
@@ -104,13 +111,15 @@ function parseChangelog(text) {
       continue;
     }
 
-    // Continuation line: indented with at least two spaces (or a tab).
-    if (bulletLines !== null && /^[ \t]{2}/.test(line)) {
+    // Continuation line: any indentation (F7: relaxed from /^[ \t]{2}/ so that
+    // 1-space-indented continuations also fold) BUT NOT a nested bullet marker
+    // (F4: `  - nested item` terminates the current bullet rather than folding).
+    if (bulletLines !== null && /^\s+/.test(line) && !/^\s+-\s/.test(line)) {
       bulletLines.push(line.trim());
       continue;
     }
 
-    // Any other line (blank, heading, etc.) terminates a pending bullet.
+    // Any other line (blank, heading, nested bullet, etc.) terminates a pending bullet.
     flushBullet();
   }
   flushBullet();

--- a/tests/changeset-cli.test.cjs
+++ b/tests/changeset-cli.test.cjs
@@ -128,12 +128,21 @@ describe('changeset cli extract: version-range changelog extraction (#3496)', ()
     assert.ok(prs.includes(102), 'multi-line bullet pr=102 must be captured');
   });
 
-  test('emits markdown when --json is not passed', (t) => {
+  test('emits markdown text (non-JSON) when --json is not passed', (t) => {
+    // Without --json the output is human-readable markdown, not JSON.
+    // Assert on structural facts derivable from the text: exactly the two
+    // matched releases appear as ## headers, using parseChangelog so we
+    // assert on version strings via the production parser rather than
+    // raw substring matches.
+    const { parseChangelog: _pc } = require(path.join(ROOT, 'scripts', 'changeset', 'serialize.cjs'));
     const r = runExtract(['--from', '1.5.13', '--to', '1.5.15'], EXTRACT_CHANGELOG);
     assert.equal(r.status, 0, `stderr=${r.stderr}`);
-    assert.ok(r.stdout.includes('1.5.15'), 'stdout markdown must contain 1.5.15');
-    assert.ok(r.stdout.includes('1.5.14'), 'stdout markdown must contain 1.5.14');
-    assert.ok(!r.stdout.includes('1.5.13'), 'stdout must not contain excluded from-version');
+    assert.ok(r.stdout.trim().length > 0, 'stdout must be non-empty');
+    const parsed = _pc(r.stdout);
+    const versions = parsed.releases.map((rel) => rel.version);
+    assert.ok(versions.includes('1.5.15'), '1.5.15 in markdown output');
+    assert.ok(versions.includes('1.5.14'), '1.5.14 in markdown output');
+    assert.ok(!versions.includes('1.5.13'), '1.5.13 must not appear in output (excluded by --from)');
   });
 
   test('missing --from or --to emits usage and exits non-zero', (t) => {

--- a/tests/changeset-cli.test.cjs
+++ b/tests/changeset-cli.test.cjs
@@ -320,7 +320,9 @@ describe('changeset cli extract: version-range changelog extraction (#3496)', ()
     assert.ok(!versions.includes('1.0.0.1'), '1.0.0.1 (4-part) must be excluded from range');
   });
 
-  // F1: workflows/update.md must reference the extract subcommand invocation
+  // F1: workflows/update.md must reference the extract subcommand invocation.
+  // allow-test-rule: reads a product workflow .md file (not CJS source) to verify
+  // the user-facing instruction was wired; there is no behavioural runtime to invoke.
   test('F1: workflows/update.md contains concrete extract subcommand invocation', (t) => {
     const workflowPath = path.join(ROOT, 'get-shit-done', 'workflows', 'update.md');
     const workflowText = fs.readFileSync(workflowPath, 'utf8');

--- a/tests/changeset-cli.test.cjs
+++ b/tests/changeset-cli.test.cjs
@@ -150,6 +150,46 @@ describe('changeset cli extract: version-range changelog extraction (#3496)', ()
     assert.notEqual(r.status, 0);
     assert.ok(r.stderr.length > 0 || r.stdout.length > 0, 'must emit usage text');
   });
+
+  test('rejects malformed --from semver (non-numeric component) with exit 1', (t) => {
+    const r = runExtract(['--from', '1.41.x', '--to', '1.5.15', '--json'], EXTRACT_CHANGELOG);
+    assert.equal(r.status, 1, `expected exit 1 for malformed --from, stderr=${r.stderr}`);
+    assert.ok(r.json, 'stdout must be valid JSON on error');
+    assert.ok(typeof r.json.error === 'string', 'error field must be present');
+    assert.ok(r.json.error.includes('--from'), 'error must mention --from');
+  });
+
+  test('rejects malformed --to semver (alphabetic) with exit 1', (t) => {
+    const r = runExtract(['--from', '1.5.13', '--to', 'foo', '--json'], EXTRACT_CHANGELOG);
+    assert.equal(r.status, 1, `expected exit 1 for malformed --to, stderr=${r.stderr}`);
+    assert.ok(r.json, 'stdout must be valid JSON on error');
+    assert.ok(typeof r.json.error === 'string', 'error field must be present');
+    assert.ok(r.json.error.includes('--to'), 'error must mention --to');
+  });
+
+  test('preserves bullets without PR trailer in extracted output', (t) => {
+    // Fixture with one no-PR bullet and one PR bullet.
+    const CHANGELOG_NO_PR = [
+      '# Changelog',
+      '',
+      '## [2.0.0] - 2026-01-01',
+      '',
+      '### Fixed',
+      '',
+      '- Documented fix without PR reference.',
+      '- Fix with PR reference. (#999)',
+    ].join('\n');
+    const r = runExtract(['--from', '1.9.9', '--to', '2.0.0', '--json'], CHANGELOG_NO_PR);
+    assert.equal(r.status, 0, `stderr=${r.stderr}`);
+    assert.ok(r.json, 'stdout must be valid JSON');
+    const section = r.json.releases[0].sections[0];
+    assert.equal(section.bullets.length, 2, 'both bullets (with and without PR) must be captured');
+    const noPrBullet = section.bullets.find((b) => b.pr === null);
+    assert.ok(noPrBullet, 'bullet without PR trailer must be present with pr: null');
+    assert.ok(noPrBullet.body.includes('Documented fix'), 'body text preserved');
+    const prBullet = section.bullets.find((b) => b.pr === 999);
+    assert.ok(prBullet, 'bullet with PR trailer must still be captured');
+  });
 });
 
 describe('changeset cli render: file-I/O wrapper (#2975)', () => {

--- a/tests/changeset-cli.test.cjs
+++ b/tests/changeset-cli.test.cjs
@@ -38,6 +38,111 @@ function runRender(args = []) {
 before(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-changeset-')); });
 after(() => { fs.rmSync(tmp, { recursive: true, force: true }); });
 
+// Fixtures for extract tests (#3496)
+// Written as arrays to avoid template-literal indentation injecting
+// leading spaces that would break the ^## regex anchor.
+const EXTRACT_CHANGELOG = [
+  '# Changelog',
+  '',
+  '## [1.5.15] - 2026-01-20',
+  '',
+  '### Added',
+  '',
+  '- Feature X. (#200)',
+  '',
+  '## [1.5.14] - 2026-01-18',
+  '',
+  '### Fixed',
+  '',
+  '- Single-line fix. (#101)',
+  '- **Multi-line fix** — first line of a long',
+  '  description that spans two lines. (#102)',
+  '',
+  '## [1.5.13] - 2026-01-15',
+  '',
+  '### Fixed',
+  '',
+  '- Old fix. (#100)',
+  '',
+  '## [1.5.10] - 2026-01-01',
+  '',
+  '### Fixed',
+  '',
+  '- Very old fix. (#50)',
+].join('\n');
+
+function runExtract(args = [], changelogText = null) {
+  const changelogFile = path.join(tmp, 'CHANGELOG-extract-test.md');
+  if (changelogText !== null) {
+    fs.writeFileSync(changelogFile, changelogText);
+  }
+  const r = cp.spawnSync(
+    process.execPath,
+    [SCRIPT, 'extract', '--changelog', changelogFile, ...args],
+    { encoding: 'utf8' },
+  );
+  return {
+    status: r.status,
+    stdout: r.stdout || '',
+    stderr: r.stderr || '',
+    json: (() => {
+      try { return JSON.parse(r.stdout); } catch { return null; }
+    })(),
+  };
+}
+
+describe('changeset cli extract: version-range changelog extraction (#3496)', () => {
+  test('exits 2 with no output when no versions fall in range', (t) => {
+    const r = runExtract(['--from', '1.5.15', '--to', '1.5.15', '--json'], EXTRACT_CHANGELOG);
+    assert.equal(r.status, 2, `expected exit 2 for empty range, stderr=${r.stderr}`);
+  });
+
+  test('extracts versions strictly after from and up to and including to', (t) => {
+    const r = runExtract(['--from', '1.5.13', '--to', '1.5.15', '--json'], EXTRACT_CHANGELOG);
+    assert.equal(r.status, 0, `stderr=${r.stderr}`);
+    assert.ok(r.json, 'stdout must be valid JSON');
+    const versions = r.json.releases.map((rel) => rel.version);
+    assert.ok(versions.includes('1.5.15'), '1.5.15 must be in range (inclusive to)');
+    assert.ok(versions.includes('1.5.14'), '1.5.14 must be in range (between from and to)');
+    assert.ok(!versions.includes('1.5.13'), '1.5.13 must NOT be in range (exclusive from)');
+    assert.ok(!versions.includes('1.5.10'), '1.5.10 must NOT be in range (below from)');
+  });
+
+  test('accepts v-prefixed version arguments', (t) => {
+    const r = runExtract(['--from', 'v1.5.13', '--to', 'v1.5.15', '--json'], EXTRACT_CHANGELOG);
+    assert.equal(r.status, 0, `stderr=${r.stderr}`);
+    assert.ok(r.json, 'stdout must be valid JSON');
+    const versions = r.json.releases.map((rel) => rel.version);
+    assert.ok(versions.includes('1.5.15'));
+    assert.ok(versions.includes('1.5.14'));
+    assert.ok(!versions.includes('1.5.13'));
+  });
+
+  test('captures multi-line bullets in extracted range', (t) => {
+    const r = runExtract(['--from', '1.5.13', '--to', '1.5.14', '--json'], EXTRACT_CHANGELOG);
+    assert.equal(r.status, 0, `stderr=${r.stderr}`);
+    const release = r.json.releases.find((rel) => rel.version === '1.5.14');
+    assert.ok(release, '1.5.14 must be in result');
+    const prs = release.sections.flatMap((s) => s.bullets.map((b) => b.pr));
+    assert.ok(prs.includes(101), 'single-line bullet pr=101 must be captured');
+    assert.ok(prs.includes(102), 'multi-line bullet pr=102 must be captured');
+  });
+
+  test('emits markdown when --json is not passed', (t) => {
+    const r = runExtract(['--from', '1.5.13', '--to', '1.5.15'], EXTRACT_CHANGELOG);
+    assert.equal(r.status, 0, `stderr=${r.stderr}`);
+    assert.ok(r.stdout.includes('1.5.15'), 'stdout markdown must contain 1.5.15');
+    assert.ok(r.stdout.includes('1.5.14'), 'stdout markdown must contain 1.5.14');
+    assert.ok(!r.stdout.includes('1.5.13'), 'stdout must not contain excluded from-version');
+  });
+
+  test('missing --from or --to emits usage and exits non-zero', (t) => {
+    const r = runExtract(['--from', '1.0.0'], EXTRACT_CHANGELOG);
+    assert.notEqual(r.status, 0);
+    assert.ok(r.stderr.length > 0 || r.stdout.length > 0, 'must emit usage text');
+  });
+});
+
 describe('changeset cli render: file-I/O wrapper (#2975)', () => {
   test('exits 0 with consumed=N when N fragments are folded into CHANGELOG.md and deleted', () => {
     fs.rmSync(path.join(tmp, '.changeset'), { recursive: true, force: true });

--- a/tests/changeset-cli.test.cjs
+++ b/tests/changeset-cli.test.cjs
@@ -95,6 +95,9 @@ describe('changeset cli extract: version-range changelog extraction (#3496)', ()
   test('exits 2 with no output when no versions fall in range', (t) => {
     const r = runExtract(['--from', '1.5.15', '--to', '1.5.15', '--json'], EXTRACT_CHANGELOG);
     assert.equal(r.status, 2, `expected exit 2 for empty range, stderr=${r.stderr}`);
+    // F11: assert JSON structure is present and releases is empty array
+    assert.ok(r.json, 'stdout must be valid JSON even on exit 2');
+    assert.strictEqual(r.json.releases.length, 0, 'releases must be empty array on exit 2');
   });
 
   test('extracts versions strictly after from and up to and including to', (t) => {
@@ -189,6 +192,156 @@ describe('changeset cli extract: version-range changelog extraction (#3496)', ()
     assert.ok(noPrBullet.body.includes('Documented fix'), 'body text preserved');
     const prBullet = section.bullets.find((b) => b.pr === 999);
     assert.ok(prBullet, 'bullet with PR trailer must still be captured');
+  });
+
+  // F2: pre-release entries must be excluded from range queries
+  test('F2: pre-release entry 1.0.0-rc.1 is excluded from range --from 0.9.9 --to 1.0.0', (t) => {
+    const CHANGELOG_WITH_PRERELEASE = [
+      '# Changelog',
+      '',
+      '## [1.0.0] - 2026-03-01',
+      '',
+      '### Added',
+      '',
+      '- Stable release. (#10)',
+      '',
+      '## [1.0.0-rc.1] - 2026-02-28',
+      '',
+      '### Added',
+      '',
+      '- Release candidate. (#9)',
+      '',
+      '## [0.9.9] - 2026-02-01',
+      '',
+      '### Fixed',
+      '',
+      '- Prior fix. (#8)',
+    ].join('\n');
+    const r = runExtract(['--from', '0.9.9', '--to', '1.0.0', '--json'], CHANGELOG_WITH_PRERELEASE);
+    assert.equal(r.status, 0, `stderr=${r.stderr}`);
+    assert.ok(r.json, 'stdout must be valid JSON');
+    const versions = r.json.releases.map((rel) => rel.version);
+    assert.ok(versions.includes('1.0.0'), '1.0.0 must be in range');
+    assert.ok(!versions.includes('1.0.0-rc.1'), '1.0.0-rc.1 (pre-release) must be excluded from range');
+    assert.ok(!versions.includes('0.9.9'), '0.9.9 must not be in range (exclusive from)');
+  });
+
+  // F3: linked-header format ## [1.42.1](url) - date must parse date correctly
+  test('F3: linked-header ## [1.42.1](url) - date parses date correctly', (t) => {
+    const CHANGELOG_LINKED = [
+      '# Changelog',
+      '',
+      '## [1.42.1](https://github.com/example/repo/releases/tag/v1.42.1) - 2026-05-15',
+      '',
+      '### Fixed',
+      '',
+      '- Linked header fix. (#300)',
+      '',
+      '## [1.42.0](https://github.com/example/repo/releases/tag/v1.42.0) - 2026-05-10',
+      '',
+      '### Added',
+      '',
+      '- Linked header feature. (#299)',
+    ].join('\n');
+    const { parseChangelog: _pc } = require(path.join(ROOT, 'scripts', 'changeset', 'serialize.cjs'));
+    const parsed = _pc(CHANGELOG_LINKED);
+    const r1421 = parsed.releases.find((r) => r.version === '1.42.1');
+    assert.ok(r1421, '1.42.1 must parse from linked header');
+    assert.equal(r1421.date, '2026-05-15', 'date must be extracted from linked header');
+    const r1420 = parsed.releases.find((r) => r.version === '1.42.0');
+    assert.ok(r1420, '1.42.0 must parse from linked header');
+    assert.equal(r1420.date, '2026-05-10', 'date must be extracted from linked header');
+  });
+
+  // F4: nested bullets must remain as separate bullets, not fold into parent
+  test('F4: nested bullets are not folded into parent bullet', (t) => {
+    const CHANGELOG_NESTED = [
+      '# Changelog',
+      '',
+      '## [3.0.0] - 2026-06-01',
+      '',
+      '### Changed',
+      '',
+      '- Parent bullet. (#400)',
+      '  - Nested child item.',
+      '- Second top-level bullet. (#401)',
+    ].join('\n');
+    const { parseChangelog: _pc } = require(path.join(ROOT, 'scripts', 'changeset', 'serialize.cjs'));
+    const parsed = _pc(CHANGELOG_NESTED);
+    const rel = parsed.releases.find((r) => r.version === '3.0.0');
+    assert.ok(rel, '3.0.0 must parse');
+    const section = rel.sections[0];
+    // The nested bullet terminates the parent; second top-level bullet is separate.
+    // We must have both PR 400 and PR 401 as distinct bullets.
+    const prs = section.bullets.map((b) => b.pr);
+    assert.ok(prs.includes(400), 'parent bullet pr=400 must be captured');
+    assert.ok(prs.includes(401), 'second top-level bullet pr=401 must be captured');
+    // The nested child must NOT have been folded into parent body
+    const parentBullet = section.bullets.find((b) => b.pr === 400);
+    assert.ok(!parentBullet.body.includes('Nested child'), 'nested child must not be folded into parent body');
+  });
+
+  // F5+F6: 4-part headers and v-prefix in-file headers
+  test('F5+F6: 4-part version in CHANGELOG is skipped, v-prefixed version parses without v', (t) => {
+    const CHANGELOG_EDGE = [
+      '# Changelog',
+      '',
+      '## [v1.0.0] - 2026-04-01',
+      '',
+      '### Fixed',
+      '',
+      '- v-prefixed header fix. (#500)',
+      '',
+      '## [1.0.0.1] - 2026-03-15',
+      '',
+      '### Fixed',
+      '',
+      '- 4-part version fix. (#501)',
+      '',
+      '## [0.9.9] - 2026-03-01',
+      '',
+      '### Fixed',
+      '',
+      '- Old fix. (#499)',
+    ].join('\n');
+    const { parseChangelog: _pc } = require(path.join(ROOT, 'scripts', 'changeset', 'serialize.cjs'));
+    const parsed = _pc(CHANGELOG_EDGE);
+
+    // F6: v-prefixed version should be stored without the leading v
+    const v100 = parsed.releases.find((r) => r.version === '1.0.0');
+    assert.ok(v100, 'v-prefixed header must parse as version 1.0.0 (v stripped)');
+
+    // Confirm extract skips 1.0.0.1 (4-part) — it appears in parsed but won't
+    // satisfy SEMVER_RE inside the range filter
+    const r = runExtract(['--from', '0.9.9', '--to', '1.0.0', '--json'], CHANGELOG_EDGE);
+    assert.equal(r.status, 0, `stderr=${r.stderr}`);
+    const versions = r.json.releases.map((rel) => rel.version);
+    assert.ok(versions.includes('1.0.0'), '1.0.0 must be in range');
+    assert.ok(!versions.includes('1.0.0.1'), '1.0.0.1 (4-part) must be excluded from range');
+  });
+
+  // F1: workflows/update.md must reference the extract subcommand invocation
+  test('F1: workflows/update.md contains concrete extract subcommand invocation', (t) => {
+    const workflowPath = path.join(ROOT, 'get-shit-done', 'workflows', 'update.md');
+    const workflowText = fs.readFileSync(workflowPath, 'utf8');
+    // The invocation is: node "$GSD_DIR/get-shit-done/scripts/changeset/cli.cjs" extract
+    // so the literal substring is 'cli.cjs" extract' (quote between script path and subcommand)
+    assert.ok(
+      workflowText.includes('cli.cjs" extract') || workflowText.includes('cli.cjs extract'),
+      'update.md must invoke cli.cjs extract (fix for #3496 BLOCKER 1)',
+    );
+    assert.ok(
+      workflowText.includes('--from') && workflowText.includes('--to'),
+      'update.md extract invocation must include --from and --to flags',
+    );
+    assert.ok(
+      workflowText.includes('--json'),
+      'update.md extract invocation must use --json for structured output',
+    );
+    assert.ok(
+      workflowText.includes('EXTRACT_EXIT') || workflowText.includes('EXTRACT_JSON'),
+      'update.md must capture exit code or JSON output from extract',
+    );
   });
 });
 

--- a/tests/changeset-serialize.test.cjs
+++ b/tests/changeset-serialize.test.cjs
@@ -87,6 +87,30 @@ describe('changeset serialize: multi-line bullet parsing (#3496)', () => {
     assert.equal(result.releases[0].sections[0].bullets.length, 1);
     assert.equal(result.releases[0].sections[0].bullets[0].pr, 3287);
   });
+
+  test('preserves bullets without (# pr) trailer as { body, pr: null } instead of dropping them', () => {
+    // Regression guard for Codex finding: bullets that lack a trailing
+    // (# NNNN) were silently discarded.  They must be stored with pr: null
+    // so callers (e.g. cmdExtract) can render them without silent loss.
+    const text = [
+      '## [1.43.0] - 2026-05-20',
+      '',
+      '### Fixed',
+      '',
+      '- Fix with a PR reference. (#4000)',
+      '- Documented fix without a PR reference.',
+      '- **Multi-line fix without trailer** — first line of description',
+      '  that continues on a second line but has no (# NNN) at the end.',
+    ].join('\n');
+    const result = parseChangelog(text);
+    const section = result.releases[0].sections[0];
+    assert.equal(section.bullets.length, 3, 'all three bullets must be captured');
+    assert.equal(section.bullets[0].pr, 4000, 'PR bullet preserved');
+    assert.equal(section.bullets[1].pr, null, 'no-PR bullet has pr: null');
+    assert.ok(section.bullets[1].body.includes('Documented fix'), 'no-PR bullet body preserved');
+    assert.equal(section.bullets[2].pr, null, 'multi-line no-PR bullet has pr: null');
+    assert.ok(section.bullets[2].body.includes('Multi-line fix without trailer'), 'multi-line no-PR body preserved');
+  });
 });
 
 describe('changeset serialize: multi-section + prior content (#2975)', () => {

--- a/tests/changeset-serialize.test.cjs
+++ b/tests/changeset-serialize.test.cjs
@@ -31,6 +31,64 @@ describe('changeset serialize: IR → markdown round-trip (#2975)', () => {
   });
 });
 
+describe('changeset serialize: multi-line bullet parsing (#3496)', () => {
+  // Regression: parseChangelog silently dropped bullets whose text wrapped
+  // across multiple indented continuation lines. The PR number (#NNNN) appears
+  // on the final continuation line, not the opening `-` line, so the
+  // single-line bullet regex never matched. Every such bullet returned 0
+  // entries for its section even though the markdown was well-formed.
+  test('parses a multi-line bullet whose (# pr) trailer is on a continuation line', () => {
+    const text = [
+      '## [1.41.0] - 2026-05-07',
+      '',
+      '### Feature',
+      '',
+      '- **Short title** — first line of a long description',
+      '  that wraps onto a second line and terminates with. (#2792)',
+      '- Single-line bullet with pr. (#2800)',
+    ].join('\n');
+    const result = parseChangelog(text);
+    assert.equal(result.releases.length, 1);
+    const section = result.releases[0].sections[0];
+    assert.equal(section.type, 'Feature');
+    assert.equal(section.bullets.length, 2, 'both bullets (multi-line and single-line) must be captured');
+    assert.equal(section.bullets[0].pr, 2792, 'multi-line bullet pr');
+    assert.equal(section.bullets[1].pr, 2800, 'single-line bullet pr');
+  });
+
+  test('parses a bullet with (# pr) on the opening line even when followed by multi-line bullets', () => {
+    const text = [
+      '## [1.42.1] - 2026-05-15',
+      '',
+      '### Fixed',
+      '',
+      '- Simple fix. (#3261)',
+      '- **Complex fix** — first line of',
+      '  a multi-line description. (#3287)',
+    ].join('\n');
+    const result = parseChangelog(text);
+    const section = result.releases[0].sections[0];
+    assert.equal(section.bullets.length, 2);
+    assert.equal(section.bullets[0].pr, 3261);
+    assert.equal(section.bullets[1].pr, 3287);
+  });
+
+  test('a multi-line bullet with linked release header is parsed correctly', () => {
+    const text = [
+      '## [1.42.1](https://github.com/gsd-build/get-shit-done/compare/v1.41.0...v1.42.1) - 2026-05-15',
+      '',
+      '### Fixed',
+      '',
+      '- **Multi-line with linked header** — description spans',
+      '  multiple lines and version header has an inline URL. (#3287)',
+    ].join('\n');
+    const result = parseChangelog(text);
+    assert.equal(result.releases[0].version, '1.42.1');
+    assert.equal(result.releases[0].sections[0].bullets.length, 1);
+    assert.equal(result.releases[0].sections[0].bullets[0].pr, 3287);
+  });
+});
+
 describe('changeset serialize: multi-section + prior content (#2975)', () => {
   const { serializeChangelog, parseChangelog } = require(require('node:path').join(__dirname, '..', 'scripts', 'changeset', 'serialize.cjs'));
 

--- a/tests/locking-bugs-1909-1916-1925-1927.test.cjs
+++ b/tests/locking-bugs-1909-1916-1925-1927.test.cjs
@@ -543,6 +543,15 @@ describe('#1927 config.json: setConfigValue must hold planning lock', () => {
   });
 
   test('both concurrent config-set calls persist their values', async () => {
+    // Deterministic concurrency via file-barrier synchronization (mirrors the
+    // locking-bugs:180 and :235 redesigns).
+    //
+    // The old Promise.all([execAsync(A), execAsync(B)]) design is non-deterministic:
+    // on a loaded Docker runner one subprocess can complete before the other has
+    // even started, meaning there is no real lock contention — or the opposite:
+    // both race O_EXCL and one observes stale fs state, causing a lost write that
+    // fails the assertion.  A barrier file forces both to be alive simultaneously
+    // before either runs the actual config-set.
     writeConfig(tmpDir, {
       model_profile: 'balanced',
       workflow: {
@@ -551,14 +560,76 @@ describe('#1927 config.json: setConfigValue must hold planning lock', () => {
       },
     });
 
-    const nodeBin = process.execPath;
-    const cmdA = `"${nodeBin}" "${TOOLS_PATH}" config-set model_profile quality --cwd "${tmpDir}"`;
-    const cmdB = `"${nodeBin}" "${TOOLS_PATH}" config-set workflow.research false --cwd "${tmpDir}"`;
+    // ── Barrier infrastructure ────────────────────────────────────────────────
+    const barrierPath = path.join(tmpDir, '.barrier-1927');
+    const readyA     = path.join(tmpDir, '.ready-1927-a');
+    const readyB     = path.join(tmpDir, '.ready-1927-b');
+    fs.writeFileSync(barrierPath, '1');
+    if (fs.existsSync(readyA)) fs.unlinkSync(readyA);
+    if (fs.existsSync(readyB)) fs.unlinkSync(readyB);
 
-    await Promise.all([
-      execAsync(cmdA, { encoding: 'utf-8' }).catch(() => {}),
-      execAsync(cmdB, { encoding: 'utf-8' }).catch(() => {}),
-    ]);
+    // ── Wrapper script ────────────────────────────────────────────────────────
+    const wrapperPath = path.join(tmpDir, '.barrier-wrapper-config-set.cjs');
+    fs.writeFileSync(wrapperPath, [
+      "'use strict';",
+      'const fs   = require("fs");',
+      'const { execFileSync } = require("child_process");',
+      'const { TOOLS_PATH, BARRIER_FILE, READY_FILE, CONFIG_KEY, CONFIG_VAL, CWD_PATH } = process.env;',
+      '',
+      'fs.writeFileSync(READY_FILE, String(process.pid));',
+      '',
+      'const sab = new SharedArrayBuffer(4);',
+      'const sai = new Int32Array(sab);',
+      'const deadline = Date.now() + 10000;',
+      'while (fs.existsSync(BARRIER_FILE)) {',
+      '  if (Date.now() > deadline) { process.stderr.write("barrier timeout\\n"); process.exit(1); }',
+      '  Atomics.wait(sai, 0, 0, 10);',
+      '}',
+      '',
+      'execFileSync(process.execPath, [TOOLS_PATH, "config-set", CONFIG_KEY, CONFIG_VAL, "--cwd", CWD_PATH], {',
+      '  stdio: "pipe",',
+      '});',
+    ].join('\n'));
+
+    const nodeBin = process.execPath;
+
+    function spawnWrapper(configKey, configVal, readyFile) {
+      return new Promise((resolve, reject) => {
+        const child = spawn(nodeBin, [wrapperPath], {
+          env: {
+            ...process.env,
+            TOOLS_PATH,
+            BARRIER_FILE: barrierPath,
+            READY_FILE:   readyFile,
+            CONFIG_KEY:   configKey,
+            CONFIG_VAL:   configVal,
+            CWD_PATH:     tmpDir,
+          },
+          stdio: 'pipe',
+        });
+        let stderr = '';
+        child.stderr.on('data', (d) => { stderr += d.toString(); });
+        child.on('close', (code) => {
+          if (code !== 0) reject(new Error(`wrapper exited ${code}: ${stderr}`));
+          else resolve();
+        });
+      });
+    }
+
+    const promiseA = spawnWrapper('model_profile', 'quality', readyA);
+    const promiseB = spawnWrapper('workflow.research', 'false', readyB);
+
+    // ── Wait for both to reach barrier, then release ──────────────────────────
+    const sab2 = new SharedArrayBuffer(4);
+    const sai2 = new Int32Array(sab2);
+    const deadline2 = Date.now() + 10000;
+    while (!fs.existsSync(readyA) || !fs.existsSync(readyB)) {
+      if (Date.now() > deadline2) throw new Error('Timed out waiting for both config-set subprocesses to reach barrier');
+      Atomics.wait(sai2, 0, 0, 10);
+    }
+    fs.unlinkSync(barrierPath);
+
+    await Promise.all([promiseA, promiseB]);
 
     const config = readConfig(tmpDir);
     assert.strictEqual(


### PR DESCRIPTION
## Fix PR

> **Using the wrong template?**
> — Enhancement: use [enhancement.md](?template=enhancement.md)
> — Feature: use [feature.md](?template=feature.md)

---

## Linked Issue

> **Required.** This PR will be auto-closed if no valid issue link is found.

Fixes #3496

> The linked issue has the `confirmed-bug` label (verified).

---

## What was broken

`parseChangelog` in `scripts/changeset/serialize.cjs` used a single-line regex to match changelog bullets. Bullets where the `(#NNNN)` PR trailer appeared on a **continuation line** (indented with two or more spaces) were silently dropped. This caused Feature/Enhancement sections with multi-line bullets to return 0 entries, making `/gsd:update` miss intermediate versions.

Additionally, `/gsd:update` had no dedicated range-aware CLI helper — extraction was vague/manual with no deterministic `(from, to]` boundary semantics.

## What this fix does

1. **`scripts/changeset/serialize.cjs`** — `parseChangelog` now folds continuation lines (lines starting with `≥2 spaces`) into the preceding bullet before applying the PR-trailer regex. Multi-line bullets are captured correctly regardless of which line carries the `(#NNNN)` trailer.

2. **`scripts/changeset/cli.cjs`** — adds an `extract` subcommand: `changeset/cli.cjs extract --from VERSION --to VERSION [--changelog FILE] [--json]`. Extracts releases strictly after `--from` (exclusive) and up to and including `--to` (inclusive). Accepts `v`-prefixed versions. Exits `2` when no releases fall in range, giving `/gsd:update` a deterministic range-aware helper.

## Root cause

The `parseChangelog` bullet-matching regex was `^- .*\(#(\d+)\)` applied line-by-line, which only matched bullets where the PR trailer was on the opening `- ` line. Multi-line bullets — common in Feature and Enhancement sections — had the trailer on a continuation line that was never joined before matching.

## Prior PRs on this issue

- **PR #3495** (closed, 2 checks failed): Added a standalone `bin/extract-changelog.cjs` script. Approach placed the extractor outside the existing changeset toolchain and had CI failures.
- **PR #3497** (closed, all checks passed but closed without merge): Same standalone script approach, refined. Closed without merge — likely because the extractor belongs integrated into the existing `scripts/changeset/cli.cjs` tool rather than as a separate script, and because `parseChangelog` itself was not fixed to handle multi-line bullets.

This PR differs: it fixes `parseChangelog` at the source (multi-line bullet folding) and integrates the `extract` subcommand into the existing `scripts/changeset/cli.cjs` rather than adding a new top-level script.

## Testing

### How I verified the fix

- `tests/changeset-serialize.test.cjs` — new tests covering multi-line bullet capture via `parseChangelog` directly; includes the regression fixture from the issue (bullet with PR trailer on continuation line)
- `tests/changeset-cli.test.cjs` — new tests for the `extract` subcommand: range boundaries, `v`-prefix handling, multi-line bullet capture in extracted range, markdown vs `--json` mode, missing-args error path
- The `emits-markdown` test uses `parseChangelog` on the output (not raw substring matching) to assert version presence

### Regression test added?

- [x] Yes — added a test that would have caught this bug

### Platforms tested

- [x] macOS
- [ ] Windows (including backslash path handling)
- [x] Linux
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific)

---

## Checklist

- [x] Issue linked above with `Fixes #3496` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`) — Mac: 3446 passed, 0 failed; Docker: 10344 passed (2 locking-bugs failures fixed by barrier redesign in follow-up commit, same pattern as #3790)
- [ ] `.changeset/` fragment added if this is a user-facing fix — added after PR number is known
- [x] No unnecessary dependencies added

## Breaking changes

None

---

## Updates after review (2026-05-21)

Reviewer findings from consolidated code review applied in commit `468dd3ae` + follow-up commits. All 15 targeted tests pass; lint: 0 violations.

### BLOCKER fixes applied

- **F1** (`get-shit-done/workflows/update.md`): `show_changes_and_confirm` step now contains a concrete `node "$GSD_DIR/get-shit-done/scripts/changeset/cli.cjs" extract --from $INSTALLED_VERSION --to $LATEST_VERSION --changelog $CHANGELOG_TMP --json` invocation with explicit exit-2 handling ("No changelog updates between vX and vY") and a fallback message. The prior prose never called the binary and was the root cause of the user-visible bug not being fixed.

- **F2** (`scripts/changeset/cli.cjs`): `releases.filter` now rejects any `rel.version` that fails `SEMVER_RE` before numeric-tuple comparison. `parseSemver('1.0.0-rc.1')` previously returned `[1,0,0]` (same as `'1.0.0'`), corrupting range queries. **Architectural choice**: skip pre-release + 4-part versions with a `stderr` warning; full semver §11 pre-release ordering deferred to a consolidation issue (see F8 below).

### MAJOR fixes applied

- **F3** (`scripts/changeset/serialize.cjs`): `releaseMatch` regex updated to `/^##\s+\[([^\]]+)\](?:\([^)]*\))?\s*(?:-\s*(\S+))?/` so linked-header format `## [1.42.1](url) - 2026-05-15` correctly captures the date.

- **F4** (`scripts/changeset/serialize.cjs`): continuation-line test now checks `!/^\s+-\s/` so `  - nested item` terminates the current bullet instead of folding into the parent body.

- **F5** (`scripts/changeset/cli.cjs`): 4-part versions (e.g. `1.0.0.1`) fail `SEMVER_RE` and are skipped by the same guard added for F2. No separate code path needed.

- **F6** (`scripts/changeset/serialize.cjs`): v-prefix stripped from in-file version capture; `## [v1.0.0]` now parses as version `"1.0.0"`.

- **F7** (`scripts/changeset/serialize.cjs`): continuation-line indentation relaxed from `/^[ \t]{2}/` to `/^\s+/` so 1-space-indented continuations fold correctly. F4's bullet-terminator guard prevents nested bullets from being folded.

- **F8** (noted, not applied): Semver consolidation — 6th distinct comparator added by this PR. **Follow-up issue should be filed** to unify all call sites. Out of scope for this PR; acknowledged in commit message.

### MINOR fixes applied

- **F9** (`scripts/changeset/cli.cjs`): unknown-command path now exits `1` instead of `2` (exit `2` is reserved for "no releases in range").

- **F10** (`scripts/changeset/cli.cjs`): text-mode exit-2 path writes `"no releases found in range (from=X, to=Y)"` to stderr.

- **F11** (`tests/changeset-cli.test.cjs`): exit-2 test now asserts `r.json` is present and `r.json.releases.length === 0`.

### Bonus fix (discovered during test run)

- `tests/locking-bugs-1909-1916-1925-1927.test.cjs` `#1927` concurrent config-set test redesigned with the same deterministic file-barrier pattern used in #3790 (locking-bugs:180 and :235). The `Promise.all([execAsync(A), execAsync(B)])` form was non-deterministic under Docker overlay-fs load; barrier ensures true concurrent contention.

### Test results after review commits

- **Mac:** 3446 passed, 0 failed
- **Docker:** 10344 passed, 0 failed (locking-bugs barrier fix covers the 2 that failed in the pre-review Docker run)