### PR TITLE
feat(help): translate command descriptions to zh-CN

### DIFF
--- a/commands/gsd/add-tests.md
+++ b/commands/gsd/add-tests.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:add-tests
-description: Generate tests for a completed phase based on UAT criteria and implementation
+description: 基于 UAT 标准和实现为已完成阶段生成测试
 argument-hint: "<phase> [additional instructions]"
 allowed-tools:
   - Read

--- a/commands/gsd/ai-integration-phase.md
+++ b/commands/gsd/ai-integration-phase.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:ai-integration-phase
-description: Generate an AI-SPEC.md design contract for phases that involve building AI systems.
+description: 为涉及构建 AI 系统的阶段生成 AI-SPEC.md 设计合同
 argument-hint: "[phase number]"
 allowed-tools:
   - Read

--- a/commands/gsd/audit-fix.md
+++ b/commands/gsd/audit-fix.md
@@ -1,7 +1,7 @@
 ---
 type: prompt
 name: gsd:audit-fix
-description: Autonomous audit-to-fix pipeline — find issues, classify, fix, test, commit
+description: 自主审计到修复管道：发现问题、分类、修复、测试、提交
 argument-hint: "--source <audit-uat> [--severity <medium|high|all>] [--max N] [--dry-run]"
 allowed-tools:
   - Read

--- a/commands/gsd/audit-milestone.md
+++ b/commands/gsd/audit-milestone.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:audit-milestone
-description: Audit milestone completion against original intent before archiving
+description: 归档前审计里程碑完成情况与原始意图的一致性
 argument-hint: "[version]"
 allowed-tools:
   - Read

--- a/commands/gsd/audit-uat.md
+++ b/commands/gsd/audit-uat.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:audit-uat
-description: Cross-phase audit of all outstanding UAT and verification items
+description: 跨阶段审计所有未完成的 UAT 和验证项目
 allowed-tools:
   - Read
   - Glob

--- a/commands/gsd/autonomous.md
+++ b/commands/gsd/autonomous.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:autonomous
-description: Run all remaining phases autonomously — discuss→plan→execute per phase
+description: 自主运行所有剩余阶段：讨论、规划、执行每个阶段
 argument-hint: "[--from N] [--to N] [--only N] [--interactive]"
 allowed-tools:
   - Read

--- a/commands/gsd/capture.md
+++ b/commands/gsd/capture.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:capture
-description: Capture ideas, tasks, notes, and seeds to their destination
+description: 捕获想法、任务、笔记和种子到目标位置
 argument-hint: "[--note | --backlog | --seed | --list] [text]"
 allowed-tools:
   - Read

--- a/commands/gsd/cleanup.md
+++ b/commands/gsd/cleanup.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:cleanup
-description: Archive accumulated phase directories from completed milestones
+description: 归档已完成里程碑中累积的阶段目录
 allowed-tools:
   - Read
   - Write

--- a/commands/gsd/code-review.md
+++ b/commands/gsd/code-review.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:code-review
-description: Review source files changed during a phase for bugs, security issues, and code quality problems
+description: 审查阶段期间更改的源文件，检查错误、安全问题和代码质量
 argument-hint: "<phase-number> [--depth=quick|standard|deep] [--files file1,file2,...] [--fix [--all] [--auto]]"
 allowed-tools:
   - Read

--- a/commands/gsd/complete-milestone.md
+++ b/commands/gsd/complete-milestone.md
@@ -1,7 +1,7 @@
 ---
 type: prompt
 name: gsd:complete-milestone
-description: Archive completed milestone and prepare for next version
+description: 归档已完成里程碑并准备下一个版本
 argument-hint: <version>
 allowed-tools:
   - Read

--- a/commands/gsd/config.md
+++ b/commands/gsd/config.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:config
-description: Configure GSD settings — workflow toggles, advanced knobs, integrations, and model profile
+description: 配置 GSD 设置：工作流开关、高级选项、集成和模型配置
 argument-hint: "[--advanced | --integrations | --profile <name>]"
 allowed-tools:
   - Read

--- a/commands/gsd/debug.md
+++ b/commands/gsd/debug.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:debug
-description: Systematic debugging with persistent state across context resets
+description: 跨上下文重置的系统化调试，具有持久状态
 argument-hint: "[list | status <slug> | continue <slug> | --diagnose] [issue description]"
 allowed-tools:
   - Read

