### PR TITLE
chore: simplify auto-close message to 'repository moved'

### DIFF
--- a/.github/workflows/auto-close-deprecated.yml
+++ b/.github/workflows/auto-close-deprecated.yml
@@ -1,4 +1,4 @@
-name: Auto-close (repository deprecated)
+name: Auto-close (repository moved)
 
 on:
   issues:
@@ -21,15 +21,13 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           gh issue comment "$NUM" --repo "$REPO" --body-file - <<'BODY'
-          ⚠️ **This repository is deprecated and unmaintained.**
+          📦 **This repository has moved and is no longer maintained here.**
 
-          The maintainer (TÂCHES) has been unreachable since 2026-04-01.
-          The `$GSD` token has been linked publicly to a rug-pull.
+          Development now happens at:
+          https://github.com/GSD-redux/get-shit-done-redux
 
-          **Please file your issue on the active fork:**
+          **Please file your issue on the active repo:**
           https://github.com/GSD-redux/get-shit-done-redux/issues/new/choose
-
-          See the README at the top of this repo for full context.
 
           This issue is being auto-closed and locked.
           BODY
@@ -46,12 +44,12 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           gh pr comment "$NUM" --repo "$REPO" --body-file - <<'BODY'
-          ⚠️ **This repository is deprecated and unmaintained.**
+          📦 **This repository has moved and is no longer maintained here.**
 
-          The maintainer (TÂCHES) has been unreachable since 2026-04-01.
-          The `$GSD` token has been linked publicly to a rug-pull.
+          Development now happens at:
+          https://github.com/GSD-redux/get-shit-done-redux
 
-          **Please re-open your PR against the active fork:**
+          **Please re-open your PR against the active repo:**
           https://github.com/GSD-redux/get-shit-done-redux
 
           (You'll need to rebase your branch against `GSD-redux/get-shit-done-redux` first.)

--- a/.github/workflows/auto-close-deprecated.yml
+++ b/.github/workflows/auto-close-deprecated.yml
@@ -24,10 +24,10 @@ jobs:
           📦 **This repository has moved and is no longer maintained here.**
 
           Development now happens at:
-          https://github.com/GSD-redux/get-shit-done-redux
+          https://github.com/open-gsd/gsd-core
 
           **Please file your issue on the active repo:**
-          https://github.com/GSD-redux/get-shit-done-redux/issues/new/choose
+          https://github.com/open-gsd/gsd-core/issues/new/choose
 
           This issue is being auto-closed and locked.
           BODY
@@ -47,12 +47,12 @@ jobs:
           📦 **This repository has moved and is no longer maintained here.**
 
           Development now happens at:
-          https://github.com/GSD-redux/get-shit-done-redux
+          https://github.com/open-gsd/gsd-core
 
           **Please re-open your PR against the active repo:**
-          https://github.com/GSD-redux/get-shit-done-redux
+          https://github.com/open-gsd/gsd-core
 
-          (You'll need to rebase your branch against `GSD-redux/get-shit-done-redux` first.)
+          (You'll need to rebase your branch against `open-gsd/gsd-core` first.)
 
           This PR is being auto-closed and locked.
           BODY


### PR DESCRIPTION
Removes the $GSD token / rug-pull messaging from the deprecation workflow. The auto-close + lock behavior is unchanged; the comment now just tells people the repo has moved and points them to the active repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)