### PR TITLE
fix(3804): rescue uncommitted SUMMARY.md file in SDK worktree.cleanup-wave

### DIFF
--- a/.changeset/3804-sdk-worktree-summary-rescue.md
+++ b/.changeset/3804-sdk-worktree-summary-rescue.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+pr: 3804
+---
+**SDK `worktree.cleanup-wave` now rescues the executor's uncommitted `SUMMARY.md` instead of blocking on it** — worktree-isolated quick/phase executors leave `SUMMARY.md` uncommitted by contract (the orchestrator commits the docs bundle in a later step), but the SDK cleanup path's porcelain dirty-check was treating that contractual artifact as `worktree_dirty` and refusing to merge, stranding the worktree and the SUMMARY. `executeWorktreeWaveCleanupPlan` now mirrors the shell-fallback rescue (`workflows/quick.md:870-883`): it walks the worktree's `.planning` tree for `*SUMMARY.md` via filesystem traversal (not `git ls-files` — gitignored `.planning/` would silently return empty), copies any new-or-differing file into the main tree, and filters the rescued paths out of the dirty-state check. Genuine non-SUMMARY dirt still blocks. Copy failures surface as `summary_rescue_failed` rather than swallow silently. (#3804)

--- a/get-shit-done/bin/lib/worktree-safety.cjs
+++ b/get-shit-done/bin/lib/worktree-safety.cjs
@@ -385,6 +385,121 @@ function gitResultOk(result) {
   return result && result.exitCode === 0 && !result.timedOut;
 }
 
