### PR TITLE
fix(milestone): header dup, phase-bullet leakage, one-liner extraction

### DIFF
--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -1517,24 +1517,39 @@ function extractOneLinerFromBody(content) {
   const normalized = content.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
   // Strip frontmatter first
   const body = normalized.replace(/^---\n[\s\S]*?\n---\n*/, '');
-  // Find the first **...** span on a line after a # heading.
-  // Two supported template forms:
-  //   1) Labeled:  **One-liner:** Real prose here.   (bug #2660 — new template)
-  //   2) Bare:     **Real prose here.**              (legacy template)
-  // For (1), the first bold span ends in a colon and the prose that follows
-  // on the same line is the one-liner. For (2), the bold span itself is the
-  // one-liner.
-  const match = body.match(/^#[^\n]*\n+\*\*([^*\n]+)\*\*([^\n]*)/m);
-  if (!match) return null;
-  const boldInner = match[1].trim();
-  const afterBold = match[2];
-  // Labeled form: bold span is a "Label:" prefix — capture prose after it.
-  if (/:\s*$/.test(boldInner)) {
-    const prose = afterBold.trim();
-    return prose.length > 0 ? prose : null;
+  // Anchor strictly to the FIRST h1 heading (single `#`). The previous
+  // pattern `^#[^\n]*` matched any heading level, so when a SUMMARY's title
+  // was not immediately followed by a `**bold**` paragraph (e.g. an intro
+  // blockquote sat between, or `## Objective` came next with prose), the
+  // regex would walk down to a later sub-heading like
+  // `### Deviation 1 — ...` and grab the bold span from the deviation body
+  // (e.g. `**Found during:** Task 3 ...`) — leaking deviation fragments into
+  // milestone accomplishments.
+  //
+  // Three supported template forms:
+  //   1) Labeled bold:  **One-liner:** Real prose here.
+  //   2) Bare bold:     **Real prose here.**
+  //   3) Blockquote:    > Real prose here.            (new — common in some templates)
+  const h1Match = body.match(/^#\s+[^\n]*\n+([^\n]*)/m);
+  if (!h1Match) return null;
+  const firstLine = h1Match[1].trim();
+  // Forms 1 + 2: bold span on the first non-blank line after the h1 title.
+  const boldMatch = firstLine.match(/^\*\*([^*\n]+)\*\*([^\n]*)/);
+  if (boldMatch) {
+    const boldInner = boldMatch[1].trim();
+    const afterBold = boldMatch[2];
+    if (/:\s*$/.test(boldInner)) {
+      const prose = afterBold.trim();
+      return prose.length > 0 ? prose : null;
+    }
+    return boldInner.length > 0 ? boldInner : null;
   }
-  // Bare form: the bold content itself is the one-liner.
-  return boldInner.length > 0 ? boldInner : null;
+  // Form 3: blockquote one-liner.
+  const quoteMatch = firstLine.match(/^>\s+(.+)$/);
+  if (quoteMatch) {
+    return quoteMatch[1].trim().replace(/^\*\*|\*\*$/g, '') || null;
+  }
+  return null;
 }
 
 // ─── Misc utilities ───────────────────────────────────────────────────────────
@@ -1743,10 +1758,19 @@ function getMilestonePhaseFilter(cwd, versionOverride) {
       }
     }
 
-    // Match both numeric phases (Phase 1:) and custom IDs (Phase PROJ-42:)
-    const phasePattern = /#{2,4}\s*Phase\s+([\w][\w.-]*)\s*:/gi;
+    // Match phase declarations in BOTH heading form (### Phase N:) and
+    // checkbox-bullet form (- [ ] **Phase N: title**). Without the bullet
+    // path, ROADMAPs whose milestone-active section lists phases as bullets
+    // (a common convention) produce an empty milestonePhaseNums set, which
+    // trips the passAll fallback below and counts every phase dir on disk
+    // as in-scope for the milestone (range-leakage bug).
+    const phaseHeadingPattern = /^#{2,4}\s*Phase\s+([\w][\w.-]*)\s*:/gim;
+    const phaseBulletPattern  = /^[-*]\s*\[[ xX]\]\s*\*\*\s*Phase\s+([\w][\w.-]*)\s*:/gim;
     let m;
-    while ((m = phasePattern.exec(roadmap)) !== null) {
+    while ((m = phaseHeadingPattern.exec(roadmap)) !== null) {
+      milestonePhaseNums.add(m[1]);
+    }
+    while ((m = phaseBulletPattern.exec(roadmap)) !== null) {
       milestonePhaseNums.add(m[1]);
     }
   } catch { /* intentionally empty */ }

--- a/get-shit-done/bin/lib/milestone.cjs
+++ b/get-shit-done/bin/lib/milestone.cjs
@@ -176,9 +176,13 @@ function cmdMilestoneComplete(cwd, version, options, raw) {
     fs.renameSync(auditFile, path.join(archiveDir, `${version}-MILESTONE-AUDIT.md`));
   }
 
-  // Create/append MILESTONES.md entry
+  // Create/append MILESTONES.md entry.
+  // When `options.name` is absent, `milestoneName` falls back to `version`
+  // (see line ~104), which produced duplicated headers like `## v5.0 v5.0`.
+  // Render the name suffix only when it differs from version.
   const accomplishmentsList = accomplishments.map(a => `- ${a}`).join('\n');
-  const milestoneEntry = `## ${version} ${milestoneName} (Shipped: ${today})\n\n**Phases completed:** ${phaseCount} phases, ${totalPlans} plans, ${totalTasks} tasks\n\n**Key accomplishments:**\n${accomplishmentsList || '- (none recorded)'}\n\n---\n\n`;
+  const headingSuffix = (milestoneName && milestoneName !== version) ? ` ${milestoneName}` : '';
+  const milestoneEntry = `## ${version}${headingSuffix} (Shipped: ${today})\n\n**Phases completed:** ${phaseCount} phases, ${totalPlans} plans, ${totalTasks} tasks\n\n**Key accomplishments:**\n${accomplishmentsList || '- (none recorded)'}\n\n---\n\n`;
 
   if (fs.existsSync(milestonesPath)) {
     const existing = fs.readFileSync(milestonesPath, 'utf-8');

--- a/tests/milestone-complete-leakage.test.cjs
+++ b/tests/milestone-complete-leakage.test.cjs
@@ -1,0 +1,230 @@
+'use strict';
+
+/**
+ * Regression tests for the three milestone.complete bugs documented in the
+ * accompanying PR:
+ *
+ *   1. Header duplication — `## v5.0 v5.0` when --name is omitted
+ *      (milestoneName falls back to version, both slots filled identically).
+ *
+ *   2. Phase-range leakage — when the active milestone section in ROADMAP.md
+ *      uses checkbox bullets (`- [ ] **Phase 26: ...**`) instead of headings
+ *      (`### Phase 26: ...`), the phase pattern matches zero entries, the
+ *      passAll fallback fires, and every phase dir on disk gets folded into
+ *      the milestone.
+ *
+ *   3. One-liner extraction noise — the regex matched the first **bold**
+ *      span after *any* heading level, so SUMMARYs whose title was not
+ *      immediately followed by bold (e.g. blockquote, or `## Objective`
+ *      and prose first) leaked deviation-section fragments like
+ *      `Found during:` or `1. [Rule 3 - Blocking] ...` as the
+ *      "one-liner" accomplishment.
+ */
+
+const { describe, test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const { createTempProject, cleanup, runGsdTools } = require('./helpers.cjs');
+const { extractOneLinerFromBody } = require('../get-shit-done/bin/lib/core.cjs');
+
+function writeRoadmap(tmpDir, content) {
+  fs.writeFileSync(path.join(tmpDir, '.planning', 'ROADMAP.md'), content);
+}
+
+function writeState(tmpDir) {
+  fs.writeFileSync(
+    path.join(tmpDir, '.planning', 'STATE.md'),
+    `# STATE\n\n## Current Position\n\n## Project Reference\n`,
+  );
+}
+
+function mkPhaseDir(tmpDir, name, opts = {}) {
+  const p = path.join(tmpDir, '.planning', 'phases', name);
+  fs.mkdirSync(p, { recursive: true });
+  if (opts.oneLiner) {
+    fs.writeFileSync(
+      path.join(p, `${name.split('-')[0]}-01-SUMMARY.md`),
+      `---\none-liner: ${opts.oneLiner}\n---\n# Summary\n`,
+    );
+  }
+  return p;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('milestone.complete header duplication (bug 1)', () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = createTempProject(); });
+  afterEach(() => { cleanup(tmpDir); });
+
+  test('omitting --name does not produce duplicated version header', () => {
+    writeRoadmap(tmpDir, `# Roadmap v1.0\n`);
+    writeState(tmpDir);
+
+    const result = runGsdTools('milestone complete v1.0', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const milestones = fs.readFileSync(path.join(tmpDir, '.planning', 'MILESTONES.md'), 'utf-8');
+    assert.ok(
+      !milestones.includes('## v1.0 v1.0'),
+      `expected no duplicated version header; got:\n${milestones.split('\n').slice(0, 5).join('\n')}`,
+    );
+    assert.ok(milestones.includes('## v1.0 (Shipped:'));
+  });
+
+  test('--name still renders correctly (no regression)', () => {
+    writeRoadmap(tmpDir, `# Roadmap v1.0\n`);
+    writeState(tmpDir);
+
+    const result = runGsdTools('milestone complete v1.0 --name MVP', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const milestones = fs.readFileSync(path.join(tmpDir, '.planning', 'MILESTONES.md'), 'utf-8');
+    assert.ok(milestones.includes('## v1.0 MVP (Shipped:'));
+    assert.ok(!milestones.includes('## v1.0 v1.0'));
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('milestone.complete phase-range leakage (bug 2)', () => {
+  let tmpDir;
+  beforeEach(() => { tmpDir = createTempProject(); });
+  afterEach(() => { cleanup(tmpDir); });
+
+  test('checkbox-bullet phase declarations are matched (no passAll leak)', () => {
+    // ROADMAP whose v1.0 section declares phases as bullets, with an
+    // unrelated phase 99 in a later section that must NOT leak in.
+    writeRoadmap(tmpDir, [
+      '# Roadmap',
+      '',
+      '## Milestones',
+      '',
+      '- 🚧 **v1.0** — Phases 1-2',
+      '',
+      '## Phases',
+      '',
+      '### 🚧 Active — v1.0 milestone-foo',
+      '',
+      '- [ ] **Phase 1: foundation** — set up things',
+      '- [ ] **Phase 2: api** — wire api',
+      '',
+      '### 🚧 Standalone outside v1.0 scope',
+      '',
+      '- [x] **Phase 99: unrelated** — should NOT count toward v1.0',
+      '',
+      '## Phase Details',
+      '',
+      '### Phase 99: unrelated',
+      '**Goal:** Not part of v1.0',
+      '',
+    ].join('\n'));
+    writeState(tmpDir);
+    mkPhaseDir(tmpDir, '01-foundation', { oneLiner: 'one-liner-1' });
+    mkPhaseDir(tmpDir, '02-api', { oneLiner: 'one-liner-2' });
+    mkPhaseDir(tmpDir, '99-unrelated', { oneLiner: 'leaked-from-phase-99' });
+
+    const result = runGsdTools('milestone complete v1.0 --name MVP', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const milestones = fs.readFileSync(path.join(tmpDir, '.planning', 'MILESTONES.md'), 'utf-8');
+    assert.ok(milestones.includes('one-liner-1'), 'phase 1 one-liner should be present');
+    assert.ok(milestones.includes('one-liner-2'), 'phase 2 one-liner should be present');
+    assert.ok(
+      !milestones.includes('leaked-from-phase-99'),
+      'phase 99 was outside v1.0 scope — its one-liner must not leak in',
+    );
+
+    // Also verify phase count in JSON output is 2, not 3.
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.phases, 2, 'should count 2 phases (1 + 2), not 3');
+  });
+
+  test('heading-style phase declarations still match (no regression)', () => {
+    writeRoadmap(tmpDir, [
+      '# Roadmap',
+      '',
+      '## 🚧 Active — v1.0',
+      '',
+      '### Phase 1: Foundation',
+      '**Goal:** Setup',
+      '',
+    ].join('\n'));
+    writeState(tmpDir);
+    mkPhaseDir(tmpDir, '01-foundation', { oneLiner: 'still-works' });
+
+    const result = runGsdTools('milestone complete v1.0 --name MVP', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const output = JSON.parse(result.output);
+    assert.strictEqual(output.phases, 1);
+    const milestones = fs.readFileSync(path.join(tmpDir, '.planning', 'MILESTONES.md'), 'utf-8');
+    assert.ok(milestones.includes('still-works'));
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('extractOneLinerFromBody — deviation-fragment leak (bug 3)', () => {
+  test('does NOT extract bold from a later sub-heading (Deviation block)', () => {
+    const body = [
+      '# Phase 26 Plan 03',
+      '',
+      '## Objective',
+      '',
+      'Some prose.',
+      '',
+      '## Deviations',
+      '',
+      '### Deviation 1 — Atomic per-task commits',
+      '',
+      '**Found during:** Task 3 (the plan\'s combined-commit step)',
+      '**Issue:** Plan asked for combined commit.',
+      '',
+    ].join('\n');
+    assert.strictEqual(extractOneLinerFromBody(body), null);
+  });
+
+  test('does NOT extract bold from Auto-fixed Issues sub-heading', () => {
+    const body = [
+      '# Phase 27 Plan 01',
+      '',
+      '## Performance',
+      '',
+      'Stats here.',
+      '',
+      '### Auto-fixed Issues',
+      '',
+      '**1. [Rule 3 - Blocking] Lockstep mock-layer patches to keep tsc clean**',
+      '- **Found during:** Task 1',
+      '',
+    ].join('\n');
+    assert.strictEqual(extractOneLinerFromBody(body), null);
+  });
+
+  test('extracts blockquote-style one-liner (template variant)', () => {
+    const body = [
+      '# Phase 26 Plan 03: Add series.* i18n namespace (EN + HE) Summary',
+      '',
+      '> Bilingual copywriting contract for the v5.0 series-builder under a new top-level namespace.',
+      '',
+      '## Objective',
+      '',
+    ].join('\n');
+    assert.strictEqual(
+      extractOneLinerFromBody(body),
+      'Bilingual copywriting contract for the v5.0 series-builder under a new top-level namespace.',
+    );
+  });
+
+  test('bare-bold one-liner still works (no regression)', () => {
+    const body = '# Title\n\n**Real prose here.**\n\n## Next';
+    assert.strictEqual(extractOneLinerFromBody(body), 'Real prose here.');
+  });
+
+  test('labeled-bold one-liner still works (no regression)', () => {
+    const body = '# Title\n\n**One-liner:** the actual prose.\n';
+    assert.strictEqual(extractOneLinerFromBody(body), 'the actual prose.');
+  });
+});


### PR DESCRIPTION
## Summary

Three independent bugs in `milestone.complete` combine to produce noisy, incorrect `MILESTONES.md` entries. All three are fixed in this PR with a new regression test file (`tests/milestone-complete-leakage.test.cjs`, 9 cases).

### Bug 1 — Header duplication (`milestone.cjs:181`)

When `--name` is omitted, `milestoneName` falls back to `version` (line ~104), producing duplicated headers:

```
## v5.0 v5.0 (Shipped: 2026-05-22)
```

**Fix:** render the name suffix only when it differs from version.

### Bug 2 — Phase-range leakage (`core.cjs getMilestonePhaseFilter`)

The phase-extraction regex only matches **heading-form** declarations (`### Phase N:`). ROADMAPs whose milestone-active section lists phases as **checkbox bullets** (`- [ ] **Phase 26: title**`) produce an empty `milestonePhaseNums` set, which trips the `passAll` fallback — and then **every** phase directory on disk gets folded into the milestone.

In real-world projects this means a phase that was explicitly scoped *outside* a milestone (but shipped during the same date window) gets pulled into that milestone's accomplishments.

**Fix:** add a second pattern that matches checkbox-bullet phase declarations alongside the existing heading pattern.

### Bug 3 — One-liner extraction noise (`core.cjs:1514 extractOneLinerFromBody`)

The pattern `^#[^\n]*\n+\*\*([^*\n]+)\*\*([^\n]*)` matches the first `**bold**` span after **any** heading level. When a SUMMARY's title is not immediately followed by bold (e.g. the title is followed by a blockquote intro, or by `## Objective` and prose first), the regex walks down through the document and grabs a `**bold**` span from a `### Deviation N — ...` or `### Auto-fixed Issues` sub-heading instead — leaking deviation fragments as if they were milestone accomplishments.

Real-world leaked bullets observed:

- `- Found during:`
- `- 1. [Rule 3 - Blocking] Lockstep mock-layer patches to keep tsc clean after type changes`

**Fix:** anchor strictly to the first h1 heading (single `#`) and only consider its immediate next non-blank line. Additionally support blockquote-style one-liners (`> Real prose here.`), which several SUMMARY templates use.

## Diff

```
get-shit-done/bin/lib/core.cjs      | 64 +++++++++++++++++++++++++------------
get-shit-done/bin/lib/milestone.cjs |  8 +++--
tests/milestone-complete-leakage.test.cjs | 222 +++++++++++++++++++ (new)
```

## Test plan

- [x] `node tests/milestone-complete-leakage.test.cjs` — 9/9 new cases pass (header dup with/without `--name`, checkbox-bullet phase detection vs unrelated heading-only phase 99 outside scope, deviation-fragment rejection ×2, blockquote one-liner support, plus bare/labeled regression guards)
- [x] `node tests/milestone.test.cjs` — all pre-existing milestone command tests still pass
- [x] `node tests/milestone-archive.test.cjs` — all pre-existing tests still pass (after `cd sdk && npm run build` — the existing test infra requires this)
- [x] `node tests/bug-2660-one-liner-extraction.test.cjs` — all 8 pre-existing tests still pass
- [x] `node tests/bug-2676-parallel-milestone-phase-complete.test.cjs` — all 4 pre-existing tests still pass

## Backward compatibility

- **Bug 1 fix** is purely cosmetic; the `${version}${milestoneName}` template only changes when both slots were redundant. The existing `--name` case still renders identically (`v1.0 MVP`).
- **Bug 2 fix** is purely additive — heading-form phase declarations still match the same way; the new bullet-form path catches a previously-unmatched case.
- **Bug 3 fix** is stricter — SUMMARYs whose first non-blank line after h1 is neither bold nor blockquote now return `null` (instead of garbage from later sub-headings). Downstream callers that were tolerating the garbage will now see the (correct) absence of a one-liner. Blockquote form is newly supported (additive, doesn't break existing extractors).

## Surfaced from

cdtr-studio v5.0 milestone close (2026-05-22). All three bugs fired in the same run, producing a `## v5.0 v5.0` header containing Phase 29 entries that were explicitly scoped outside v5.0, plus the two orphan bullets quoted above. Three prior cdtr-studio milestone closes (v3.0, v4.0, v5.0) had to manually clean up the same pattern — documented as a recurring carryover item in each cycle's deferred-items table:

> \`gsd-tools milestone complete\` auto-extraction noise + phase-range leakage — counted Phase 25 + 999.x into v4.0 close; produced 60+ noisy accomplishment bullets. Manually corrected at v4.0 close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)