### PR TITLE
fix(state): stop plan-phase from corrupting milestone progress counters

### DIFF
--- a/get-shit-done/bin/lib/plan-scan.generated.cjs
+++ b/get-shit-done/bin/lib/plan-scan.generated.cjs
@@ -22,6 +22,13 @@ function isRootPlanFile(fileName) {
         return false;
     if (PLAN_PRE_BOUNCE_RE.test(fileName))
         return false;
+    // A summary file from the legacy <N>-PLAN-<NN> flat layout (e.g.
+    // 14-PLAN-01-SUMMARY.md) contains the substring "PLAN" and would otherwise
+    // be mis-classified as a plan by the broad /PLAN/i fallback below — inflating
+    // plan counts and pushing completed phases below their completion ratio.
+    // Reject summaries before that fallback.
+    if (isRootSummaryFile(fileName))
+        return false;
     if (fileName.endsWith('-PLAN.md') || fileName === 'PLAN.md')
         return true;
     return /\.md$/i.test(fileName) && /PLAN/i.test(fileName);

--- a/get-shit-done/bin/lib/state.cjs
+++ b/get-shit-done/bin/lib/state.cjs
@@ -1318,37 +1318,39 @@ function cmdStatePlannedPhase(cwd, phaseNumber, planCount, raw) {
     return;
   }
 
-  let content = fs.readFileSync(statePath, 'utf-8');
   const today = new Date().toISOString().split('T')[0];
   const updated = [];
 
-  // Update Status
-  let result = stateReplaceField(content, 'Status', 'Ready to execute');
-  if (result) { content = result; updated.push('Status'); }
+  // resync:false — a plan-phase run updates per-phase body fields only and must
+  // not resync the milestone-wide progress.* counters from a half-planned disk
+  // snapshot (#3242 precedent; body-only writes preserve curated progress).
+  readModifyWriteStateMd(statePath, (content) => {
+    // Update Status
+    let result = stateReplaceField(content, 'Status', 'Ready to execute');
+    if (result) { content = result; updated.push('Status'); }
 
-  // Update Total Plans in Phase
-  if (planCount !== null && planCount !== undefined) {
-    result = stateReplaceField(content, 'Total Plans in Phase', String(planCount));
-    if (result) { content = result; updated.push('Total Plans in Phase'); }
-  }
+    // Update Total Plans in Phase
+    if (planCount !== null && planCount !== undefined) {
+      result = stateReplaceField(content, 'Total Plans in Phase', String(planCount));
+      if (result) { content = result; updated.push('Total Plans in Phase'); }
+    }
 
-  // Update Last Activity
-  result = stateReplaceField(content, 'Last Activity', today);
-  if (result) { content = result; updated.push('Last Activity'); }
+    // Update Last Activity
+    result = stateReplaceField(content, 'Last Activity', today);
+    if (result) { content = result; updated.push('Last Activity'); }
 
-  // Update Last Activity Description
-  result = stateReplaceField(content, 'Last Activity Description', `Phase ${phaseNumber} planning complete — ${planCount || '?'} plans ready`);
-  if (result) { content = result; updated.push('Last Activity Description'); }
+    // Update Last Activity Description
+    result = stateReplaceField(content, 'Last Activity Description', `Phase ${phaseNumber} planning complete — ${planCount || '?'} plans ready`);
+    if (result) { content = result; updated.push('Last Activity Description'); }
 
-  // Update Current Position section
-  content = updateCurrentPositionFields(content, {
-    status: 'Ready to execute',
-    lastActivity: `${today} -- Phase ${phaseNumber} planning complete`,
-  });
+    // Update Current Position section
+    content = updateCurrentPositionFields(content, {
+      status: 'Ready to execute',
+      lastActivity: `${today} -- Phase ${phaseNumber} planning complete`,
+    });
 
-  if (updated.length > 0) {
-    writeStateMd(statePath, content, cwd);
-  }
+    return content;
+  }, cwd, { resync: false });
 
   output({ updated, phase: phaseNumber, plan_count: planCount }, raw, updated.length > 0 ? 'true' : 'false');
 }