--- a/commands/gsd/discuss-phase.md
+++ b/commands/gsd/discuss-phase.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:discuss-phase
-description: Gather phase context through adaptive questioning before planning.
+description: 规划前通过适应性提问收集阶段上下文
 argument-hint: "<phase> [--all] [--auto] [--chain] [--batch] [--analyze] [--text] [--power] [--assumptions]"
 allowed-tools:
   - Read

--- a/commands/gsd/docs-update.md
+++ b/commands/gsd/docs-update.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:docs-update
-description: Generate or update project documentation verified against the codebase
+description: 生成或更新经代码库验证的项目文档
 argument-hint: "[--force] [--verify-only]"
 allowed-tools:
   - Read

--- a/commands/gsd/eval-review.md
+++ b/commands/gsd/eval-review.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:eval-review
-description: Audit an executed AI phase's evaluation coverage and produce an EVAL-REVIEW.md remediation plan.
+description: 审计已执行 AI 阶段的评估覆盖率并生成 EVAL-REVIEW.md 补救计划
 argument-hint: "[phase number]"
 allowed-tools:
   - Read

--- a/commands/gsd/execute-phase.md
+++ b/commands/gsd/execute-phase.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:execute-phase
-description: Execute all plans in a phase with wave-based parallelization
+description: 以波次并行方式执行阶段中的所有计划
 argument-hint: "<phase-number> [--wave N] [--gaps-only] [--interactive] [--tdd]"
 allowed-tools:
   - Read

--- a/commands/gsd/explore.md
+++ b/commands/gsd/explore.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:explore
-description: Socratic ideation and idea routing — think through ideas before committing to plans
+description: 探索式构思和想法路由：在提交到计划前思考想法
 allowed-tools:
   - Read
   - Write

--- a/commands/gsd/extract-learnings.md
+++ b/commands/gsd/extract-learnings.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:extract-learnings
-description: Extract decisions, lessons, patterns, and surprises from completed phase artifacts
+description: 从已完成阶段工件中提取决策、教训、模式和意外发现
 argument-hint: <phase-number>
 allowed-tools:
   - Read

--- a/commands/gsd/fast.md
+++ b/commands/gsd/fast.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:fast
-description: Execute a trivial task inline — no subagents, no planning overhead
+description: 内联执行简单任务——无子代理、无规划开销
 argument-hint: "[task description]"
 allowed-tools:
   - Read

--- a/commands/gsd/forensics.md
+++ b/commands/gsd/forensics.md
@@ -1,7 +1,7 @@
 ---
 type: prompt
 name: gsd:forensics
-description: Post-mortem investigation for failed GSD workflows — diagnoses what went wrong.
+description: 失败 GSD 工作流的事后调查：诊断出了什么问题
 argument-hint: "[problem description]"
 allowed-tools:
   - Read

--- a/commands/gsd/graphify.md
+++ b/commands/gsd/graphify.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:graphify
-description: "Build, query, and inspect the project knowledge graph in .planning/graphs/"
+description: "在 .planning/graphs/ 中构建、查询和检查项目知识图谱"
 argument-hint: "[build|query <term>|status|diff]"
 allowed-tools:
   - Read

--- a/commands/gsd/health.md
+++ b/commands/gsd/health.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:health
-description: Diagnose planning directory health and optionally repair issues
+description: 诊断规划目录健康状况并可选修复问题
 argument-hint: "[--repair] [--context]"
 allowed-tools:
   - Read

--- a/commands/gsd/help.md
+++ b/commands/gsd/help.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:help
-description: Show available GSD commands and usage guide
+description: 显示可用的 GSD 命令和使用指南
 argument-hint: "[--brief | --full | <topic> | --brief <topic>]"
 allowed-tools:
   - Read

--- a/commands/gsd/import.md
+++ b/commands/gsd/import.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:import
-description: Ingest external plans with conflict detection against project decisions before writing anything.
+description: 导入外部计划并在写入前进行与项目决策的冲突检测
 argument-hint: "--from <filepath> | --from-gsd2"
 allowed-tools:
   - Read

