### PR TITLE
chore(config): default `git.branching_strategy` to "phase"

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -91,7 +91,7 @@ GSD stores project settings in `.planning/config.json`. Created during `/gsd-new
     "min_plans_for_parallel": 2
   },
   "git": {
-    "branching_strategy": "none",
+    "branching_strategy": "phase",
     "create_tag": true,
     "phase_branch_template": "gsd/phase-{phase}-{slug}",
     "milestone_branch_template": "gsd/{milestone}-{slug}",
@@ -547,7 +547,7 @@ All four fields are **optional and additive** — STATE.md files without them ke
 
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
-| `git.branching_strategy` | enum | `none` | `none`, `phase`, or `milestone` |
+| `git.branching_strategy` | enum | `phase` | `none`, `phase`, or `milestone` |
 | `git.base_branch` | string | `main` | The integration branch that phase/milestone branches are created from and merged back into. Override when your repo uses `master` or a release branch |
 | `git.create_tag` | boolean | `true` | Create a git tag (`v[X.Y]`) on milestone completion. Set to `false` for projects with their own release flow |
 | `git.phase_branch_template` | string | `gsd/phase-{phase}-{slug}` | Branch name template for phase strategy |

--- a/get-shit-done/references/planning-config.md
+++ b/get-shit-done/references/planning-config.md
@@ -9,7 +9,7 @@ Configuration options for `.planning/` directory behavior.
   "search_gitignored": false
 },
 "git": {
-  "branching_strategy": "none",
+  "branching_strategy": "phase",
   "base_branch": null,
   "phase_branch_template": "gsd/phase-{phase}-{slug}",
   "milestone_branch_template": "gsd/{milestone}-{slug}",
@@ -28,7 +28,7 @@ Configuration options for `.planning/` directory behavior.
 |--------|---------|-------------|
 | `commit_docs` | `true` | Whether to commit planning artifacts to git |
 | `search_gitignored` | `false` | Add `--no-ignore` to broad rg searches |
-| `git.branching_strategy` | `"none"` | Git branching approach: `"none"`, `"phase"`, or `"milestone"` |
+| `git.branching_strategy` | `"phase"` | Git branching approach: `"none"`, `"phase"`, or `"milestone"` |
 | `git.base_branch` | `null` (auto-detect) | Target branch for PRs and merges (e.g. `"master"`, `"develop"`). When `null`, auto-detects from `git symbolic-ref refs/remotes/origin/HEAD`, falling back to `"main"`. |
 | `git.create_tag` | `true` | Create git tags on milestone completion |
 | `git.phase_branch_template` | `"gsd/phase-{phase}-{slug}"` | Branch template for phase strategy |
@@ -136,11 +136,11 @@ To use uncommitted mode:
 | `phase` | At `execute-phase` start | Single phase | User merges after phase |
 | `milestone` | At first `execute-phase` of milestone | Entire milestone | At `complete-milestone` |
 
-**When `git.branching_strategy: "none"` (default):**
+**When `git.branching_strategy: "none"`:**
 - All work commits to current branch
 - Standard GSD behavior
 
-**When `git.branching_strategy: "phase"`:**
+**When `git.branching_strategy: "phase"` (default):**
 - `execute-phase` creates/switches to a branch before execution
 - Branch name from `phase_branch_template` (e.g., `gsd/phase-03-authentication`)
 - All plan commits go to that branch

--- a/sdk/shared/config-defaults.manifest.json
+++ b/sdk/shared/config-defaults.manifest.json
@@ -14,7 +14,7 @@
   "mode": "interactive",
   "claude_md_path": "./CLAUDE.md",
   "git": {
-    "branching_strategy": "none",
+    "branching_strategy": "phase",
     "create_tag": true,
     "base_branch": null,
     "phase_branch_template": "gsd/phase-{phase}-{slug}",

--- a/sdk/src/config.test.ts
+++ b/sdk/src/config.test.ts
@@ -207,7 +207,7 @@ describe('loadConfig', () => {
     });
 
     const config = await loadConfig(tmpDir);
-    expect(config.git.branching_strategy).toBe('none');
+    expect(config.git.branching_strategy).toBe('phase');
     expect(config.git.phase_branch_template).toBe('gsd/phase-{phase}-{slug}');
     expect(config.agent_skills).toEqual({});
   });

--- a/sdk/src/query/validate.ts
+++ b/sdk/src/query/validate.ts
@@ -845,7 +845,7 @@ export const validateHealth: QueryHandler = async (args, projectDir, workstream)
               model_profile: 'balanced',
               commit_docs: false,
               search_gitignored: false,
-              branching_strategy: 'none',
+              branching_strategy: 'phase',
               phase_branch_template: 'feat/phase-{phase}',
               milestone_branch_template: 'feat/{milestone}',
               quick_branch_template: 'fix/{slug}',


### PR DESCRIPTION
## Summary

Flips the shipped manifest default for `git.branching_strategy` from `"none"` → `"phase"`. New projects initialized via `gsd new-project` now get per-phase branching baked into `.planning/config.json`, so `execute-phase` always works on a `gsd/phase-{phase}-{slug}` branch by default.

## Why

`"none"` commits straight to the current branch (often `main`), with no PR and no review. Aligning the default with `"phase"` makes the published tool consistent with the increasingly common "every change reaches `main` via a PR" workflow — particularly relevant when teams pair `gsd` with PR-gated review automation.

Existing projects are unaffected: a `.planning/config.json` already on disk wins over the manifest default. Users who prefer `"none"` can set it explicitly per-project or in `~/.gsd/defaults.json`.

## Changes

- **`sdk/shared/config-defaults.manifest.json`** — `git.branching_strategy: "phase"`
- **`get-shit-done/references/planning-config.md`** — example, default column, `(default)` label moved from `none` → `phase`
- **`docs/CONFIGURATION.md`** — example + table default updated
- **`sdk/src/query/validate.ts`** — `createConfig`/`resetConfig` repair fallback also writes `"phase"` for consistency (this is the "known-safe defaults" write path used when a project's `config.json` is missing/corrupted)
- **`sdk/src/config.test.ts`** — pre-project test expects the new built-in default (still asserts the built-in default wins over `~/.gsd/defaults.json`)

i18n doc copies (`docs/zh-CN/**`, `docs/ja-JP/**`, `docs/ko-KR/**`) are intentionally **not** touched in this PR — they're a coordinated follow-up sweep.

## Tests

- Full CJS unit suite (`node scripts/run-tests.cjs --suite unit`): green ✅
- Targeted vitest on affected SDK files (`sdk/src/config.test.ts`, `sdk/src/query/init*.test.ts`, `sdk/src/query/decomposed-handlers.test.ts`): green ✅
- Targeted configuration + branching CJS tests (`tests/configuration-*`, `tests/bug-3523-*`, `tests/bug-2916-*`, `tests/quick-branching.test.cjs`): 49/49 ✅

Pre-existing failures on `origin/main` (NOT caused by this change, verified with stash + detach + re-run):
- `initExecutePhase > keeps same-milestone archived phase directory instead of nulling it (#3469)`
- `initRemoveWorkspace > returns error when name arg missing`
- `initRemoveWorkspace > rejects path separator in workspace name (T-14-01)`

## Migration / compatibility

- **No migration needed for existing projects** — they have a materialized `.planning/config.json` and that wins.
- **Pre-project mode** (callers that read defaults before init): now returns `"phase"`. Code that hardcodes the assumption it'll be `"none"` should be checked; the SDK no longer makes that promise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)