### PR TITLE
fix(#3863): extractCurrentMilestone skips CLOSED sibling on shared semver prefix

### DIFF
--- a/.changeset/3863-extract-milestone-skip-closed-sibling.md
+++ b/.changeset/3863-extract-milestone-skip-closed-sibling.md
@@ -1,0 +1,5 @@
+---
+type: Fixed
+issue: 3863
+---
+**`extractCurrentMilestone` no longer selects a CLOSED sub-milestone when STATE.md `milestone` is a shared semver prefix.** When a roadmap contains both a closed sub-milestone (e.g. `## v8.0 Overview — v8.0-F (CLOSED FAIL)`) and an active sub-milestone (e.g. `## v8.0-B Overview (STARTED)`) under the same semver prefix recorded in STATE.md (`milestone: v8.0`), the `'mi'` first-match regex in `get-shit-done/bin/lib/core.cjs:969-973` always returned the closed heading. Downstream `phase.insert`, `phase.complete`, `init.phase-op`, and `roadmap` queries then failed with "Phase N not found in current milestone" despite the active phase row plainly existing. The fix switches to `'gmi'` `matchAll` iteration, skips headings containing `CLOSED|ARCHIVED|ABANDONED|SHIPPED|FAIL(ED)?|✅|🗄️` markers, and falls back to the first match if every candidate is closed (preserves legacy single-closed-milestone behavior). Preamble boundary is now computed from the first milestone heading position independently of `sectionStart` so closed-sibling content does not leak into the returned slice when the matched section is later in the file. (#3863)

--- a/get-shit-done/bin/lib/core.cjs
+++ b/get-shit-done/bin/lib/core.cjs
@@ -965,12 +965,35 @@ function extractCurrentMilestone(content, cwd) {
 
   // 3. Find the section matching this version
   // Match headings like: ## Roadmap v3.0: Name, ## v3.0 Name, etc.
+  //
+  // When STATE.md milestone field is a shared semver prefix (e.g. "v8.0") that
+  // appears in multiple ROADMAP.md headings — typically a closed sub-milestone
+  // (## v8.0 Overview — v8.0-F (CLOSED FAIL)) plus an active one
+  // (## v8.0-B Overview (STARTED)) — the first non-closed match is preferred.
+  // Without this skip, the active milestone section would be silently excluded
+  // and downstream phase.insert / phase.complete / init.phase-op queries would
+  // fail with "Phase N not found in current milestone" despite the phase row
+  // existing in the active sub-milestone block. See #NNNN.
   const escapedVersion = escapeRegex(version);
   const sectionPattern = new RegExp(
     `(^#{1,3}\\s+.*${escapedVersion}[^\\n]*)`,
-    'mi'
+    'gmi'
   );
-  const sectionMatch = content.match(sectionPattern);
+  const CLOSED_MILESTONE_MARKERS = /\b(?:CLOSED|ARCHIVED|ABANDONED|SHIPPED|FAIL(?:ED)?)\b|✅|🗄️/i;
+
+  let sectionMatch = null;
+  const allMatches = Array.from(content.matchAll(sectionPattern));
+  for (const m of allMatches) {
+    if (!CLOSED_MILESTONE_MARKERS.test(m[1])) {
+      sectionMatch = m;
+      break;
+    }
+  }
+  // Fallback: if every match contains a closed marker, return the first match
+  // to preserve legacy behavior (single closed milestone still loads its section).
+  if (!sectionMatch && allMatches.length > 0) {
+    sectionMatch = allMatches[0];
+  }
 
   if (!sectionMatch) return stripShippedMilestones(content);
 
@@ -1014,14 +1037,18 @@ function extractCurrentMilestone(content, cwd) {
     charOffset += line.length + 1;
   }
 
-  // Return everything before the current milestone section (non-milestone content
-  // like title, overview) plus the current milestone section
-  const beforeMilestones = content.slice(0, sectionStart);
+  // Return content before the FIRST milestone heading (title, overview, non-milestone
+  // preamble) plus the current milestone section. We compute `firstMilestoneStart`
+  // independently of `sectionStart` so that when an active milestone follows a
+  // closed sibling sharing the same semver prefix (skipped above), the closed
+  // milestone's content is NOT pulled into the preamble. Strip <details> blocks
+  // since they are definitely shipped content.
+  const firstMilestoneMatch = content.match(/^#{1,3}\s+.*v\d+\.\d+[^\n]*/m);
+  const firstMilestoneStart = firstMilestoneMatch ? firstMilestoneMatch.index : sectionStart;
+  const preamble = content
+    .slice(0, firstMilestoneStart)
+    .replace(/<details>[\s\S]*?<\/details>/gi, '');
   const currentSection = content.slice(sectionStart, sectionEnd);
-
-  // Also include any content before the first milestone heading (title, overview, etc.)
-  // but strip any <details> blocks in it (these are definitely shipped)
-  const preamble = beforeMilestones.replace(/<details>[\s\S]*?<\/details>/gi, '');
 
   return preamble + currentSection;
 }

--- a/tests/bug-3863-extract-milestone-shared-prefix.test.cjs
+++ b/tests/bug-3863-extract-milestone-shared-prefix.test.cjs
@@ -1,0 +1,232 @@
+'use strict';
+
+/**
+ * GSD Tools Tests - extractCurrentMilestone shared semver prefix bug
+ *
+ * Bug: When STATE.md milestone field is a shared semver prefix (e.g. "v8.0")
+ *   that appears in multiple ROADMAP.md headings — typically a closed
+ *   sub-milestone (## v8.0 Overview — v8.0-F (CLOSED FAIL)) plus an active one
+ *   (## v8.0-B Overview (STARTED)) — the original `'mi'` regex first-match
+ *   returned the closed section. Downstream phase.insert / phase.complete /
+ *   init.phase-op then failed with "Phase N not found in current milestone".
+ *
+ * Fix: enumerate all milestone-heading matches via `'gmi'` matchAll, skip
+ *   headings containing closed markers (CLOSED|ARCHIVED|ABANDONED|SHIPPED|
+ *   FAIL(ED)?|✅|🗄️), prefer first non-closed; fall back to first match if
+ *   every candidate is closed (preserves legacy single-closed-milestone load).
+ */
+
+process.env.GSD_TEST_MODE = '1';
+
+const { describe, test } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const fs = require('node:fs');
+const { createTempProject, cleanup } = require('./helpers.cjs');
+
+const CORE = path.join(__dirname, '..', 'get-shit-done', 'bin', 'lib', 'core.cjs');
+const { extractCurrentMilestone } = require(CORE);
+
+function writeState(tmpDir, milestoneValue) {
+  fs.writeFileSync(
+    path.join(tmpDir, '.planning', 'STATE.md'),
+    `---\nmilestone: ${milestoneValue}\n---\n# State\n`
+  );
+}
+
+describe('extractCurrentMilestone — shared semver prefix bug', () => {
+  test('skips closed v8.0-F first match when active v8.0-B follows (STATE milestone: v8.0)', () => {
+    const tmpDir = createTempProject('gsd-test-extract-prefix-');
+    try {
+      writeState(tmpDir, 'v8.0');
+      const roadmap = [
+        '# Project Roadmap',
+        '',
+        '## v8.0 Overview — v8.0-F (CLOSED FAIL 2026-05-18)',
+        '',
+        '- v8.0-F closed content here',
+        '',
+        '### Phase 24: ARCHIVED',
+        '',
+        '## v8.0-B Overview (STARTED 2026-05-18)',
+        '',
+        '- v8.0-B active content here',
+        '',
+        '### Phase 31: EVAL',
+        '',
+      ].join('\n');
+
+      const result = extractCurrentMilestone(roadmap, tmpDir);
+
+      assert.ok(
+        result.includes('v8.0-B Overview (STARTED 2026-05-18)'),
+        'should include active v8.0-B section'
+      );
+      assert.ok(
+        result.includes('Phase 31: EVAL'),
+        'should include Phase 31 row from active v8.0-B'
+      );
+      assert.ok(
+        !result.includes('v8.0-F closed content here'),
+        'should NOT include closed v8.0-F section body when active sibling exists'
+      );
+    } finally {
+      cleanup(tmpDir);
+    }
+  });
+
+  test('skips closed v8.0-F + v8.0-B (both CLOSED), returns active v8.0-C (STATE milestone: v8.0)', () => {
+    const tmpDir = createTempProject('gsd-test-extract-prefix-');
+    try {
+      writeState(tmpDir, 'v8.0');
+      const roadmap = [
+        '# Project Roadmap',
+        '',
+        '## v8.0 Overview — v8.0-F (CLOSED FAIL 2026-05-18)',
+        '- v8.0-F closed',
+        '',
+        '## v8.0-B Overview (CLOSED FAIL 2026-05-23)',
+        '- v8.0-B closed',
+        '',
+        '## v8.0-C Overview (STARTED 2026-05-23)',
+        '- v8.0-C active content here',
+        '',
+      ].join('\n');
+
+      const result = extractCurrentMilestone(roadmap, tmpDir);
+
+      assert.ok(
+        result.includes('v8.0-C Overview (STARTED 2026-05-23)'),
+        'should select active v8.0-C section over two closed predecessors'
+      );
+      assert.ok(
+        !result.includes('v8.0-F closed'),
+        'should NOT include closed v8.0-F'
+      );
+      assert.ok(
+        !result.includes('v8.0-B closed'),
+        'should NOT include closed v8.0-B'
+      );
+    } finally {
+      cleanup(tmpDir);
+    }
+  });
+
+  test('explicit milestone version (v8.0-C) matches only its own section, ignores siblings', () => {
+    const tmpDir = createTempProject('gsd-test-extract-prefix-');
+    try {
+      writeState(tmpDir, 'v8.0-C');
+      const roadmap = [
+        '# Project Roadmap',
+        '',
+        '## v8.0 Overview — v8.0-F (CLOSED FAIL)',
+        '- v8.0-F body',
+        '',
+        '## v8.0-B Overview (CLOSED FAIL)',
+        '- v8.0-B body',
+        '',
+        '## v8.0-C Overview (STARTED)',
+        '- v8.0-C body active',
+        '',
+      ].join('\n');
+
+      const result = extractCurrentMilestone(roadmap, tmpDir);
+
+      assert.ok(result.includes('v8.0-C body active'));
+      assert.ok(!result.includes('v8.0-F body'));
+      assert.ok(!result.includes('v8.0-B body'));
+    } finally {
+      cleanup(tmpDir);
+    }
+  });
+
+  test('fallback to first match when every candidate is closed (legacy behavior)', () => {
+    const tmpDir = createTempProject('gsd-test-extract-prefix-');
+    try {
+      writeState(tmpDir, 'v8.0');
+      const roadmap = [
+        '# Project Roadmap',
+        '',
+        '## v8.0 Overview — v8.0-F (CLOSED FAIL)',
+        '- closed body 1',
+        '',
+        '## v8.0-B Overview (CLOSED FAIL)',
+        '- closed body 2',
+        '',
+      ].join('\n');
+
+      const result = extractCurrentMilestone(roadmap, tmpDir);
+
+      // Both are closed — legacy first-match fallback returns the first one.
+      assert.ok(
+        result.includes('## v8.0 Overview — v8.0-F (CLOSED FAIL)'),
+        'should fall back to first match when all candidates are closed'
+      );
+    } finally {
+      cleanup(tmpDir);
+    }
+  });
+
+  test('archived marker variations are recognized (ARCHIVED, ABANDONED, ✅, 🗄️)', () => {
+    const variants = [
+      '## v8.0 Overview — v8.0-F (ARCHIVED)',
+      '## v8.0 Overview — v8.0-F (ABANDONED 2026-05-14)',
+      '## ✅ v8.0 Overview — v8.0-F',
+      '## 🗄️ v8.0 Overview — v8.0-F',
+      '## v8.0 Overview — v8.0-F (SHIPPED)',
+      '## v8.0 Overview — v8.0-F (FAILED)',
+    ];
+    for (const closedHeading of variants) {
+      const tmpDir = createTempProject('gsd-test-extract-prefix-');
+      try {
+        writeState(tmpDir, 'v8.0');
+        const roadmap = [
+          '# Project Roadmap',
+          '',
+          closedHeading,
+          '- closed body',
+          '',
+          '## v8.0-B Overview (STARTED)',
+          '- active body content',
+          '',
+        ].join('\n');
+
+        const result = extractCurrentMilestone(roadmap, tmpDir);
+
+        assert.ok(
+          result.includes('active body content'),
+          `should skip closed marker "${closedHeading}" and select active v8.0-B`
+        );
+        assert.ok(
+          !result.includes('- closed body'),
+          `should NOT include closed body for marker "${closedHeading}"`
+        );
+      } finally {
+        cleanup(tmpDir);
+      }
+    }
+  });
+
+  test('single milestone (no closed sibling) — no regression', () => {
+    const tmpDir = createTempProject('gsd-test-extract-prefix-');
+    try {
+      writeState(tmpDir, 'v3.0');
+      const roadmap = [
+        '# Project Roadmap',
+        '',
+        '## v3.0 Initial Release (STARTED)',
+        '- v3.0 active body',
+        '',
+        '### Phase 1: SETUP',
+        '',
+      ].join('\n');
+
+      const result = extractCurrentMilestone(roadmap, tmpDir);
+
+      assert.ok(result.includes('v3.0 active body'));
+      assert.ok(result.includes('Phase 1: SETUP'));
+    } finally {
+      cleanup(tmpDir);
+    }
+  });
+});


### PR DESCRIPTION
## Linked Issue

Fixes #3863

## What was broken

`extractCurrentMilestone()` in `get-shit-done/bin/lib/core.cjs:969-973` built a heading-section regex with `'mi'` flag and used `content.match()` — first-match only. When STATE.md `milestone:` was a shared semver prefix (e.g. `v8.0`) and the ROADMAP.md contained both a closed sub-milestone (`## v8.0 Overview — v8.0-F (CLOSED FAIL)`) and an active sub-milestone (`## v8.0-B Overview (STARTED)`), the first match was always the closed one. Downstream `phase.insert`, `phase.complete`, `init.phase-op`, and `roadmap` queries silently returned the closed section, producing "Phase N not found in current milestone" errors despite the active phase row plainly existing.

In the affected project this triggered 3 manual ROADMAP/STATE workarounds across `Phase 31.1`, `Phase 31.2`, and `Phase 32` inserts — each recorded as `"Nth manual workaround for gsd-tools extractCurrentMilestone regex bug"` in STATE.md Roadmap Evolution log.

## What this fix does

1. Replace `'mi'` first-match regex with `'gmi'` `matchAll` iteration.
2. Skip headings containing closed-milestone markers: `CLOSED|ARCHIVED|ABANDONED|SHIPPED|FAIL(ED)?|✅|🗄️`.
3. Prefer first non-closed match; fall back to first match if every candidate is closed (preserves legacy single-closed-milestone behavior).
4. Compute preamble boundary from the **first milestone heading position** independently of `sectionStart`, so closed-sibling content does not leak into the returned slice when the matched section is later in the file.

## Root cause

The original implementation assumed `sectionStart` would always be the first milestone heading position (true for single-milestone or first-match-correct cases). The `'mi'` flag's first-match semantics combined with `^#{1,3}\\s+.*${escapedVersion}[^\\n]*` matching ANY heading containing the version substring meant closed sub-milestones sharing the STATE semver prefix always won. Preamble computation as `content.slice(0, sectionStart)` then pulled the closed sibling into the returned content when the fix made `sectionStart` move to a later heading.

## Testing

### How I verified the fix

- Added regression: `tests/bug-3863-extract-milestone-shared-prefix.test.cjs` (6 subtests):
  1. Skips closed `v8.0-F` first match when active `v8.0-B` follows (STATE milestone: `v8.0`)
  2. Skips closed `v8.0-F` + `v8.0-B` (both CLOSED), returns active `v8.0-C` (STATE milestone: `v8.0`)
  3. Explicit milestone version (`v8.0-C`) matches only its own section, ignores siblings
  4. Fallback to first match when every candidate is closed (legacy behavior)
  5. Marker variations recognized: `CLOSED`, `ARCHIVED`, `ABANDONED`, `SHIPPED`, `FAILED`, `✅`, `🗄️`
  6. Single milestone (no closed sibling) — no regression

- Ran full test suite locally:
  ```
  npm test
  # tests 5434
  # suites 957
  # pass 5434
  # fail 0
  ```

### Regression test added?

- [x] Yes — `tests/bug-3863-extract-milestone-shared-prefix.test.cjs` covers all 6 scenarios; would have caught the bug.

### Platforms tested

- [x] macOS
- [ ] Windows
- [ ] Linux
- [ ] N/A

### Runtimes tested

- [x] Claude Code
- [ ] Gemini CLI
- [ ] OpenCode
- [ ] Other
- [ ] N/A

---

## Checklist

- [x] Issue linked above with `Fixes #3863`
- [ ] Linked issue has the `confirmed-bug` label (maintainer to apply)
- [x] Fix is scoped to the reported bug — no unrelated changes included
- [x] Regression test added
- [x] All existing tests pass (`npm test` 5434/5434)
- [x] `.changeset/3863-extract-milestone-skip-closed-sibling.md` fragment added
- [x] No unnecessary dependencies added

## Breaking changes

None. Behavior change is strictly additive (skip closed siblings); legacy single-closed-milestone behavior preserved via fallback.