--- a/commands/gsd/inbox.md
+++ b/commands/gsd/inbox.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:inbox
-description: Triage and review open GitHub issues and PRs against project templates and contribution guidelines.
+description: 根据项目模板和贡献指南对 GitHub 开放问题和 PR 进行分类和审查
 argument-hint: "[--issues] [--prs] [--label] [--close-incomplete] [--repo owner/repo]"
 allowed-tools:
   - Read

--- a/commands/gsd/ingest-docs.md
+++ b/commands/gsd/ingest-docs.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:ingest-docs
-description: Bootstrap or merge a .planning/ setup from existing ADRs, PRDs, SPECs, and docs in a repo.
+description: 从仓库中的现有 ADR、PRD、SPEC 和文档引导或合并 .planning/ 设置
 argument-hint: "[path] [--mode new|merge] [--manifest <file>] [--resolve auto|interactive]"
 allowed-tools:
   - Read

--- a/commands/gsd/manager.md
+++ b/commands/gsd/manager.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:manager
-description: Interactive command center for managing multiple phases from one terminal
+description: 从一个终端管理多个阶段的交互式命令中心
 argument-hint: "[--analyze-deps]"
 allowed-tools:
   - Read

--- a/commands/gsd/map-codebase.md
+++ b/commands/gsd/map-codebase.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:map-codebase
-description: Analyze codebase with parallel mapper agents to produce .planning/codebase/ documents
+description: 使用并行映射代理分析代码库，生成 .planning/codebase/ 文档
 argument-hint: "[--fast [--focus tech|arch|quality|concerns]] [--query <term>|status|diff|refresh] [area]"
 allowed-tools:
   - Read

--- a/commands/gsd/milestone-summary.md
+++ b/commands/gsd/milestone-summary.md
@@ -1,7 +1,7 @@
 ---
 type: prompt
 name: gsd:milestone-summary
-description: Generate a comprehensive project summary from milestone artifacts for team onboarding and review
+description: 从里程碑工件生成综合项目摘要，用于团队入职和审查
 argument-hint: "[version]"
 allowed-tools:
   - Read

--- a/commands/gsd/mvp-phase.md
+++ b/commands/gsd/mvp-phase.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:mvp-phase
-description: Plan a phase as a vertical MVP slice — user story, SPIDR splitting, then plan-phase
+description: 将阶段规划为垂直 MVP 切片：用户故事、SPIDR 拆分，然后 plan-phase
 argument-hint: "<phase-number>"
 allowed-tools:
   - Read

--- a/commands/gsd/new-milestone.md
+++ b/commands/gsd/new-milestone.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:new-milestone
-description: Start a new milestone cycle — update PROJECT.md and route to requirements
+description: 开始新的里程碑周期：更新 PROJECT.md 并路由到需求
 argument-hint: "[milestone name, e.g., 'v1.1 Notifications']"
 allowed-tools:
   - Read

--- a/commands/gsd/new-project.md
+++ b/commands/gsd/new-project.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:new-project
-description: Initialize a new project with deep context gathering and PROJECT.md
+description: 通过深度上下文收集初始化新项目并创建 PROJECT.md
 argument-hint: "[--auto]"
 allowed-tools:
   - Read

--- a/commands/gsd/ns-context.md
+++ b/commands/gsd/ns-context.md
@@ -1,6 +1,6 @@
 ---
 name: gsd-context
-description: "codebase intelligence | map graphify docs learnings"
+description: "代码库智能 | 映射 图谱化 文档 知识"
 argument-hint: ""
 allowed-tools:
   - Read

--- a/commands/gsd/ns-ideate.md
+++ b/commands/gsd/ns-ideate.md
@@ -1,6 +1,6 @@
 ---
 name: gsd-ideate
-description: "exploration capture | explore sketch spike spec capture"
+description: "探索捕获 | 探索 草图 试验 规范 捕获"
 argument-hint: ""
 allowed-tools:
   - Read

--- a/commands/gsd/ns-manage.md
+++ b/commands/gsd/ns-manage.md
@@ -1,6 +1,6 @@
 ---
 name: gsd-manage
-description: "config workspace | workstreams thread update ship inbox"
+description: "配置工作区 | 工作流 线程 更新 发布 收件箱"
 argument-hint: ""
 allowed-tools:
   - Read