--- a/sdk/src/query/decomposed-handlers.test.ts
+++ b/sdk/src/query/decomposed-handlers.test.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtemp, writeFile, mkdir, rm } from 'node:fs/promises';
+import { mkdtemp, writeFile, readFile, mkdir, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
@@ -14,6 +14,7 @@ import { agentSkills } from './skills.js';
 import { roadmapUpdatePlanProgress } from './roadmap-update-plan-progress.js';
 import { requirementsMarkComplete } from './roadmap.js';
 import { statePlannedPhase } from './state-mutation.js';
+import { extractFrontmatter } from './frontmatter.js';
 import { verifySchemaDrift } from './verify.js';
 import { todoMatchPhase, statsJson, progressBar } from './progress.js';
 import { milestoneComplete } from './phase-lifecycle.js';
@@ -116,6 +117,48 @@ describe('statePlannedPhase', () => {
     const result = await statePlannedPhase([], tmpDir);
     const data = result.data as Record<string, unknown>;
     expect(data.error).toMatch(/phase required/);
+  });
+
+  it('preserves curated progress.* frontmatter on a plan-phase run (resync:false)', async () => {
+    // A plan-phase run updates per-phase body fields only. It must NOT resync
+    // the milestone-wide progress.* counters from disk — doing so clobbers
+    // curated values with a half-planned snapshot. Mirrors the #3242 precedent
+    // already applied to body-only state.update writes.
+    const statePath = join(tmpDir, '.planning', 'STATE.md');
+    await writeFile(statePath, [
+      '---',
+      'milestone: v3.0',
+      'progress:',
+      '  total_phases: 5',
+      '  completed_phases: 4',
+      '  total_plans: 41',
+      '  completed_plans: 41',
+      '  percent: 80',
+      '---',
+      '',
+      '# State',
+      '',
+      '## Current Position',
+      'Status: Executing',
+      'Total Plans in Phase: 0',
+      'Last Activity: 2020-01-01',
+      'Last Activity Description: none',
+      '',
+    ].join('\n'));
+
+    await statePlannedPhase(['--phase', '10', '--name', 'queries', '--plans', '2'], tmpDir);
+
+    const after = await readFile(statePath, 'utf-8');
+    const fm = extractFrontmatter(after) as { progress?: Record<string, unknown> };
+    const progress = fm.progress ?? {};
+    // Disk would recalc to total_plans: 2 / completed_plans: 1 (phases 09+10).
+    // The curated block must survive untouched. String() coercion keeps the
+    // assertion robust to the frontmatter parser's scalar typing.
+    expect(String(progress.total_phases)).toBe('5');
+    expect(String(progress.completed_phases)).toBe('4');
+    expect(String(progress.total_plans)).toBe('41');
+    expect(String(progress.completed_plans)).toBe('41');
+    expect(String(progress.percent)).toBe('80');
   });
 });
 