+// Errors during *.planning traversal that should be treated as "no SUMMARY to
+// rescue" rather than a hard rescue failure — matches the shell rescue's
+// `2>/dev/null` suppression (workflows/quick.md:870-883).
+const BENIGN_FS_TRAVERSAL_ERRORS = new Set(['ENOENT', 'EACCES', 'ENOTDIR']);
+
+/**
+ * Rescue uncommitted *SUMMARY.md files out of an executor worktree before the
+ * cleanup loop's dirty-state check (#3804).
+ *
+ * Worktree-isolated executors leave SUMMARY.md uncommitted in their .planning
+ * tree by contract (workflows/quick.md:757-758); the orchestrator commits the
+ * docs bundle in Step 8 from the main tree. Without this rescue, the porcelain
+ * dirty-check at the next step sees the uncommitted SUMMARY and refuses to
+ * merge — the same scenario the shell-fallback rescue at workflows/quick.md:870-883
+ * handles. This is the SDK-side equivalent.
+ *
+ * Discovery uses filesystem traversal, not `git ls-files --exclude-standard`,
+ * because projects often gitignore .planning/ and the git form silently returns
+ * empty in that case (the original 2024 footgun referenced in workflows/quick.md:872).
+ * Symlinks are skipped defensively to avoid traversal loops.
+ *
+ * Returns `{ ok: true, rescued: [...relPaths] }` listing every SUMMARY found in
+ * the worktree's .planning tree (whether copied or already-identical in main).
+ * Returns `{ ok: false, reason: 'summary_rescue_failed', file, error }` on the
+ * first copy or read failure — never silently swallows.
+ */
+function rescueWorktreeSummaries(worktreePath, repoRoot, deps = {}) {
+  const fsApi = deps.fs || fs;
+  const planningRoot = path.join(worktreePath, '.planning');
+  const summaries = [];
+  walkForSummaries(planningRoot, fsApi, summaries);
+
+  const rescued = [];
+  for (const absSrc of summaries) {
+    const relPath = path.relative(worktreePath, absSrc);
+    // Normalise to POSIX separators for the rescued/report set: git porcelain
+    // output uses '/' on every platform, and downstream callers (the dirty-state
+    // filter, the CLI JSON output) must compare against that shape. path.relative
+    // emits '\\' on Windows — without this normalisation, the filter would miss.
+    const relPathPosix = toPosixPath(relPath);
+    const destAbs = path.join(repoRoot, relPath);
+    try {
+      if (fsApi.existsSync(destAbs)) {
+        const srcBytes = Buffer.from(fsApi.readFileSync(absSrc));
+        const destBytes = Buffer.from(fsApi.readFileSync(destAbs));
+        if (srcBytes.equals(destBytes)) {
+          rescued.push(relPathPosix);
+          continue;
+        }
+      }
+      fsApi.mkdirSync(path.dirname(destAbs), { recursive: true });
+      fsApi.copyFileSync(absSrc, destAbs);
+      rescued.push(relPathPosix);
+    } catch (err) {
+      return {
+        ok: false,
+        reason: 'summary_rescue_failed',
+        file: relPathPosix,
+        error: err && err.message ? err.message : String(err),
+      };
+    }
+  }
+  return { ok: true, rescued };
+}
+
+function toPosixPath(p) {
+  return path.sep === '\\' ? p.split('\\').join('/') : p;
+}
+
+function walkForSummaries(dirPath, fsApi, out) {
+  let entries;
+  try {
+    entries = fsApi.readdirSync(dirPath, { withFileTypes: true });
+  } catch (err) {
+    if (err && BENIGN_FS_TRAVERSAL_ERRORS.has(err.code)) return;
+    throw err;
+  }
+  for (const ent of entries) {
+    if (ent.isSymbolicLink()) continue;
+    const child = path.join(dirPath, ent.name);
+    if (ent.isDirectory()) {
+      walkForSummaries(child, fsApi, out);
+    } else if (ent.isFile() && /SUMMARY\.md$/.test(ent.name)) {
+      out.push(child);
+    }
+  }
+}
+
+/**
+ * Drop porcelain lines whose path is in `rescuedRelPaths`. Returns the remaining
+ * dirty-state output (empty string when only rescued SUMMARYs were present).
+ * Porcelain format used: `XY path` (2-char status + space + path) — adequate for
+ * the SUMMARY.md case (untracked, no spaces, no rename). Quoted paths and rename
+ * lines (`R  old -> new`) fall through unchanged and still trip the dirty check.
+ */
+function filterPorcelainAgainstRescued(porcelainOutput, rescuedRelPaths) {
+  if (!porcelainOutput) return '';
+  // Defensive normalisation: rescueWorktreeSummaries already returns POSIX-shape
+  // paths, but if any caller ever passes a Windows-shape '\\'-separated rescued
+  // list, the string-equality lookup below would silently miss every match and
+  // the SUMMARY would fall through into the dirty-state output. Belt-and-braces.
+  const rescuedSet = new Set(
+    (rescuedRelPaths || []).map((p) => (p && p.indexOf('\\') >= 0 ? p.split('\\').join('/') : p))
+  );
+  const lines = porcelainOutput.split('\n');
+  const kept = [];
+  for (const line of lines) {
+    if (!line) continue;
+    const filePath = line.length > 3 ? line.slice(3) : line;
+    if (rescuedSet.has(filePath)) continue;
+    kept.push(line);
+  }
+  return kept.join('\n');
+}
+
 function executeWorktreeWaveCleanupPlan(plan, deps = {}) {
   const execGit = deps.execGit || execGitDefault;
   const entries = Array.isArray(plan?.entries) ? plan.entries : [];
@@ -453,11 +568,38 @@ function executeWorktreeWaveCleanupPlan(plan, deps = {}) {
       break;
     }
 
+    // Rescue uncommitted *SUMMARY.md before the dirty-state check (#3804).
+    // The executor contract leaves SUMMARY.md uncommitted by design; without
+    // this rescue, the SDK cleanup path treats the contractual artifact as
+    // blocking dirt — strictly weaker than the shell fallback it supersedes.
+    const rescue = rescueWorktreeSummaries(entry.worktree_path, plan.repoRoot, deps);
+    if (!rescue.ok) {
+      result.status = 'blocked';
+      result.reason = rescue.reason;
+      result.file = rescue.file;
+      result.stderr = rescue.error || '';
+      results.push(result);
+      pending.push(...entries.slice(i + 1));
+      ok = false;
+      break;
+    }
+    result.rescued = rescue.rescued;
+
     const worktreeStatus = execGit(['-C', entry.worktree_path, 'status', '--porcelain', '--untracked-files=all'], { cwd: plan.repoRoot });
-    if (!gitResultOk(worktreeStatus) || worktreeStatus.stdout) {
+    if (!gitResultOk(worktreeStatus)) {
       result.status = 'blocked';
       result.reason = 'worktree_dirty';
-      result.stderr = worktreeStatus?.stdout || worktreeStatus?.stderr || '';
+      result.stderr = worktreeStatus?.stderr || '';
+      results.push(result);
+      pending.push(...entries.slice(i + 1));
+      ok = false;
+      break;
+    }
+    const remainingDirty = filterPorcelainAgainstRescued(worktreeStatus.stdout || '', rescue.rescued);
+    if (remainingDirty) {
+      result.status = 'blocked';
+      result.reason = 'worktree_dirty';
+      result.stderr = remainingDirty;
       results.push(result);
       pending.push(...entries.slice(i + 1));
       ok = false;
@@ -867,4 +1009,8 @@ module.exports = {
   cmdWorktreeCleanupWave,
   reapOrphanWorktrees,
   cmdWorktreeReapOrphans,
+  // Exported for cross-platform regression tests (#3804 — git porcelain output
+  // always uses '/', but path.relative emits '\\' on Windows).
+  filterPorcelainAgainstRescued,
+  rescueWorktreeSummaries,
 };

--- a/tests/worktree-safety.test.cjs
+++ b/tests/worktree-safety.test.cjs
@@ -33,6 +33,7 @@ const {
   snapshotWorktreeInventory,
   planWorktreeWaveCleanup,
   executeWorktreeWaveCleanupPlan,
+  filterPorcelainAgainstRescued,
 } = require(WORKTREE_SAFETY_PATH);
 
 const isWindows = process.platform === 'win32';
@@ -60,6 +61,91 @@ function makeTimeoutStub() {
       error: Object.assign(new Error('spawnSync git ETIMEDOUT'), { code: 'ETIMEDOUT' }),
     };
   };
+}
+
+/**
+ * In-memory fs stub for `executeWorktreeWaveCleanupPlan`'s SUMMARY-rescue path (#3804).
+ *
+ * `files`     — map of absolute path → string|Buffer contents (the worktree's filesystem)
+ * `writeFails`— map of absolute dest path → Error to throw on copyFileSync
+ *
+ * Tracks every successful copy in `written` so tests can assert what was rescued.
+ * Models just enough fs surface to support the rescue helper: readdirSync (with
+ * withFileTypes), existsSync (file OR directory), readFileSync, mkdirSync,
+ * copyFileSync. Symlinks are never produced — the rescue must skip them, so
+ * absence is the assertion.
+ */
+function makeFsStub({ files = {}, writeFails = {} } = {}) {
+  const fsFiles = { ...files };
+  const written = {};
+  function directChildren(dirPath) {
+    const prefix = dirPath.endsWith('/') ? dirPath : dirPath + '/';
+    const children = new Map();
+    for (const filePath of Object.keys(fsFiles)) {
+      if (!filePath.startsWith(prefix)) continue;
+      const rest = filePath.slice(prefix.length);
+      if (!rest) continue;
+      const segs = rest.split('/');
+      const name = segs[0];
+      const isDir = segs.length > 1;
+      if (!children.has(name)) children.set(name, isDir);
+      else if (isDir) children.set(name, true);
+    }
+    return children;
+  }
+  return {
+    files: fsFiles,
+    written,
+    readdirSync(dirPath, opts) {
+      const children = directChildren(dirPath);
+      if (children.size === 0 && !directExists(fsFiles, dirPath)) {
+        throw Object.assign(new Error(`ENOENT: ${dirPath}`), { code: 'ENOENT' });
+      }
+      const dirents = [];
+      for (const [name, isDir] of children) {
+        dirents.push({
+          name,
+          isDirectory: () => isDir,
+          isFile: () => !isDir,
+          isSymbolicLink: () => false,
+        });
+      }
+      return opts && opts.withFileTypes ? dirents : dirents.map((d) => d.name);
+    },
+    existsSync(p) {
+      if (Object.prototype.hasOwnProperty.call(fsFiles, p)) return true;
+      return directExists(fsFiles, p);
+    },
+    readFileSync(p) {
+      if (!Object.prototype.hasOwnProperty.call(fsFiles, p)) {
+        throw Object.assign(new Error(`ENOENT: ${p}`), { code: 'ENOENT' });
+      }
+      const v = fsFiles[p];
+      return Buffer.isBuffer(v) ? v : Buffer.from(v);
+    },
+    mkdirSync(_p, _opts) {
+      // no-op — directory existence is inferred from file paths in `files`.
+    },
+    copyFileSync(src, dest) {
+      if (Object.prototype.hasOwnProperty.call(writeFails, dest)) {
+        throw writeFails[dest];
+      }
+      if (!Object.prototype.hasOwnProperty.call(fsFiles, src)) {
+        throw Object.assign(new Error(`ENOENT: ${src}`), { code: 'ENOENT' });
+      }
+      const v = fsFiles[src];
+      written[dest] = Buffer.isBuffer(v) ? v : Buffer.from(v);
+      fsFiles[dest] = written[dest];
+    },
+  };
+}
+
+function directExists(files, dirPath) {
+  const prefix = dirPath.endsWith('/') ? dirPath : dirPath + '/';
+  for (const filePath of Object.keys(files)) {
+    if (filePath.startsWith(prefix)) return true;
+  }
+  return false;
 }
 
 // ─── resolveWorktreeContext ───────────────────────────────────────────────────
@@ -689,5 +775,250 @@ describe('executeWorktreeWaveCleanupPlan', () => {
     assert.equal(calls.some((call) => call.startsWith('merge worktree-agent-a1')), false);
     assert.equal(calls.some((call) => call === 'worktree remove /repo/.claude/worktrees/agent-a1 --force'), false);
     assert.equal(calls.some((call) => call === 'branch -D worktree-agent-a1'), false);
+  });
+
+  // ─── #3804: rescue uncommitted *SUMMARY.md before the dirty-state check ─────
+  // The executor contract (workflows/quick.md:757-758) instructs worktree-isolated
+  // executors NOT to commit SUMMARY.md — the orchestrator commits it in Step 8.
+  // Before #3804, the SDK cleanup path's porcelain check treated that uncommitted
+  // SUMMARY as "worktree_dirty" and refused to merge, leaving the worktree mounted
+  // and the SUMMARY stranded. The shell-fallback rescue (workflows/quick.md:870-883)
+  // handled this; the SDK path did not. These tests pin the SDK rescue.
+  test('rescues uncommitted *SUMMARY.md before merge/remove (#3804)', () => {
+    const summarySrc = '/repo/.claude/worktrees/agent-a1/.planning/quick/qk-001-SUMMARY.md';
+    const summaryDest = '/repo/main/.planning/quick/qk-001-SUMMARY.md';
+    const fsStub = makeFsStub({ files: { [summarySrc]: '# qk-001 summary\n' } });
+
+    const calls = [];
+    const plan = {
+      ok: true,
+      repoRoot: '/repo/main',
+      action: 'cleanup_wave',
+      discovery: 'manifest',
+      entries: [{
+        agent_id: 'a1',
+        worktree_path: '/repo/.claude/worktrees/agent-a1',
+        branch: 'worktree-agent-a1',
+        expected_base: 'abc123',
+      }],
+    };
+
+    const result = executeWorktreeWaveCleanupPlan(plan, {
+      fs: fsStub,
+      execGit: (args) => {
+        calls.push(args.join(' '));
+        const key = args.join(' ');
+        if (key === '-C /repo/.claude/worktrees/agent-a1 rev-parse --abbrev-ref HEAD') {
+          return { exitCode: 0, stdout: 'worktree-agent-a1', stderr: '' };
+        }
+        if (key === 'merge-base HEAD worktree-agent-a1') {
+          return { exitCode: 0, stdout: 'abc123', stderr: '' };
+        }
+        if (key === 'diff --diff-filter=D --name-only HEAD...worktree-agent-a1') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key === '-C /repo/.claude/worktrees/agent-a1 status --porcelain --untracked-files=all') {
+          return { exitCode: 0, stdout: '?? .planning/quick/qk-001-SUMMARY.md', stderr: '' };
+        }
+        return { exitCode: 0, stdout: '', stderr: '' };
+      },
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.entries[0].status, 'merged_removed');
+    assert.equal(result.entries[0].reason, 'ok');
+    assert.deepEqual(result.entries[0].rescued, ['.planning/quick/qk-001-SUMMARY.md']);
+    assert.ok(fsStub.written[summaryDest], 'rescued SUMMARY landed in main tree');
+    assert.equal(fsStub.written[summaryDest].toString(), '# qk-001 summary\n');
+    assert.ok(calls.some((c) => c.startsWith('merge worktree-agent-a1')), 'merge step ran');
+    assert.ok(calls.some((c) => c === 'worktree remove /repo/.claude/worktrees/agent-a1 --force'), 'worktree removed');
+    assert.ok(calls.some((c) => c === 'branch -D worktree-agent-a1'), 'branch deleted');
+  });
+
+  test('rescues SUMMARY but still blocks on non-SUMMARY dirt (#3804)', () => {
+    const summarySrc = '/repo/.claude/worktrees/agent-a1/.planning/quick/qk-002-SUMMARY.md';
+    const summaryDest = '/repo/main/.planning/quick/qk-002-SUMMARY.md';
+    const fsStub = makeFsStub({ files: { [summarySrc]: '# qk-002 summary\n' } });
+
+    const calls = [];
+    const plan = {
+      ok: true,
+      repoRoot: '/repo/main',
+      action: 'cleanup_wave',
+      discovery: 'manifest',
+      entries: [{
+        agent_id: 'a1',
+        worktree_path: '/repo/.claude/worktrees/agent-a1',
+        branch: 'worktree-agent-a1',
+        expected_base: 'abc123',
+      }],
+    };
+
+    const result = executeWorktreeWaveCleanupPlan(plan, {
+      fs: fsStub,
+      execGit: (args) => {
+        calls.push(args.join(' '));
+        const key = args.join(' ');
+        if (key === '-C /repo/.claude/worktrees/agent-a1 rev-parse --abbrev-ref HEAD') {
+          return { exitCode: 0, stdout: 'worktree-agent-a1', stderr: '' };
+        }
+        if (key === 'merge-base HEAD worktree-agent-a1') {
+          return { exitCode: 0, stdout: 'abc123', stderr: '' };
+        }
+        if (key === 'diff --diff-filter=D --name-only HEAD...worktree-agent-a1') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key === '-C /repo/.claude/worktrees/agent-a1 status --porcelain --untracked-files=all') {
+          return {
+            exitCode: 0,
+            stdout: '?? .planning/quick/qk-002-SUMMARY.md\n?? scratch.txt',
+            stderr: '',
+          };
+        }
+        throw new Error(`unexpected git call after rescue+dirty: ${key}`);
+      },
+    });
+
+    // SUMMARY was rescued even though the worktree was blocked — operator still
+    // gets the artifact, just has to investigate the genuine dirt.
+    assert.ok(fsStub.written[summaryDest], 'SUMMARY rescued before dirty check fired');
+    assert.equal(result.ok, false);
+    assert.equal(result.entries[0].reason, 'worktree_dirty');
+    // The filtered porcelain in stderr should mention scratch.txt but NOT the SUMMARY line.
+    assert.match(result.entries[0].stderr, /scratch\.txt/);
+    assert.doesNotMatch(result.entries[0].stderr, /SUMMARY\.md/);
+    // merge/remove/delete must not have run.
+    assert.equal(calls.some((c) => c.startsWith('merge worktree-agent-a1')), false);
+  });
+
+  test('surfaces summary_rescue_failed when copy throws (#3804)', () => {
+    const summarySrc = '/repo/.claude/worktrees/agent-a1/.planning/quick/qk-003-SUMMARY.md';
+    const summaryDest = '/repo/main/.planning/quick/qk-003-SUMMARY.md';
+    const fsStub = makeFsStub({
+      files: { [summarySrc]: '# qk-003 summary\n' },
+      writeFails: {
+        [summaryDest]: Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' }),
+      },
+    });
+
+    const calls = [];
+    const plan = {
+      ok: true,
+      repoRoot: '/repo/main',
+      action: 'cleanup_wave',
+      discovery: 'manifest',
+      entries: [{
+        agent_id: 'a1',
+        worktree_path: '/repo/.claude/worktrees/agent-a1',
+        branch: 'worktree-agent-a1',
+        expected_base: 'abc123',
+      }],
+    };
+
+    const result = executeWorktreeWaveCleanupPlan(plan, {
+      fs: fsStub,
+      execGit: (args) => {
+        calls.push(args.join(' '));
+        const key = args.join(' ');
+        if (key === '-C /repo/.claude/worktrees/agent-a1 rev-parse --abbrev-ref HEAD') {
+          return { exitCode: 0, stdout: 'worktree-agent-a1', stderr: '' };
+        }
+        if (key === 'merge-base HEAD worktree-agent-a1') {
+          return { exitCode: 0, stdout: 'abc123', stderr: '' };
+        }
+        if (key === 'diff --diff-filter=D --name-only HEAD...worktree-agent-a1') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        throw new Error(`unexpected git call after rescue failure: ${key}`);
+      },
+    });
+
+    assert.equal(result.ok, false);
+    assert.equal(result.entries[0].reason, 'summary_rescue_failed');
+    assert.equal(result.entries[0].file, '.planning/quick/qk-003-SUMMARY.md');
+    assert.match(result.entries[0].stderr, /EACCES/);
+    // The dirty check, merge, remove, and branch-delete must NOT have run after rescue failure.
+    assert.equal(calls.some((c) => c.endsWith('status --porcelain --untracked-files=all')), false);
+    assert.equal(calls.some((c) => c.startsWith('merge worktree-agent-a1')), false);
+    assert.equal(calls.some((c) => c === 'worktree remove /repo/.claude/worktrees/agent-a1 --force'), false);
+    assert.equal(calls.some((c) => c === 'branch -D worktree-agent-a1'), false);
+  });
+
+  // #3804 cross-platform: git's porcelain plumbing always emits '/' regardless
+  // of OS, but Node's path.relative() emits '\\' on Windows. Without normalisation
+  // the filter's string-equality lookup misses on Windows and the worktree blocks
+  // identically to the original bug — just on a different platform. Pin both
+  // shapes here so the regression doesn't sneak back.
+  test('filters POSIX-style porcelain even when rescued paths use Windows separators (#3804)', () => {
+    // Simulate what path.relative would emit on Windows for the same logical path.
+    const rescuedWinShape = ['.planning\\quick\\qk-001-SUMMARY.md'];
+    const porcelainPosix = '?? .planning/quick/qk-001-SUMMARY.md';
+
+    const remaining = filterPorcelainAgainstRescued(porcelainPosix, rescuedWinShape);
+
+    assert.equal(remaining, '', 'rescued SUMMARY filtered out despite separator mismatch');
+  });
+
+  test('filter still flags non-rescued dirt when rescued paths use Windows separators (#3804)', () => {
+    const rescuedWinShape = ['.planning\\quick\\qk-001-SUMMARY.md'];
+    const porcelainPosix = '?? .planning/quick/qk-001-SUMMARY.md\n?? scratch.txt';
+
+    const remaining = filterPorcelainAgainstRescued(porcelainPosix, rescuedWinShape);
+
+    assert.equal(remaining, '?? scratch.txt', 'scratch.txt remains; SUMMARY filtered');
+  });
+
+  test('skips identical SUMMARY already in main tree but still filters porcelain (#3804)', () => {
+    const summarySrc = '/repo/.claude/worktrees/agent-a1/.planning/quick/qk-004-SUMMARY.md';
+    const summaryDest = '/repo/main/.planning/quick/qk-004-SUMMARY.md';
+    const fsStub = makeFsStub({
+      files: {
+        [summarySrc]: '# qk-004 summary\n',
+        // Already in main with identical bytes — cmp -s would short-circuit.
+        [summaryDest]: '# qk-004 summary\n',
+      },
+    });
+
+    const calls = [];
+    const plan = {
+      ok: true,
+      repoRoot: '/repo/main',
+      action: 'cleanup_wave',
+      discovery: 'manifest',
+      entries: [{
+        agent_id: 'a1',
+        worktree_path: '/repo/.claude/worktrees/agent-a1',
+        branch: 'worktree-agent-a1',
+        expected_base: 'abc123',
+      }],
+    };
+
+    const result = executeWorktreeWaveCleanupPlan(plan, {
+      fs: fsStub,
+      execGit: (args) => {
+        calls.push(args.join(' '));
+        const key = args.join(' ');
+        if (key === '-C /repo/.claude/worktrees/agent-a1 rev-parse --abbrev-ref HEAD') {
+          return { exitCode: 0, stdout: 'worktree-agent-a1', stderr: '' };
+        }
+        if (key === 'merge-base HEAD worktree-agent-a1') {
+          return { exitCode: 0, stdout: 'abc123', stderr: '' };
+        }
+        if (key === 'diff --diff-filter=D --name-only HEAD...worktree-agent-a1') {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        }
+        if (key === '-C /repo/.claude/worktrees/agent-a1 status --porcelain --untracked-files=all') {
+          return { exitCode: 0, stdout: '?? .planning/quick/qk-004-SUMMARY.md', stderr: '' };
+        }
+        return { exitCode: 0, stdout: '', stderr: '' };
+      },
+    });
+
+    // No new write — bytes identical, so copy was a no-op.
+    assert.equal(fsStub.written[summaryDest], undefined, 'copy skipped when bytes match');
+    // But the file is still tracked as "rescued" so the dirty check filters it.
+    assert.equal(result.ok, true);
+    assert.equal(result.entries[0].status, 'merged_removed');
+    assert.deepEqual(result.entries[0].rescued, ['.planning/quick/qk-004-SUMMARY.md']);
   });
 });