--- a/commands/gsd/ns-project.md
+++ b/commands/gsd/ns-project.md
@@ -1,6 +1,6 @@
 ---
 name: gsd-project
-description: "project lifecycle | milestones audits summary"
+description: "项目生命周期 | 里程碑 审计 摘要"
 argument-hint: ""
 allowed-tools:
   - Read

--- a/commands/gsd/ns-review.md
+++ b/commands/gsd/ns-review.md
@@ -1,6 +1,6 @@
 ---
 name: gsd-quality
-description: "quality gates | code review debug audit security eval ui"
+description: "质量门 | 代码审查 调试 审计 安全 评估 UI"
 argument-hint: ""
 allowed-tools:
   - Read

--- a/commands/gsd/ns-workflow.md
+++ b/commands/gsd/ns-workflow.md
@@ -1,6 +1,6 @@
 ---
 name: gsd-workflow
-description: "workflow | discuss plan execute verify phase progress"
+description: "工作流 | 讨论 规划 执行 验证 阶段 进度"
 argument-hint: ""
 allowed-tools:
   - Read

--- a/commands/gsd/pause-work.md
+++ b/commands/gsd/pause-work.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:pause-work
-description: Create context handoff when pausing work mid-phase
+description: 阶段中间暂停工作时创建上下文交接
 argument-hint: "[--report]"
 allowed-tools:
   - Read

--- a/commands/gsd/phase.md
+++ b/commands/gsd/phase.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:phase
-description: CRUD for phases in ROADMAP.md — add, insert, remove, or edit phases
+description: ROADMAP.md 中阶段的增删改查：添加、插入、删除或编辑阶段
 argument-hint: "[--insert | --remove | --edit] <phase-name-or-number>"
 allowed-tools:
   - Read

--- a/commands/gsd/plan-phase.md
+++ b/commands/gsd/plan-phase.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:plan-phase
-description: Create detailed phase plan (PLAN.md) with verification loop
+description: 创建详细阶段计划 (PLAN.md) 并带验证循环
 argument-hint: "[phase] [--auto] [--research] [--skip-research] [--research-phase <N>] [--view] [--gaps] [--skip-verify] [--prd <file>] [--ingest <path-or-glob>] [--ingest-format <auto|nygard|madr|narrative>] [--reviews] [--text] [--tdd] [--mvp]"
 allowed-tools:
   - Read

--- a/commands/gsd/plan-review-convergence.md
+++ b/commands/gsd/plan-review-convergence.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:plan-review-convergence
-description: "Cross-AI plan convergence loop — replan with review feedback until no HIGH concerns remain."
+description: "跨 AI 计划收敛循环：使用审查反馈重新规划直到没有高关注度"
 argument-hint: "<phase> [--codex] [--gemini] [--claude] [--opencode] [--ollama] [--lm-studio] [--llama-cpp] [--text] [--ws <name>] [--all] [--max-cycles N]"
 allowed-tools:
   - Read

--- a/commands/gsd/pr-branch.md
+++ b/commands/gsd/pr-branch.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:pr-branch
-description: Create a clean PR branch by filtering out .planning/ commits — ready for code review
+description: 通过过滤 .planning/ 提交创建干净的 PR 分支，准备代码审查
 argument-hint: "[target branch, default: main]"
 allowed-tools:
   - Bash

--- a/commands/gsd/profile-user.md
+++ b/commands/gsd/profile-user.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:profile-user
-description: Generate developer behavioral profile and create Claude-discoverable artifacts
+description: 生成开发者行为配置文件并创建 Claude 可发现的工件
 argument-hint: "[--questionnaire] [--refresh]"
 allowed-tools:
   - Read

--- a/commands/gsd/progress.md
+++ b/commands/gsd/progress.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:progress
-description: Check progress, advance workflow, or dispatch freeform intent — the unified GSD situational command
+description: 检查进度、推进工作流或分发自由意图：统一的 GSD 情境命令
 argument-hint: "[--forensic | --next | --do \"task description\"]"
 allowed-tools:
   - Read