--- a/sdk/src/query/plan-scan.test.ts
+++ b/sdk/src/query/plan-scan.test.ts
@@ -3,7 +3,45 @@ import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
-import { scanPhasePlans } from './plan-scan.js';
+import { isRootPlanFile, scanPhasePlans } from './plan-scan.js';
+
+describe('isRootPlanFile', () => {
+  // Legacy <N>-PLAN-<NN> flat layout (pre-#3139): the summary filename
+  // `14-PLAN-01-SUMMARY.md` contains the substring "PLAN", so the broad
+  // /PLAN/i fallback used to mis-classify it as a plan file — double-counting
+  // every summary as a plan and dragging the phase's completion ratio down.
+  it('rejects a legacy -PLAN-NN-SUMMARY.md summary masquerading as a plan', () => {
+    expect(isRootPlanFile('14-PLAN-01-SUMMARY.md')).toBe(false);
+  });
+
+  it('still accepts the matching legacy -PLAN-NN.md plan file', () => {
+    expect(isRootPlanFile('14-PLAN-01.md')).toBe(true);
+  });
+});
+
+describe('scanPhasePlans — legacy <N>-PLAN-<NN> flat layout', () => {
+  it('does not double-count -PLAN-NN-SUMMARY.md files as plans', async () => {
+    const tmpDir = await mkdtemp(join(tmpdir(), 'gsd-plan-scan-legacy-'));
+    try {
+      const phaseDir = join(tmpDir, 'phases', '14');
+      await mkdir(phaseDir, { recursive: true });
+      for (const n of ['01', '02', '03', '04']) {
+        await writeFile(join(phaseDir, `14-PLAN-${n}.md`), '# Plan');
+        await writeFile(join(phaseDir, `14-PLAN-${n}-SUMMARY.md`), '# Summary');
+      }
+
+      // Four plans, four summaries → a completed phase. Before the fix this
+      // reported planCount: 8 (summaries counted as plans) and completed: false.
+      expect(scanPhasePlans(phaseDir)).toMatchObject({
+        planCount: 4,
+        summaryCount: 4,
+        completed: true,
+      });
+    } finally {
+      await rm(tmpDir, { recursive: true, force: true });
+    }
+  });
+});
 
 describe('scanPhasePlans', () => {
   it('counts flat and nested plan files while excluding derivative files', async () => {

--- a/sdk/src/query/plan-scan.ts
+++ b/sdk/src/query/plan-scan.ts
@@ -16,6 +16,12 @@ export interface PhasePlanScan {
 export function isRootPlanFile(fileName: string): boolean {
   if (PLAN_OUTLINE_RE.test(fileName)) return false;
   if (PLAN_PRE_BOUNCE_RE.test(fileName)) return false;
+  // A summary file from the legacy <N>-PLAN-<NN> flat layout (e.g.
+  // 14-PLAN-01-SUMMARY.md) contains the substring "PLAN" and would otherwise
+  // be mis-classified as a plan by the broad /PLAN/i fallback below — inflating
+  // plan counts and pushing completed phases below their completion ratio.
+  // Reject summaries before that fallback.
+  if (isRootSummaryFile(fileName)) return false;
   if (fileName.endsWith('-PLAN.md') || fileName === 'PLAN.md') return true;
   return /\.md$/i.test(fileName) && /PLAN/i.test(fileName);
 }

--- a/sdk/src/query/state-mutation.ts
+++ b/sdk/src/query/state-mutation.ts
@@ -1193,7 +1193,11 @@ export const statePlannedPhase: QueryHandler = async (args, projectDir, workstre
       lastActivity: `${today} -- Phase ${phaseLabel} planning complete`,
     });
     return content;
-  }, workstream);
+    // resync:false — a plan-phase run updates per-phase body fields only and
+    // must not resync the milestone-wide progress.* counters from a
+    // half-planned disk snapshot (#3242 precedent; body-only writes preserve
+    // curated progress).
+  }, workstream, { resync: false });
 
   return { data: { updated, phase: phaseNumber, plan_count: planCount } };
 };

--- a/tests/plan-scan-generator.test.cjs
+++ b/tests/plan-scan-generator.test.cjs
@@ -48,6 +48,7 @@ describe('plan-scan-generator parity: isRootPlanFile', async () => {
     { label: 'rejects -PLAN-OUTLINE.md', name: 'something-PLAN-OUTLINE.md', expected: false },
     { label: 'rejects .pre-bounce.md', name: 'PLAN.pre-bounce.md', expected: false },
     { label: 'rejects SUMMARY.md', name: 'SUMMARY.md', expected: false },
+    { label: 'rejects legacy -PLAN-NN-SUMMARY.md', name: '14-PLAN-01-SUMMARY.md', expected: false },
     { label: 'rejects unrelated file', name: 'README.md', expected: false },
   ];
 

--- a/tests/state.test.cjs
+++ b/tests/state.test.cjs
@@ -629,6 +629,57 @@ milestone: v1.0
   });
 });
 