### PR DESCRIPTION
## Fix PR

---

## Linked Issue

Fixes #3804

The linked issue has the `confirmed-bug` label.

---

## What was broken

`gsd-sdk query worktree.cleanup-wave` refused to clean up worktrees holding an executor's contractually-uncommitted `SUMMARY.md`. `executeWorktreeWaveCleanupPlan` (`get-shit-done/bin/lib/worktree-safety.cjs:456–465`) ran `git status --porcelain` and treated any output as `worktree_dirty`, so the file `workflows/quick.md:757–758` instructs the executor to leave uncommitted always tripped the check:

```json
{"ok":false,"reason":"cleanup_blocked",
 "entries":[{"reason":"worktree_dirty",
             "stderr":"?? .planning/quick/qk-001-SUMMARY.md"}]}
```

The shell-fallback rescue at `workflows/quick.md:870–883` already handled this state; `quick.md` Step 6 prefers the SDK path over the fallback, so the preferred path was strictly weaker than the path it superseded.

## What this fix does

Adds two helpers in `get-shit-done/bin/lib/worktree-safety.cjs` and wires them between the existing deletions check and dirty check in `executeWorktreeWaveCleanupPlan`:

- **`rescueWorktreeSummaries`** walks `<worktree>/.planning` recursively for `*SUMMARY.md` via `fs.readdirSync` (filesystem traversal, not `git ls-files` — the #2296 footgun: gitignored `.planning/` silently returns empty there). Copies missing-or-byte-differing files into `repoRoot` using a `cmp -s`-equivalent byte compare. Skips symlinks defensively. Copy or read failures surface as `summary_rescue_failed` with the file path and error string — never swallowed.
- **`filterPorcelainAgainstRescued`** drops rescued lines from porcelain output by path lookup. Non-SUMMARY dirt (e.g. stray `scratch.txt`) still trips `worktree_dirty`, so cleanup is stronger-than-shell on genuine-dirt detection while matching shell on SUMMARY rescue.

Both the producer (`rescueWorktreeSummaries`) and the consumer (`filterPorcelainAgainstRescued`) normalise paths to POSIX separators via a small `toPosixPath` helper. Git porcelain always emits `/`, but `path.relative` emits `\` on Windows — without normalisation the filter would miss on Windows identically to the original bug, just on a different platform.

Each entry's result gains an additive `rescued: [...]` field listing the POSIX-shape relative paths that were saved.

## Root cause

#3384 introduced the SDK-based cleanup path for atomicity and structured JSON output, replacing the inline shell cleanup in `quick.md` Step 6. The port carried over the branch/base/deletions safety checks but did not carry over the SUMMARY rescue from `workflows/quick.md:870–883` and added a strict porcelain dirty check that wasn't in the shell flow. The combination means the contractual uncommitted SUMMARY now trips a check that didn't exist when the contract was designed.

## Testing

### How I verified the fix

- `node --test tests/worktree-safety.test.cjs` — **39/39 pass** (33 baseline + 6 new). 4 new tests cover happy path, mixed-dirt blocking, copy-failure surfacing, and byte-identical short-circuit; 2 new tests pin cross-platform robustness by feeding the filter Windows-shape (`\\`-separated) rescued paths against POSIX porcelain.
- `node scripts/run-tests.cjs --suite unit` — **5190/5190 pass**.
- `node scripts/run-tests.cjs --suite install` — **6/6 pass** (no package-shape regression).
- **End-to-end repro against real git**: built a temp repo + worktree + uncommitted `.planning/quick/qk-001-SUMMARY.md` matching the issue's "Repro" steps and ran `node get-shit-done/bin/gsd-tools.cjs worktree cleanup-wave --manifest …`. Before the fix this returned `{"ok":false,"reason":"cleanup_blocked",…}` and left the worktree mounted; after the fix it returns `{"ok":true,"rescued":[".planning/quick/qk-001-SUMMARY.md"],"status":"merged_removed"}`, the worktree directory is gone, the branch is deleted, the merge commit is in `git log`, and the SUMMARY is in the main tree.

### Regression test added?

- [x] Yes — six new tests in `tests/worktree-safety.test.cjs` inside the existing `describe('executeWorktreeWaveCleanupPlan')` block, alongside the existing `'blocks dirty worktrees'` test.

### Platforms tested

- [x] macOS
- [ ] Windows (cross-platform separator handling is exercised by the two Windows-shape unit tests; runtime on Windows itself was not exercised locally — relying on CI)
- [ ] Linux (relying on CI)
- [ ] N/A (not platform-specific)

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other: ___
- [ ] N/A (not runtime-specific — fix is in the SDK module shared by all runtimes via `gsd-tools.cjs`)

---

## Checklist

- [x] Issue linked above with `Fixes #3804` — **PR will be auto-closed if missing**
- [x] Linked issue has the `confirmed-bug` label
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added (or explained why not)
- [x] All existing tests pass (`npm test`)
- [x] `.changeset/` fragment added: `.changeset/3804-sdk-worktree-summary-rescue.md`
- [x] No unnecessary dependencies added

## Breaking changes

None. The change is additive on the JSON output (new `rescued: [...]` field on entries; new `summary_rescue_failed` reason value only emitted on filesystem copy failures that previously surfaced as `worktree_dirty`). The behavioural change is that cleanup-wave now succeeds on a state that previously failed — i.e. the fix itself — which is the intended contract.