--- a/commands/gsd/quick.md
+++ b/commands/gsd/quick.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:quick
-description: Execute a quick task with GSD guarantees (atomic commits, state tracking) but skip optional agents
+description: 执行快速任务并保留 GSD 保障（原子提交、状态跟踪），跳过可选代理
 argument-hint: "[list | status <slug> | resume <slug> | --full] [--validate] [--discuss] [--research] [task description]"
 allowed-tools:
   - Read

--- a/commands/gsd/resume-work.md
+++ b/commands/gsd/resume-work.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:resume-work
-description: Resume work from previous session with full context restoration
+description: 从上一个会话恢复工作，恢复完整上下文
 allowed-tools:
   - Read
   - Bash

--- a/commands/gsd/review-backlog.md
+++ b/commands/gsd/review-backlog.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:review-backlog
-description: Review and promote backlog items to active milestone
+description: 审查并将积压项提升到活动里程碑
 allowed-tools:
   - Read
   - Write

--- a/commands/gsd/review.md
+++ b/commands/gsd/review.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:review
-description: Request cross-AI peer review of phase plans from external AI CLIs
+description: 从外部 AI CLI 请求跨 AI 同行审查阶段计划
 argument-hint: "--phase N [--gemini] [--claude] [--codex] [--opencode] [--qwen] [--cursor] [--all]"
 allowed-tools:
   - Read

--- a/commands/gsd/secure-phase.md
+++ b/commands/gsd/secure-phase.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:secure-phase
-description: Retroactively verify threat mitigations for a completed phase
+description: 事后验证已完成阶段的威胁缓解
 argument-hint: "[phase number]"
 allowed-tools:
   - Read

--- a/commands/gsd/settings.md
+++ b/commands/gsd/settings.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:settings
-description: Configure GSD workflow toggles and model profile
+description: 配置 GSD 工作流开关和模型配置
 allowed-tools:
   - Read
   - Write

--- a/commands/gsd/ship.md
+++ b/commands/gsd/ship.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:ship
-description: Create PR, run review, and prepare for merge after verification passes
+description: 创建 PR、运行审查，验证通过后准备合并
 argument-hint: "[phase number or milestone, e.g., '4' or 'v1.0']"
 allowed-tools:
   - Read

--- a/commands/gsd/sketch.md
+++ b/commands/gsd/sketch.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:sketch
-description: Sketch UI/design ideas with throwaway HTML mockups, or propose what to sketch next (frontier mode)
+description: 使用可丢弃 HTML 模型草图 UI/设计想法，或提议下一步草图内容
 argument-hint: "[design idea to explore] [--quick] [--text] [--wrap-up] or [frontier]"
 allowed-tools:
   - Read

--- a/commands/gsd/spec-phase.md
+++ b/commands/gsd/spec-phase.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:spec-phase
-description: Clarify WHAT a phase delivers with ambiguity scoring; produces a SPEC.md before discuss-phase.
+description: 通过模糊评分澄清阶段交付什么；在讨论阶段前生成 SPEC.md
 argument-hint: "<phase> [--auto] [--text]"
 allowed-tools:
   - Read

--- a/commands/gsd/spike.md
+++ b/commands/gsd/spike.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:spike
-description: Spike an idea through experiential exploration, or propose what to spike next (frontier mode)
+description: 通过体验式探索试验想法，或提议下一步试验内容
 argument-hint: "[idea to validate] [--quick] [--text] [--wrap-up] or [frontier]"
 allowed-tools:
   - Read

--- a/commands/gsd/stats.md
+++ b/commands/gsd/stats.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:stats
-description: Display project statistics — phases, plans, requirements, git metrics, and timeline
+description: 显示项目统计：阶段、计划、需求、git 指标和时间线
 allowed-tools:
   - Read
   - Bash

--- a/commands/gsd/surface.md
+++ b/commands/gsd/surface.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:surface
-description: Toggle which skills are surfaced — apply a profile, list, or disable a cluster without reinstall
+description: 切换显示哪些技能：应用配置文件、列表或禁用集群而无需重新安装
 argument-hint: "[list|status|profile <name>|disable <cluster>|enable <cluster>|reset]"
 allowed-tools:
   - Read

--- a/commands/gsd/thread.md
+++ b/commands/gsd/thread.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:thread
-description: Manage persistent context threads for cross-session work
+description: 管理跨会话工作的持久上下文线程
 argument-hint: "[list [--open | --resolved] | close <slug> | status <slug> | name | description]"
 allowed-tools:
   - Read