+describe('state planned-phase frontmatter progress preservation', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = createTempProject();
+  });
+
+  afterEach(() => {
+    cleanup(tmpDir);
+  });
+
+  test('does not resync milestone progress.* counters on a plan-phase run', () => {
+    // A plan-phase run updates per-phase body fields (Total Plans in Phase,
+    // Status, Last Activity). It must leave the milestone-wide progress.*
+    // counters alone — resyncing them from a half-planned disk snapshot is the
+    // bug. Curated values use distinctive numbers that no disk scan of this
+    // (empty) project could coincidentally produce.
+    fs.writeFileSync(
+      path.join(tmpDir, '.planning', 'STATE.md'),
+      [
+        '---',
+        'milestone: v3.0',
+        'progress:',
+        '  total_phases: 7',
+        '  completed_phases: 6',
+        '  total_plans: 99',
+        '  completed_plans: 88',
+        '  percent: 90',
+        '---',
+        '',
+        '# Project State',
+        '',
+        '**Status:** In progress',
+        '**Total Plans in Phase:** 0',
+        '**Last Activity:** 2020-01-01',
+        '**Last Activity Description:** none',
+        '',
+      ].join('\n')
+    );
+
+    const result = runGsdTools('state planned-phase --phase 2 --name foo --plans 5', tmpDir);
+    assert.ok(result.success, `Command failed: ${result.error}`);
+
+    const content = fs.readFileSync(path.join(tmpDir, '.planning', 'STATE.md'), 'utf-8');
+    assert.ok(content.includes('total_plans: 99'), 'curated total_plans preserved, not resynced from disk');
+    assert.ok(content.includes('completed_plans: 88'), 'curated completed_plans preserved, not resynced from disk');
+    // And the per-phase body field the command is actually responsible for is updated.
+    assert.ok(content.includes('**Total Plans in Phase:** 5'), 'per-phase plan count updated in body');
+  });
+});
+
 // ─────────────────────────────────────────────────────────────────────────────
 // stateExtractField and stateReplaceField helpers
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
@
## Fix PR

## Linked Issue

Fixes #3881

> The linked issue (#3881) documents both root causes with repro. Awaiting `confirmed` label — happy to wait on maintainer confirmation before review.

## What was broken

A `state planned-phase` run silently overwrote the milestone-wide `progress.*` frontmatter in STATE.md (it should only touch per-phase body fields), via two independent defects.

## What this fix does

1. **resync clobber** — `statePlannedPhase` (`sdk/src/query/state-mutation.ts`) and `cmdStatePlannedPhase` (`get-shit-done/bin/lib/state.cjs`) now route through `readModifyWriteStateMd(..., { resync: false })`, so a plan-phase run preserves curated `progress.*` counters instead of rebuilding them from a half-planned disk snapshot. This is the same contract `state.update` body-only writes already use (#3242 Bug A).
2. **legacy summary double-count** — `isRootPlanFile` (`sdk/src/query/plan-scan.ts`) now rejects summary files before the broad `/PLAN/i` fallback, so `14-PLAN-01-SUMMARY.md` is no longer counted as a plan. Regenerated `plan-scan.generated.cjs` via `npm run gen:plan-scan`; `check:plan-scan-fresh` passes.

## Root cause

See #3881. In short: (1) the plan-phase handlers used the full-resync write path; (2) the legacy `<N>-PLAN-<NN>` flat layout produces summary filenames containing the substring "PLAN", which the fallback mis-classified as plans. Canonical `NN-MM-SUMMARY.md` names are unaffected, so the symptom looked intermittent.

## Testing

### How I verified the fix

RED→GREEN regression tests, all passing:
- `sdk/src/query/plan-scan.test.ts` — `isRootPlanFile` rejects `14-PLAN-01-SUMMARY.md` / accepts `14-PLAN-01.md`; `scanPhasePlans` legacy layout reports `planCount: 4, completed: true` (was `8 / false`).
- `tests/plan-scan-generator.test.cjs` — SDK↔generated-CJS parity for the legacy summary fixture.
- `sdk/src/query/decomposed-handlers.test.ts` — `statePlannedPhase` preserves a curated `progress.*` block.
- `tests/state.test.cjs` — `state planned-phase` does not resync `progress.*` from disk (and still updates the per-phase `Total Plans in Phase`).

`npm run lint:tests` clean. Full SDK suite shows only pre-existing, environment-specific failures (golden parity for `intel`/`resolve-model`, EACCES/symlink/home-path tests) that are identical on `main` with these changes stashed — this PR introduces zero new failures.

### Regression test added?

- [x] Yes — added tests that would have caught this bug

### Platforms tested

- [x] Windows (including backslash path handling)
- [ ] macOS / Linux — N/A locally; logic is path-agnostic

### Runtimes tested

- [x] Claude Code

## Checklist

- [x] Source-of-truth edited (`plan-scan.ts`, `state-mutation.ts`), generated artifact regenerated, CJS fallback kept in parity (`state.cjs`).
- [x] `check:plan-scan-fresh` passes.
- [x] Changeset fragment included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@