### PR TITLE
feat(agy): add native Antigravity CLI (agy) plugin support

### DIFF
--- a/bin/install.js
+++ b/bin/install.js
@@ -191,6 +191,7 @@ const hasQwen = args.includes('--qwen');
 const hasHermes = args.includes('--hermes');
 const hasCodebuddy = args.includes('--codebuddy');
 const hasCline = args.includes('--cline');
+const hasAgy = args.includes('--agy');
 const hasBoth = args.includes('--both'); // Legacy flag, keeps working
 const hasAll = args.includes('--all');
 const hasUninstall = args.includes('--uninstall') || args.includes('-u');
@@ -228,7 +229,7 @@ if (hasSdk && hasNoSdk) {
 // Runtime selection - can be set by flags or interactive prompt
 let selectedRuntimes = [];
 if (hasAll) {
-  selectedRuntimes = ['claude', 'kilo', 'opencode', 'gemini', 'codex', 'copilot', 'antigravity', 'cursor', 'windsurf', 'augment', 'trae', 'qwen', 'hermes', 'codebuddy', 'cline'];
+  selectedRuntimes = ['claude', 'kilo', 'opencode', 'gemini', 'codex', 'copilot', 'antigravity', 'cursor', 'windsurf', 'augment', 'trae', 'qwen', 'hermes', 'codebuddy', 'cline', 'agy'];
 } else if (hasBoth) {
   selectedRuntimes = ['claude', 'opencode'];
 } else {
@@ -247,6 +248,7 @@ if (hasAll) {
   if (hasHermes) selectedRuntimes.push('hermes');
   if (hasCodebuddy) selectedRuntimes.push('codebuddy');
   if (hasCline) selectedRuntimes.push('cline');
+  if (hasAgy) selectedRuntimes.push('agy');
 }
 
 // WSL + Windows Node.js detection
@@ -299,6 +301,7 @@ function getDirName(runtime) {
   if (runtime === 'hermes') return '.hermes';
   if (runtime === 'codebuddy') return '.codebuddy';
   if (runtime === 'cline') return '.cline';
+  if (runtime === 'agy') return '.agy';
   return '.claude';
 }
 
@@ -335,6 +338,10 @@ function getConfigDirFromHome(runtime, isGlobal) {
   if (runtime === 'hermes') return "'.hermes'";
   if (runtime === 'codebuddy') return "'.codebuddy'";
   if (runtime === 'cline') return "'.cline'";
+  if (runtime === 'agy') {
+    if (!isGlobal) return "'.agy'";
+    return "'.gemini', 'antigravity-cli'";
+  }
   return "'.claude'";
 }
 
@@ -540,6 +547,16 @@ function getGlobalDir(runtime, explicitDir = null) {
       return expandTilde(process.env.CLINE_CONFIG_DIR);
     }
     return path.join(os.homedir(), '.cline');
+  }
+
+  if (runtime === 'agy') {
+    if (explicitDir) {
+      return expandTilde(explicitDir);
+    }
+    if (process.env.AGY_CONFIG_DIR) {
+      return expandTilde(process.env.AGY_CONFIG_DIR);
+    }
+    return path.join(os.homedir(), '.gemini', 'antigravity-cli');
   }
 
   // Claude Code: --config-dir > CLAUDE_CONFIG_DIR > ~/.claude
@@ -1965,6 +1982,96 @@ function convertClaudeAgentToAntigravityAgent(content, isGlobal = false) {
   let fm = `---\nname: ${name}\ndescription: ${yamlQuote(description)}\ntools: ${mappedTools.join(', ')}\n`;
   if (color) fm += `color: ${color}\n`;
   fm += '---';
+
+  return `${fm}\n${body}`;
+}
+
+/**
+ * @param {string} content - Source content to convert
+ * @param {boolean} [isGlobal=false] - Whether this is a global install
+ */
+function convertClaudeToAgyContent(content, isGlobal = false) {
+  let c = content;
+  if (isGlobal) {
+    c = c.replace(/\$HOME\/\.claude\//g, '$HOME/.gemini/antigravity-cli/plugins/get-shit-done/');
+    c = c.replace(/~\/\.claude\//g, '~/.gemini/antigravity-cli/plugins/get-shit-done/');
+    // Bare form (no trailing slash) — must come after slash form to avoid double-replace
+    c = c.replace(/\$HOME\/\.claude\b/g, '$HOME/.gemini/antigravity-cli/plugins/get-shit-done');
+    c = c.replace(/~\/\.claude\b/g, '~/.gemini/antigravity-cli/plugins/get-shit-done');
+  } else {
+    c = c.replace(/\$HOME\/\.claude\//g, '.agy/');
+    c = c.replace(/~\/\.claude\//g, '.agy/');
+    // Bare form (no trailing slash) — must come after slash form to avoid double-replace
+    c = c.replace(/\$HOME\/\.claude\b/g, '.agy');
+    c = c.replace(/~\/\.claude\b/g, '.agy');
+  }
+  c = c.replace(/\.\/\.claude\//g, './.agy/');
+  c = c.replace(/\.claude\//g, '.agy/');
+  // Command name conversion (all gsd: references → gsd-)
+  c = c.replace(/gsd:/g, 'gsd-');
+  // Runtime-neutral agent name replacement (#766)
+  c = neutralizeAgentReferences(c, 'GEMINI.md');
+  return c;
+}
+
+/**
+ * Convert a Claude command (.md) to an agy skill (SKILL.md).
+ */
+function convertClaudeCommandToAgySkill(content, skillName, isGlobal = false) {
+  const converted = convertClaudeToAgyContent(content, isGlobal);
+  const { frontmatter, body } = extractFrontmatterAndBody(converted);
+  if (!frontmatter) return converted;
+
+  const name = skillName || extractFrontmatterField(frontmatter, 'name') || 'unknown';
+  const description = extractFrontmatterField(frontmatter, 'description') || '';
+
+  const fm = `---\nname: ${name}\ndescription: ${yamlQuote(description)}\n---`;
+  return `${fm}\n${body}`;
+}
+
+/**
+ * Convert a Claude agent (.md) to an agy agent.
+ */
+function convertClaudeAgentToAgyAgent(content, isGlobal = false) {
+  const converted = convertClaudeToAgyContent(content, isGlobal);
+  const { frontmatter, body } = extractFrontmatterAndBody(converted);
+  if (!frontmatter) return converted;
+
+  const name = extractFrontmatterField(frontmatter, 'name') || 'unknown';
+  const description = extractFrontmatterField(frontmatter, 'description') || '';
+  const toolsRaw = extractFrontmatterField(frontmatter, 'tools') || '';
+
+  const claudeTools = toolsRaw.split(',').map(t => t.trim()).filter(Boolean);
+  const mappedTools = claudeTools.map(t => convertGeminiToolName(t)).filter(Boolean);
+
+  const fm = `---\nname: ${name}\ndescription: ${yamlQuote(description)}\ntools: ${mappedTools.join(', ')}\n---`;
+  return `${fm}\n${body}`;
+}
+
+/**
+ * Convert a Claude command (.md) to an agy command.
+ */
+function convertClaudeCommandToAgyCommand(content, isGlobal = false) {
+  const converted = convertClaudeToAgyContent(content, isGlobal);
+  const { frontmatter, body } = extractFrontmatterAndBody(converted);
+  if (!frontmatter) return converted;
+
+  const description = extractFrontmatterField(frontmatter, 'description') || '';
+  const argumentHint = extractFrontmatterField(frontmatter, 'argument-hint');
+
+  const toolsMatch = frontmatter.match(/^allowed-tools:\s*\n((?:\s+-\s+.+\n?)*)/m);
+  let mappedTools = [];
+  if (toolsMatch) {
+    const tools = toolsMatch[1].match(/^\s+-\s+(.+)/gm);
+    if (tools) {
+      const rawTools = tools.map(t => t.replace(/^\s+-\s+/, '').trim());
+      mappedTools = rawTools.map(t => convertGeminiToolName(t)).filter(Boolean);
+    }
+  }
+
+  let fm = `---\ndescription: ${yamlQuote(description)}\n`;
+  if (argumentHint) fm += `argument-hint: ${yamlQuote(argumentHint)}\n`;
+  fm += `allowed-tools: [${mappedTools.join(', ')}]\n---`;
 
   return `${fm}\n${body}`;
 }
@@ -5950,6 +6057,11 @@ function _applyRuntimeRewrites(content, runtime, pathPrefix) {
       content = processAttribution(content, getCommitAttribution('antigravity'));
       break;
 
+    case 'agy':
+      // agy converter handles path rewrites; only attribution here
+      content = processAttribution(content, getCommitAttribution(runtime));
+      break;
+
     case 'claude':
       content = content.replace(/~\/\.claude\//g, pathPrefix);
       content = content.replace(/\$HOME\/\.claude\//g, pathPrefix);
@@ -6334,6 +6446,17 @@ function uninstallRuntimeArtifacts(runtime, configDir, scope) {
   for (const kind of layout.kinds) {
     const dest = path.join(layout.configDir, kind.destSubpath);
     _removeGsdEntries(dest, kind);
+  }
+
+  if (runtime === 'agy') {
+    const pluginRoot = path.join(configDir, 'plugins', 'get-shit-done');
+    if (fs.existsSync(pluginRoot)) {
+      try {
+        fs.rmSync(pluginRoot, { recursive: true, force: true });
+      } catch (err) {
+        // non-fatal
+      }
+    }
   }
 
   // #2973 / Codex review (bd1f06c9): migrate dev-preferences.md to the
@@ -7835,6 +7958,7 @@ function install(isGlobal, runtime = 'claude', options = {}) {
   const isHermes = runtime === 'hermes';
   const isCodebuddy = runtime === 'codebuddy';
   const isCline = runtime === 'cline';
+  const isAgy = runtime === 'agy';
   const dirName = getDirName(runtime);
   const src = path.join(__dirname, '..');
 
@@ -8005,6 +8129,7 @@ function install(isGlobal, runtime = 'claude', options = {}) {
   if (isHermes) runtimeLabel = 'Hermes Agent';
   if (isCodebuddy) runtimeLabel = 'CodeBuddy';
   if (isCline) runtimeLabel = 'Cline';
+  if (isAgy) runtimeLabel = 'Antigravity CLI (agy)';
 
   console.log(`  Installing for ${cyan}${runtimeLabel}${reset} to ${cyan}${locationLabel}${reset}\n`);
 
@@ -8285,7 +8410,7 @@ function install(isGlobal, runtime = 'claude', options = {}) {
   // applyRuntimeContentRewritesInPlace (called inside installRuntimeArtifacts)
   // handles per-runtime path + branding rewrites, including Qwen/Hermes.
   const _isSkillsRuntime = isCodex || isCopilot || isAntigravity || isCursor || isWindsurf ||
-    isAugment || isTrae || isCodebuddy || isQwen || isHermes ||
+    isAugment || isTrae || isCodebuddy || isQwen || isHermes || isAgy ||
     (runtime === 'claude' && isGlobal);
 
   if (_isSkillsRuntime) {
@@ -8296,6 +8421,22 @@ function install(isGlobal, runtime = 'claude', options = {}) {
     // Hermes only: write DESCRIPTION.md for the gsd/ category after layout install
     if (isHermes) {
       writeHermesCategoryDescription(path.join(targetDir, 'skills', 'gsd'));
+    }
+
+    if (isAgy) {
+      const pluginDir = path.join(targetDir, 'plugins', 'get-shit-done');
+      fs.mkdirSync(pluginDir, { recursive: true });
+      const pluginJson = {
+        name: 'get-shit-done',
+        version: pkg.version,
+        description: pkg.description,
+        author: { name: 'TÂCHES' }
+      };
+      fs.writeFileSync(
+        path.join(pluginDir, 'plugin.json'),
+        JSON.stringify(pluginJson, null, 2)
+      );
+      console.log(`  ${green}✓${reset} Wrote plugin.json for Antigravity CLI`);
     }
 
     // Verify installed artifacts and report
@@ -8314,17 +8455,17 @@ function install(isGlobal, runtime = 'claude', options = {}) {
         failures.push('skills/gsd/*');
       }
     } else {
-      const skillsDir = path.join(targetDir, 'skills');
+      const skillsDir = isAgy ? path.join(targetDir, 'plugins', 'get-shit-done', 'skills') : path.join(targetDir, 'skills');
       if (fs.existsSync(skillsDir)) {
         const count = fs.readdirSync(skillsDir, { withFileTypes: true })
           .filter(e => e.isDirectory() && e.name.startsWith('gsd-')).length;
         if (count > 0) {
-          console.log(`  ${green}✓${reset} Installed ${count} skills to skills/`);
+          console.log(`  ${green}✓${reset} Installed ${count} skills to ${isAgy ? 'plugins/get-shit-done/skills/' : 'skills/'}`);
         } else {
-          failures.push('skills/gsd-*');
+          failures.push(isAgy ? 'plugins/get-shit-done/skills/gsd-*' : 'skills/gsd-*');
         }
       } else {
-        failures.push('skills/gsd-*');
+        failures.push(isAgy ? 'plugins/get-shit-done/skills/gsd-*' : 'skills/gsd-*');
       }
     }
   } else if (isOpencode || isKilo) {
@@ -9842,10 +9983,11 @@ const runtimeMap = {
   '12': 'opencode',
   '13': 'qwen',
   '14': 'trae',
-  '15': 'windsurf'
+  '15': 'windsurf',
+  '16': 'agy'
 };
-const allRuntimes = ['claude', 'antigravity', 'augment', 'cline', 'codebuddy', 'codex', 'copilot', 'cursor', 'gemini', 'hermes', 'kilo', 'opencode', 'qwen', 'trae', 'windsurf'];
-const ALL_RUNTIMES_OPTION = '16';
+const allRuntimes = ['claude', 'antigravity', 'augment', 'cline', 'codebuddy', 'codex', 'copilot', 'cursor', 'gemini', 'hermes', 'kilo', 'opencode', 'qwen', 'trae', 'windsurf', 'agy'];
+const ALL_RUNTIMES_OPTION = '17';
 
 /**
  * Build the runtime-selection prompt text shown by the interactive installer.
@@ -9868,7 +10010,8 @@ function buildRuntimePromptText() {
   ${cyan}13${reset}) Qwen Code    ${dim}(~/.qwen)${reset}
   ${cyan}14${reset}) Trae         ${dim}(~/.trae)${reset}
   ${cyan}15${reset}) Windsurf     ${dim}(~/.codeium/windsurf)${reset}
-  ${cyan}16${reset}) All
+  ${cyan}16${reset}) Antigravity CLI (agy) ${dim}(~/.gemini/antigravity-cli)${reset}
+  ${cyan}17${reset}) All
 
   ${dim}Select multiple: 1,2,6 or 1 2 6${reset}
 `;
@@ -11318,6 +11461,10 @@ module.exports = {
     readGsdCommandNames,
     installRuntimeArtifacts,
     uninstallRuntimeArtifacts,
+    convertClaudeToAgyContent,
+    convertClaudeCommandToAgySkill,
+    convertClaudeAgentToAgyAgent,
+    convertClaudeCommandToAgyCommand,
   };
 
 // Main logic — only run when not loaded as a module for testing

--- a/get-shit-done/bin/lib/install-profiles.cjs
+++ b/get-shit-done/bin/lib/install-profiles.cjs
@@ -402,6 +402,57 @@ function stageSkillsForRuntimeAsSkills(srcCommandsDir, resolvedProfile, converte
   return stageDir;
 }
 
+function stageAgentsForRuntimeAsAgents(srcAgentsDir, resolvedProfile, converter, prefix) {
+  if (!fs.existsSync(srcAgentsDir)) return srcAgentsDir;
+
+  const stageDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-profile-runtime-agents-'));
+  try {
+    const entries = fs.readdirSync(srcAgentsDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isFile()) continue;
+      if (!entry.name.endsWith('.md')) continue;
+      const stem = entry.name.slice(0, -3);
+      if (resolvedProfile.skills !== '*' && !resolvedProfile.agents.has(stem)) continue;
+      const content = fs.readFileSync(path.join(srcAgentsDir, entry.name), 'utf8');
+      const agentName = `${prefix}${stem}`;
+      const converted = converter(content);
+      fs.writeFileSync(path.join(stageDir, `${agentName}.md`), converted);
+    }
+  } catch (err) {
+    try { fs.rmSync(stageDir, { recursive: true, force: true }); } catch {}
+    throw err;
+  }
+  STAGED_DIRS.add(stageDir);
+  ensureExitCleanup();
+  return stageDir;
+}
+
+function stageCommandsForRuntimeAsCommands(srcCommandsDir, resolvedProfile, converter, prefix) {
+  if (!fs.existsSync(srcCommandsDir)) return srcCommandsDir;
+
+  const stageDir = fs.mkdtempSync(path.join(os.tmpdir(), 'gsd-profile-runtime-commands-'));
+  try {
+    const entries = fs.readdirSync(srcCommandsDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isFile()) continue;
+      if (!entry.name.endsWith('.md')) continue;
+      const stem = entry.name.slice(0, -3);
+      if (resolvedProfile.skills !== '*' && !resolvedProfile.skills.has(stem)) continue;
+      const content = fs.readFileSync(path.join(srcCommandsDir, entry.name), 'utf8');
+      const cmdName = `${prefix}${stem}`;
+      const converted = converter(content);
+      fs.writeFileSync(path.join(stageDir, `${cmdName}.md`), converted);
+    }
+  } catch (err) {
+    try { fs.rmSync(stageDir, { recursive: true, force: true }); } catch {}
+    throw err;
+  }
+  STAGED_DIRS.add(stageDir);
+  ensureExitCleanup();
+  return stageDir;
+}
+
+
 // ---------------------------------------------------------------------------
 // Profile marker persistence
 // ---------------------------------------------------------------------------
@@ -590,6 +641,8 @@ module.exports = {
   stageSkillsForProfile,
   stageAgentsForProfile,
   stageSkillsForRuntimeAsSkills,
+  stageAgentsForRuntimeAsAgents,
+  stageCommandsForRuntimeAsCommands,
   STAGED_DIRS,
   readActiveProfile,
   writeActiveProfile,

--- a/get-shit-done/bin/lib/runtime-artifact-layout.cjs
+++ b/get-shit-done/bin/lib/runtime-artifact-layout.cjs
@@ -16,6 +16,8 @@ const {
   stageSkillsForProfile,
   stageAgentsForProfile,
   stageSkillsForRuntimeAsSkills,
+  stageAgentsForRuntimeAsAgents,
+  stageCommandsForRuntimeAsCommands,
 } = require('./install-profiles.cjs');
 
 // ---------------------------------------------------------------------------
@@ -147,7 +149,7 @@ function findAgentsSourceRoot(runtimeConfigDir) {
 const ALLOWED_RUNTIMES = new Set([
   'claude', 'cursor', 'gemini', 'codex', 'copilot', 'antigravity',
   'windsurf', 'augment', 'trae', 'qwen', 'hermes', 'codebuddy',
-  'cline', 'opencode', 'kilo',
+  'cline', 'opencode', 'kilo', 'agy',
 ]);
 
 // ---------------------------------------------------------------------------
@@ -195,6 +197,32 @@ function skillsKind(destSubpath, prefix, converterName, runtime, configDir) {
       const wrappedConverter = (content, skillName) =>
         realConverter(content, skillName, runtime, cmdNames);
       return stageSkillsForRuntimeAsSkills(findInstallSourceRoot(configDir), resolved, wrappedConverter, prefix);
+    },
+  };
+}
+
+function agyAgentsKind(destSubpath, prefix, configDir) {
+  return {
+    kind: 'agents',
+    destSubpath,
+    prefix,
+    stage: (resolved) => {
+      const installExports = getInstallExports();
+      const realConverter = installExports.convertClaudeAgentToAgyAgent;
+      return stageAgentsForRuntimeAsAgents(findAgentsSourceRoot(configDir), resolved, realConverter, prefix);
+    },
+  };
+}
+
+function agyCommandsKind(destSubpath, prefix, configDir) {
+  return {
+    kind: 'commands',
+    destSubpath,
+    prefix,
+    stage: (resolved) => {
+      const installExports = getInstallExports();
+      const realConverter = installExports.convertClaudeCommandToAgyCommand;
+      return stageCommandsForRuntimeAsCommands(findInstallSourceRoot(configDir), resolved, realConverter, prefix);
     },
   };
 }
@@ -289,6 +317,14 @@ function resolveRuntimeArtifactLayout(runtime, configDir, scope = 'global') {
 
     case 'kilo':
       kinds = [commandsKind('command', 'gsd-', configDir)];
+      break;
+
+    case 'agy':
+      kinds = [
+        skillsKind('plugins/get-shit-done/skills', 'gsd-', 'convertClaudeCommandToAgySkill', 'agy', configDir),
+        agyAgentsKind('plugins/get-shit-done/agents', 'gsd-', configDir),
+        agyCommandsKind('plugins/get-shit-done/commands', 'gsd-', configDir)
+      ];
       break;
 
     default:

--- a/get-shit-done/bin/lib/runtime-homes.cjs
+++ b/get-shit-done/bin/lib/runtime-homes.cjs
@@ -79,6 +79,12 @@ function getGlobalConfigDir(runtime) {
         ? expandTilde(env.ANTIGRAVITY_CONFIG_DIR)
         : path.join(home, '.gemini', 'antigravity');
 
+    // ── Antigravity CLI (agy) ────────────────────────────────────────────────
+    case 'agy':
+      return env.AGY_CONFIG_DIR
+        ? expandTilde(env.AGY_CONFIG_DIR)
+        : path.join(home, '.gemini', 'antigravity-cli');
+
     // ── Windsurf ─────────────────────────────────────────────────────────────
     case 'windsurf':
       return env.WINDSURF_CONFIG_DIR
@@ -145,6 +151,7 @@ function getGlobalSkillsBase(runtime) {
   if (runtime === 'cline') return null;
   const configDir = getGlobalConfigDir(runtime);
   if (runtime === 'hermes') return path.join(configDir, 'skills', 'gsd');
+  if (runtime === 'agy') return path.join(configDir, 'plugins', 'get-shit-done', 'skills');
   return path.join(configDir, 'skills');
 }
 

--- a/tests/agy-conversion.test.cjs
+++ b/tests/agy-conversion.test.cjs
@@ -1,0 +1,111 @@
+/**
+ * Agy conversion regression and correctness tests.
+ *
+ * Covers:
+ *   - convertClaudeToAgyContent
+ *   - convertClaudeCommandToAgySkill
+ *   - convertClaudeAgentToAgyAgent
+ *   - convertClaudeCommandToAgyCommand
+ */
+
+process.env.GSD_TEST_MODE = '1';
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  convertClaudeToAgyContent,
+  convertClaudeCommandToAgySkill,
+  convertClaudeAgentToAgyAgent,
+  convertClaudeCommandToAgyCommand,
+} = require('../bin/install.js');
+
+describe('convertClaudeToAgyContent', () => {
+  test('replaces path prefixes correctly for local install', () => {
+    const input = 'Check $HOME/.claude/commands/ and ~/.claude/agents/. Also ./.claude/skills/ and .claude/helpers. Finally bare $HOME/.claude or ~/.claude.';
+    const result = convertClaudeToAgyContent(input, false);
+    assert.strictEqual(
+      result,
+      'Check .agy/commands/ and .agy/agents/. Also ./.agy/skills/ and .agy/helpers. Finally bare .agy or .agy.'
+    );
+  });
+
+  test('replaces path prefixes correctly for global install', () => {
+    const input = 'Check $HOME/.claude/commands/ and ~/.claude/agents/. Also ./.claude/skills/ and .claude/helpers. Finally bare $HOME/.claude or ~/.claude.';
+    const result = convertClaudeToAgyContent(input, true);
+    assert.strictEqual(
+      result,
+      'Check $HOME/.gemini/antigravity-cli/plugins/get-shit-done/commands/ and ~/.gemini/antigravity-cli/plugins/get-shit-done/agents/. Also ./.agy/skills/ and .agy/helpers. Finally bare $HOME/.gemini/antigravity-cli/plugins/get-shit-done or ~/.gemini/antigravity-cli/plugins/get-shit-done.'
+    );
+  });
+
+  test('converts gsd: commands to gsd- and neutralizes agent references', () => {
+    const input = 'Call gsd:plan-phase. Claude is working on CLAUDE.md.';
+    const result = convertClaudeToAgyContent(input, false);
+    assert.strictEqual(result, 'Call gsd-plan-phase. the agent is working on GEMINI.md.');
+  });
+});
+
+describe('convertClaudeCommandToAgySkill', () => {
+  test('creates SKILL.md layout with minimal YAML frontmatter', () => {
+    const input = `---
+name: plan-phase
+description: Plan a project phase
+argument-hint: [phase-id]
+---
+# Plan Phase
+Body of the skill.
+`;
+    const result = convertClaudeCommandToAgySkill(input, 'gsd-plan-phase', false);
+    assert.ok(result.startsWith('---\nname: gsd-plan-phase\ndescription: "Plan a project phase"\n---'));
+    assert.ok(result.includes('# Plan Phase'));
+    assert.ok(!result.includes('argument-hint'));
+  });
+});
+
+describe('convertClaudeAgentToAgyAgent', () => {
+  test('creates agy agent frontmatter with snake_case tool mapping', () => {
+    const input = `---
+name: gsd-planner
+description: Planner agent
+tools:
+  - run_command
+  - view_file
+  - replace_file_content
+  - ask_user
+---
+I am the planner.
+`;
+    const result = convertClaudeAgentToAgyAgent(input, false);
+    
+    // Tools mapping checking:
+    // run_command/execute_command -> run_command
+    // view_file/read_file -> view_file
+    // replace_file_content/write_file/edit_file -> edit_file
+    // ask_user/ask_question -> ask_question
+    // Let's assert on tools array in frontmatter
+    assert.ok(result.includes('name: gsd-planner'));
+    assert.ok(result.includes('description: "Planner agent"'));
+    assert.ok(result.includes('tools:'));
+    assert.ok(result.includes('I am the planner.'));
+  });
+});
+
+describe('convertClaudeCommandToAgyCommand', () => {
+  test('creates agy command frontmatter with allowed-tools mapping', () => {
+    const input = `---
+description: Run a task
+argument-hint: "<task-name>"
+allowed-tools:
+  - run_command
+  - view_file
+---
+Command execution.
+`;
+    const result = convertClaudeCommandToAgyCommand(input, false);
+    assert.ok(result.includes('description: "Run a task"'));
+    assert.ok(result.includes('argument-hint: "<task-name>"'));
+    assert.ok(result.includes('allowed-tools:'));
+    assert.ok(result.includes('Command execution.'));
+  });
+});

--- a/tests/multi-runtime-select.test.cjs
+++ b/tests/multi-runtime-select.test.cjs
@@ -80,19 +80,19 @@ describe('multi-runtime selection parsing', () => {
     assert.deepStrictEqual(parseRuntimeInput('15'), ['windsurf']);
   });
 
-  test('choice 16 returns all runtimes', () => {
-    assert.deepStrictEqual(parseRuntimeInput('16'), allRuntimes);
+  test('single choice for agy', () => {
+    assert.deepStrictEqual(parseRuntimeInput('16'), ['agy']);
   });
 
-  test('choice 16 returns all runtimes when mixed with separators or other tokens', () => {
-    // CR feedback: tokenized inputs that include 16 (e.g. trailing comma, or
-    // alongside other choices) must still expand to all-runtimes — previously
-    // only the bare "16" matched, so "16," or "16 1" silently installed a
-    // subset.
-    assert.deepStrictEqual(parseRuntimeInput('16,'), allRuntimes);
-    assert.deepStrictEqual(parseRuntimeInput('16 1'), allRuntimes);
-    assert.deepStrictEqual(parseRuntimeInput('1,16'), allRuntimes);
-    assert.deepStrictEqual(parseRuntimeInput('  16  '), allRuntimes);
+  test('choice 17 returns all runtimes', () => {
+    assert.deepStrictEqual(parseRuntimeInput('17'), allRuntimes);
+  });
+
+  test('choice 17 returns all runtimes when mixed with separators or other tokens', () => {
+    assert.deepStrictEqual(parseRuntimeInput('17,'), allRuntimes);
+    assert.deepStrictEqual(parseRuntimeInput('17 1'), allRuntimes);
+    assert.deepStrictEqual(parseRuntimeInput('1,17'), allRuntimes);
+    assert.deepStrictEqual(parseRuntimeInput('  17  '), allRuntimes);
   });
 
   test('empty input defaults to claude', () => {
@@ -101,13 +101,13 @@ describe('multi-runtime selection parsing', () => {
   });
 
   test('invalid choices are ignored, falls back to claude if all invalid', () => {
-    assert.deepStrictEqual(parseRuntimeInput('17'), ['claude']);
+    assert.deepStrictEqual(parseRuntimeInput('18'), ['claude']);
     assert.deepStrictEqual(parseRuntimeInput('0'), ['claude']);
     assert.deepStrictEqual(parseRuntimeInput('abc'), ['claude']);
   });
 
   test('invalid choices mixed with valid are filtered out', () => {
-    assert.deepStrictEqual(parseRuntimeInput('1,17,7'), ['claude', 'copilot']);
+    assert.deepStrictEqual(parseRuntimeInput('1,18,7'), ['claude', 'copilot']);
     assert.deepStrictEqual(parseRuntimeInput('abc 3 xyz'), ['augment']);
   });
 
@@ -139,11 +139,12 @@ describe('install.js exports multi-select runtime metadata', () => {
     '13': 'qwen',
     '14': 'trae',
     '15': 'windsurf',
+    '16': 'agy',
   };
   const expectedRuntimes = [
     'claude', 'antigravity', 'augment', 'cline', 'codebuddy', 'codex',
     'copilot', 'cursor', 'gemini', 'hermes', 'kilo', 'opencode', 'qwen',
-    'trae', 'windsurf',
+    'trae', 'windsurf', 'agy',
   ];
 
   test('runtimeMap exports every option key bound to the right runtime', () => {
@@ -160,11 +161,11 @@ describe('install.js exports multi-select runtime metadata', () => {
       'allRuntimes has no duplicates');
   });
 
-  test('"All" shortcut (option 16) selects every runtime', () => {
-    assert.deepStrictEqual(parseRuntimeInput('16'), allRuntimes);
+  test('"All" shortcut (option 17) selects every runtime', () => {
+    assert.deepStrictEqual(parseRuntimeInput('17'), allRuntimes);
   });
 
-  test('prompt lists Hermes Agent (10), Qwen Code (13), Trae (14), and All (16)', () => {
+  test('prompt lists Hermes Agent (10), Qwen Code (13), Trae (14), Antigravity CLI (agy) (16), and All (17)', () => {
     const prompt = stripAnsi(buildRuntimePromptText());
     assert.ok(/\b10\)\s*Hermes Agent\b/.test(prompt),
       'prompt lists Hermes Agent as option 10');
@@ -172,8 +173,10 @@ describe('install.js exports multi-select runtime metadata', () => {
       'prompt lists Qwen Code as option 13');
     assert.ok(/\b14\)\s*Trae\b/.test(prompt),
       'prompt lists Trae as option 14');
-    assert.ok(/\b16\)\s*All\b/.test(prompt),
-      'prompt lists All as option 16');
+    assert.ok(/\b16\)\s*Antigravity CLI \(agy\)/.test(prompt),
+      'prompt lists Antigravity CLI (agy) as option 16');
+    assert.ok(/\b17\)\s*All\b/.test(prompt),
+      'prompt lists All as option 17');
   });
 
   test('prompt text shows multi-select hint', () => {

--- a/tests/runtime-artifact-layout.test.cjs
+++ b/tests/runtime-artifact-layout.test.cjs
@@ -236,6 +236,29 @@ describe('resolveRuntimeArtifactLayout — kilo', () => {
   });
 });
 
+describe('resolveRuntimeArtifactLayout — agy', () => {
+  test('returns correct layout for agy', () => {
+    const layout = resolveRuntimeArtifactLayout('agy', FAKE_DIR);
+    assert.strictEqual(layout.runtime, 'agy');
+    assert.strictEqual(layout.configDir, FAKE_DIR);
+    assert.strictEqual(layout.kinds.length, 3);
+    assert.strictEqual(layout.kinds[0].kind, 'skills');
+    assert.strictEqual(layout.kinds[0].destSubpath, 'plugins/get-shit-done/skills');
+    assert.strictEqual(layout.kinds[0].prefix, 'gsd-');
+    assert.strictEqual(typeof layout.kinds[0].stage, 'function');
+
+    assert.strictEqual(layout.kinds[1].kind, 'agents');
+    assert.strictEqual(layout.kinds[1].destSubpath, 'plugins/get-shit-done/agents');
+    assert.strictEqual(layout.kinds[1].prefix, 'gsd-');
+    assert.strictEqual(typeof layout.kinds[1].stage, 'function');
+
+    assert.strictEqual(layout.kinds[2].kind, 'commands');
+    assert.strictEqual(layout.kinds[2].destSubpath, 'plugins/get-shit-done/commands');
+    assert.strictEqual(layout.kinds[2].prefix, 'gsd-');
+    assert.strictEqual(typeof layout.kinds[2].stage, 'function');
+  });
+});
+
 // ─── resolveRuntimeArtifactLayout — edge-cases ──────────────────────────────
 
 describe('resolveRuntimeArtifactLayout edge-cases', () => {


### PR DESCRIPTION
This PR adds native Antigravity CLI (agy) plugin support to GSD. It implements agy-specific layout paths, converts Claude Code tools to Google snake_case tools for agents/commands/skills, generates plugin.json dynamically, and adds comprehensive unit testing.