--- a/commands/gsd/ui-phase.md
+++ b/commands/gsd/ui-phase.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:ui-phase
-description: Generate UI design contract (UI-SPEC.md) for frontend phases
+description: 为前端阶段生成 UI 设计合同 (UI-SPEC.md)
 argument-hint: "[phase]"
 allowed-tools:
   - Read

--- a/commands/gsd/ui-review.md
+++ b/commands/gsd/ui-review.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:ui-review
-description: Retroactive 6-pillar visual audit of implemented frontend code
+description: 已实现前端代码的事后 6 支柱视觉审计
 argument-hint: "[phase]"
 allowed-tools:
   - Read

--- a/commands/gsd/ultraplan-phase.md
+++ b/commands/gsd/ultraplan-phase.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:ultraplan-phase
-description: "[BETA] Offload plan phase to Claude Code's ultraplan cloud; review in browser and import back."
+description: "[BETA] 将规划阶段卸载到 Claude Code 的 ultraplan 云；在浏览器中审查并导入回来"
 argument-hint: "[phase-number]"
 allowed-tools:
   - Read

--- a/commands/gsd/undo.md
+++ b/commands/gsd/undo.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:undo
-description: "Safe git revert. Roll back phase or plan commits using the phase manifest with dependency checks."
+description: "安全 git 回退。使用阶段清单和依赖检查回滚阶段或计划提交"
 argument-hint: "--last N | --phase NN | --plan NN-MM"
 allowed-tools:
   - Read

--- a/commands/gsd/update.md
+++ b/commands/gsd/update.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:update
-description: Update GSD to latest version with changelog display
+description: 更新 GSD 到最新版本并显示更新日志
 argument-hint: "[--sync | --reapply]"
 allowed-tools:
   - Read

--- a/commands/gsd/validate-phase.md
+++ b/commands/gsd/validate-phase.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:validate-phase
-description: Retroactively audit and fill Nyquist validation gaps for a completed phase
+description: 事后审计并填补已完成阶段的 Nyquist 验证差距
 argument-hint: "[phase number]"
 allowed-tools:
   - Read

--- a/commands/gsd/verify-work.md
+++ b/commands/gsd/verify-work.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:verify-work
-description: Validate built features through conversational UAT
+description: 通过对话式 UAT 验证构建的功能
 argument-hint: "[phase number, e.g., '4'] [--ws <name>]"
 allowed-tools:
   - Read

--- a/commands/gsd/workspace.md
+++ b/commands/gsd/workspace.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:workspace
-description: Manage GSD workspaces — create, list, or remove isolated workspace environments
+description: 管理 GSD 工作区：创建、列出或移除隔离工作区环境
 argument-hint: "[--new | --list | --remove] [name]"
 allowed-tools:
   - Read

--- a/commands/gsd/workstreams.md
+++ b/commands/gsd/workstreams.md
@@ -1,6 +1,6 @@
 ---
 name: gsd:workstreams
-description: Manage parallel workstreams — list, create, switch, status, progress, complete, and resume
+description: 管理并行工作流：列出、创建、切换、状态、进度、完成和恢复
 allowed-tools:
   - Read
   - Bash


### PR DESCRIPTION
## Summary

Translate all GSD command `description` fields from English to Chinese, enabling Chinese-speaking users to see localized descriptions in terminal autocomplete.

## Changes

- 67 command files in `commands/gsd/*.md` updated
- Only the `description:` YAML frontmatter field modified
- All command names, flags, argument-hints remain in English
- Internal prompts and workflow logic untouched

## Example

| Before | After |
|--------|-------|
| `codebase intelligence \| map graphify docs learnings` | `代码库智能 \| 映射 图谱化 文档 知识` |
| `workflow \| discuss plan execute verify phase progress` | `工作流 \| 讨论 规划 执行 验证 阶段 进度` |
| `Systematic debugging with persistent state across context resets` | `跨上下文重置的系统化调试，具有持久状态` |

## Scope

This is purely a display-layer translation. No behavioral changes, no new features, no breaking changes.

## Related

- Complements `help/modes/zh-CN/` translations (PR #3900, now closed)
- Addresses Chinese localization gap for terminal command discovery
